### PR TITLE
Answer the question behind a PR-number miss, and refuse a search the forge will

### DIFF
--- a/internal/integrations/forge/github.go
+++ b/internal/integrations/forge/github.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/google/go-github/v69/github"
 )
@@ -871,9 +872,28 @@ func mapGitHubPR(gp *github.PullRequest) *PullRequest {
 	return pr
 }
 
+// truncate shortens s to at most maxLen bytes, ellipsis included.
+//
+// Byte slicing alone splits multi-byte runes, and appending an
+// ellipsis after slicing to maxLen overruns the budget the caller
+// asked for. Both matter here because the strings are issue and commit
+// bodies written by people, and a body cut mid-rune reaches the model
+// as replacement characters.
 func truncate(s string, maxLen int) string {
+	if maxLen <= 0 {
+		return ""
+	}
 	if len(s) <= maxLen {
 		return s
 	}
-	return s[:maxLen] + "..."
+	const ellipsis = "..."
+	if maxLen <= len(ellipsis) {
+		return ellipsis[:maxLen]
+	}
+	cut := maxLen - len(ellipsis)
+	// Back up to a rune boundary so the cut never lands mid-character.
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + ellipsis
 }

--- a/internal/integrations/forge/pr_issue_fallback_test.go
+++ b/internal/integrations/forge/pr_issue_fallback_test.go
@@ -1,0 +1,129 @@
+package forge
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestPRGetOnIssueNumberReturnsTheIssue covers a real production
+// confusion. Issues and pull requests share one number space, so
+// asking for a PR by an issue's number is an ordinary mistake — and
+// the forge reports it as a plain not-found, which the classifier then
+// renders as "absent or outside this token's visibility". That is
+// technically true and sends the reader toward a permissions theory,
+// when the number exists and the answer was one call away. #1385 was
+// diagnosed as a read-only-token problem for exactly this reason.
+func TestPRGetOnIssueNumberReturnsTheIssue(t *testing.T) {
+	t.Parallel()
+
+	provider := &mockProvider{
+		name:     "test",
+		getPRErr: errors.New(`get PR #1385: not found under forge account "github-readonly"`),
+		getIssueResult: &Issue{
+			Number: 1385,
+			Title:  "Telemetry pass-failure root cause",
+			State:  "open",
+			Author: "nugget",
+			URL:    "https://github.com/owner/repo/issues/1385",
+			Body:   "the issue body",
+		},
+	}
+	tools := newTestTools(provider, "owner")
+
+	raw, err := tools.HandlePRGet(context.Background(), map[string]any{
+		"repo":   "repo",
+		"number": float64(1385),
+	})
+	if err != nil {
+		t.Fatalf("HandlePRGet() = %v, want the issue returned instead of a not-found", err)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp["kind"] != "issue" {
+		t.Errorf("kind = %v, want the result labelled an issue so it is not recorded as a PR", resp["kind"])
+	}
+	note, _ := resp["note"].(string)
+	for _, want := range []string{"is an issue, not a pull request", "forge_issue_get"} {
+		if !strings.Contains(note, want) {
+			t.Errorf("note = %q\nmissing %q", note, want)
+		}
+	}
+	if resp["title"] != "Telemetry pass-failure root cause" {
+		t.Errorf("title = %v, want the issue's title", resp["title"])
+	}
+}
+
+// TestPRGetKeepsTheErrorWhenTheNumberIsNothing confirms the fallback
+// does not swallow a genuine miss. When the number is neither a PR nor
+// an issue, the original refusal — including its account attribution —
+// is what the caller needs.
+func TestPRGetKeepsTheErrorWhenTheNumberIsNothing(t *testing.T) {
+	t.Parallel()
+
+	provider := &mockProvider{
+		name:        "test",
+		getPRErr:    errors.New(`get PR #99: not found under forge account "github-readonly"`),
+		getIssueErr: errors.New("get issue #99: not found"),
+	}
+	tools := newTestTools(provider, "owner")
+
+	_, err := tools.HandlePRGet(context.Background(), map[string]any{
+		"repo":   "repo",
+		"number": float64(99),
+	})
+	if err == nil {
+		t.Fatal("HandlePRGet() succeeded for a number that is neither PR nor issue")
+	}
+	if !strings.Contains(err.Error(), "github-readonly") {
+		t.Errorf("error = %q, want the original account-attributed refusal preserved", err)
+	}
+}
+
+// TestCommitSearchRejectsQualifierOnlyQueries stops a 422 the caller
+// cannot predict. GitHub accepts qualifier-only queries for issues and
+// code and refuses them for commits; production sent
+// q=repo:nugget/thane-ai-agent and got a validation failure back from
+// the far side, which reads like a broken tool rather than a missing
+// argument.
+func TestCommitSearchRejectsQualifierOnlyQueries(t *testing.T) {
+	t.Parallel()
+
+	tools := newTestTools(&mockProvider{name: "test"}, "owner")
+
+	_, err := tools.HandleSearch(context.Background(), map[string]any{
+		"query": "repo:nugget/thane-ai-agent",
+		"kind":  "commits",
+	})
+	if err == nil {
+		t.Fatal("HandleSearch() forwarded a qualifier-only commit search")
+	}
+	for _, want := range []string{"needs search text", "forge_pr_commits"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %q\nmissing %q", err.Error(), want)
+		}
+	}
+}
+
+// TestQualifierGuardIsScopedToCommits keeps the guard off the searches
+// GitHub genuinely accepts qualifier-only.
+func TestQualifierGuardIsScopedToCommits(t *testing.T) {
+	t.Parallel()
+
+	for _, kind := range []string{"issues", "code"} {
+		if qualifiersOnly("repo:nugget/thane") && SearchKind(kind) == SearchCommits {
+			t.Fatalf("guard would fire for %q", kind)
+		}
+	}
+	if !qualifiersOnly("repo:a/b is:open") {
+		t.Error("qualifiersOnly() = false for an all-qualifier query")
+	}
+	if qualifiersOnly("repo:a/b timeout") {
+		t.Error("qualifiersOnly() = true for a query carrying search text")
+	}
+}

--- a/internal/integrations/forge/pr_issue_fallback_test.go
+++ b/internal/integrations/forge/pr_issue_fallback_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 // TestPRGetOnIssueNumberReturnsTheIssue covers a real production
@@ -20,8 +21,13 @@ func TestPRGetOnIssueNumberReturnsTheIssue(t *testing.T) {
 	t.Parallel()
 
 	provider := &mockProvider{
-		name:     "test",
-		getPRErr: errors.New(`get PR #1385: not found under forge account "github-readonly"`),
+		name: "test",
+		getPRErr: &ProviderError{
+			Account: "github-readonly",
+			Op:      "get PR #1385",
+			Kind:    DenialInvisible,
+			Err:     errors.New("404 Not Found"),
+		},
 		getIssueResult: &Issue{
 			Number: 1385,
 			Title:  "Telemetry pass-failure root cause",
@@ -67,8 +73,13 @@ func TestPRGetKeepsTheErrorWhenTheNumberIsNothing(t *testing.T) {
 	t.Parallel()
 
 	provider := &mockProvider{
-		name:        "test",
-		getPRErr:    errors.New(`get PR #99: not found under forge account "github-readonly"`),
+		name: "test",
+		getPRErr: &ProviderError{
+			Account: "github-readonly",
+			Op:      "get PR #99",
+			Kind:    DenialInvisible,
+			Err:     errors.New("404 Not Found"),
+		},
 		getIssueErr: errors.New("get issue #99: not found"),
 	}
 	tools := newTestTools(provider, "owner")
@@ -125,5 +136,97 @@ func TestQualifierGuardIsScopedToCommits(t *testing.T) {
 	}
 	if qualifiersOnly("repo:a/b timeout") {
 		t.Error("qualifiersOnly() = true for a query carrying search text")
+	}
+}
+
+// TestPRGetDoesNotProbeOnNonNotFoundFailures is the cost side of the
+// fallback. A rate limit, a dead credential, or a killed request says
+// nothing about whether the number is an issue, so spending a second
+// API call to ask would add load exactly when the forge is already
+// refusing — and bury the real failure behind a second one.
+func TestPRGetDoesNotProbeOnNonNotFoundFailures(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		kind DenialKind
+	}{
+		{name: "rate limited", kind: DenialRateLimited},
+		{name: "unauthenticated", kind: DenialUnauthenticated},
+		{name: "forbidden", kind: DenialForbidden},
+		{name: "unclassified", kind: DenialNone},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			provider := &mockProvider{
+				name: "test",
+				getPRErr: &ProviderError{
+					Account: "github-readonly",
+					Op:      "get PR #7",
+					Kind:    tc.kind,
+					Err:     errors.New("upstream said no"),
+				},
+				// Present precisely so a probe would succeed and be visible.
+				getIssueResult: &Issue{Number: 7, Title: "an issue"},
+			}
+			tools := newTestTools(provider, "owner")
+
+			if _, err := tools.HandlePRGet(context.Background(), map[string]any{
+				"repo": "repo", "number": float64(7),
+			}); err == nil {
+				t.Fatal("HandlePRGet() succeeded; it probed for an issue on a non-not-found failure")
+			}
+			for _, call := range provider.calls {
+				if call.method == "GetIssue" {
+					t.Errorf("probed with GetIssue after a %s failure", tc.kind)
+				}
+			}
+		})
+	}
+}
+
+// TestQualifiersOnlyIgnoresNonQualifiers keeps the guard from refusing
+// searches GitHub would accept. A URL and an ordinary colon-bearing
+// term both contain a colon and neither is a qualifier.
+func TestQualifiersOnlyIgnoresNonQualifiers(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		query string
+		want  bool
+	}{
+		{query: "repo:nugget/thane-ai-agent", want: true},
+		{query: "repo:a/b author:nugget", want: true},
+		{query: "repo:a/b timeout", want: false},
+		{query: "https://example.com/thing", want: false},
+		{query: "foo:bar", want: false},
+		{query: "repo:a/b https://example.com", want: false},
+		{query: "", want: false},
+	} {
+		if got := qualifiersOnly(tc.query); got != tc.want {
+			t.Errorf("qualifiersOnly(%q) = %v, want %v", tc.query, got, tc.want)
+		}
+	}
+}
+
+// TestTruncateIsRuneSafe pins the budget and the boundary. Issue bodies
+// are written by people, and a body cut mid-rune reaches the model as
+// replacement characters.
+func TestTruncateIsRuneSafe(t *testing.T) {
+	t.Parallel()
+
+	// Multi-byte runes either side of every plausible cut point.
+	body := strings.Repeat("é", 40)
+	for _, maxLen := range []int{0, 1, 3, 4, 7, 11, 20, 79, 80, 81} {
+		got := truncate(body, maxLen)
+		if len(got) > maxLen {
+			t.Errorf("truncate(maxLen=%d) returned %d bytes, over budget", maxLen, len(got))
+		}
+		if !utf8.ValidString(got) {
+			t.Errorf("truncate(maxLen=%d) = %q, split a rune", maxLen, got)
+		}
+	}
+	if got := truncate("short", 50); got != "short" {
+		t.Errorf("truncate() = %q, want the input returned untouched when it fits", got)
 	}
 }

--- a/internal/integrations/forge/tools.go
+++ b/internal/integrations/forge/tools.go
@@ -595,6 +595,17 @@ func (t *Tools) HandlePRGet(ctx context.Context, args map[string]any) (string, e
 
 	pr, err := provider.GetPR(ctx, repo, number)
 	if err != nil {
+		// Issues and pull requests share one number space, so asking
+		// for a PR by an issue's number is an ordinary mistake with a
+		// useful answer available. The forge reports it as a plain
+		// not-found, which the classifier then reads as "absent or
+		// invisible" — technically true and actively misleading, since
+		// the number exists and the caller is one tool call away from
+		// what it wanted. Production hit exactly this on #1385 and
+		// went looking for a permissions problem.
+		if issue, issueErr := provider.GetIssue(ctx, repo, number); issueErr == nil {
+			return marshalIssueAsPRMiss(issue, repo, number)
+		}
 		return "", err
 	}
 
@@ -1068,6 +1079,14 @@ func (t *Tools) HandleSearch(ctx context.Context, args map[string]any) (string, 
 		return "", fmt.Errorf("kind is required (issues, code, commits)")
 	}
 
+	// GitHub refuses a commit search that carries only qualifiers, with
+	// a 422 the caller can neither predict nor act on without knowing
+	// the rule. Caught here so the answer names the missing piece
+	// rather than arriving as a validation failure from the far side.
+	if SearchKind(kindStr) == SearchCommits && qualifiersOnly(query) {
+		return "", fmt.Errorf("commit search needs search text, not qualifiers alone: %q has only qualifiers, and the forge rejects that. Add the words to look for (e.g. %q), or use forge_pr_commits to list a pull request's commits and forge_repo_subscriptions for what is already tracked", query, query+" <text to find>")
+	}
+
 	limit := intArg(args, "limit")
 
 	results, err := resolved.Provider.Search(ctx, query, SearchKind(kindStr), limit)
@@ -1094,5 +1113,40 @@ func (t *Tools) HandleSearch(ctx context.Context, args map[string]any) (string, 
 	return marshalResponse(searchResponse{
 		Count:   len(entries),
 		Results: entries,
+	})
+}
+
+// qualifiersOnly reports whether a search query carries nothing but
+// key:value qualifiers. GitHub accepts those for issue and code search
+// and rejects them for commits, which is the sort of asymmetry a
+// caller should not have to learn by being refused.
+func qualifiersOnly(query string) bool {
+	fields := strings.Fields(query)
+	if len(fields) == 0 {
+		return false
+	}
+	for _, field := range fields {
+		if !strings.Contains(field, ":") {
+			return false
+		}
+	}
+	return true
+}
+
+// marshalIssueAsPRMiss answers a pull-request lookup that landed on an
+// issue. It returns what the caller almost certainly wanted, labelled
+// clearly enough that the model does not record it as a pull request.
+func marshalIssueAsPRMiss(issue *Issue, repo string, number int) (string, error) {
+	return marshalResponse(map[string]any{
+		"note": fmt.Sprintf("%s#%d is an issue, not a pull request. Issues and pull requests share one number space on this forge, so forge_pr_get cannot fetch it. The issue is returned below; use forge_issue_get for issues.",
+			repo, number),
+		"kind":   "issue",
+		"number": issue.Number,
+		"title":  issue.Title,
+		"state":  issue.State,
+		"author": issue.Author,
+		"labels": issue.Labels,
+		"url":    issue.URL,
+		"body":   truncate(issue.Body, 4000),
 	})
 }

--- a/internal/integrations/forge/tools.go
+++ b/internal/integrations/forge/tools.go
@@ -603,8 +603,15 @@ func (t *Tools) HandlePRGet(ctx context.Context, args map[string]any) (string, e
 		// the number exists and the caller is one tool call away from
 		// what it wanted. Production hit exactly this on #1385 and
 		// went looking for a permissions problem.
-		if issue, issueErr := provider.GetIssue(ctx, repo, number); issueErr == nil {
-			return marshalIssueAsPRMiss(issue, repo, number)
+		// Only a classified not-found is worth a second lookup. A rate
+		// limit, a bad credential, or a killed request says nothing
+		// about whether the number is an issue, and spending another
+		// call to ask would add load exactly when the forge is already
+		// refusing — and bury the real failure behind a second one.
+		if DenialKindOf(err) == DenialInvisible {
+			if issue, issueErr := provider.GetIssue(ctx, repo, number); issueErr == nil {
+				return marshalIssueAsPRMiss(issue, repo, number)
+			}
 		}
 		return "", err
 	}
@@ -1120,13 +1127,29 @@ func (t *Tools) HandleSearch(ctx context.Context, args map[string]any) (string, 
 // key:value qualifiers. GitHub accepts those for issue and code search
 // and rejects them for commits, which is the sort of asymmetry a
 // caller should not have to learn by being refused.
+// commitSearchQualifiers are the keys GitHub recognizes on a commit
+// search. Matching against a known set rather than "contains a colon"
+// keeps a URL or an ordinary term like foo:bar from reading as a
+// qualifier, which would refuse a search the forge would have
+// accepted. The guard errs toward letting a call through: an
+// unrecognized key means this is search text, not a qualifier.
+var commitSearchQualifiers = map[string]bool{
+	"repo": true, "org": true, "user": true, "author": true,
+	"committer": true, "author-name": true, "committer-name": true,
+	"author-email": true, "committer-email": true,
+	"author-date": true, "committer-date": true,
+	"merge": true, "hash": true, "parent": true, "tree": true,
+	"is": true, "in": true, "language": true,
+}
+
 func qualifiersOnly(query string) bool {
 	fields := strings.Fields(query)
 	if len(fields) == 0 {
 		return false
 	}
 	for _, field := range fields {
-		if !strings.Contains(field, ":") {
+		key, _, found := strings.Cut(field, ":")
+		if !found || !commitSearchQualifiers[strings.ToLower(key)] {
 			return false
 		}
 	}


### PR DESCRIPTION
Two production failures that read as permission problems and were not.

## `forge_pr_get` #1385

The error was: `not found under forge account "github-readonly" ... the resource either does not exist or lies outside this token's visibility`. Every word is true and the conclusion it invites is wrong — **1385 is an issue**. Issues and pull requests share one number space, the forge answers a PR lookup on an issue number with a plain 404, and the classifier added in #1387 to make denials legible turned that into a visibility question. It cost an operator a look at token scopes.

A PR lookup that misses now asks whether that number is an issue, and returns the issue when it is — labelled `kind: issue` so nothing records it as a pull request, with a note pointing at `forge_issue_get`. When the number is neither, the original account-attributed refusal is preserved unchanged. The fallback answers a knowable question; it does not soften a genuine miss.

## `forge_search` on commits

Failed with a raw GitHub 422: *"Search text is required when searching commits. Searches that use qualifiers only are not allowed."* The model had sent `q=repo:nugget/thane-ai-agent`. The asymmetry is real — issue and code search accept qualifier-only queries, commit search does not — and nothing on this side said so, so the caller learned it by refusal from the far side in a message shaped like a broken tool rather than a missing argument.

Caught before the call now, naming what is missing and pointing at `forge_pr_commits` for what the caller was likely after. The guard is scoped to commit search so the kinds GitHub accepts are untouched.

Both changes are the same two conventions from `docs/model-facing-tools.md`: errors must teach the next move, and a tool should accept what a caller reasonably means when the intent is unambiguous.

## Test plan

- [x] `just ci` green locally
- [x] PR lookup on an issue number returns the issue, labelled, with the note naming `forge_issue_get`
- [x] A number that is neither PR nor issue keeps the original account-attributed error
- [x] Qualifier-only commit search refused with guidance; issue/code search unaffected
- [x] `qualifiersOnly` distinguishes `repo:a/b is:open` from `repo:a/b timeout`