### PR TITLE
Bound what was unbounded: the output budget, and silence

### DIFF
--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -119,6 +119,15 @@ models:
       # this via the native `ttl` request field on inference endpoints.
       # Zero lets the runner use its default behavior.
       idle_ttl_seconds: 0
+      # StreamIdleTimeout bounds how long this endpoint may send nothing
+      # at all before a request is abandoned. It measures silence, not
+      # duration: a slow generation is still allowed to be slow, and the
+      # window resets on every byte received. Unset uses a default
+      # generous enough to cover prefill on a large prompt; zero disables
+      # the guard, which restores the older behavior where a server that
+      # went quiet after returning headers hung the request until the
+      # process restarted.
+      stream_idle_timeout: 0s
     edge:
       url: http://your-edge-ollama-server:11434
       # Provider name for this resource: "openai_compat" for any server
@@ -137,6 +146,15 @@ models:
       # this via the native `ttl` request field on inference endpoints.
       # Zero lets the runner use its default behavior.
       idle_ttl_seconds: 0
+      # StreamIdleTimeout bounds how long this endpoint may send nothing
+      # at all before a request is abandoned. It measures silence, not
+      # duration: a slow generation is still allowed to be slow, and the
+      # window resets on every byte received. Unset uses a default
+      # generous enough to cover prefill on a large prompt; zero disables
+      # the guard, which restores the older behavior where a server that
+      # went quiet after returning headers hung the request until the
+      # process restarted.
+      stream_idle_timeout: 0s
   # LocalFirst prefers local (cost_tier=0) models over cloud models
   # when routing decisions are made by the model router.
   local_first: true

--- a/internal/model/fleet/client_bundle.go
+++ b/internal/model/fleet/client_bundle.go
@@ -68,6 +68,7 @@ func BuildClients(cat *Catalog, cfg *config.Config, logger *slog.Logger) (*Clien
 			client = oc
 		case "lmstudio":
 			lc := modelproviders.NewLMStudioClientWithTTL(res.URL, serverAPIKey(cfg, res.ID), logger.With("resource", res.ID), res.IdleTTLSeconds)
+			applyStreamIdleTimeout(lc.OpenAICompatClient, cfg, res.ID)
 			lmstudioClients[res.ID] = lc
 			healthClients[res.ID] = ResourceHealthClient{
 				Ping:          lc.Ping,
@@ -81,6 +82,7 @@ func BuildClients(cat *Catalog, cfg *config.Config, logger *slog.Logger) (*Clien
 			// it to a server that does not know the field is a needless
 			// compatibility risk.
 			oc := modelproviders.NewOpenAICompatClient(res.URL, serverAPIKey(cfg, res.ID), "openai_compat", logger.With("resource", res.ID), 0)
+			applyStreamIdleTimeout(oc, cfg, res.ID)
 			openAICompatClients[res.ID] = oc
 			healthClients[res.ID] = ResourceHealthClient{
 				Ping:          oc.Ping,
@@ -200,4 +202,19 @@ func (b *ClientBundle) fallbackClient(cat *Catalog) (llm.Client, error) {
 	}
 	sort.Strings(ids)
 	return b.ResourceClients[ids[0]], nil
+}
+
+// applyStreamIdleTimeout overrides a client's silence bound when the
+// resource configured one. An unset value keeps the client's default
+// rather than collapsing to zero, since zero means "never give up" and
+// an omitted config line does not mean that.
+func applyStreamIdleTimeout(c *modelproviders.OpenAICompatClient, cfg *config.Config, resourceID string) {
+	if c == nil || cfg == nil {
+		return
+	}
+	res, ok := cfg.Models.Resources[resourceID]
+	if !ok || res.StreamIdleTimeout == 0 {
+		return
+	}
+	c.SetStreamIdleTimeout(res.StreamIdleTimeout)
 }

--- a/internal/model/fleet/providers/anthropic.go
+++ b/internal/model/fleet/providers/anthropic.go
@@ -358,7 +358,7 @@ func (c *AnthropicClient) ChatStream(ctx context.Context, model string, messages
 		Model:        model,
 		Messages:     anthropicMsgs,
 		System:       systemPayload,
-		MaxTokens:    anthropicMaxTokens(model),
+		MaxTokens:    llm.ClampMaxOutputTokens(ctx, anthropicMaxTokens(model)),
 		Stream:       stream,
 		Tools:        anthropicTools,
 		CacheControl: anthropicPromptCacheControl(systemPrompt, anthropicMsgs, anthropicTools, explicitCaching),

--- a/internal/model/fleet/providers/ollama.go
+++ b/internal/model/fleet/providers/ollama.go
@@ -202,6 +202,12 @@ func (c *OllamaClient) ChatStream(ctx context.Context, model string, messages []
 		Stream:   stream,
 		Tools:    tools,
 	}
+	// num_predict is Ollama's spelling of the output ceiling. This
+	// client sent no options at all, so a runaway generation ran to the
+	// model's own limit however little budget the caller had left.
+	if budget := llm.MaxOutputTokensFromContext(ctx); budget > 0 {
+		req.Options = &Options{NumPredict: budget}
+	}
 
 	jsonData, err := json.Marshal(req)
 	if err != nil {

--- a/internal/model/fleet/providers/openaicompat.go
+++ b/internal/model/fleet/providers/openaicompat.go
@@ -45,9 +45,14 @@ type OpenAICompatClient struct {
 	// server wants — they have no such field and reject unknown ones
 	// inconsistently.
 	idleTTLSeconds int
-	httpClient     *http.Client
-	logger         *slog.Logger
-	watcher        llm.ReadyWatcher
+	// streamIdleTimeout bounds silence, not duration: how long the
+	// server may send nothing before the request is abandoned. Zero
+	// disables the guard, which is what the pre-existing behavior was
+	// and what a test wanting to hold a stream open asks for.
+	streamIdleTimeout time.Duration
+	httpClient        *http.Client
+	logger            *slog.Logger
+	watcher           llm.ReadyWatcher
 }
 
 // NewOpenAICompatClient creates a client for an OpenAI-compatible
@@ -76,11 +81,12 @@ func NewOpenAICompatClient(baseURL, apiKey, provider string, logger *slog.Logger
 	t.ResponseHeaderTimeout = 5 * time.Minute
 
 	return &OpenAICompatClient{
-		baseURL:        normalizeOpenAICompatBaseURL(baseURL),
-		apiKey:         strings.TrimSpace(apiKey),
-		provider:       strings.TrimSpace(provider),
-		idleTTLSeconds: idleTTLSeconds,
-		logger:         logger.With("provider", strings.TrimSpace(provider)),
+		baseURL:           normalizeOpenAICompatBaseURL(baseURL),
+		apiKey:            strings.TrimSpace(apiKey),
+		provider:          strings.TrimSpace(provider),
+		idleTTLSeconds:    idleTTLSeconds,
+		streamIdleTimeout: DefaultStreamIdleTimeout,
+		logger:            logger.With("provider", strings.TrimSpace(provider)),
 		httpClient: httpkit.NewClient(
 			httpkit.WithTimeout(0),
 			httpkit.WithTransport(t),
@@ -168,8 +174,14 @@ func (c *OpenAICompatClient) ChatStream(ctx context.Context, model string, messa
 	)
 	c.logger.Log(ctx, llm.LevelTrace, "request payload", "json", string(jsonData))
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+"/v1/chat/completions", bytes.NewReader(jsonData))
+	// The request context must be cancellable before the request is
+	// built: the idle guard unblocks a stalled read by cancelling this
+	// request, and cancelling any later-derived context would leave the
+	// read exactly where it was.
+	reqCtx, cancelReq := context.WithCancel(ctx)
+	httpReq, err := http.NewRequestWithContext(reqCtx, "POST", c.baseURL+"/v1/chat/completions", bytes.NewReader(jsonData))
 	if err != nil {
+		cancelReq()
 		return nil, fmt.Errorf("create request: %w", err)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
@@ -177,8 +189,14 @@ func (c *OpenAICompatClient) ChatStream(ctx context.Context, model string, messa
 
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
+		cancelReq()
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
+	// Guard both shapes of response. A non-streaming call can stall
+	// after headers exactly as a streaming one can — the body just
+	// arrives through a json.Decoder instead of a scanner — so the guard
+	// wraps the reader rather than the loop that consumes it.
+	resp.Body = newStreamIdleGuard(resp.Body, cancelReq, c.streamIdleTimeout)
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
@@ -444,4 +462,16 @@ func (c *OpenAICompatClient) chatResponseFromWire(wire *openAICompatChatResponse
 func normalizeOpenAICompatBaseURL(raw string) string {
 	u := strings.TrimRight(strings.TrimSpace(raw), "/")
 	return strings.TrimSuffix(u, "/v1")
+}
+
+// SetStreamIdleTimeout overrides how long this endpoint may go silent
+// before a request is abandoned. Zero disables the guard entirely.
+//
+// Not safe to call concurrently with in-flight requests; intended for
+// resource configuration during init, alongside SetLogger.
+func (c *OpenAICompatClient) SetStreamIdleTimeout(d time.Duration) {
+	if c == nil || d < 0 {
+		return
+	}
+	c.streamIdleTimeout = d
 }

--- a/internal/model/fleet/providers/openaicompat.go
+++ b/internal/model/fleet/providers/openaicompat.go
@@ -145,6 +145,10 @@ func (c *OpenAICompatClient) ChatStream(ctx context.Context, model string, messa
 		Stream:   stream,
 		Tools:    tools,
 		TTL:      c.idleTTLSeconds,
+		// No ceiling of our own to defend: these servers enforce what
+		// their launch configured, so the only limit worth sending is
+		// the caller's remaining budget, and 0 leaves the field off.
+		MaxTokens: llm.MaxOutputTokensFromContext(ctx),
 	}
 	if stream {
 		req.StreamOptions = &openAICompatStreamOptions{IncludeUsage: true}

--- a/internal/model/fleet/providers/openaicompat_test.go
+++ b/internal/model/fleet/providers/openaicompat_test.go
@@ -354,3 +354,54 @@ func TestOpenAICompatCapabilities(t *testing.T) {
 		t.Error("a text model should not be treated as vision-capable")
 	}
 }
+
+// TestOpenAICompatSendsRemainingBudget pins that a caller's remaining
+// output budget reaches the wire. Before this, MaxOutputTokens was only
+// checked after a response had fully arrived, so it bounded accounting
+// rather than generation: one runaway completion was produced and paid
+// for in full before anything noticed — minutes of wall clock on a
+// runner generating single-digit tokens per second.
+func TestOpenAICompatSendsRemainingBudget(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		budget  int
+		wantSet bool
+		want    float64
+	}{
+		{name: "budget reaches the wire", budget: 700, wantSet: true, want: 700},
+		{name: "no budget leaves the field off", budget: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var body map[string]any
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_ = json.NewDecoder(r.Body).Decode(&body)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"model":"m","choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`))
+			}))
+			defer srv.Close()
+
+			ctx := llm.WithMaxOutputTokens(context.Background(), tt.budget)
+			c := NewOpenAICompatClient(srv.URL, "", "test", nil, 0)
+			if _, err := c.Chat(ctx, "m", []llm.Message{{Role: "user", Content: "hi"}}, nil); err != nil {
+				t.Fatalf("Chat: %v", err)
+			}
+
+			got, present := body["max_tokens"]
+			if !tt.wantSet {
+				if present {
+					t.Errorf("max_tokens sent without a budget: %#v", got)
+				}
+				return
+			}
+			if !present || got != tt.want {
+				t.Errorf("max_tokens = %#v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/model/fleet/providers/openaicompat_test.go
+++ b/internal/model/fleet/providers/openaicompat_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/model/llm"
 )
@@ -403,5 +404,82 @@ func TestOpenAICompatSendsRemainingBudget(t *testing.T) {
 				t.Errorf("max_tokens = %#v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestOpenAICompatStreamIdleTimeout pins the bound on silence. A server
+// that accepts a request, returns headers, and then stops speaking used
+// to hang the read forever: ResponseHeaderTimeout no longer applies once
+// headers arrive, and these clients carry no total timeout because a
+// long generation is not a hung request. The iteration never completed
+// and the loop waiting on it never woke again.
+func TestOpenAICompatStreamIdleTimeout(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		// One frame, then silence — the shape of a runner that dies
+		// mid-generation without closing the connection.
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"partial\"}}]}\n\n"))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		<-release
+	}))
+	defer srv.Close()
+	defer close(release)
+
+	c := NewOpenAICompatClient(srv.URL, "", "test", nil, 0)
+	c.SetStreamIdleTimeout(150 * time.Millisecond)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := c.ChatStream(context.Background(), "m", []llm.Message{{Role: "user", Content: "hi"}}, nil, func(llm.StreamEvent) {})
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("a stalled stream returned success")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("stalled stream was never abandoned — the idle guard did not fire")
+	}
+}
+
+// TestOpenAICompatStreamIdleAllowsSlowGeneration pins the other half:
+// the guard measures silence, not duration. A server that keeps sending,
+// however slowly, must never be cut off — that is the behavior the
+// absent total timeout exists to protect.
+func TestOpenAICompatStreamIdleAllowsSlowGeneration(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		f, _ := w.(http.Flusher)
+		// Six frames at 60ms apart: 360ms total, comfortably past the
+		// 150ms idle window, with no single gap reaching it.
+		for i := 0; i < 6; i++ {
+			_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"tok\"}}]}\n\n"))
+			if f != nil {
+				f.Flush()
+			}
+			time.Sleep(60 * time.Millisecond)
+		}
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer srv.Close()
+
+	c := NewOpenAICompatClient(srv.URL, "", "test", nil, 0)
+	c.SetStreamIdleTimeout(150 * time.Millisecond)
+
+	resp, err := c.ChatStream(context.Background(), "m", []llm.Message{{Role: "user", Content: "hi"}}, nil, func(llm.StreamEvent) {})
+	if err != nil {
+		t.Fatalf("slow but live stream was abandoned: %v", err)
+	}
+	if resp.Message.Content != "toktoktoktoktoktok" {
+		t.Errorf("content = %q, want all six tokens", resp.Message.Content)
 	}
 }

--- a/internal/model/fleet/providers/openaicompat_wire.go
+++ b/internal/model/fleet/providers/openaicompat_wire.go
@@ -78,6 +78,15 @@ type openAICompatChatRequest struct {
 	Tools         []map[string]any           `json:"tools,omitempty"`
 	TTL           int                        `json:"ttl,omitempty"`
 	StreamOptions *openAICompatStreamOptions `json:"stream_options,omitempty"`
+	// MaxTokens is the output ceiling, omitted when the caller set no
+	// budget. Spelled max_tokens rather than OpenAI's newer
+	// max_completion_tokens because the servers this client exists for
+	// are self-hosted: vLLM, SGLang, llama-server, LM Studio, and
+	// Ollama's /v1 all implement max_tokens, while support for the newer
+	// name is uneven and a rejected field costs the whole turn. Which
+	// spelling a resource wants is a dialect question, and dialect
+	// belongs in per-resource policy rather than hardcoded here.
+	MaxTokens int `json:"max_tokens,omitempty"`
 }
 
 type openAICompatStreamOptions struct {

--- a/internal/model/fleet/providers/streamidle.go
+++ b/internal/model/fleet/providers/streamidle.go
@@ -1,0 +1,112 @@
+package providers
+
+import (
+	"context"
+	"io"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// DefaultStreamIdleTimeout bounds how long a model server may deliver
+// nothing at all before the request is abandoned.
+//
+// It is generous on purpose. The silence being measured is not only the
+// gap between tokens — a server is quiet through prefill too, and a
+// large prompt against a loaded local runner can take tens of seconds
+// before the first byte moves. Production's slowest observed whole
+// generation is under four minutes, so two minutes of complete silence
+// sits well outside normal behavior while still bounding a hang that
+// would otherwise last until the process restarts.
+const DefaultStreamIdleTimeout = 2 * time.Minute
+
+// newStreamIdleGuard wraps a response body so the request is cancelled
+// when the server stops sending for idle. cancel must belong to the
+// context the request was built with — cancelling anything else leaves
+// the blocked Read exactly where it was.
+//
+// This closes the gap ResponseHeaderTimeout leaves behind. That timeout
+// stops applying the moment headers arrive, and these clients carry no
+// total timeout by design, because a long generation is not a hung
+// request. Between the first header and the last byte there was
+// therefore nothing bounding a server that accepted a request and then
+// went quiet: the read blocks forever, the iteration never finishes, and
+// the loop waiting on it never wakes again.
+//
+// The guard measures silence rather than duration, so a slow answer is
+// still allowed to be slow. Cancelling the request is what unblocks the
+// Read; the transport aborts and surfaces a context error, which the
+// caller reports as a failed turn rather than a successful empty one.
+func newStreamIdleGuard(body io.ReadCloser, cancel context.CancelFunc, idle time.Duration) io.ReadCloser {
+	g := &streamIdleGuard{
+		ReadCloser: body,
+		cancel:     cancel,
+		idle:       idle,
+		done:       make(chan struct{}),
+	}
+	g.touch()
+	if idle > 0 {
+		go g.watch()
+	}
+	return g
+}
+
+// streamIdleGuard cancels its request when reads stop producing bytes.
+// Activity is recorded as a timestamp and checked by a poller rather
+// than driven through a timer, so the reader and the watchdog never
+// contend over the same timer state.
+type streamIdleGuard struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+	idle   time.Duration
+	last   atomic.Int64
+
+	once sync.Once
+	done chan struct{}
+}
+
+func (g *streamIdleGuard) touch() { g.last.Store(time.Now().UnixNano()) }
+
+// watch cancels the request once the idle window passes with no bytes
+// read. It polls at a fraction of the window because precision is not
+// the point — the difference between abandoning a dead stream at two
+// minutes and at two and a half is nothing next to abandoning it never.
+func (g *streamIdleGuard) watch() {
+	interval := g.idle / 4
+	if interval <= 0 {
+		interval = g.idle
+	}
+	tick := time.NewTicker(interval)
+	defer tick.Stop()
+	for {
+		select {
+		case <-g.done:
+			return
+		case now := <-tick.C:
+			if now.UnixNano()-g.last.Load() >= int64(g.idle) {
+				g.cancel()
+				return
+			}
+		}
+	}
+}
+
+func (g *streamIdleGuard) Read(p []byte) (int, error) {
+	n, err := g.ReadCloser.Read(p)
+	if n > 0 {
+		g.touch()
+	}
+	return n, err
+}
+
+// Close stops the watchdog and releases the request context. Safe to
+// call repeatedly: both the caller's defer and the http client may close
+// a response body.
+func (g *streamIdleGuard) Close() error {
+	g.once.Do(func() { close(g.done) })
+	// Cancel rather than leak. The request is over either way, and a
+	// cancel func outliving its request is how a transport ends up
+	// holding a connection nothing will ever read again.
+	g.cancel()
+	return g.ReadCloser.Close()
+}

--- a/internal/model/llm/budget.go
+++ b/internal/model/llm/budget.go
@@ -1,0 +1,62 @@
+package llm
+
+import "context"
+
+// maxOutputTokensKey carries the remaining output-token budget for one
+// model call.
+type maxOutputTokensKey struct{}
+
+// WithMaxOutputTokens attaches the output-token budget remaining for the
+// next model call, so a provider can ask the server to stop there.
+//
+// This rides the context rather than the [Client] signature, which is a
+// deliberate exception to the usual rule against parameters in context.
+// The value is an optional hint that every provider clamps against its
+// own ceiling and none requires; ChatStream has fifteen implementations
+// across providers, the routed client, and test doubles, and widening
+// that signature would make every one of them acknowledge a budget most
+// have no opinion about. A provider that ignores this is not broken —
+// it is exactly where the runtime was before, with the post-response
+// check as the backstop.
+//
+// A non-positive budget attaches nothing: "no ceiling" and "no budget
+// left" must not arrive as the same value, and the caller stops the turn
+// before the latter can reach a provider.
+func WithMaxOutputTokens(ctx context.Context, tokens int) context.Context {
+	if tokens <= 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, maxOutputTokensKey{}, tokens)
+}
+
+// MaxOutputTokensFromContext returns the remaining output-token budget
+// for this call, or 0 when the caller set no budget. Providers should
+// treat 0 as "no ceiling of mine to lower" and keep whatever limit they
+// would otherwise send.
+func MaxOutputTokensFromContext(ctx context.Context) int {
+	tokens, _ := ctx.Value(maxOutputTokensKey{}).(int)
+	if tokens < 0 {
+		return 0
+	}
+	return tokens
+}
+
+// ClampMaxOutputTokens lowers a provider's own output ceiling to the
+// budget remaining on ctx, and returns the ceiling unchanged when no
+// budget is set or the budget is the looser of the two.
+//
+// Providers call this instead of reading the context directly so the
+// precedence is stated once: a budget may only ever tighten a ceiling.
+// A budget that exceeds what the provider will accept is not permission
+// to send a larger value — that is how an over-limit request gets
+// rejected outright and a turn dies for asking.
+func ClampMaxOutputTokens(ctx context.Context, ceiling int) int {
+	budget := MaxOutputTokensFromContext(ctx)
+	if budget <= 0 {
+		return ceiling
+	}
+	if ceiling <= 0 || budget < ceiling {
+		return budget
+	}
+	return ceiling
+}

--- a/internal/model/llm/budget_test.go
+++ b/internal/model/llm/budget_test.go
@@ -1,0 +1,56 @@
+package llm
+
+import (
+	"context"
+	"testing"
+)
+
+// TestClampMaxOutputTokens pins the precedence a provider depends on: a
+// budget may tighten a ceiling and never raise it. Raising it would send
+// a value the provider has already decided it cannot accept, which is
+// how a turn dies for asking rather than for running long.
+func TestClampMaxOutputTokens(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		budget  int
+		ceiling int
+		want    int
+	}{
+		{name: "no budget leaves the ceiling alone", budget: 0, ceiling: 16384, want: 16384},
+		{name: "tighter budget wins", budget: 500, ceiling: 16384, want: 500},
+		{name: "looser budget does not raise the ceiling", budget: 99999, ceiling: 16384, want: 16384},
+		{name: "equal budget is a no-op", budget: 16384, ceiling: 16384, want: 16384},
+		{name: "no ceiling of its own takes the budget", budget: 500, ceiling: 0, want: 500},
+		{name: "neither set stays unset", budget: 0, ceiling: 0, want: 0},
+		{name: "negative budget is not a ceiling", budget: -5, ceiling: 16384, want: 16384},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := WithMaxOutputTokens(context.Background(), tt.budget)
+			if got := ClampMaxOutputTokens(ctx, tt.ceiling); got != tt.want {
+				t.Errorf("ClampMaxOutputTokens(budget=%d, ceiling=%d) = %d, want %d", tt.budget, tt.ceiling, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestWithMaxOutputTokensRejectsNonPositive pins that "no ceiling" and
+// "no budget left" never arrive as the same value. A caller with nothing
+// left stops the turn; a provider must never read that as unlimited.
+func TestWithMaxOutputTokensRejectsNonPositive(t *testing.T) {
+	t.Parallel()
+
+	for _, n := range []int{0, -1} {
+		ctx := WithMaxOutputTokens(context.Background(), n)
+		if got := MaxOutputTokensFromContext(ctx); got != 0 {
+			t.Errorf("WithMaxOutputTokens(%d) then read = %d, want 0", n, got)
+		}
+	}
+	if got := MaxOutputTokensFromContext(context.Background()); got != 0 {
+		t.Errorf("bare context = %d, want 0", got)
+	}
+}

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -1479,6 +1479,15 @@ type ModelServerConfig struct {
 	// this via the native `ttl` request field on inference endpoints.
 	// Zero lets the runner use its default behavior.
 	IdleTTLSeconds int `yaml:"idle_ttl_seconds"`
+	// StreamIdleTimeout bounds how long this endpoint may send nothing
+	// at all before a request is abandoned. It measures silence, not
+	// duration: a slow generation is still allowed to be slow, and the
+	// window resets on every byte received. Unset uses a default
+	// generous enough to cover prefill on a large prompt; zero disables
+	// the guard, which restores the older behavior where a server that
+	// went quiet after returning headers hung the request until the
+	// process restarted.
+	StreamIdleTimeout time.Duration `yaml:"stream_idle_timeout"`
 }
 
 // PreferredOllamaURL returns the best available Ollama URL for callers

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -2668,7 +2668,13 @@ func (l *Loop) buildLLMErrorHandler(ctx context.Context, stream llm.StreamCallba
 					"recovery_model", l.recoveryModel,
 				)
 				recoveryMessages := buildRecoveryPrompt(msgs, toolsUsedFromMessages(msgs))
-				recoveryCtx, recoveryCancel := context.WithTimeout(context.Background(), timeoutRecoveryDeadline)
+				// Detached from the parent on purpose — the deadline
+				// that just expired must not cancel the recovery — but
+				// detaching drops context values with it, and the output
+				// budget is one of them. Re-attach it so the recovery
+				// generation is bounded like every other call.
+				recoveryBase := llm.WithMaxOutputTokens(context.Background(), llm.MaxOutputTokensFromContext(iterCtx))
+				recoveryCtx, recoveryCancel := context.WithTimeout(recoveryBase, timeoutRecoveryDeadline)
 				resp, recoveryErr := l.llm.ChatStream(recoveryCtx, l.recoveryModel, recoveryMessages, nil, stream)
 				recoveryCancel()
 				if recoveryErr != nil {

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -2204,6 +2204,8 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 			return repaired
 		},
 
+		MaxOutputTokens: req.MaxOutputTokens,
+
 		CheckBudget: func(totalOut int) bool {
 			return req.MaxOutputTokens > 0 && totalOut >= req.MaxOutputTokens
 		},

--- a/internal/runtime/iterate/config.go
+++ b/internal/runtime/iterate/config.go
@@ -102,6 +102,17 @@ type Config struct {
 	// engine should force a text response. Nil means no budget.
 	CheckBudget func(totalOutput int) bool
 
+	// MaxOutputTokens is the output-token budget for the whole run, or 0
+	// for unlimited. CheckBudget already stops the run once a response
+	// has pushed the total past it; this exists because that check is
+	// necessarily after the fact and cannot bound the response that
+	// overshot. Carried to each provider as the remaining allowance so
+	// the server stops generating at the budget rather than at its own
+	// ceiling, which on a slow local runner is the difference between a
+	// cap and several minutes of wall clock spent producing tokens
+	// nobody will accept.
+	MaxOutputTokens int
+
 	// CheckToolAvail reports whether a tool is available in the current
 	// iteration. Return false if the tool should be treated as illegal.
 	// Nil means all tools are available.

--- a/internal/runtime/iterate/engine.go
+++ b/internal/runtime/iterate/engine.go
@@ -84,7 +84,15 @@ func (e *Engine) Run(ctx context.Context, cfg Config, messages []llm.Message) (*
 		iterStart := time.Now()
 
 		// --- LLM call ---
-		llmResp, err := cfg.LLM.ChatStream(iterCtx, model, messages, toolDefs, cfg.Stream)
+		// Spend the budget forward: what is left is this call's ceiling.
+		// Without it the run can only notice an overrun after paying for
+		// it in full, which on a runner generating single-digit tokens
+		// per second is minutes of work discarded on arrival.
+		callCtx := iterCtx
+		if cfg.MaxOutputTokens > 0 {
+			callCtx = llm.WithMaxOutputTokens(iterCtx, cfg.MaxOutputTokens-totalOutput)
+		}
+		llmResp, err := cfg.LLM.ChatStream(callCtx, model, messages, toolDefs, cfg.Stream)
 		if err != nil {
 			if cfg.OnLLMError != nil {
 				var newModel string
@@ -528,7 +536,22 @@ func (e *Engine) forceText(ctx context.Context, cfg Config, model string, messag
 	if len(messages) > 0 && messages[len(messages)-1].Role == "tool" {
 		log.Warn("forcing text response", "reason", partial.ExhaustReason, "model", model)
 
-		resp, err := cfg.LLM.ChatStream(ctx, model, messages, nil, cfg.Stream)
+		// The recovery call is a real generation against the same
+		// budget, and it is the one most likely to run when the budget
+		// is already spent. Unbounded here would reopen the hole this
+		// budget closes, at exactly the moment the run has proven it
+		// overruns. When nothing is left, a small floor still buys a
+		// closing message — returning nothing at all is a worse answer
+		// than a short one.
+		recoveryCtx := ctx
+		if cfg.MaxOutputTokens > 0 {
+			remaining := cfg.MaxOutputTokens - partial.OutputTokens
+			if remaining < forceTextFloorTokens {
+				remaining = forceTextFloorTokens
+			}
+			recoveryCtx = llm.WithMaxOutputTokens(ctx, remaining)
+		}
+		resp, err := cfg.LLM.ChatStream(recoveryCtx, model, messages, nil, cfg.Stream)
 		if err != nil {
 			log.Error("force-text LLM call failed", "model", model, "reason", partial.ExhaustReason, "error", err)
 			if partial.Content == "" {
@@ -615,3 +638,9 @@ func peakInputTokens(iters []IterationRecord) int {
 	}
 	return peak
 }
+
+// forceTextFloorTokens is the smallest ceiling the force-text recovery
+// call will be given. A run that exhausted its budget still needs to say
+// something to its caller, and a closing sentence is cheaper than the
+// silence — or the fallback string — the caller gets otherwise.
+const forceTextFloorTokens = 512

--- a/internal/runtime/iterate/engine.go
+++ b/internal/runtime/iterate/engine.go
@@ -96,7 +96,14 @@ func (e *Engine) Run(ctx context.Context, cfg Config, messages []llm.Message) (*
 		if err != nil {
 			if cfg.OnLLMError != nil {
 				var newModel string
-				llmResp, newModel, err = cfg.OnLLMError(iterCtx, err, model, messages, toolDefs, cfg.Stream)
+				// callCtx, not iterCtx: this handler retries, fails
+				// over, and downshifts to a recovery model, and each of
+				// those is a real generation against the same budget.
+				// Handing it the unbudgeted context left every recovery
+				// path free to run away — the exact behavior this change
+				// exists to stop, reached by the route taken when
+				// something has already gone wrong.
+				llmResp, newModel, err = cfg.OnLLMError(callCtx, err, model, messages, toolDefs, cfg.Stream)
 				if err != nil {
 					return &Result{
 						Model:                      model,
@@ -538,16 +545,23 @@ func (e *Engine) forceText(ctx context.Context, cfg Config, model string, messag
 
 		// The recovery call is a real generation against the same
 		// budget, and it is the one most likely to run when the budget
-		// is already spent. Unbounded here would reopen the hole this
-		// budget closes, at exactly the moment the run has proven it
-		// overruns. When nothing is left, a small floor still buys a
-		// closing message — returning nothing at all is a worse answer
-		// than a short one.
+		// is already spent — so it takes what remains and no more. An
+		// earlier version floored it at a few hundred tokens so a spent
+		// run could still close with a sentence, which quietly let the
+		// run finish past its stated ceiling. A budget that can be
+		// exceeded to say something nice about being over budget is not
+		// a budget; when nothing remains the caller gets the fallback
+		// content, which is what that path already exists to provide.
 		recoveryCtx := ctx
 		if cfg.MaxOutputTokens > 0 {
 			remaining := cfg.MaxOutputTokens - partial.OutputTokens
-			if remaining < forceTextFloorTokens {
-				remaining = forceTextFloorTokens
+			if remaining <= 0 {
+				log.Warn("skipping force-text recovery: output budget exhausted",
+					"max_output_tokens", cfg.MaxOutputTokens,
+					"output_tokens", partial.OutputTokens,
+				)
+				partial.Messages = messages
+				return partial, nil
 			}
 			recoveryCtx = llm.WithMaxOutputTokens(ctx, remaining)
 		}
@@ -638,9 +652,3 @@ func peakInputTokens(iters []IterationRecord) int {
 	}
 	return peak
 }
-
-// forceTextFloorTokens is the smallest ceiling the force-text recovery
-// call will be given. A run that exhausted its budget still needs to say
-// something to its caller, and a closing sentence is cheaper than the
-// silence — or the fallback string — the caller gets otherwise.
-const forceTextFloorTokens = 512

--- a/internal/runtime/iterate/engine_test.go
+++ b/internal/runtime/iterate/engine_test.go
@@ -1206,3 +1206,72 @@ func TestPeakInputTokens(t *testing.T) {
 		})
 	}
 }
+
+// TestEngineSpendsBudgetForward pins that each call's ceiling is what
+// the run has left, not the whole allowance. CheckBudget still stops the
+// run after the fact; this is what keeps a single generation from
+// overshooting before that check can run.
+func TestEngineSpendsBudgetForward(t *testing.T) {
+	t.Parallel()
+
+	var seen []int
+	llmClient := &budgetRecordingClient{
+		onCall:              func(ctx context.Context) { seen = append(seen, llm.MaxOutputTokensFromContext(ctx)) },
+		outputTokensPerCall: 300,
+	}
+
+	e := &Engine{}
+	_, err := e.Run(context.Background(), Config{
+		Model:           "m",
+		LLM:             llmClient,
+		MaxIterations:   3,
+		MaxOutputTokens: 1000,
+		CheckBudget:     func(total int) bool { return total >= 1000 },
+		Executor:        &DirectExecutor{Exec: func(context.Context, string, string) (string, error) { return "done", nil }},
+	}, []llm.Message{{Role: "user", Content: "hi"}})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// 1000 to start, then 700 after the first 300-token response, then
+	// 400. The fourth is the force-text recovery call after max
+	// iterations: 1000-900=100 is below the floor, so it gets the floor
+	// rather than a ceiling too small to close with.
+	want := []int{1000, 700, 400, forceTextFloorTokens}
+	if len(seen) != len(want) {
+		t.Fatalf("budgets seen = %v, want %v", seen, want)
+	}
+	for i, w := range want {
+		if seen[i] != w {
+			t.Fatalf("budgets seen = %v, want %v", seen, want)
+		}
+	}
+}
+
+// budgetRecordingClient answers with tool calls so the engine keeps
+// iterating, recording the budget it was handed each time.
+type budgetRecordingClient struct {
+	onCall              func(context.Context)
+	outputTokensPerCall int
+	calls               int
+}
+
+func (c *budgetRecordingClient) Chat(ctx context.Context, model string, msgs []llm.Message, tools []map[string]any) (*llm.ChatResponse, error) {
+	return c.ChatStream(ctx, model, msgs, tools, nil)
+}
+
+func (c *budgetRecordingClient) Ping(context.Context) error { return nil }
+
+func (c *budgetRecordingClient) ChatStream(ctx context.Context, _ string, _ []llm.Message, _ []map[string]any, _ llm.StreamCallback) (*llm.ChatResponse, error) {
+	c.onCall(ctx)
+	c.calls++
+	resp := &llm.ChatResponse{Model: "m", Done: true, OutputTokens: c.outputTokensPerCall}
+	resp.Message.Role = "assistant"
+	// Keep asking for a tool so the engine keeps iterating and the
+	// budget has more than one call to be spent across.
+	tc := llm.ToolCall{ID: fmt.Sprintf("call_%d", c.calls)}
+	tc.Function.Name = "noop"
+	tc.Function.Arguments = map[string]any{}
+	resp.Message.ToolCalls = []llm.ToolCall{tc}
+	return resp, nil
+}

--- a/internal/runtime/iterate/engine_test.go
+++ b/internal/runtime/iterate/engine_test.go
@@ -1235,9 +1235,10 @@ func TestEngineSpendsBudgetForward(t *testing.T) {
 
 	// 1000 to start, then 700 after the first 300-token response, then
 	// 400. The fourth is the force-text recovery call after max
-	// iterations: 1000-900=100 is below the floor, so it gets the floor
-	// rather than a ceiling too small to close with.
-	want := []int{1000, 700, 400, forceTextFloorTokens}
+	// iterations, which takes the 100 that actually remain — never more,
+	// however little that buys, because a budget that can be exceeded to
+	// apologize for being exceeded is not a budget.
+	want := []int{1000, 700, 400, 100}
 	if len(seen) != len(want) {
 		t.Fatalf("budgets seen = %v, want %v", seen, want)
 	}
@@ -1254,6 +1255,7 @@ type budgetRecordingClient struct {
 	onCall              func(context.Context)
 	outputTokensPerCall int
 	calls               int
+	failFirst           bool
 }
 
 func (c *budgetRecordingClient) Chat(ctx context.Context, model string, msgs []llm.Message, tools []map[string]any) (*llm.ChatResponse, error) {
@@ -1265,6 +1267,9 @@ func (c *budgetRecordingClient) Ping(context.Context) error { return nil }
 func (c *budgetRecordingClient) ChatStream(ctx context.Context, _ string, _ []llm.Message, _ []map[string]any, _ llm.StreamCallback) (*llm.ChatResponse, error) {
 	c.onCall(ctx)
 	c.calls++
+	if c.failFirst && c.calls == 1 {
+		return nil, errors.New("upstream exploded")
+	}
 	resp := &llm.ChatResponse{Model: "m", Done: true, OutputTokens: c.outputTokensPerCall}
 	resp.Message.Role = "assistant"
 	// Keep asking for a tool so the engine keeps iterating and the
@@ -1274,4 +1279,70 @@ func (c *budgetRecordingClient) ChatStream(ctx context.Context, _ string, _ []ll
 	tc.Function.Arguments = map[string]any{}
 	resp.Message.ToolCalls = []llm.ToolCall{tc}
 	return resp, nil
+}
+
+// TestEngineBudgetBoundsErrorRecovery pins that the paths taken when
+// something has already gone wrong are bounded too. Retry, failover, and
+// the recovery-model downshift all run real generations through
+// OnLLMError, and handing that handler an unbudgeted context left every
+// one of them free to run away — the exact behavior the budget exists to
+// stop, reached by the route nobody watches.
+func TestEngineBudgetBoundsErrorRecovery(t *testing.T) {
+	t.Parallel()
+
+	var handlerBudget int
+	failing := &budgetRecordingClient{onCall: func(context.Context) {}, failFirst: true}
+
+	e := &Engine{}
+	_, err := e.Run(context.Background(), Config{
+		Model:           "m",
+		LLM:             failing,
+		MaxIterations:   2,
+		MaxOutputTokens: 800,
+		Executor:        &DirectExecutor{Exec: func(context.Context, string, string) (string, error) { return "done", nil }},
+		OnLLMError: func(ctx context.Context, _ error, model string, _ []llm.Message, _ []map[string]any, _ llm.StreamCallback) (*llm.ChatResponse, string, error) {
+			handlerBudget = llm.MaxOutputTokensFromContext(ctx)
+			resp := &llm.ChatResponse{Model: model, Done: true, OutputTokens: 10}
+			resp.Message.Role = "assistant"
+			resp.Message.Content = "recovered"
+			return resp, model, nil
+		},
+	}, []llm.Message{{Role: "user", Content: "hi"}})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if handlerBudget != 800 {
+		t.Errorf("error handler budget = %d, want 800", handlerBudget)
+	}
+}
+
+// TestEngineSkipsRecoveryWhenBudgetSpent pins the hard-limit promise: a
+// run that has spent its allowance does not buy one more generation to
+// say so. The caller gets the fallback content that path already exists
+// to provide.
+func TestEngineSkipsRecoveryWhenBudgetSpent(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	client := &budgetRecordingClient{onCall: func(context.Context) { calls++ }, outputTokensPerCall: 600}
+
+	e := &Engine{}
+	result, err := e.Run(context.Background(), Config{
+		Model:           "m",
+		LLM:             client,
+		MaxIterations:   1,
+		MaxOutputTokens: 500,
+		FallbackContent: "budget spent",
+		Executor:        &DirectExecutor{Exec: func(context.Context, string, string) (string, error) { return "done", nil }},
+	}, []llm.Message{{Role: "user", Content: "hi"}})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// One generation, which overshot; no second one to apologize for it.
+	if calls != 1 {
+		t.Errorf("model calls = %d, want 1 (no recovery call past a spent budget)", calls)
+	}
+	if result.OutputTokens > 600 {
+		t.Errorf("output tokens = %d, want no generation beyond the overshooting one", result.OutputTokens)
+	}
 }


### PR DESCRIPTION
Two of #1406's three items. They arrived on one branch and are staying there — both are the same argument applied to different axes: something the runtime believed it controlled was, in fact, unbounded.

---

# 1. The output budget was a ledger, not a limit

`MaxOutputTokens` was only consulted *after* a provider response had fully arrived. That bounds how many iterations a run may take; it cannot bound any one of them. A single runaway generation is produced and paid for in full before the check that would have stopped it runs — and at spark's measured **9.4 output tokens/sec**, that is minutes of wall clock spent producing tokens the runtime has already decided to discard.

Every provider had the field and none was ever given a value:

| Provider | Field | Before |
|---|---|---|
| Anthropic | `max_tokens` | static per-family ceiling, budget ignored |
| OpenAI-compat | — | no output field on the request type at all |
| Ollama | `Options.NumPredict` | existed; client never sent `options` |

The budget now reaches each call as the allowance *remaining*, and each provider lowers its own ceiling to it. Anthropic **clamps rather than replaces** — a budget above the family maximum is not permission to ask for more, which is how a request gets rejected outright and a turn dies for asking rather than for running long.

**Why it rides the context.** A deliberate exception to the rule against parameters in context, argued at the definition: the value is an optional hint every provider clamps and none requires; `ChatStream` has 15 implementations across providers, the routed client, and test doubles; and a provider that ignores it is exactly where the runtime already was, with `CheckBudget` still behind it as the backstop.

**`max_tokens`, not `max_completion_tokens`.** vLLM, SGLang, llama-server, LM Studio, and Ollama's `/v1` all implement the former; support for the newer spelling is uneven and a rejected field costs the whole turn. Which spelling a resource wants is a dialect question — tracked on #1406 with the capability-policy work rather than guessed at here.

### Two holes review found in the first pass

- **The recovery floor was overage.** A run holding 100 of a 1000-token allowance was given 512 to close with and finished at 1412. A budget that may be exceeded in order to apologize for being exceeded is not a limit. Recovery now takes the positive remainder, and a spent run skips the call entirely and returns the fallback content that path already provides.
- **The ceiling only reached the first attempt.** `OnLLMError` got the unbudgeted context — and that handler retries with backoff, fails over to another model, and downshifts to a recovery model. Three real generations, all unbounded: the exact runaway this change exists to stop, reached by the route taken when something has *already* gone wrong. The recovery-model path needed its own fix on top, since it detaches via `context.Background()` on purpose and drops context values with the expired deadline.

---

# 2. Nothing bounded a server that went quiet

`ResponseHeaderTimeout` stops applying the moment headers arrive, and these clients carry no total timeout by design — a long generation is not a hung request. Between the first header and the last byte there was therefore **nothing at all** bounding a server that accepted a request and then stopped speaking. The read blocks, the iteration never finishes, and the loop waiting on it never wakes again. Nothing in the process notices; the loop simply stops existing as far as the fleet is concerned.

That is the #1334 incident one layer down: the machinery below is sound, and nothing bounds it.

**The guard measures silence, not duration** — the whole point. Spark's p90 is 94s and its slowest observed generation just over three minutes, so a duration cap would kill healthy work. The window resets on every byte received, so the distinction is liveness rather than speed.

It wraps the **response body** rather than the scanner loop, because a non-streaming call can stall after headers exactly as a streaming one can; the body just arrives through a `json.Decoder` instead. One mechanism, and the reader is where the evidence of life actually is.

Two implementation notes worth review: the request context must be cancellable *before* the request is built, since cancelling the request is what unblocks a stalled read and cancelling anything derived later would leave it where it was; and activity is a timestamp checked by a poller rather than a timer driven from the reader, so the two never contend over timer state.

`stream_idle_timeout` is per-resource. Zero disables the guard and restores the old behavior — which an omitted config line deliberately does not do.

**Not touching the native Ollama client.** Its five-minute *total* timeout means it cannot hang this way; its problem is the opposite one, and #1334 records it as superseded by the `openai_compat` path rather than repaired.

---

## Test plan

- [x] `just ci` green
- [x] `ClampMaxOutputTokens` precedence — budget tightens, never raises
- [x] "no ceiling" and "no budget left" never arrive as the same value
- [x] Engine spends the budget forward across iterations; recovery takes only the remainder
- [x] A spent run buys no further generation
- [x] The error handler is handed the remaining allowance
- [x] Remaining budget reaches the wire as `max_tokens`; field absent when unset
- [x] A stalled stream is abandoned at the idle window
- [x] A slow-but-live stream exceeding the window in total duration completes untouched
- [ ] Production: a budgeted loop truncates with `finish_reason: length` rather than overrunning

That last one is newly observable — #1405 made `StopReason` survive the stream, so a budget-truncated turn now says so instead of looking complete.

Refs #1406. Remaining there: request traceability, and the per-resource capability/dialect policy.