### PR TITLE
Context fill measures one call, not a turn's worth of calls

### DIFF
--- a/internal/app/adapters.go
+++ b/internal/app/adapters.go
@@ -1016,6 +1016,7 @@ func (a *loopAdapter) Run(ctx context.Context, req looppkg.Request, stream loopp
 		Model:                    resp.Model,
 		FinishReason:             resp.FinishReason,
 		InputTokens:              resp.InputTokens,
+		PeakInputTokens:          resp.PeakInputTokens,
 		OutputTokens:             resp.OutputTokens,
 		CacheCreationInputTokens: resp.CacheCreationInputTokens,
 		CacheReadInputTokens:     resp.CacheReadInputTokens,

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -144,6 +144,7 @@ type Response struct {
 	Model                    string                              `json:"model"`
 	FinishReason             string                              `json:"finish_reason"`
 	InputTokens              int                                 `json:"input_tokens,omitempty"`
+	PeakInputTokens          int                                 `json:"peak_input_tokens,omitempty"`
 	OutputTokens             int                                 `json:"output_tokens,omitempty"`
 	CacheCreationInputTokens int                                 `json:"cache_creation_input_tokens,omitempty"`
 	CacheReadInputTokens     int                                 `json:"cache_read_input_tokens,omitempty"`
@@ -2563,6 +2564,7 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 		Model:                    iterResult.Model,
 		FinishReason:             finishReason,
 		InputTokens:              iterResult.InputTokens,
+		PeakInputTokens:          iterResult.PeakInputTokens,
 		OutputTokens:             iterResult.OutputTokens,
 		CacheCreationInputTokens: iterResult.CacheCreationInputTokens,
 		CacheReadInputTokens:     iterResult.CacheReadInputTokens,

--- a/internal/runtime/iterate/engine.go
+++ b/internal/runtime/iterate/engine.go
@@ -94,6 +94,7 @@ func (e *Engine) Run(ctx context.Context, cfg Config, messages []llm.Message) (*
 						Model:                      model,
 						UpstreamRequestID:          latestUpstreamRequestID(iterations),
 						InputTokens:                totalInput,
+						PeakInputTokens:            peakInputTokens(iterations),
 						OutputTokens:               totalOutput,
 						CacheCreationInputTokens:   totalCacheCreate,
 						CacheCreation5mInputTokens: totalCacheCreate5m,
@@ -114,6 +115,7 @@ func (e *Engine) Run(ctx context.Context, cfg Config, messages []llm.Message) (*
 					Model:                      model,
 					UpstreamRequestID:          latestUpstreamRequestID(iterations),
 					InputTokens:                totalInput,
+					PeakInputTokens:            peakInputTokens(iterations),
 					OutputTokens:               totalOutput,
 					CacheCreationInputTokens:   totalCacheCreate,
 					CacheCreation5mInputTokens: totalCacheCreate5m,
@@ -166,6 +168,7 @@ func (e *Engine) Run(ctx context.Context, cfg Config, messages []llm.Message) (*
 				Model:                      model,
 				UpstreamRequestID:          latestUpstreamRequestID(iterations),
 				InputTokens:                totalInput,
+				PeakInputTokens:            peakInputTokens(iterations),
 				OutputTokens:               totalOutput,
 				CacheCreationInputTokens:   totalCacheCreate,
 				CacheCreation5mInputTokens: totalCacheCreate5m,
@@ -477,6 +480,7 @@ func (e *Engine) Run(ctx context.Context, cfg Config, messages []llm.Message) (*
 			Model:                      model,
 			UpstreamRequestID:          latestUpstreamRequestID(iterations),
 			InputTokens:                totalInput,
+			PeakInputTokens:            peakInputTokens(iterations),
 			OutputTokens:               totalOutput,
 			CacheCreationInputTokens:   totalCacheCreate,
 			CacheCreation5mInputTokens: totalCacheCreate5m,
@@ -500,6 +504,7 @@ func (e *Engine) Run(ctx context.Context, cfg Config, messages []llm.Message) (*
 		Model:                      model,
 		UpstreamRequestID:          latestUpstreamRequestID(iterations),
 		InputTokens:                totalInput,
+		PeakInputTokens:            peakInputTokens(iterations),
 		OutputTokens:               totalOutput,
 		CacheCreationInputTokens:   totalCacheCreate,
 		CacheCreation5mInputTokens: totalCacheCreate5m,
@@ -540,6 +545,14 @@ func (e *Engine) forceText(ctx context.Context, cfg Config, model string, messag
 		partial.OutputTokens += resp.OutputTokens
 		partial.CacheCreationInputTokens += resp.CacheCreationInputTokens
 		partial.CacheReadInputTokens += resp.CacheReadInputTokens
+		// The recovery call is a real call against the same window, and
+		// it carries the whole accumulated message history — so it is
+		// frequently the largest of the turn. It records no
+		// IterationRecord, so peak has to be raised here or the turn
+		// most at risk of overflow is the one that under-reports.
+		if resp.InputTokens > partial.PeakInputTokens {
+			partial.PeakInputTokens = resp.InputTokens
+		}
 		messages = append(messages, resp.Message)
 
 		content := resp.Message.Content
@@ -581,6 +594,21 @@ func (e *Engine) forceText(ctx context.Context, cfg Config, model string, messag
 // request ID across iterations, or "" when none captured one. Used to
 // surface the final iteration's provider-side ID on Result without
 // forcing every Result construction site to dig into Iterations.
+// peakInputTokens returns the largest single-call input token count among
+// the recorded iterations. It reads the records rather than tracking a
+// running maximum beside totalInput so the two can never disagree: every
+// Result site already derives from this slice, and a call that failed
+// before producing a record contributes no usage to either number.
+func peakInputTokens(iters []IterationRecord) int {
+	peak := 0
+	for _, it := range iters {
+		if it.InputTokens > peak {
+			peak = it.InputTokens
+		}
+	}
+	return peak
+}
+
 func latestUpstreamRequestID(iters []IterationRecord) string {
 	for i := len(iters) - 1; i >= 0; i-- {
 		if iters[i].UpstreamRequestID != "" {

--- a/internal/runtime/iterate/engine.go
+++ b/internal/runtime/iterate/engine.go
@@ -545,14 +545,6 @@ func (e *Engine) forceText(ctx context.Context, cfg Config, model string, messag
 		partial.OutputTokens += resp.OutputTokens
 		partial.CacheCreationInputTokens += resp.CacheCreationInputTokens
 		partial.CacheReadInputTokens += resp.CacheReadInputTokens
-		// The recovery call is a real call against the same window, and
-		// it carries the whole accumulated message history — so it is
-		// frequently the largest of the turn. It records no
-		// IterationRecord, so peak has to be raised here or the turn
-		// most at risk of overflow is the one that under-reports.
-		if resp.InputTokens > partial.PeakInputTokens {
-			partial.PeakInputTokens = resp.InputTokens
-		}
 		messages = append(messages, resp.Message)
 
 		content := resp.Message.Content
@@ -585,7 +577,13 @@ func (e *Engine) forceText(ctx context.Context, cfg Config, model string, messag
 		partial.Content = content
 	}
 
+	// partial was built before the recovery call, so both of these are
+	// stale by exactly that one iteration. Recomputing from the records
+	// covers it without a second accumulation path — and the recovery
+	// call matters most here: it carries the whole accumulated history,
+	// so it is frequently the largest single call of the turn.
 	partial.UpstreamRequestID = latestUpstreamRequestID(partial.Iterations)
+	partial.PeakInputTokens = peakInputTokens(partial.Iterations)
 	partial.Messages = messages
 	return partial, nil
 }
@@ -594,6 +592,15 @@ func (e *Engine) forceText(ctx context.Context, cfg Config, model string, messag
 // request ID across iterations, or "" when none captured one. Used to
 // surface the final iteration's provider-side ID on Result without
 // forcing every Result construction site to dig into Iterations.
+func latestUpstreamRequestID(iters []IterationRecord) string {
+	for i := len(iters) - 1; i >= 0; i-- {
+		if iters[i].UpstreamRequestID != "" {
+			return iters[i].UpstreamRequestID
+		}
+	}
+	return ""
+}
+
 // peakInputTokens returns the largest single-call input token count among
 // the recorded iterations. It reads the records rather than tracking a
 // running maximum beside totalInput so the two can never disagree: every
@@ -607,13 +614,4 @@ func peakInputTokens(iters []IterationRecord) int {
 		}
 	}
 	return peak
-}
-
-func latestUpstreamRequestID(iters []IterationRecord) string {
-	for i := len(iters) - 1; i >= 0; i-- {
-		if iters[i].UpstreamRequestID != "" {
-			return iters[i].UpstreamRequestID
-		}
-	}
-	return ""
 }

--- a/internal/runtime/iterate/engine_test.go
+++ b/internal/runtime/iterate/engine_test.go
@@ -1169,3 +1169,40 @@ func TestLatestUpstreamRequestID(t *testing.T) {
 		})
 	}
 }
+
+// TestPeakInputTokens pins the distinction the fill gauge depends on:
+// InputTokens sums a turn's spend, while PeakInputTokens reports the
+// largest single call — the only one comparable to a context window.
+func TestPeakInputTokens(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   []IterationRecord
+		want int
+	}{
+		{name: "no iterations", in: nil, want: 0},
+		{name: "single call", in: []IterationRecord{{InputTokens: 24000}}, want: 24000},
+		{
+			// The production shape: each call resends system prompt and
+			// tool defs, so the sum (112316) far exceeds any one call.
+			name: "growing tool-calling turn",
+			in:   []IterationRecord{{InputTokens: 35000}, {InputTokens: 37316}, {InputTokens: 40000}},
+			want: 40000,
+		},
+		{
+			name: "peak is not the last call",
+			in:   []IterationRecord{{InputTokens: 40000}, {InputTokens: 12000}},
+			want: 40000,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := peakInputTokens(tt.in); got != tt.want {
+				t.Errorf("peakInputTokens = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/runtime/iterate/types.go
+++ b/internal/runtime/iterate/types.go
@@ -63,7 +63,20 @@ type Result struct {
 	UpstreamRequestID string
 
 	// InputTokens is the cumulative input token count across all iterations.
+	// It answers "what did this turn cost", which is why usage accounting
+	// reads it. It is the wrong number for "how full was the context":
+	// summing every call in a tool-calling turn double-counts the system
+	// prompt and tool definitions once per iteration, so a turn that took
+	// five cheap round-trips reports more input than a single call that
+	// genuinely filled the window. Use PeakInputTokens for anything
+	// compared against a context window.
 	InputTokens int
+
+	// PeakInputTokens is the largest single-call input token count among
+	// the iterations — the closest this turn came to the model's context
+	// limit, and the only one of the two that is comparable to a context
+	// window. Zero when no iteration reported usage.
+	PeakInputTokens int
 
 	// OutputTokens is the cumulative output token count across all iterations.
 	OutputTokens int

--- a/internal/runtime/loop/config.go
+++ b/internal/runtime/loop/config.go
@@ -470,8 +470,15 @@ type IterationResult struct {
 	// FinishReason is the agent runner's terminal reason. Values other than
 	// "stop" expose semantic exhaustion such as illegal_tool or token_budget.
 	FinishReason string
-	// InputTokens is the number of input tokens consumed.
+	// InputTokens is the number of input tokens consumed across every
+	// model call this iteration made — the iteration's input spend, not
+	// the size of any one prompt.
 	InputTokens int
+	// PeakInputTokens is the largest single call's input token count in
+	// this iteration. Compare this against ContextWindow; InputTokens
+	// sums the system prompt and tool definitions once per model call
+	// and so exceeds the window long before any prompt approaches it.
+	PeakInputTokens int
 	// OutputTokens is the number of output tokens produced.
 	OutputTokens int
 	// ContextWindow is the maximum context size (in tokens) of the model used.
@@ -639,8 +646,14 @@ type Status struct {
 	TotalInputTokens int `json:"total_input_tokens"`
 	// TotalOutputTokens is the cumulative output tokens across all iterations.
 	TotalOutputTokens int `json:"total_output_tokens"`
-	// LastInputTokens is the input token count from the most recent iteration.
+	// LastInputTokens is the input tokens the most recent iteration spent
+	// in total, summed over every model call it made. It is a spend
+	// figure, not a prompt size.
 	LastInputTokens int `json:"last_input_tokens,omitempty"`
+	// LastPeakInputTokens is the largest single model call within that
+	// iteration — how close the turn actually came to the context
+	// window, and the figure ContextFillPct is derived from.
+	LastPeakInputTokens int `json:"last_peak_input_tokens,omitempty"`
 	// LastOutputTokens is the output token count from the most recent iteration.
 	LastOutputTokens int `json:"last_output_tokens,omitempty"`
 	// ContextWindow is the maximum context size (in tokens) of the model used.

--- a/internal/runtime/loop/config.go
+++ b/internal/runtime/loop/config.go
@@ -528,8 +528,15 @@ type IterationSnapshot struct {
 	Model string `json:"model,omitempty"`
 	// FinishReason is the runner terminal reason for this iteration.
 	FinishReason string `json:"finish_reason,omitempty"`
-	// InputTokens consumed by this iteration.
+	// InputTokens consumed by this iteration, summed over every model
+	// call it made.
 	InputTokens int `json:"input_tokens,omitempty"`
+	// PeakInputTokens is the largest single model call within this
+	// iteration — the figure to compare against ContextWindow. Summing
+	// the calls counts the system prompt and tool definitions once per
+	// call, so InputTokens outruns the window without any prompt
+	// approaching it.
+	PeakInputTokens int `json:"peak_input_tokens,omitempty"`
 	// OutputTokens produced by this iteration.
 	OutputTokens int `json:"output_tokens,omitempty"`
 	// ContextWindow is the model's maximum context size in tokens.

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -125,6 +125,7 @@ type Response struct {
 	Model                    string                              `yaml:"model,omitempty" json:"model,omitempty"`
 	FinishReason             string                              `yaml:"finish_reason,omitempty" json:"finish_reason,omitempty"`
 	InputTokens              int                                 `yaml:"input_tokens,omitempty" json:"input_tokens,omitempty"`
+	PeakInputTokens          int                                 `yaml:"peak_input_tokens,omitempty" json:"peak_input_tokens,omitempty"`
 	OutputTokens             int                                 `yaml:"output_tokens,omitempty" json:"output_tokens,omitempty"`
 	CacheCreationInputTokens int                                 `yaml:"cache_creation_input_tokens,omitempty" json:"cache_creation_input_tokens,omitempty"`
 	CacheReadInputTokens     int                                 `yaml:"cache_read_input_tokens,omitempty" json:"cache_read_input_tokens,omitempty"`
@@ -224,9 +225,13 @@ type Loop struct {
 	totalInputTokens  int
 	totalOutputTokens int
 	lastInputTokens   int
-	lastOutputTokens  int
-	contextWindow     int
-	lastError         string
+	// lastPeakInputTokens is the largest single model call of the most
+	// recent turn. It is the only token figure comparable to
+	// contextWindow; lastInputTokens sums every call in the turn.
+	lastPeakInputTokens int
+	lastOutputTokens    int
+	contextWindow       int
+	lastError           string
 
 	// sleepUntil is the scheduled wake instant while the loop is in a
 	// timer-based sleep (zero when processing or event-driven); currentSleep
@@ -783,6 +788,7 @@ func (l *Loop) Status() Status {
 		TotalInputTokens:      l.totalInputTokens,
 		TotalOutputTokens:     l.totalOutputTokens,
 		LastInputTokens:       l.lastInputTokens,
+		LastPeakInputTokens:   l.lastPeakInputTokens,
 		LastOutputTokens:      l.lastOutputTokens,
 		ContextWindow:         l.contextWindow,
 		LastError:             l.lastError,
@@ -1658,6 +1664,10 @@ func (l *Loop) run(ctx context.Context) {
 				result.InputTokens = inputTokens
 				delete(summary, "input_tokens")
 			}
+			if peakInputTokens, ok := summary["peak_input_tokens"].(int); ok && result != nil {
+				result.PeakInputTokens = peakInputTokens
+				delete(summary, "peak_input_tokens")
+			}
 			if outputTokens, ok := summary["output_tokens"].(int); ok && result != nil {
 				result.OutputTokens = outputTokens
 				delete(summary, "output_tokens")
@@ -1880,6 +1890,7 @@ func (l *Loop) run(ctx context.Context) {
 				l.totalInputTokens += result.InputTokens
 				l.totalOutputTokens += result.OutputTokens
 				l.lastInputTokens = result.InputTokens
+				l.lastPeakInputTokens = result.PeakInputTokens
 				l.lastOutputTokens = result.OutputTokens
 				if result.ContextWindow > 0 {
 					l.contextWindow = result.ContextWindow
@@ -2388,6 +2399,7 @@ func (l *Loop) runAgentTurn(ctx context.Context, req Request, stream StreamCallb
 		Model:              resp.Model,
 		FinishReason:       resp.FinishReason,
 		InputTokens:        resp.InputTokens,
+		PeakInputTokens:    resp.PeakInputTokens,
 		OutputTokens:       resp.OutputTokens,
 		ContextWindow:      resp.ContextWindow,
 		ToolsUsed:          resp.ToolsUsed,

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -1909,6 +1909,7 @@ func (l *Loop) run(ctx context.Context) {
 				snap.FinishReason = result.FinishReason
 				snap.RequestID = result.RequestID
 				snap.InputTokens = result.InputTokens
+				snap.PeakInputTokens = result.PeakInputTokens
 				snap.OutputTokens = result.OutputTokens
 				snap.ContextWindow = result.ContextWindow
 				snap.ElapsedMs = result.Elapsed.Milliseconds()
@@ -2010,17 +2011,18 @@ func (l *Loop) run(ctx context.Context) {
 			// per-iteration logger correlation.
 			if err == nil && l.config.PostIterate != nil {
 				postResult := IterationResult{
-					ConvID:         convID,
-					Model:          result.Model,
-					FinishReason:   result.FinishReason,
-					InputTokens:    result.InputTokens,
-					OutputTokens:   result.OutputTokens,
-					ToolsUsed:      result.ToolsUsed,
-					EffectiveTools: append([]string(nil), result.EffectiveTools...),
-					ActiveTags:     append([]string(nil), result.ActiveTags...),
-					Elapsed:        result.Elapsed,
-					Supervisor:     result.Supervisor,
-					Sleep:          sleep,
+					ConvID:          convID,
+					Model:           result.Model,
+					FinishReason:    result.FinishReason,
+					InputTokens:     result.InputTokens,
+					PeakInputTokens: result.PeakInputTokens,
+					OutputTokens:    result.OutputTokens,
+					ToolsUsed:       result.ToolsUsed,
+					EffectiveTools:  append([]string(nil), result.EffectiveTools...),
+					ActiveTags:      append([]string(nil), result.ActiveTags...),
+					Elapsed:         result.Elapsed,
+					Supervisor:      result.Supervisor,
+					Sleep:           sleep,
 				}
 				if postErr := l.config.PostIterate(iterCtx, postResult); postErr != nil {
 					iterLog.Warn("PostIterate callback failed", "error", postErr)

--- a/internal/runtime/loop/loop_view.go
+++ b/internal/runtime/loop/loop_view.go
@@ -134,8 +134,13 @@ type LoopView struct {
 	TotalInputTokens  *int `json:"total_input_tokens"`
 	TotalOutputTokens *int `json:"total_output_tokens"`
 	LastInputTokens   *int `json:"last_input_tokens"`
-	ContextWindow     *int `json:"context_window"`
-	ContextFillPct    *int `json:"context_fill_pct"`
+	// LastPeakInputTokens is the largest single model call of the last
+	// turn. ContextFillPct is this over ContextWindow — never
+	// LastInputTokens, which sums the whole turn and would report a
+	// five-call turn as five times as full as the same prompt sent once.
+	LastPeakInputTokens *int `json:"last_peak_input_tokens"`
+	ContextWindow       *int `json:"context_window"`
+	ContextFillPct      *int `json:"context_fill_pct"`
 
 	// ---- error state ----
 	ConsecutiveErrors *int    `json:"consecutive_errors"`
@@ -548,14 +553,20 @@ func applyLiveTelemetry(v *LoopView, s Status, now time.Time) {
 		totalIn := s.TotalInputTokens
 		totalOut := s.TotalOutputTokens
 		lastIn := s.LastInputTokens
+		lastPeak := s.LastPeakInputTokens
 		v.TotalInputTokens = &totalIn
 		v.TotalOutputTokens = &totalOut
 		v.LastInputTokens = &lastIn
+		v.LastPeakInputTokens = &lastPeak
 		if s.ContextWindow > 0 {
 			cw := s.ContextWindow
 			v.ContextWindow = &cw
-			if s.LastInputTokens > 0 {
-				pct := s.LastInputTokens * 100 / s.ContextWindow
+			// Fill is the peak single call over the window. Turns
+			// recorded before peak was tracked carry 0, and reporting no
+			// fill is the honest answer there — the old cumulative
+			// number was not a fill percentage at all.
+			if s.LastPeakInputTokens > 0 {
+				pct := s.LastPeakInputTokens * 100 / s.ContextWindow
 				v.ContextFillPct = &pct
 			}
 		}

--- a/internal/runtime/loop/loop_view_test.go
+++ b/internal/runtime/loop/loop_view_test.go
@@ -29,6 +29,7 @@ func TestLoopViewResolver_FromStatus_RunningService(t *testing.T) {
 		TotalInputTokens:      2104882,
 		TotalOutputTokens:     51440,
 		LastInputTokens:       18000,
+		LastPeakInputTokens:   12000,
 		ContextWindow:         200000,
 		ConsecutiveErrors:     0,
 		LastError:             "",
@@ -59,8 +60,11 @@ func TestLoopViewResolver_FromStatus_RunningService(t *testing.T) {
 		t.Errorf("Attempts = %v, want 141", v.Attempts)
 	}
 	// Precomputed so the model never divides: 18000*100/200000 = 9.
-	if v.ContextFillPct == nil || *v.ContextFillPct != 9 {
-		t.Errorf("ContextFillPct = %v, want 9", v.ContextFillPct)
+	// Fill is the peak single call (12000) over the window, not the
+	// turn's cumulative input (18000) — a turn that made several calls
+	// is not proportionally closer to overflowing.
+	if v.ContextFillPct == nil || *v.ContextFillPct != 6 {
+		t.Errorf("ContextFillPct = %v, want 6", v.ContextFillPct)
 	}
 	// 138 - 135 = 3 successful turns since the last supervisor pass.
 	if v.SupervisorItersAgo == nil || *v.SupervisorItersAgo != 3 {
@@ -259,7 +263,7 @@ func TestDefinitionViewResolver_FromDefinition_RunningOverlaysLive(t *testing.T)
 	live := Status{
 		ID: "lp_res", Name: "reservoir", State: State("sleeping"),
 		StartedAt: now.Add(-2 * time.Hour), Iterations: 50, Attempts: 51,
-		TotalInputTokens: 1000, ContextWindow: 200000, LastInputTokens: 20000,
+		TotalInputTokens: 1000, ContextWindow: 200000, LastInputTokens: 32000, LastPeakInputTokens: 20000,
 		EffectiveTags: []EffectiveTag{{Tag: "water", From: "self"}},
 		Config:        Config{Operation: OperationService},
 	}
@@ -576,3 +580,68 @@ func TestDefinitionViewResolver_FromDefinition_LiveEnvelopeWins(t *testing.T) {
 		t.Errorf("envelope = %#v, want the live 1h/24h/6h, not the stored spec's", v.SleepEnvelope)
 	}
 }
+
+// TestLoopViewResolver_ContextFillUsesPeakNotCumulative pins the bug this
+// metric had in production: a metacognitive turn reported 85% fill on a
+// 131072 window while no single call exceeded ~29% of it, because the
+// gauge divided the turn's summed input by a per-call window. The
+// reported number tracked how many tool-calling round-trips a turn took,
+// not context pressure.
+func TestLoopViewResolver_ContextFillUsesPeakNotCumulative(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		lastIn   int
+		peakIn   int
+		window   int
+		wantPct  *int
+		wantPeak int
+	}{
+		{
+			name: "production metacognitive turn", lastIn: 112316, peakIn: 38000,
+			window: 131072, wantPct: intPtr(28), wantPeak: 38000,
+		},
+		{
+			name: "single-call turn reports the same either way", lastIn: 24000, peakIn: 24000,
+			window: 131072, wantPct: intPtr(18), wantPeak: 24000,
+		},
+		{
+			// Turns recorded before peak was tracked report no fill
+			// rather than resurrecting the cumulative figure.
+			name: "no peak recorded yields no fill", lastIn: 112316, peakIn: 0,
+			window: 131072, wantPct: nil, wantPeak: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			st := Status{
+				ID: "l1", Name: "metacognitive", State: StateSleeping,
+				LastInputTokens:     tt.lastIn,
+				LastPeakInputTokens: tt.peakIn,
+				ContextWindow:       tt.window,
+			}
+			v := NewLoopViewResolver([]Status{st}, nil, time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC)).FromStatus(st)
+
+			switch {
+			case tt.wantPct == nil && v.ContextFillPct != nil:
+				t.Errorf("ContextFillPct = %d, want nil", *v.ContextFillPct)
+			case tt.wantPct != nil && v.ContextFillPct == nil:
+				t.Errorf("ContextFillPct = nil, want %d", *tt.wantPct)
+			case tt.wantPct != nil && *v.ContextFillPct != *tt.wantPct:
+				t.Errorf("ContextFillPct = %d, want %d", *v.ContextFillPct, *tt.wantPct)
+			}
+			if v.LastPeakInputTokens == nil || *v.LastPeakInputTokens != tt.wantPeak {
+				t.Errorf("LastPeakInputTokens = %v, want %d", v.LastPeakInputTokens, tt.wantPeak)
+			}
+			if v.LastInputTokens == nil || *v.LastInputTokens != tt.lastIn {
+				t.Errorf("LastInputTokens = %v, want %d (cumulative spend is preserved)", v.LastInputTokens, tt.lastIn)
+			}
+		})
+	}
+}
+
+func intPtr(n int) *int { return &n }

--- a/internal/runtime/loop/loop_view_test.go
+++ b/internal/runtime/loop/loop_view_test.go
@@ -59,10 +59,10 @@ func TestLoopViewResolver_FromStatus_RunningService(t *testing.T) {
 	if v.Attempts == nil || *v.Attempts != 141 {
 		t.Errorf("Attempts = %v, want 141", v.Attempts)
 	}
-	// Precomputed so the model never divides: 18000*100/200000 = 9.
-	// Fill is the peak single call (12000) over the window, not the
-	// turn's cumulative input (18000) — a turn that made several calls
-	// is not proportionally closer to overflowing.
+	// Precomputed so the model never divides, from the peak single call
+	// rather than the turn's cumulative input: 12000*100/200000 = 6,
+	// not 18000*100/200000 = 9. A turn that made several calls is not
+	// proportionally closer to overflowing.
 	if v.ContextFillPct == nil || *v.ContextFillPct != 6 {
 		t.Errorf("ContextFillPct = %v, want 6", v.ContextFillPct)
 	}

--- a/internal/server/api/loops_test.go
+++ b/internal/server/api/loops_test.go
@@ -84,7 +84,7 @@ func TestHandleLoops_IncludesLoopView(t *testing.T) {
 	s := quietServer(fakeLoopReg{statuses: []looppkg.Status{
 		{ID: "p", Name: "parent", State: looppkg.StateSleeping},
 		{ID: "c", Name: "child", State: looppkg.StateSleeping, ParentID: "p",
-			ContextWindow: 200000, LastInputTokens: 100000},
+			ContextWindow: 200000, LastInputTokens: 180000, LastPeakInputTokens: 100000},
 	}})
 
 	rr := httptest.NewRecorder()
@@ -117,7 +117,9 @@ func TestHandleLoops_IncludesLoopView(t *testing.T) {
 	if child.View.ParentName == nil || *child.View.ParentName != "parent" {
 		t.Errorf("child parent_name = %v, want \"parent\"", child.View.ParentName)
 	}
-	// Precomputed so the client never divides.
+	// Precomputed so the client never divides, and derived from the peak
+	// single call (100000) rather than the turn's cumulative input
+	// (180000) — the latter is spend, not occupancy.
 	if child.View.ContextFillPct == nil || *child.View.ContextFillPct != 50 {
 		t.Errorf("child context_fill_pct = %v, want 50", child.View.ContextFillPct)
 	}

--- a/internal/server/api/uiharness.go
+++ b/internal/server/api/uiharness.go
@@ -96,7 +96,7 @@ func harnessLoops() []looppkg.Status {
 			StartedAt: boot, LastWakeAt: now.Add(-2 * time.Second),
 			Iterations: 1423, Attempts: 1440,
 			TotalInputTokens: 9_200_000, TotalOutputTokens: 1_100_000,
-			LastInputTokens: 7400, LastOutputTokens: 820, ContextWindow: 200000,
+			LastInputTokens: 7400, LastPeakInputTokens: 5100, LastOutputTokens: 820, ContextWindow: 200000,
 			RecentConvIDs: []string{"conv-supervisor"},
 		},
 		{
@@ -116,7 +116,7 @@ func harnessLoops() []looppkg.Status {
 		{
 			ID: "signal/aimee", Name: "signal/aimee", State: looppkg.StateProcessing, ParentID: "signal",
 			StartedAt: now.Add(-90 * time.Minute), LastWakeAt: now.Add(-1 * time.Second),
-			Iterations: 12, Attempts: 12, LastInputTokens: 5200, LastOutputTokens: 640, ContextWindow: 200000,
+			Iterations: 12, Attempts: 12, LastInputTokens: 5200, LastPeakInputTokens: 5200, LastOutputTokens: 640, ContextWindow: 200000,
 			RecentConvIDs: []string{"conv-aimee"},
 		},
 		{
@@ -136,7 +136,7 @@ func harnessLoops() []looppkg.Status {
 		{
 			ID: "hor_conditions", Name: "hor_conditions", State: looppkg.StateSleeping, ParentID: "temporal",
 			StartedAt: boot, Iterations: 2, Attempts: 2,
-			TotalInputTokens: 309_853, TotalOutputTokens: 5_252, LastInputTokens: 29_702,
+			TotalInputTokens: 309_853, TotalOutputTokens: 5_252, LastInputTokens: 29_702, LastPeakInputTokens: 14_310,
 			ContextWindow: 131072, RecentConvIDs: []string{"conv-hor"},
 		},
 	}

--- a/internal/server/openapi/native.yaml
+++ b/internal/server/openapi/native.yaml
@@ -1724,7 +1724,12 @@ components:
           example: 318204
         last_input_tokens:
           type: integer
-          description: Input token count from the most recent iteration.
+          description: Input tokens the most recent iteration spent in total, summed over every model call it made. A spend figure, not a prompt size — compare last_peak_input_tokens against context_window instead.
+          readOnly: true
+          example: 21480
+        last_peak_input_tokens:
+          type: integer
+          description: Largest single model call within the most recent iteration — how close that turn actually came to context_window, and the figure context_fill_pct derives from.
           readOnly: true
           example: 9123
         last_output_tokens:
@@ -1785,7 +1790,8 @@ components:
         attempts: 145
         total_input_tokens: 1284532
         total_output_tokens: 318204
-        last_input_tokens: 9123
+        last_input_tokens: 21480
+        last_peak_input_tokens: 9123
         last_output_tokens: 2048
         context_window: 200000
         consecutive_errors: 0
@@ -1868,9 +1874,12 @@ components:
         last_supervisor_delta:
           type: [string, "null"]
           description: Signed-second delta to the most recent supervisor review (e.g. "-15120s"); null when none has run. The wall-clock companion to supervisor_iters_ago, which counts turns rather than time.
+        last_peak_input_tokens:
+          type: [integer, "null"]
+          description: Largest single model call of the last turn; null for handler-only loops. The token figure comparable to context_window — last_input_tokens sums the whole turn.
         context_fill_pct:
           type: [integer, "null"]
-          description: Last input tokens as a percentage of the context window; null for handler-only loops.
+          description: last_peak_input_tokens as a percentage of the context window; null for handler-only loops and for turns recorded before peak tracking, since the cumulative figure was never a fill percentage.
         consecutive_errors:
           type: [integer, "null"]
           description: Length of the current error streak.
@@ -1898,6 +1907,7 @@ components:
           eligible: true
           next_wake_delta: "+5953s"
           current_sleep_duration: "5940s"
+          last_peak_input_tokens: 84000
           context_fill_pct: 42
           consecutive_errors: 0
           last_error: null
@@ -1927,7 +1937,12 @@ components:
           example: claude-opus-4-8
         input_tokens:
           type: integer
-          description: Input tokens consumed by this iteration.
+          description: Input tokens consumed by this iteration, summed over every model call it made.
+          readOnly: true
+          example: 21480
+        peak_input_tokens:
+          type: integer
+          description: Largest single model call within this iteration — the figure to compare against context_window.
           readOnly: true
           example: 9123
         output_tokens:

--- a/internal/server/web/static/app.js
+++ b/internal/server/web/static/app.js
@@ -1439,6 +1439,7 @@ function buildLoopEntity(loop) {
     iterations: loop.iterations || 0,
     attempts: loop.attempts || 0,
     lastInputTokens: loop.last_input_tokens || 0,
+    lastPeakInputTokens: loop.last_peak_input_tokens || 0,
     lastOutputTokens: loop.last_output_tokens || 0,
     totalInputTokens: loop.total_input_tokens || 0,
     totalOutputTokens: loop.total_output_tokens || 0,
@@ -3149,9 +3150,13 @@ function renderNode(loop) {
     }
   }
 
-  // Ring thickness represents context utilization percentage.
-  const ctxPct = (capacity.contextWindow > 0 && loop.last_input_tokens > 0)
-    ? Math.min(1, loop.last_input_tokens / capacity.contextWindow)
+  // Ring thickness represents context utilization percentage. Peak is
+  // the largest single model call of the turn — last_input_tokens sums
+  // every call and would thicken the ring for a chatty turn that never
+  // came near the window.
+  const ctxPeak = loop.last_peak_input_tokens || 0;
+  const ctxPct = (capacity.contextWindow > 0 && ctxPeak > 0)
+    ? Math.min(1, ctxPeak / capacity.contextWindow)
     : 0;
   const minStroke = 2;
   const maxStroke = 8;
@@ -4157,7 +4162,9 @@ function renderLoopGlanceHeader(loop) {
   }));
 
   const cw = loop.context_window || view.context_window || 0;
-  const used = loop.last_input_tokens || (loop._llmContext && loop._llmContext.est_tokens) || 0;
+  // Peak single call, not the turn's cumulative input: this figure is
+  // rendered against the context window.
+  const used = loop.last_peak_input_tokens || (loop._llmContext && loop._llmContext.est_tokens) || 0;
   const pct = (view.context_fill_pct != null) ? view.context_fill_pct
     : (cw > 0 && used > 0 ? Math.round((used * 100) / cw) : null);
   if (pct != null) {

--- a/internal/server/web/static/app.js
+++ b/internal/server/web/static/app.js
@@ -1036,7 +1036,12 @@ function getLoopContextFill(loop) {
   const recent = loop && loop.recent_iterations && loop.recent_iterations[0];
   if (!recent) return 0;
   const win = Number(recent.context_window) || getLoopContextWindow(loop);
-  const used = Number(recent.input_tokens) || 0;
+  // Peak single call, never the iteration's summed input: a turn that
+  // made five tool-calling round trips resends the system prompt and
+  // tool definitions each time, so the sum reaches the window long
+  // before any one prompt does — and this value drives the ring's
+  // pressure color, which is exactly where that lie turns red.
+  const used = Number(recent.peak_input_tokens) || 0;
   if (!(win > 0)) return 0;
   return Math.max(0, Math.min(1, used / win));
 }


### PR DESCRIPTION
## The number was fiction

The loop dashboard reported `metacognitive` at 85% of a 131072-token window, `archivist` at 113%, and `comal_county_burn_ban_monitor` at 139%. Measured against the actual requests, none of them came close:

| loop | LLM iterations | cumulative input | **reported** | peak single call | **real fill** |
|---|---|---|---|---|---|
| comal_county_burn_ban_monitor | 5 | 182,384 | 139% | ~36,476 | **27%** |
| archivist | 4 | 148,574 | 113% | ~37,143 | **28%** |
| email-default-handler | 4 | 117,136 | 89% | ~29,284 | **22%** |
| garage-bays | 3 | 116,493 | 88% | ~38,831 | **29%** |
| metacognitive | 3 | 112,316 | 85% | ~37,439 | **28%** |

`ContextFillPct` divided `LastInputTokens` by the context window. `LastInputTokens` carries `Response.InputTokens`, which `internal/runtime/iterate/types.go` documents as *"the cumulative input token count across all iterations."* A tool-calling turn resends the system prompt and every tool definition on each round trip, so the sum counts that fixed payload once per call.

The reported percentage tracked **how many round trips a turn took**, not context pressure. Reported ≈ real × iterations, and the correlation held to within a point across every loop measured. `internal/runtime/loop/config.go` even documented the field as "the input token count from the most recent iteration" — the doc said per-call, the data was cumulative.

## Why it mattered more than a wrong gauge

Asked why a subordinate loop kept re-raising a settled concern, the production core loop read this number off its own diagnostics and concluded:

> "its context is overflowing too. `context_fill_pct: 118`, `last_input_tokens: 155371` against a `131072` window. … even if I *had* been writing feedback into its durable document, there's a real chance it gets truncated before the model reads it."

Sound reasoning from a fabricated fact. It pointed the investigation at prompt size and away from the real defect (#1403). An agent that reasons from its own instrumentation inherits that instrumentation's bugs as beliefs.

## The fix

A second number, not a redefinition of the first.

- **`InputTokens` stays cumulative.** It is the turn's spend, and usage accounting is right to read it. Its doc comment now says so, and says explicitly what it must not be used for.
- **`PeakInputTokens` is the largest single call** — the only figure comparable to a context window. It is derived from the per-iteration records every `Result` already carries (`peakInputTokens(iterations)`, mirroring the existing `latestUpstreamRequestID` pattern) rather than tracked as a running maximum, so the two can never drift apart, and a call that failed before producing a record contributes to neither.
- **The force-text recovery call raises the peak explicitly.** It carries the whole accumulated message history and records no `IterationRecord`, so without this the turn most at risk of overflow is the one that under-reports.
- Threaded `iterate.Result` → `agent.Response` → `internal/app/adapters.go` → `loop.Response`/`IterationResult`/`Status`/`LoopView`, and `ContextFillPct` now divides the peak.
- **The web console recomputed the same wrong ratio client-side in two places** — the graph node's ring thickness and the glance metric — both now read `last_peak_input_tokens`.

A turn recorded before peak existed reports no fill at all rather than falling back to the old value. That is the honest answer: the cumulative number was never a fill percentage.

## Test plan

- [x] `just ci` green (architecture metrics at or under baseline)
- [x] `peakInputTokens` unit table, including the production shape (3 growing calls) and peak-not-last
- [x] `ContextFillPct` derives from peak, not cumulative — with the real metacognitive numbers as a case
- [x] Zero peak yields nil fill rather than resurrecting the cumulative figure
- [x] `LastInputTokens` still reports cumulative spend unchanged
- [x] Existing view/API fixtures updated to carry both figures so they assert the distinction
- [ ] Production: confirm fill drops to the 20–30% band after deploy

## Related

- #1403 — the core-attention reply gap this number obscured.
- Not addressed here: thane sends no `num_ctx` to Ollama, so the window it believes in is never asserted on the wire. Spark currently has `gpt-oss:120b` loaded at the full 131072, so it happens to agree — by luck, not control. Worth its own issue.