### PR TITLE
Tell a loop what it already follows, and that ~ is allowed

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -378,7 +378,11 @@ Repository subscriptions require `wake_loop` so event handling is owned by
 an existing loop, usually one created with `thane_loop_create`
 (`operation: service`) for a specific managed document. Pass
 `local_checkout` when the loop should read a local mirror checkout; the
-poller syncs that checkout before delivering repository events. The path
+poller syncs that checkout before delivering repository events. The
+path may be absolute, working-directory-relative, or `~`-prefixed; a
+leading `~` expands against the account Thane runs as, which is the
+form to prefer — an agent that guesses at a home directory can write a
+real path under the wrong user. The path
 must be empty or an existing Thane-owned mirror checkout; non-empty
 directories and unmarked git checkouts are refused. Unfollowing leaves
 the checkout on disk. The follow performs the initial clone itself, so

--- a/internal/integrations/forge/bindings_test.go
+++ b/internal/integrations/forge/bindings_test.go
@@ -352,3 +352,58 @@ func TestSubscriptionToolsHonorBinding(t *testing.T) {
 		}
 	})
 }
+
+// TestContextCarriesExistingSubscriptions covers the gap that made a
+// production loop re-follow a repository it already had. Nothing in the
+// injected forge block named its subscriptions, so the reasonable
+// opening move on every wake was to subscribe again — and while doing
+// so it guessed a home directory that does not exist on that host.
+func TestContextCarriesExistingSubscriptions(t *testing.T) {
+	t.Parallel()
+
+	tools := newMultiAccountTools()
+	store := newTestSubscriptionStore(t)
+	for _, sub := range []ProjectSubscription{
+		{ID: "sub-ro", Account: "github-readonly", Repo: "nugget/thane", Branch: "main",
+			CheckoutPath: "/srv/checkouts/thane", LastSyncedSHA: "abc123",
+			TrackCommits: true, WakeTarget: messages.LoopWakeTarget{Name: "watcher"}, CreatedAt: time.Now()},
+		{ID: "sub-rw", Account: "github-primary", Repo: "nugget/secret-thing", Branch: "main",
+			TrackCommits: true, WakeTarget: messages.LoopWakeTarget{Name: "watcher"}, CreatedAt: time.Now()},
+	} {
+		if err := store.Add(sub); err != nil {
+			t.Fatalf("seed %s: %v", sub.ID, err)
+		}
+	}
+	tools.service.subscriptions = store
+	provider := newContextProvider(tools.service, nil)
+
+	t.Run("a bound loop sees its own and can tell it is already following", func(t *testing.T) {
+		t.Parallel()
+		out, err := provider.TagContext(boundCtx("github-readonly"), agentctx.ContextRequest{})
+		if err != nil {
+			t.Fatalf("TagContext: %v", err)
+		}
+		for _, want := range []string{"nugget/thane", "sub-ro", "/srv/checkouts/thane", "abc123"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("context = %q\nmissing %q", out, want)
+			}
+		}
+		// The binding narrows subscriptions the same way it narrows accounts.
+		if strings.Contains(out, "nugget/secret-thing") {
+			t.Errorf("context = %q\nleaks a subscription on another account", out)
+		}
+	})
+
+	t.Run("an unbound reader sees all of them", func(t *testing.T) {
+		t.Parallel()
+		out, err := provider.TagContext(context.Background(), agentctx.ContextRequest{})
+		if err != nil {
+			t.Fatalf("TagContext: %v", err)
+		}
+		for _, want := range []string{"nugget/thane", "nugget/secret-thing"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("context = %q\nmissing %q", out, want)
+			}
+		}
+	})
+}

--- a/internal/integrations/forge/context.go
+++ b/internal/integrations/forge/context.go
@@ -55,6 +55,30 @@ type forgeContextJSON struct {
 	BindingError string `json:"binding_error,omitempty"`
 
 	RecentOps []recentOpJSON `json:"recent_operations,omitempty"`
+
+	// Subscriptions are the repositories already followed. Without
+	// them a tagged loop has no way to know what it is subscribed to
+	// short of calling forge_repo_subscriptions, so the reasonable
+	// opening move on every wake is "make sure I am subscribed" — which
+	// is a wasted call at best. Production did exactly that: a watcher
+	// re-followed a repository it already had, and invented a home
+	// directory for the checkout while it was at it.
+	Subscriptions []contextSubscriptionJSON `json:"subscriptions,omitempty"`
+}
+
+// contextSubscriptionJSON is the compact view of a followed repository.
+// Deliberately smaller than the forge_repo_subscriptions payload: this
+// rides in every prompt that carries the forge tag, and its job is to
+// answer "am I already watching this, and where is the checkout" — not
+// to replace the tool.
+type contextSubscriptionJSON struct {
+	SubscriptionID string `json:"subscription_id"`
+	Account        string `json:"account"`
+	Repo           string `json:"repo"`
+	Branch         string `json:"branch,omitempty"`
+	LocalCheckout  string `json:"local_checkout,omitempty"`
+	WakeLoop       string `json:"wake_loop,omitempty"`
+	LastSyncedSHA  string `json:"last_synced_sha,omitempty"`
 }
 
 // recentOpJSON is a single recent operation with delta timestamp.
@@ -102,6 +126,23 @@ func (p *ContextProvider) buildContext(bound string) (string, error) {
 	}
 
 	output := forgeContextJSON{Forges: views}
+
+	// Narrowed by the same binding as the account list: a bound loop
+	// should not be shown subscriptions it could not act on.
+	for _, sub := range p.service.Subscriptions() {
+		if bound != "" && sub.Account != bound {
+			continue
+		}
+		output.Subscriptions = append(output.Subscriptions, contextSubscriptionJSON{
+			SubscriptionID: sub.ID,
+			Account:        sub.Account,
+			Repo:           sub.Repo,
+			Branch:         sub.Branch,
+			LocalCheckout:  sub.CheckoutPath,
+			WakeLoop:       sub.WakeTarget.Name,
+			LastSyncedSHA:  sub.LastSyncedSHA,
+		})
+	}
 
 	// A binding naming an account that is not configured would
 	// otherwise render an empty list, which reads as "no forge here"

--- a/internal/integrations/forge/service.go
+++ b/internal/integrations/forge/service.go
@@ -36,6 +36,7 @@ type Service struct {
 	tools           *Tools
 	contextProvider *ContextProvider
 	poller          *SubscriptionPoller
+	subscriptions   *SubscriptionStore
 }
 
 // NewService creates a complete forge runtime from configuration and shared
@@ -65,8 +66,9 @@ func NewService(cfg Config, deps ServiceDependencies) (*Service, error) {
 	subscriptions := NewSubscriptionStore(deps.State, deps.Logger, cfg.MaxSubscriptions)
 
 	service := &Service{
-		manager: manager,
-		logger:  deps.Logger,
+		manager:       manager,
+		logger:        deps.Logger,
+		subscriptions: subscriptions,
 	}
 	service.tools = newTools(service, opLog, deps.Logger, subscriptions)
 	service.tools.SetLoopResolver(deps.LoopResolver)
@@ -138,6 +140,19 @@ func (s *Service) AccountsInConfigOrder() []AccountConfig {
 		out = append(out, s.manager.configs[name])
 	}
 	return out
+}
+
+// Subscriptions returns the repository subscriptions this instance
+// holds, or nil when the surface is disabled.
+func (s *Service) Subscriptions() []ProjectSubscription {
+	if s == nil || s.subscriptions == nil {
+		return nil
+	}
+	subs, err := s.subscriptions.List()
+	if err != nil {
+		return nil
+	}
+	return subs
 }
 
 // SubscriptionPollingEnabled reports whether repository polling is enabled by

--- a/internal/integrations/forge/subscription_tool_provider.go
+++ b/internal/integrations/forge/subscription_tool_provider.go
@@ -43,7 +43,7 @@ func (t *Tools) subscriptionToolDefinitions() []*toolpkg.Tool {
 					},
 					"local_checkout": map[string]any{
 						"type":        "string",
-						"description": "Optional absolute or working-directory-relative path to keep as a read-only mirror checkout. The follow clones into this path before returning, so the working tree exists when the call succeeds and a failed clone fails the call. The poller keeps it current afterwards; with polling disabled it is created but never refreshed. The path must be empty or an existing Thane-owned mirror checkout; non-empty directories and unmarked git checkouts are refused. The subscription poller syncs this path before waking the loop and leaves it on disk when unfollowed.",
+						"description": "Optional path to keep as a read-only mirror checkout. Absolute, working-directory-relative, or ~-prefixed. A leading ~ is expanded against the account Thane runs as, so prefer the ~ form over guessing a home directory: an absolute path under the wrong user is not an error, it is a real location nobody intended. The follow clones into this path before returning, so the working tree exists when the call succeeds and a failed clone fails the call. The poller keeps it current afterwards; with polling disabled it is created but never refreshed. The path must be empty or an existing Thane-owned mirror checkout; non-empty directories and unmarked git checkouts are refused. The subscription poller syncs this path before waking the loop and leaves it on disk when unfollowed.",
 					},
 					"wake_loop": forgeWakeLoopDefinition(),
 				},


### PR DESCRIPTION
Two model-facing gaps, both found by watching a live production loop rather than in review.

## A loop cannot see its own subscriptions

`thane_dev_watcher` called `forge_repo_follow` for a repository it was already subscribed to. It had no way to know it was: the injected forge block carries accounts and recent operations and says nothing about subscriptions. "Make sure I am subscribed" is a reasonable opening move on a wake, and the only way to actually check was a tool call the model had no reason to think it needed.

The block now carries the subscriptions themselves — repo, branch, checkout path, wake target, last synced SHA — narrowed by the account binding exactly as the account list is. Deliberately more compact than the `forge_repo_subscriptions` payload: this rides in every forge-tagged prompt, and its job is to answer "am I already watching this, and where is the checkout", not to replace the tool.

## Nothing told it `~` was allowed

While making that unnecessary call it passed `local_checkout=/Users/david/Thane/repos/thane-ai-agent` — a user that does not exist on that host. The schema said the path must be "absolute or working-directory-relative" and never mentioned that a leading `~` is expanded (support added in #1391 that nothing advertised), so a model needing an absolute path guessed one from the owner's name.

The description now names the `~` form and says why to prefer it: an absolute path under the wrong user is not an error, it is a real location nobody intended.

## Note

The duplicate-admission gate from #1394 is what kept this harmless. Because the store's checks now run before the clone, the call failed on "already exists" rather than attempting to create a tree under a nonexistent user. The previous ordering would have tried the mkdir first.

## Test plan

- [x] `just ci` green locally
- [x] A bound loop sees its own subscriptions in context, including checkout path and last synced SHA
- [x] Subscriptions are narrowed by the account binding — another account's are not leaked
- [x] An unbound reader sees all of them