### PR TITLE
Context expansion only worked when the model was not loaded

### DIFF
--- a/internal/model/fleet/providers/lmstudio.go
+++ b/internal/model/fleet/providers/lmstudio.go
@@ -234,6 +234,48 @@ func (c *LMStudioClient) LoadModel(ctx context.Context, model string, contextLen
 	return &result, nil
 }
 
+// UnloadModel asks LM Studio to release a loaded model instance.
+//
+// LM Studio has no reconfigure-in-place operation: every load starts a new
+// instance, so growing a model's context window means holding two copies of
+// its weights unless the resident one is released first. A host without room
+// for the second copy refuses the load outright — and refuses a smaller
+// window as readily as a larger one, because what does not fit is the
+// weights, not the window.
+func (c *LMStudioClient) UnloadModel(ctx context.Context, instanceID string) error {
+	reqBody := lmStudioUnloadRequest{InstanceID: strings.TrimSpace(instanceID)}
+	if reqBody.InstanceID == "" {
+		return fmt.Errorf("instance id is required")
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+"/api/v1/models/unload", bytes.NewReader(jsonData))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	c.setAuth(httpReq)
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		errBody := httpkit.ReadErrorBody(resp.Body, 4096)
+		c.logger.Error("unload model API error", "status", resp.StatusCode, "body", errBody, "instance_id", reqBody.InstanceID)
+		return fmt.Errorf("API error %d: %s", resp.StatusCode, errBody)
+	}
+
+	c.logger.Info("model unloaded", "instance_id", reqBody.InstanceID)
+	return nil
+}
+
 func (c *LMStudioClient) handleStreaming(ctx context.Context, requestedModel string, validToolNames []string, body io.Reader, callback llm.StreamCallback) (*llm.ChatResponse, error) {
 	scanner := bufio.NewScanner(body)
 	scanner.Buffer(make([]byte, 0, 64*1024), 2*1024*1024)

--- a/internal/model/fleet/providers/lmstudio.go
+++ b/internal/model/fleet/providers/lmstudio.go
@@ -264,7 +264,9 @@ func (c *LMStudioClient) UnloadModel(ctx context.Context, instanceID string) err
 	if err != nil {
 		return fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	// The success body is not read for its content, but it still has to be
+	// drained for the connection to return to this shared client's pool.
+	defer httpkit.DrainAndClose(resp.Body, 4096)
 
 	if resp.StatusCode != http.StatusOK {
 		errBody := httpkit.ReadErrorBody(resp.Body, 4096)

--- a/internal/model/fleet/providers/lmstudio_test.go
+++ b/internal/model/fleet/providers/lmstudio_test.go
@@ -690,3 +690,38 @@ func TestLMStudioChatStream_ChunklessStreamErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestLMStudioUnloadModel(t *testing.T) {
+	t.Parallel()
+
+	var gotPath, gotInstance string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		var req struct {
+			InstanceID string `json:"instance_id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode unload request: %v", err)
+		}
+		gotInstance = req.InstanceID
+		_ = json.NewEncoder(w).Encode(map[string]any{"instance_id": req.InstanceID})
+	}))
+	defer srv.Close()
+
+	client := NewLMStudioClient(srv.URL, "", nil)
+	if err := client.UnloadModel(context.Background(), "google/gemma-3-4b:2"); err != nil {
+		t.Fatalf("UnloadModel() error = %v", err)
+	}
+	if gotPath != "/api/v1/models/unload" {
+		t.Fatalf("path = %q, want /api/v1/models/unload", gotPath)
+	}
+	if gotInstance != "google/gemma-3-4b:2" {
+		t.Fatalf("instance_id = %q, want google/gemma-3-4b:2", gotInstance)
+	}
+
+	// An instance id is required: LM Studio releases an instance, not a
+	// model, and a model may have several loaded at once.
+	if err := client.UnloadModel(context.Background(), "  "); err == nil {
+		t.Fatal("UnloadModel(blank) error = nil, want instance id required")
+	}
+}

--- a/internal/model/fleet/providers/lmstudio_wire.go
+++ b/internal/model/fleet/providers/lmstudio_wire.go
@@ -33,6 +33,12 @@ type lmStudioLoadRequest struct {
 	EchoLoadConfig bool   `json:"echo_load_config,omitempty"`
 }
 
+// lmStudioUnloadRequest releases one loaded instance. LM Studio identifies
+// the instance rather than the model, since a model may have several.
+type lmStudioUnloadRequest struct {
+	InstanceID string `json:"instance_id"`
+}
+
 type LMStudioLoadResponse struct {
 	Type            string         `json:"type,omitempty"`
 	InstanceID      string         `json:"instance_id,omitempty"`

--- a/internal/model/fleet/runtime.go
+++ b/internal/model/fleet/runtime.go
@@ -14,6 +14,12 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 )
 
+// restoreLoadTimeout bounds the rollback that puts a deployment's previous
+// context window back after a failed expansion. It is generous because it
+// covers a model load, and it exists only so a rollback running outside the
+// request's cancellation cannot hang indefinitely.
+const restoreLoadTimeout = 5 * time.Minute
+
 // RefreshResult describes the outcome of a runtime inventory refresh.
 type RefreshResult struct {
 	Changed  bool
@@ -118,6 +124,10 @@ func (r *Runtime) SetLogger(logger *slog.Logger) {
 	if r == nil || r.bundle == nil || logger == nil {
 		return
 	}
+	// The runtime logs on its own account too — context expansion warnings,
+	// rollback notices — so it has to move off the bootstrap handler with
+	// the provider clients rather than keeping the logger it started with.
+	r.log = logger
 	for id, oc := range r.bundle.OllamaClients {
 		oc.SetLogger(logger.With("resource", id))
 	}
@@ -321,7 +331,15 @@ func (r *Runtime) PrepareExplicitModel(ctx context.Context, ref string, contextS
 		// now serving nothing. Put back what was there rather than leaving
 		// a working model unloaded because a larger window was unavailable.
 		if unloaded && previousWindow > 0 {
-			if _, restoreErr := client.LoadModel(ctx, dep.ModelName, previousWindow); restoreErr != nil {
+			// Deliberately not the request's context. The commonest reason
+			// for the load to have failed is that ctx was canceled or timed
+			// out, and reusing it would make the rollback fail on the spot —
+			// turning a refused expansion into an unloaded deployment every
+			// time, which is the one outcome this is here to prevent.
+			restoreCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), restoreLoadTimeout)
+			defer cancel()
+
+			if _, restoreErr := client.LoadModel(restoreCtx, dep.ModelName, previousWindow); restoreErr != nil {
 				return nil, errors.Join(err, fmt.Errorf("restore previous context window %d: %w", previousWindow, restoreErr))
 			}
 			r.logger().Warn("context expansion failed, restored previous window",
@@ -330,7 +348,7 @@ func (r *Runtime) PrepareExplicitModel(ctx context.Context, ref string, contextS
 				"requested", contextSize,
 				"restored", previousWindow,
 			)
-			if _, refreshErr := r.refreshLocked(ctx); refreshErr != nil {
+			if _, refreshErr := r.refreshLocked(restoreCtx); refreshErr != nil {
 				return nil, errors.Join(err, refreshErr)
 			}
 		}

--- a/internal/model/fleet/runtime.go
+++ b/internal/model/fleet/runtime.go
@@ -2,6 +2,7 @@ package fleet
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -34,8 +35,17 @@ type Runtime struct {
 	registry *Registry
 	bundle   *ClientBundle
 	client   *llm.DynamicClient
+	log      *slog.Logger
 
 	refreshMu sync.Mutex
+}
+
+// logger returns the runtime's logger, defaulting when one was not supplied.
+func (r *Runtime) logger() *slog.Logger {
+	if r == nil || r.log == nil {
+		return slog.Default()
+	}
+	return r.log
 }
 
 // AnthropicRateLimitSnapshot is a JSON-friendly view of the latest
@@ -86,6 +96,7 @@ func NewRuntime(ctx context.Context, base *Catalog, cfg *config.Config, logger *
 		registry: registry,
 		bundle:   bundle,
 		client:   llm.NewDynamicClient(client),
+		log:      logger,
 	}
 	if _, err := rt.Refresh(ctx); err != nil {
 		return nil, err
@@ -281,8 +292,48 @@ func (r *Runtime) PrepareExplicitModel(ctx context.Context, ref string, contextS
 	if client == nil {
 		return nil, fmt.Errorf("lmstudio resource %q is unavailable", dep.ResourceID)
 	}
+
+	// Release the resident instance before loading its replacement. A load
+	// always starts a new instance, so without this the runner is asked to
+	// hold two copies of the weights and refuses on any host that cannot —
+	// which is to say expansion would work only when the model is not
+	// already loaded, the one case where it is not needed.
+	previousWindow := dep.LoadedContextWindow
+	unloaded := false
+	if instanceID := strings.TrimSpace(dep.LoadedInstanceID); instanceID != "" {
+		if unloadErr := client.UnloadModel(ctx, instanceID); unloadErr != nil {
+			// Not fatal: the load may still succeed where there is room for
+			// both, and failing here would be strictly worse than today.
+			r.logger().Warn("unload before context expansion failed, loading anyway",
+				"resource", dep.ResourceID,
+				"deployment", dep.ID,
+				"instance_id", instanceID,
+				"error", unloadErr,
+			)
+		} else {
+			unloaded = true
+		}
+	}
+
 	loadResp, err := client.LoadModel(ctx, dep.ModelName, contextSize)
 	if err != nil {
+		// The unload succeeded and the load did not, so the deployment is
+		// now serving nothing. Put back what was there rather than leaving
+		// a working model unloaded because a larger window was unavailable.
+		if unloaded && previousWindow > 0 {
+			if _, restoreErr := client.LoadModel(ctx, dep.ModelName, previousWindow); restoreErr != nil {
+				return nil, errors.Join(err, fmt.Errorf("restore previous context window %d: %w", previousWindow, restoreErr))
+			}
+			r.logger().Warn("context expansion failed, restored previous window",
+				"resource", dep.ResourceID,
+				"deployment", dep.ID,
+				"requested", contextSize,
+				"restored", previousWindow,
+			)
+			if _, refreshErr := r.refreshLocked(ctx); refreshErr != nil {
+				return nil, errors.Join(err, refreshErr)
+			}
+		}
 		return nil, err
 	}
 

--- a/internal/model/fleet/runtime_test.go
+++ b/internal/model/fleet/runtime_test.go
@@ -380,3 +380,114 @@ func TestRuntimePrepareExplicitModel_RestoresPreviousWindowWhenLoadFails(t *test
 		t.Fatalf("LoadedContextWindow = %d, want the registry to reflect the restored 4096", dep.LoadedContextWindow)
 	}
 }
+
+// The commonest reason for an expansion to fail is that the request's
+// context was canceled or timed out. If the rollback ran on that same
+// context it would fail on the spot, so the very situation most likely to
+// trigger a rollback would also be the one where it never happens.
+func TestRuntimePrepareExplicitModel_RestoresPreviousWindowAfterContextCancel(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	loadedContext := 4096
+	loadedInstance := "google/gemma-3-4b"
+	var loadSizes []int
+	cancelRequest := func() {}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/models/unload":
+			mu.Lock()
+			loadedContext = 0
+			loadedInstance = ""
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]any{"instance_id": "google/gemma-3-4b"})
+		case "/api/v1/models":
+			mu.Lock()
+			current, instance := loadedContext, loadedInstance
+			mu.Unlock()
+			model := map[string]any{
+				"key":                "google/gemma-3-4b",
+				"type":               "llm",
+				"architecture":       "gemma3",
+				"format":             "mlx",
+				"max_context_length": 131072,
+			}
+			if instance != "" {
+				model["loaded_instances"] = []map[string]any{{
+					"id":     instance,
+					"config": map[string]any{"context_length": current},
+				}}
+			}
+			_ = json.NewEncoder(w).Encode(struct {
+				Models []map[string]any `json:"models"`
+			}{Models: []map[string]any{model}})
+		case "/api/v1/models/load":
+			var req struct {
+				ContextLength int `json:"context_length"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode load request: %v", err)
+			}
+			mu.Lock()
+			loadSizes = append(loadSizes, req.ContextLength)
+			mu.Unlock()
+			if req.ContextLength > 4096 {
+				// The caller gives up while the expansion is in flight — a
+				// canceled turn, a deadline, an operator interrupt.
+				cancelRequest()
+				http.Error(w, `{"error":{"message":"insufficient system resources"}}`, http.StatusInternalServerError)
+				return
+			}
+			mu.Lock()
+			loadedContext = req.ContextLength
+			loadedInstance = "google/gemma-3-4b"
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(modelproviders.LMStudioLoadResponse{
+				Type:       "llm",
+				InstanceID: "google/gemma-3-4b",
+				Status:     "loaded",
+			})
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	cfg := &config.Config{
+		Models: config.ModelsConfig{
+			Resources: map[string]config.ModelServerConfig{
+				"deepslate": {URL: srv.URL, Provider: "lmstudio"},
+			},
+		},
+	}
+	base, err := BuildCatalog(cfg)
+	if err != nil {
+		t.Fatalf("BuildCatalog: %v", err)
+	}
+	runtime, err := NewRuntime(context.Background(), base, cfg, nil)
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cancelRequest = cancel
+
+	if _, err := runtime.PrepareExplicitModel(ctx, "deepslate/google/gemma-3-4b", 65536); err == nil {
+		t.Fatal("PrepareExplicitModel error = nil, want the failed expansion reported")
+	}
+
+	mu.Lock()
+	gotSizes := loadSizes
+	gotContext := loadedContext
+	gotInstance := loadedInstance
+	mu.Unlock()
+
+	if len(gotSizes) != 2 || gotSizes[1] != 4096 {
+		t.Fatalf("load sizes = %v, want the 4096 restore attempted despite the canceled context", gotSizes)
+	}
+	if gotContext != 4096 || gotInstance == "" {
+		t.Fatalf("runner left at context=%d instance=%q, want the previous window serving again", gotContext, gotInstance)
+	}
+}

--- a/internal/model/fleet/runtime_test.go
+++ b/internal/model/fleet/runtime_test.go
@@ -70,9 +70,24 @@ func TestRuntimePrepareExplicitModel_LoadsLMStudioContext(t *testing.T) {
 
 	var mu sync.Mutex
 	loadedContext := 4096
+	var ops []string
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
+		case "/api/v1/models/unload":
+			var req struct {
+				InstanceID string `json:"instance_id"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode unload request: %v", err)
+			}
+			if req.InstanceID != "google/gemma-3-4b" {
+				t.Fatalf("unload instance_id = %q, want google/gemma-3-4b", req.InstanceID)
+			}
+			mu.Lock()
+			ops = append(ops, "unload")
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]any{"instance_id": req.InstanceID})
 		case "/api/v1/models":
 			mu.Lock()
 			current := loadedContext
@@ -113,6 +128,7 @@ func TestRuntimePrepareExplicitModel_LoadsLMStudioContext(t *testing.T) {
 			}
 			mu.Lock()
 			loadedContext = req.ContextLength
+			ops = append(ops, "load")
 			mu.Unlock()
 			_ = json.NewEncoder(w).Encode(modelproviders.LMStudioLoadResponse{
 				Type:       "llm",
@@ -161,6 +177,16 @@ func TestRuntimePrepareExplicitModel_LoadsLMStudioContext(t *testing.T) {
 	}
 	if prep.Resolved != "deepslate/google/gemma-3-4b" {
 		t.Fatalf("prep.Resolved = %q, want deepslate/google/gemma-3-4b", prep.Resolved)
+	}
+
+	// The resident instance has to be released first: a load always starts a
+	// new one, so loading over a live instance asks the runner to hold two
+	// copies of the weights and is refused wherever there is not room.
+	mu.Lock()
+	gotOps := strings.Join(ops, ",")
+	mu.Unlock()
+	if gotOps != "unload,load" {
+		t.Fatalf("provider calls = %q, want \"unload,load\"", gotOps)
 	}
 
 	dep, err = runtime.Registry().Catalog().ResolveDeploymentRef("deepslate/google/gemma-3-4b")
@@ -240,4 +266,117 @@ func TestRuntime_SetLogger_NilGuards(t *testing.T) {
 
 	rt = &Runtime{bundle: &ClientBundle{}}
 	rt.SetLogger(nil) // nil logger
+}
+
+// Unloading before loading opens a window where the deployment is serving
+// nothing. If the larger load is then refused — which is exactly what a
+// memory-constrained runner does — the previous window has to go back, or a
+// failed expansion would cost the operator a working model.
+func TestRuntimePrepareExplicitModel_RestoresPreviousWindowWhenLoadFails(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	loadedContext := 4096
+	loadedInstance := "google/gemma-3-4b"
+	var loadSizes []int
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/models/unload":
+			mu.Lock()
+			loadedContext = 0
+			loadedInstance = ""
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]any{"instance_id": "google/gemma-3-4b"})
+		case "/api/v1/models":
+			mu.Lock()
+			current, instance := loadedContext, loadedInstance
+			mu.Unlock()
+			model := map[string]any{
+				"key":                "google/gemma-3-4b",
+				"type":               "llm",
+				"architecture":       "gemma3",
+				"format":             "mlx",
+				"max_context_length": 131072,
+			}
+			if instance != "" {
+				model["loaded_instances"] = []map[string]any{{
+					"id":     instance,
+					"config": map[string]any{"context_length": current},
+				}}
+			}
+			_ = json.NewEncoder(w).Encode(struct {
+				Models []map[string]any `json:"models"`
+			}{Models: []map[string]any{model}})
+		case "/api/v1/models/load":
+			var req struct {
+				ContextLength int `json:"context_length"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode load request: %v", err)
+			}
+			mu.Lock()
+			loadSizes = append(loadSizes, req.ContextLength)
+			mu.Unlock()
+			// The runner refuses the expansion but can still hold what it
+			// had, the shape of a resource guardrail on a busy host.
+			if req.ContextLength > 4096 {
+				http.Error(w, `{"error":{"message":"Model loading was stopped due to insufficient system resources"}}`, http.StatusInternalServerError)
+				return
+			}
+			mu.Lock()
+			loadedContext = req.ContextLength
+			loadedInstance = "google/gemma-3-4b"
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(modelproviders.LMStudioLoadResponse{
+				Type:       "llm",
+				InstanceID: "google/gemma-3-4b",
+				Status:     "loaded",
+			})
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	cfg := &config.Config{
+		Models: config.ModelsConfig{
+			Resources: map[string]config.ModelServerConfig{
+				"deepslate": {URL: srv.URL, Provider: "lmstudio"},
+			},
+		},
+	}
+	base, err := BuildCatalog(cfg)
+	if err != nil {
+		t.Fatalf("BuildCatalog: %v", err)
+	}
+	runtime, err := NewRuntime(context.Background(), base, cfg, nil)
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+
+	if _, err := runtime.PrepareExplicitModel(context.Background(), "deepslate/google/gemma-3-4b", 65536); err == nil {
+		t.Fatal("PrepareExplicitModel error = nil, want the refused expansion reported")
+	}
+
+	mu.Lock()
+	gotSizes := loadSizes
+	gotContext := loadedContext
+	gotInstance := loadedInstance
+	mu.Unlock()
+
+	if len(gotSizes) != 2 || gotSizes[0] != 65536 || gotSizes[1] != 4096 {
+		t.Fatalf("load sizes = %v, want [65536 4096] — the attempt then the restore", gotSizes)
+	}
+	if gotContext != 4096 || gotInstance == "" {
+		t.Fatalf("runner left at context=%d instance=%q, want the previous 4096 window serving again", gotContext, gotInstance)
+	}
+
+	dep, err := runtime.Registry().Catalog().ResolveDeploymentRef("deepslate/google/gemma-3-4b")
+	if err != nil {
+		t.Fatalf("ResolveDeploymentRef after failed prepare: %v", err)
+	}
+	if dep.LoadedContextWindow != 4096 {
+		t.Fatalf("LoadedContextWindow = %d, want the registry to reflect the restored 4096", dep.LoadedContextWindow)
+	}
 }

--- a/internal/runtime/agent/context_sizing.go
+++ b/internal/runtime/agent/context_sizing.go
@@ -96,6 +96,27 @@ func desiredLoadContextTokens(requiredTokens, maxContextWindow int) int {
 	return desired
 }
 
+// growLoadContextTokens sizes a reload after the runner has rejected a
+// request the estimate said would fit.
+//
+// The estimate cannot be trusted here — the runner has just demonstrated it
+// was low — so it serves only as a floor, and the growth comes from doubling
+// the window that actually failed. That is deliberately not a jump straight
+// to the advertised maximum: on local runners a window costs load time and
+// resident memory in proportion to its size, and the maximum can be twenty
+// times what the request needs. Doubling recovers from an estimate that was
+// somewhat wrong without paying for one that was catastrophically wrong.
+func growLoadContextTokens(requiredTokens, loadedWindow, maxContextWindow int) int {
+	target := desiredLoadContextTokens(requiredTokens, maxContextWindow)
+	if doubled := loadedWindow * 2; doubled > target {
+		target = doubled
+	}
+	if maxContextWindow > 0 && target > maxContextWindow {
+		target = maxContextWindow
+	}
+	return target
+}
+
 func roughTokenCount(s string) int {
 	s = strings.TrimSpace(s)
 	if s == "" {

--- a/internal/runtime/agent/model_context_recovery.go
+++ b/internal/runtime/agent/model_context_recovery.go
@@ -1,0 +1,198 @@
+package agent
+
+import (
+	"context"
+	"strings"
+
+	"github.com/nugget/thane-ai-agent/internal/model/llm"
+)
+
+// Recovery from a runner rejecting a request its loaded context window
+// cannot hold. Separate from model selection because it runs after the
+// choice has been made and the provider has disagreed with it.
+
+func (l *Loop) maybeRetryExplicitModelAfterProviderContextError(
+	ctx context.Context,
+	model string,
+	err error,
+	msgs []llm.Message,
+	toolDefs []map[string]any,
+	stream llm.StreamCallback,
+) (*llm.ChatResponse, string, error, bool) {
+	if l == nil || l.modelRuntime == nil || err == nil {
+		return nil, "", nil, false
+	}
+	if !isLMStudioLoadedContextError(err) {
+		return nil, "", nil, false
+	}
+
+	cat := l.currentModelCatalog()
+	if cat == nil {
+		return nil, "", nil, false
+	}
+	dep, resolveErr := cat.ResolveDeploymentRef(model)
+	if resolveErr != nil {
+		return nil, "", nil, false
+	}
+	if strings.TrimSpace(dep.Provider) != "lmstudio" {
+		return nil, "", nil, false
+	}
+
+	changed := false
+	retryModel := dep.ID
+	retryUpstreamModel := strings.TrimSpace(dep.LoadedInstanceID)
+	refreshResolvedModel := func() error {
+		result, refreshErr := l.modelRuntime.Refresh(ctx)
+		if refreshErr != nil {
+			return refreshErr
+		}
+		if result != nil && result.Changed {
+			changed = true
+			if l.router != nil && l.modelRegistry != nil {
+				l.router.UpdateConfig(l.modelRegistry.Catalog().RouterConfig(0))
+			}
+		}
+		refreshedCat := l.currentModelCatalog()
+		if refreshedCat == nil {
+			return nil
+		}
+		refreshedDep, resolveErr := refreshedCat.ResolveDeploymentRef(model)
+		if resolveErr != nil {
+			return resolveErr
+		}
+		dep = refreshedDep
+		retryModel = dep.ID
+		retryUpstreamModel = strings.TrimSpace(dep.LoadedInstanceID)
+		return nil
+	}
+	if refreshErr := refreshResolvedModel(); refreshErr != nil {
+		return nil, "", refreshErr, true
+	}
+	growTo := func(target int) error {
+		if dep.MaxContextWindow <= 0 || target <= dep.LoadedContextWindow {
+			return nil
+		}
+		prep, prepErr := l.modelRuntime.PrepareExplicitModel(ctx, dep.ID, target)
+		if prepErr != nil {
+			return prepErr
+		}
+		if prep != nil {
+			changed = prep.Changed
+			if strings.TrimSpace(prep.Resolved) != "" {
+				retryModel = prep.Resolved
+			}
+			if strings.TrimSpace(prep.Instance) != "" {
+				retryUpstreamModel = strings.TrimSpace(prep.Instance)
+			}
+			if changed && l.router != nil && l.modelRegistry != nil {
+				l.router.UpdateConfig(l.modelRegistry.Catalog().RouterConfig(0))
+			}
+		}
+		return nil
+	}
+
+	retryContext := growLoadContextTokens(
+		estimateRequestContextTokens(msgs, toolDefs),
+		dep.LoadedContextWindow,
+		dep.MaxContextWindow,
+	)
+	if growErr := growTo(retryContext); growErr != nil {
+		return nil, "", growErr, true
+	}
+
+	// escalateToMax is the second and last growth this recovery will attempt.
+	// The measured window is the cheap guess; if the runner rejects that too,
+	// there is nothing left to infer from and the deployment's advertised
+	// maximum is the only remaining answer — which is what this path always
+	// reached for before the growth was bounded. Two loads is the ceiling, so
+	// a wrong guess costs one extra load rather than an unbounded climb.
+	escalatedToMax := false
+	escalateToMax := func() (bool, error) {
+		if escalatedToMax || dep.MaxContextWindow <= 0 || retryContext >= dep.MaxContextWindow {
+			return false, nil
+		}
+		escalatedToMax = true
+		if growErr := growTo(dep.MaxContextWindow); growErr != nil {
+			return false, growErr
+		}
+		return true, nil
+	}
+
+	retryCall := func(tools []map[string]any) (*llm.ChatResponse, error) {
+		if retryUpstreamModel != "" {
+			if client := l.modelRuntime.LMStudioClient(dep.ResourceID); client != nil {
+				resp, err := client.ChatStream(ctx, retryUpstreamModel, msgs, tools, stream)
+				if resp != nil {
+					resp.Model = retryModel
+				}
+				return resp, err
+			}
+		}
+		return l.llm.ChatStream(ctx, retryModel, msgs, tools, stream)
+	}
+
+	// Dropping the tool schemas is the cheaper lever than growing the window
+	// again, and for a model LM Studio has to prompt into tool use they are
+	// what inflated the prompt in the first place. So escalate here only when
+	// that lever is unavailable; where it is available the tool-free retry
+	// below runs first and escalates only if it, too, is still too large.
+	toolsAreALever := len(toolDefs) > 0 && !dep.TrainedForToolUse
+
+	if changed {
+		resp, retryErr := retryCall(toolDefs)
+		if retryErr == nil {
+			return resp, retryModel, nil, true
+		}
+		if !toolsAreALever && isLMStudioLoadedContextError(retryErr) {
+			escalated, escalateErr := escalateToMax()
+			if escalateErr != nil {
+				return nil, "", escalateErr, true
+			}
+			if escalated {
+				resp, retryErr = retryCall(toolDefs)
+				if retryErr == nil {
+					return resp, retryModel, nil, true
+				}
+			}
+		}
+		if !toolsAreALever || !isLMStudioLoadedContextError(retryErr) {
+			return nil, "", retryErr, true
+		}
+	}
+
+	if toolsAreALever && strings.TrimSpace(retryModel) != "" {
+		resp, retryErr := retryCall(nil)
+		if retryErr == nil {
+			return resp, retryModel, nil, true
+		}
+		if isLMStudioLoadedContextError(retryErr) {
+			escalated, escalateErr := escalateToMax()
+			if escalateErr != nil {
+				return nil, "", escalateErr, true
+			}
+			if escalated {
+				resp, retryErr = retryCall(nil)
+				if retryErr == nil {
+					return resp, retryModel, nil, true
+				}
+			}
+		}
+		if changed || isLMStudioLoadedContextError(retryErr) {
+			return nil, "", retryErr, true
+		}
+	}
+
+	if !changed {
+		return nil, "", nil, false
+	}
+	return nil, "", nil, false
+}
+
+func isLMStudioLoadedContextError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(strings.TrimSpace(err.Error()))
+	return strings.Contains(msg, "tokens to keep from the initial prompt is greater than the context length") &&
+		strings.Contains(msg, "load the model with a larger context length")
+}

--- a/internal/runtime/agent/model_selection.go
+++ b/internal/runtime/agent/model_selection.go
@@ -224,8 +224,13 @@ func (l *Loop) maybeRetryExplicitModelAfterProviderContextError(
 	if refreshErr := refreshResolvedModel(); refreshErr != nil {
 		return nil, "", refreshErr, true
 	}
-	if dep.MaxContextWindow > dep.LoadedContextWindow && dep.MaxContextWindow > 0 {
-		prep, prepErr := l.modelRuntime.PrepareExplicitModel(ctx, dep.ID, dep.MaxContextWindow)
+	retryContext := growLoadContextTokens(
+		estimateRequestContextTokens(msgs, toolDefs),
+		dep.LoadedContextWindow,
+		dep.MaxContextWindow,
+	)
+	if dep.MaxContextWindow > dep.LoadedContextWindow && dep.MaxContextWindow > 0 && retryContext > dep.LoadedContextWindow {
+		prep, prepErr := l.modelRuntime.PrepareExplicitModel(ctx, dep.ID, retryContext)
 		if prepErr != nil {
 			return nil, "", prepErr, true
 		}

--- a/internal/runtime/agent/model_selection.go
+++ b/internal/runtime/agent/model_selection.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/nugget/thane-ai-agent/internal/model/fleet"
-	"github.com/nugget/thane-ai-agent/internal/model/llm"
 	"github.com/nugget/thane-ai-agent/internal/model/router"
 )
 
@@ -167,126 +166,6 @@ func (l *Loop) maybePrepareExplicitModel(ctx context.Context, ref string, needsT
 	return prep != nil && prep.Changed, nil
 }
 
-func (l *Loop) maybeRetryExplicitModelAfterProviderContextError(
-	ctx context.Context,
-	model string,
-	err error,
-	msgs []llm.Message,
-	toolDefs []map[string]any,
-	stream llm.StreamCallback,
-) (*llm.ChatResponse, string, error, bool) {
-	if l == nil || l.modelRuntime == nil || err == nil {
-		return nil, "", nil, false
-	}
-	if !isLMStudioLoadedContextError(err) {
-		return nil, "", nil, false
-	}
-
-	cat := l.currentModelCatalog()
-	if cat == nil {
-		return nil, "", nil, false
-	}
-	dep, resolveErr := cat.ResolveDeploymentRef(model)
-	if resolveErr != nil {
-		return nil, "", nil, false
-	}
-	if strings.TrimSpace(dep.Provider) != "lmstudio" {
-		return nil, "", nil, false
-	}
-
-	changed := false
-	retryModel := dep.ID
-	retryUpstreamModel := strings.TrimSpace(dep.LoadedInstanceID)
-	refreshResolvedModel := func() error {
-		result, refreshErr := l.modelRuntime.Refresh(ctx)
-		if refreshErr != nil {
-			return refreshErr
-		}
-		if result != nil && result.Changed {
-			changed = true
-			if l.router != nil && l.modelRegistry != nil {
-				l.router.UpdateConfig(l.modelRegistry.Catalog().RouterConfig(0))
-			}
-		}
-		refreshedCat := l.currentModelCatalog()
-		if refreshedCat == nil {
-			return nil
-		}
-		refreshedDep, resolveErr := refreshedCat.ResolveDeploymentRef(model)
-		if resolveErr != nil {
-			return resolveErr
-		}
-		dep = refreshedDep
-		retryModel = dep.ID
-		retryUpstreamModel = strings.TrimSpace(dep.LoadedInstanceID)
-		return nil
-	}
-	if refreshErr := refreshResolvedModel(); refreshErr != nil {
-		return nil, "", refreshErr, true
-	}
-	retryContext := growLoadContextTokens(
-		estimateRequestContextTokens(msgs, toolDefs),
-		dep.LoadedContextWindow,
-		dep.MaxContextWindow,
-	)
-	if dep.MaxContextWindow > dep.LoadedContextWindow && dep.MaxContextWindow > 0 && retryContext > dep.LoadedContextWindow {
-		prep, prepErr := l.modelRuntime.PrepareExplicitModel(ctx, dep.ID, retryContext)
-		if prepErr != nil {
-			return nil, "", prepErr, true
-		}
-		if prep != nil {
-			changed = prep.Changed
-			if strings.TrimSpace(prep.Resolved) != "" {
-				retryModel = prep.Resolved
-			}
-			if strings.TrimSpace(prep.Instance) != "" {
-				retryUpstreamModel = strings.TrimSpace(prep.Instance)
-			}
-			if changed && l.router != nil && l.modelRegistry != nil {
-				l.router.UpdateConfig(l.modelRegistry.Catalog().RouterConfig(0))
-			}
-		}
-	}
-
-	retryCall := func(tools []map[string]any) (*llm.ChatResponse, error) {
-		if retryUpstreamModel != "" {
-			if client := l.modelRuntime.LMStudioClient(dep.ResourceID); client != nil {
-				resp, err := client.ChatStream(ctx, retryUpstreamModel, msgs, tools, stream)
-				if resp != nil {
-					resp.Model = retryModel
-				}
-				return resp, err
-			}
-		}
-		return l.llm.ChatStream(ctx, retryModel, msgs, tools, stream)
-	}
-
-	if changed {
-		resp, retryErr := retryCall(toolDefs)
-		if retryErr == nil {
-			return resp, retryModel, nil, true
-		}
-		if len(toolDefs) == 0 || dep.TrainedForToolUse || !isLMStudioLoadedContextError(retryErr) {
-			return nil, "", retryErr, true
-		}
-	}
-
-	if len(toolDefs) > 0 && !dep.TrainedForToolUse && strings.TrimSpace(retryModel) != "" {
-		resp, retryErr := retryCall(nil)
-		if retryErr == nil {
-			return resp, retryModel, nil, true
-		}
-		if changed || isLMStudioLoadedContextError(retryErr) {
-			return nil, "", retryErr, true
-		}
-	}
-
-	if !changed {
-		return nil, "", nil, false
-	}
-	return nil, "", nil, false
-}
-
 func messagesNeedImages(msgs []Message) bool {
 	for _, msg := range msgs {
 		if len(msg.Images) > 0 {
@@ -294,15 +173,6 @@ func messagesNeedImages(msgs []Message) bool {
 		}
 	}
 	return false
-}
-
-func isLMStudioLoadedContextError(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := strings.ToLower(strings.TrimSpace(err.Error()))
-	return strings.Contains(msg, "tokens to keep from the initial prompt is greater than the context length") &&
-		strings.Contains(msg, "load the model with a larger context length")
 }
 
 func isContextWindowIncompatible(err error) bool {

--- a/internal/runtime/agent/model_selection_test.go
+++ b/internal/runtime/agent/model_selection_test.go
@@ -1508,3 +1508,122 @@ func TestGrowLoadContextTokens(t *testing.T) {
 		})
 	}
 }
+
+// Doubling is a guess, and a guess can be wrong by more than a factor of
+// two. When the runner rejects the doubled window as well, the recovery has
+// to fall back to the deployment's advertised maximum — the answer this path
+// always reached for before the growth was bounded — rather than giving up
+// with a window it merely hoped would be enough.
+func TestRun_ExplicitModelEscalatesToMaxWhenDoublingIsNotEnough(t *testing.T) {
+	var mu sync.Mutex
+	loadedContext := 24000
+	var loadSizes []int
+	chatCalls := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/models/unload":
+			_ = json.NewEncoder(w).Encode(map[string]any{"instance_id": "google/gemma-3-4b"})
+		case "/api/v1/models":
+			mu.Lock()
+			current := loadedContext
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(struct {
+				Models []map[string]any `json:"models"`
+			}{
+				Models: []map[string]any{{
+					"key":                "google/gemma-3-4b",
+					"type":               "llm",
+					"architecture":       "gemma3",
+					"format":             "mlx",
+					"max_context_length": 131072,
+					"capabilities":       map[string]any{"trained_for_tool_use": true},
+					"loaded_instances": []map[string]any{{
+						"id":     "google/gemma-3-4b",
+						"config": map[string]any{"context_length": current},
+					}},
+				}},
+			})
+		case "/api/v1/models/load":
+			var req struct {
+				ContextLength int `json:"context_length"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode load request: %v", err)
+			}
+			mu.Lock()
+			loadSizes = append(loadSizes, req.ContextLength)
+			loadedContext = req.ContextLength
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(modelproviders.LMStudioLoadResponse{
+				Type:       "llm",
+				InstanceID: "google/gemma-3-4b",
+				Status:     "loaded",
+			})
+		case "/v1/chat/completions":
+			mu.Lock()
+			current := loadedContext
+			chatCalls++
+			mu.Unlock()
+			// Only the full 131072 window can serve this request, so the
+			// doubling to 48000 is rejected exactly as the original was.
+			if current < 131072 {
+				http.Error(w, `{"error":"The number of tokens to keep from the initial prompt is greater than the context length. Try to load the model with a larger context length, or provide a shorter input"}`, http.StatusBadRequest)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"model": "deepslate/google/gemma-3-4b",
+				"choices": []map[string]any{{
+					"index":   0,
+					"message": map[string]any{"role": "assistant", "content": "ok"},
+				}},
+				"usage": map[string]any{"prompt_tokens": 12, "completion_tokens": 2},
+			})
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	cfg := &config.Config{
+		Models: config.ModelsConfig{
+			Default: "gpt-oss:20b",
+			Resources: map[string]config.ModelServerConfig{
+				"spark":     {URL: "http://spark.example", Provider: "ollama"},
+				"deepslate": {URL: srv.URL, Provider: "lmstudio"},
+			},
+			Available: []config.ModelConfig{
+				{Name: "gpt-oss:20b", Resource: "spark", SupportsTools: true, ContextWindow: 8192},
+			},
+		},
+	}
+	cat, err := fleet.BuildCatalog(cfg)
+	if err != nil {
+		t.Fatalf("fleet.BuildCatalog: %v", err)
+	}
+	runtime, err := fleet.NewRuntime(context.Background(), cat, cfg, nil)
+	if err != nil {
+		t.Fatalf("fleet.NewRuntime: %v", err)
+	}
+	loop := buildTestLoopWithLLM(runtime.Client(), []string{"ha_get_state"})
+	loop.UseModelRegistry(runtime.Registry())
+	loop.UseModelRuntime(runtime)
+
+	resp, err := loop.Run(context.Background(), &Request{
+		Model:    "deepslate/google/gemma-3-4b",
+		Messages: []Message{{Role: "user", Content: "Reply with exactly ok"}},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Run() error = %v, want the escalation to reach a window that serves", err)
+	}
+	if strings.TrimSpace(resp.Content) != "ok" {
+		t.Fatalf("resp.Content = %q, want ok", resp.Content)
+	}
+
+	mu.Lock()
+	gotSizes := loadSizes
+	mu.Unlock()
+	if len(gotSizes) != 2 || gotSizes[0] != 48000 || gotSizes[1] != 131072 {
+		t.Fatalf("load sizes = %v, want [48000 131072] — the doubling, then the maximum", gotSizes)
+	}
+}

--- a/internal/runtime/agent/model_selection_test.go
+++ b/internal/runtime/agent/model_selection_test.go
@@ -475,6 +475,10 @@ func TestRun_ExplicitModelPreparesLoadedContextAndRetries(t *testing.T) {
 					}},
 				}},
 			})
+		case "/api/v1/models/unload":
+			// The resident instance is released before its replacement is
+			// loaded; see TestRuntimePrepareExplicitModel_LoadsLMStudioContext.
+			_ = json.NewEncoder(w).Encode(map[string]any{"instance_id": "google/gemma-3-4b"})
 		case "/api/v1/models/load":
 			var req struct {
 				Model         string `json:"model"`
@@ -735,6 +739,8 @@ func TestRun_ExplicitModelRetriesProviderContextErrorAfterLMStudioLoad(t *testin
 					}},
 				}},
 			})
+		case "/api/v1/models/unload":
+			_ = json.NewEncoder(w).Encode(map[string]any{"instance_id": "google/gemma-3-4b"})
 		case "/api/v1/models/load":
 			var req struct {
 				Model         string `json:"model"`
@@ -746,8 +752,12 @@ func TestRun_ExplicitModelRetriesProviderContextErrorAfterLMStudioLoad(t *testin
 			if req.Model != "google/gemma-3-4b" {
 				t.Fatalf("load model = %q, want google/gemma-3-4b", req.Model)
 			}
-			if req.ContextLength != 131072 {
-				t.Fatalf("context_length = %d, want 131072", req.ContextLength)
+			// Recovery doubles the window that failed rather than jumping to
+			// the advertised 131072 maximum: the estimate is known to be low,
+			// but not known to be twenty times low, and a window costs load
+			// time and resident memory in proportion to its size.
+			if req.ContextLength != 48000 {
+				t.Fatalf("context_length = %d, want 48000 — twice the 24000 window that failed", req.ContextLength)
 			}
 			mu.Lock()
 			loadedContext = req.ContextLength
@@ -771,7 +781,10 @@ func TestRun_ExplicitModelRetriesProviderContextErrorAfterLMStudioLoad(t *testin
 			chatCalls++
 			lastToolCount = len(req.Tools)
 			mu.Unlock()
-			if current < 131072 {
+			// The starting window is what fails; any window larger than it
+			// serves. The recovery is not required to reach the advertised
+			// maximum, only to grow past what was rejected.
+			if current <= 24000 {
 				http.Error(w, `{"error":"The number of tokens to keep from the initial prompt is greater than the context length. Try to load the model with a larger context length, or provide a shorter input"}`, http.StatusBadRequest)
 				return
 			}
@@ -864,8 +877,8 @@ func TestRun_ExplicitModelRetriesProviderContextErrorAfterLMStudioLoad(t *testin
 	if gotChatCalls != 3 {
 		t.Fatalf("chat calls = %d, want 3", gotChatCalls)
 	}
-	if gotLoadedContext != 131072 {
-		t.Fatalf("loadedContext = %d, want 131072", gotLoadedContext)
+	if gotLoadedContext != 48000 {
+		t.Fatalf("loadedContext = %d, want 48000 — grown past the failed window, not to the maximum", gotLoadedContext)
 	}
 	if gotLastToolCount != 0 {
 		t.Fatalf("last tool count = %d, want 0 on final retry", gotLastToolCount)
@@ -875,8 +888,8 @@ func TestRun_ExplicitModelRetriesProviderContextErrorAfterLMStudioLoad(t *testin
 	if err != nil {
 		t.Fatalf("ResolveDeploymentRef after retry: %v", err)
 	}
-	if dep.LoadedContextWindow != 131072 || dep.ContextWindow != 131072 {
-		t.Fatalf("deployment context after retry = loaded:%d context:%d, want 131072/131072", dep.LoadedContextWindow, dep.ContextWindow)
+	if dep.LoadedContextWindow != 48000 || dep.ContextWindow != 48000 {
+		t.Fatalf("deployment context after retry = loaded:%d context:%d, want 48000/48000", dep.LoadedContextWindow, dep.ContextWindow)
 	}
 	if dep.TrainedForToolUse {
 		t.Fatal("dep.TrainedForToolUse = true, want false from LM Studio inventory")
@@ -1441,5 +1454,57 @@ func TestRun_ExplicitModelPreflightDoesNotRequireOutputHeadroom(t *testing.T) {
 	}
 	if len(mock.calls) == 0 {
 		t.Fatal("llm calls = 0, want the provider reached rather than preflight-rejected")
+	}
+}
+
+// After the runner rejects a request the estimate said would fit, the
+// estimate is known to be low — so it may only floor the retry, and the
+// growth has to come from the window that actually failed. Jumping to the
+// advertised maximum would recover too, at the cost of a load proportional
+// to a window the request never needed.
+func TestGrowLoadContextTokens(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		required int
+		loaded   int
+		max      int
+		want     int
+	}{
+		{
+			name: "doubles the window that failed",
+			// The 12732 window that failed in production, with an estimate
+			// that had said ~12769 would fit.
+			required: 12769, loaded: 12732, max: 262144, want: 25464,
+		},
+		{
+			name:     "estimate floors the retry when it exceeds the doubling",
+			required: 100000, loaded: 12732, max: 262144, want: 100000 + reservedOutputContextTokens,
+		},
+		{
+			name:     "never exceeds the advertised maximum",
+			required: 200000, loaded: 200000, max: 262144, want: 262144,
+		},
+		{
+			name:     "cold deployment falls back to the estimate",
+			required: 12769, loaded: 0, max: 262144, want: 12769 + reservedOutputContextTokens,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := growLoadContextTokens(tt.required, tt.loaded, tt.max)
+			if got != tt.want {
+				t.Fatalf("growLoadContextTokens(%d, %d, %d) = %d, want %d", tt.required, tt.loaded, tt.max, got, tt.want)
+			}
+			if tt.max > 0 && got > tt.max {
+				t.Fatalf("growLoadContextTokens() = %d, exceeds max %d", got, tt.max)
+			}
+			if got <= tt.loaded && tt.loaded < tt.max {
+				t.Fatalf("growLoadContextTokens() = %d, must exceed the failed window %d", got, tt.loaded)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## The thing I expected to find, and didn't

#1395 revives a recovery path that reloads an LM Studio deployment at `MaxContextWindow`. On centro that is 262144, and centro had just refused to load 24576, so the obvious conclusion was that the recovery asks for more than the host can give.

That conclusion was wrong. centro loads 262144 without complaint. What it will not do is load *anything* while a copy of the model is already resident:

| Action | Result |
| --- | --- |
| `load(262144)` while resident at 65536 | 500 — insufficient system resources |
| `load(8192)` while resident at 65536 | 500 — insufficient system resources |
| `unload` → `load(262144)` | **loaded** |

The second row is the whole diagnosis. A window a third the size of what is already running is refused exactly as hard as the maximum. The guardrail is not weighing the context window; it is weighing a **second copy of the weights**, because `/api/v1/models/load` always starts a new instance and never reconfigures the running one.

## Which inverts the feature

`maybePrepareExplicitModel` and `maybeRetryExplicitModelAfterProviderContextError` both exist to grow a window that is too small for the request. Neither unloads first. So on any host that cannot hold two copies of the weights:

**Context expansion worked only when the model was not already loaded** — which is the one case where it is not needed.

That reframes the original incident behind #1395. Thane's load at 12732 succeeded because the model happened to be cold. Had it been resident at 4096, the expansion would have failed outright and the empty-completion symptom would have looked identical.

On a host with room to spare the failure is quieter but not better: the same code accumulates duplicate instances. The `google/gemma-3-4b:3` suffix already present in this repo's test fixtures is exactly that shape.

## No flag can fix it

The load endpoint validates keys strictly — unknown ones come back `400 unrecognized_keys` — which makes it easy to ask what it supports. Of `unload_other_instances`, `replace`, `reuse_existing`, `instance_id`, `unload_existing`, `force`, `ttl`, `idle_ttl`, `gpu`, `kv_cache_quantization`, exactly none exist. Only `flash_attention` is real, and it is unrelated.

Thane also had no unload capability at all: `LMStudioClient` had `LoadModel` and nothing else.

## The changes

**Unload before load.** New `LMStudioClient.UnloadModel`, called by `PrepareExplicitModel` against the tracked `LoadedInstanceID` before the replacement is loaded. An unload failure is logged and the load still attempted, since it may succeed where there is room for both and failing there would be strictly worse than today.

**Put it back if the load fails.** Unloading first opens a gap where the deployment serves nothing — that gap is new, and it is the one thing this change could make worse. So a refused expansion reloads the previous window and refreshes the registry, rather than costing the operator a model that was working before Thane tried to improve it.

**Grow, don't leap.** The recovery asked for the maximum because the estimate could not be trusted — the runner had just rejected a request the estimate said would fit. Fair, but expensive: a window costs load time and resident memory in proportion to its size, and the maximum can be twenty times the requirement. The estimate now floors the retry instead of setting it, and the growth comes from doubling the window that actually failed. Still climbs to the maximum when it must.

`Runtime` also now keeps the `*slog.Logger` it is already handed, which it previously discarded — the unload and restore paths need somewhere to report.

## Test plan

- [x] `just ci` passes locally
- [x] New: `UnloadModel` posts to `/api/v1/models/unload` with the instance id, and requires one
- [x] New: `PrepareExplicitModel` calls unload then load, in that order
- [x] New: a refused expansion restores the previous window — asserts the load sizes are `[65536 4096]`, that the runner is left serving 4096 again, and that the registry reflects it
- [x] New: `growLoadContextTokens` doubles the failed window, floors on the estimate when that is larger, never exceeds the maximum, and falls back to the estimate for a cold deployment
- [x] Updated: `TestRun_ExplicitModelRetriesProviderContextErrorAfterLMStudioLoad` asserted the old jump-to-maximum behaviour and now asserts the doubling, with its fixture gating success on "larger than the window that failed" rather than on reaching the maximum
- [ ] Confirm on prod after deploy that an expansion of a resident model succeeds

## Prod note

centro is currently loaded at 65536 by hand, which is why it is serving. That was a mitigation for #1395 and it is also, unintentionally, a workaround for this bug — the window is large enough that nothing needs to expand it. Once this lands the manual step stops being load-bearing.
