### PR TITLE
Make a provider call able to explain itself

### DIFF
--- a/internal/model/fleet/client_bundle.go
+++ b/internal/model/fleet/client_bundle.go
@@ -67,7 +67,7 @@ func BuildClients(cat *Catalog, cfg *config.Config, logger *slog.Logger) (*Clien
 			}
 			client = oc
 		case "lmstudio":
-			lc := modelproviders.NewLMStudioClientWithTTL(res.URL, serverAPIKey(cfg, res.ID), logger.With("resource", res.ID), res.IdleTTLSeconds)
+			lc := modelproviders.NewLMStudioClientWithTTL(res.URL, serverAPIKey(cfg, res.ID), res.ID, logger.With("resource", res.ID), res.IdleTTLSeconds)
 			applyStreamIdleTimeout(lc.OpenAICompatClient, cfg, res.ID)
 			lmstudioClients[res.ID] = lc
 			healthClients[res.ID] = ResourceHealthClient{
@@ -81,7 +81,7 @@ func BuildClients(cat *Catalog, cfg *config.Config, logger *slog.Logger) (*Clien
 			// No idle TTL — that is an LM Studio extension, and sending
 			// it to a server that does not know the field is a needless
 			// compatibility risk.
-			oc := modelproviders.NewOpenAICompatClient(res.URL, serverAPIKey(cfg, res.ID), "openai_compat", logger.With("resource", res.ID), 0)
+			oc := modelproviders.NewOpenAICompatClient(res.URL, serverAPIKey(cfg, res.ID), "openai_compat", res.ID, logger.With("resource", res.ID), 0)
 			applyStreamIdleTimeout(oc, cfg, res.ID)
 			openAICompatClients[res.ID] = oc
 			healthClients[res.ID] = ResourceHealthClient{

--- a/internal/model/fleet/inventory_test.go
+++ b/internal/model/fleet/inventory_test.go
@@ -152,7 +152,7 @@ func TestDiscoverInventory_OpenAICompat(t *testing.T) {
 	cat := &Catalog{Resources: []Resource{{ID: "spark", Provider: "openai_compat", URL: srv.URL}}}
 	bundle := &ClientBundle{
 		OpenAICompatClients: map[string]*modelproviders.OpenAICompatClient{
-			"spark": modelproviders.NewOpenAICompatClient(srv.URL, "", "openai_compat", nil, 0),
+			"spark": modelproviders.NewOpenAICompatClient(srv.URL, "", "openai_compat", "res", nil, 0),
 		},
 	}
 

--- a/internal/model/fleet/providers/lmstudio.go
+++ b/internal/model/fleet/providers/lmstudio.go
@@ -25,14 +25,16 @@ type LMStudioClient struct {
 
 // NewLMStudioClient creates a new LM Studio client.
 func NewLMStudioClient(baseURL, apiKey string, logger *slog.Logger) *LMStudioClient {
-	return NewLMStudioClientWithTTL(baseURL, apiKey, logger, 0)
+	return NewLMStudioClientWithTTL(baseURL, apiKey, "", logger, 0)
 }
 
-// NewLMStudioClientWithTTL creates a new LM Studio client with a
-// resource-level idle TTL hint for inference requests.
-func NewLMStudioClientWithTTL(baseURL, apiKey string, logger *slog.Logger, idleTTLSeconds int) *LMStudioClient {
+// NewLMStudioClientWithTTL creates an LM Studio client bound to a named
+// resource, with a resource-level idle TTL hint for inference requests.
+// resource may be empty for ad-hoc clients that no configured endpoint
+// backs; it only names the endpoint in log lines.
+func NewLMStudioClientWithTTL(baseURL, apiKey, resource string, logger *slog.Logger, idleTTLSeconds int) *LMStudioClient {
 	return &LMStudioClient{
-		OpenAICompatClient: NewOpenAICompatClient(baseURL, apiKey, "lmstudio", logger, idleTTLSeconds),
+		OpenAICompatClient: NewOpenAICompatClient(baseURL, apiKey, "lmstudio", resource, logger, idleTTLSeconds),
 	}
 }
 

--- a/internal/model/fleet/providers/lmstudio_test.go
+++ b/internal/model/fleet/providers/lmstudio_test.go
@@ -302,7 +302,7 @@ func TestLMStudioChat_NonStreamingToolCalls(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewLMStudioClientWithTTL(srv.URL, "secret-token", nil, 600)
+	client := NewLMStudioClientWithTTL(srv.URL, "secret-token", "res", nil, 600)
 	resp, err := client.Chat(context.Background(), "qwen3:8b", []llm.Message{{Role: "user", Content: "check the sun"}}, []map[string]any{
 		{"type": "function", "function": map[string]any{"name": "ha_get_state"}},
 	})

--- a/internal/model/fleet/providers/openaicompat.go
+++ b/internal/model/fleet/providers/openaicompat.go
@@ -1,12 +1,10 @@
 package providers
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -14,6 +12,7 @@ import (
 
 	"github.com/nugget/thane-ai-agent/internal/model/llm"
 	"github.com/nugget/thane-ai-agent/internal/platform/httpkit"
+	"github.com/nugget/thane-ai-agent/internal/platform/logging"
 )
 
 // OpenAICompatClient speaks the OpenAI chat-completions protocol to any
@@ -50,16 +49,20 @@ type OpenAICompatClient struct {
 	// disables the guard, which is what the pre-existing behavior was
 	// and what a test wanting to hold a stream open asks for.
 	streamIdleTimeout time.Duration
-	httpClient        *http.Client
-	logger            *slog.Logger
-	watcher           llm.ReadyWatcher
+	// resource names the configured endpoint this client serves. Kept
+	// as a value, not only baked into c.logger, so it can be re-applied
+	// onto the request-scoped logger from context.
+	resource   string
+	httpClient *http.Client
+	logger     *slog.Logger
+	watcher    llm.ReadyWatcher
 }
 
 // NewOpenAICompatClient creates a client for an OpenAI-compatible
 // endpoint. provider is a label for logs (e.g. "vllm", "ollama"); it does
 // not change the wire protocol. Pass idleTTLSeconds only for servers that
 // honor the LM Studio `ttl` extension.
-func NewOpenAICompatClient(baseURL, apiKey, provider string, logger *slog.Logger, idleTTLSeconds int) *OpenAICompatClient {
+func NewOpenAICompatClient(baseURL, apiKey, provider, resource string, logger *slog.Logger, idleTTLSeconds int) *OpenAICompatClient {
 	if baseURL == "" {
 		baseURL = "http://localhost:1234"
 	}
@@ -84,6 +87,7 @@ func NewOpenAICompatClient(baseURL, apiKey, provider string, logger *slog.Logger
 		baseURL:           normalizeOpenAICompatBaseURL(baseURL),
 		apiKey:            strings.TrimSpace(apiKey),
 		provider:          strings.TrimSpace(provider),
+		resource:          strings.TrimSpace(resource),
 		idleTTLSeconds:    idleTTLSeconds,
 		streamIdleTimeout: DefaultStreamIdleTimeout,
 		logger:            logger.With("provider", strings.TrimSpace(provider)),
@@ -186,10 +190,25 @@ func (c *OpenAICompatClient) ChatStream(ctx context.Context, model string, messa
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 	c.setAuth(httpReq)
+	// Claim an identity upstream. A request that dies at the network
+	// layer never receives a server-side id, and that is exactly the
+	// failure worth correlating; a header the caller set is the only
+	// handle that exists on both sides of it.
+	clientRequestID := logging.RequestIDFromContext(ctx)
+	if clientRequestID != "" {
+		httpReq.Header.Set("X-Client-Request-Id", clientRequestID)
+	}
+
+	log := c.callLogger(ctx).With("model", model, "stream", stream)
+	started := time.Now()
 
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
 		cancelReq()
+		log.Error("request failed",
+			"error", err,
+			"elapsed_ms", time.Since(started).Milliseconds(),
+		)
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
 	// Guard both shapes of response. A non-streaming call can stall
@@ -199,9 +218,19 @@ func (c *OpenAICompatClient) ChatStream(ctx context.Context, model string, messa
 	resp.Body = newStreamIdleGuard(resp.Body, cancelReq, c.streamIdleTimeout)
 	defer resp.Body.Close()
 
+	// The header is the better handle when a server sets one: it exists
+	// on error responses too, where there is no completion object to
+	// carry an id.
+	headerRequestID := strings.TrimSpace(resp.Header.Get("x-request-id"))
+
 	if resp.StatusCode != http.StatusOK {
 		errBody := httpkit.ReadErrorBody(resp.Body, 4096)
-		c.logger.Error("API error", "status", resp.StatusCode, "body", errBody)
+		log.Error("API error",
+			"status", resp.StatusCode,
+			"body", errBody,
+			"upstream_request_id", headerRequestID,
+			"elapsed_ms", time.Since(started).Milliseconds(),
+		)
 		return nil, fmt.Errorf("API error %d: %s", resp.StatusCode, errBody)
 	}
 
@@ -215,201 +244,33 @@ func (c *OpenAICompatClient) ChatStream(ctx context.Context, model string, messa
 		if err != nil {
 			return nil, err
 		}
-		c.logger.Debug("response received",
+		if headerRequestID != "" {
+			result.UpstreamRequestID = headerRequestID
+		}
+		log.Debug("response received",
 			"model", result.Model,
 			"input_tokens", result.InputTokens,
 			"output_tokens", result.OutputTokens,
 			"tool_calls", len(result.Message.ToolCalls),
+			"finish_reason", result.StopReason,
+			"upstream_request_id", result.UpstreamRequestID,
+			"total_ms", time.Since(started).Milliseconds(),
 		)
 		c.logger.Log(ctx, llm.LevelTrace, "response content", "content", result.Message.Content)
 		return result, nil
 	}
 
-	return c.handleStreaming(ctx, model, validToolNames, resp.Body, callback)
+	return c.handleStreaming(ctx, model, validToolNames, resp.Body, callback, streamTrace{
+		log:        log,
+		started:    started,
+		upstreamID: headerRequestID,
+	})
 }
 
 func (c *OpenAICompatClient) setAuth(req *http.Request) {
 	if strings.TrimSpace(c.apiKey) != "" {
 		req.Header.Set("Authorization", "Bearer "+c.apiKey)
 	}
-}
-
-func (c *OpenAICompatClient) handleStreaming(ctx context.Context, requestedModel string, validToolNames []string, body io.Reader, callback llm.StreamCallback) (*llm.ChatResponse, error) {
-	scanner := bufio.NewScanner(body)
-	scanner.Buffer(make([]byte, 0, 64*1024), 2*1024*1024)
-
-	var (
-		eventLines     []string
-		contentBuilder strings.Builder
-		model          = requestedModel
-		role           = "assistant"
-		createdAt      time.Time
-		usage          openAICompatUsage
-		toolAcc        = make(map[int]*openAICompatToolAccumulator)
-		done           bool
-		chunks         int
-		finishReason   string
-		upstreamID     string
-	)
-
-	processEvent := func(data string) error {
-		if data == "" {
-			return nil
-		}
-		if data == "[DONE]" {
-			return io.EOF
-		}
-		// An error frame decodes cleanly into openAICompatChatResponse — every
-		// field it carries is unknown to that type — so it would otherwise
-		// pass through as a chunk contributing nothing, turning an upstream
-		// failure into a silently empty completion. Check for it first.
-		if errText := openAICompatStreamErrorText(data); errText != "" {
-			return fmt.Errorf("stream error: %s", errText)
-		}
-
-		var chunk openAICompatChatResponse
-		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
-			return fmt.Errorf("decode stream chunk: %w", err)
-		}
-		chunks++
-		if chunk.Model != "" {
-			model = chunk.Model
-		}
-		if chunk.ID != "" {
-			upstreamID = chunk.ID
-		}
-		if chunk.Created > 0 {
-			createdAt = time.Unix(chunk.Created, 0).UTC()
-		}
-		if chunk.Usage != nil {
-			usage = *chunk.Usage
-		}
-		for _, choice := range chunk.Choices {
-			// The terminating frame carries finish_reason with an empty
-			// delta, so read it before the delta guard skips the choice.
-			// This is the provider's own termination signal — "length",
-			// "tool_calls", "stop", and the pause_turn family — which
-			// the iteration layer records and operators read to tell a
-			// truncated answer from a complete one.
-			if choice.FinishReason != nil && strings.TrimSpace(*choice.FinishReason) != "" {
-				finishReason = strings.TrimSpace(*choice.FinishReason)
-			}
-			if choice.Delta == nil {
-				continue
-			}
-			if choice.Delta.Role != "" {
-				role = choice.Delta.Role
-			}
-			if choice.Delta.Content != "" {
-				contentBuilder.WriteString(choice.Delta.Content)
-				callback(llm.StreamEvent{Kind: llm.KindToken, Token: choice.Delta.Content})
-			}
-			for _, tc := range choice.Delta.ToolCalls {
-				acc := toolAcc[tc.Index]
-				if acc == nil {
-					acc = &openAICompatToolAccumulator{}
-					toolAcc[tc.Index] = acc
-				}
-				if tc.ID != "" {
-					acc.ID = tc.ID
-				}
-				if tc.Function.Name != "" {
-					acc.Name = tc.Function.Name
-				}
-				if tc.Function.Arguments != "" {
-					acc.Args.WriteString(tc.Function.Arguments)
-				}
-			}
-		}
-		return nil
-	}
-
-	for scanner.Scan() {
-		line := scanner.Text()
-		switch {
-		case line == "":
-			if len(eventLines) == 0 {
-				continue
-			}
-			err := processEvent(strings.Join(eventLines, "\n"))
-			eventLines = eventLines[:0]
-			if err == io.EOF {
-				done = true
-				break
-			}
-			if err != nil {
-				return nil, err
-			}
-		case strings.HasPrefix(line, "data:"):
-			eventLines = append(eventLines, strings.TrimSpace(strings.TrimPrefix(line, "data:")))
-		}
-		if done {
-			break
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("read stream: %w", err)
-	}
-	if len(eventLines) > 0 {
-		if err := processEvent(strings.Join(eventLines, "\n")); err != nil && err != io.EOF {
-			return nil, err
-		}
-	}
-
-	toolCalls, err := decodeOpenAICompatToolCalls(toolAcc)
-	if err != nil {
-		return nil, err
-	}
-
-	// Frame count is not evidence of a completion. A role-only opening
-	// frame or a usage-only trailer both increment it, so a stream that
-	// carried nothing but scaffolding and then closed cleanly would pass
-	// a chunks>0 check and return Done:true with no content, no tool
-	// calls, and zero tokens — the fabricated success this client exists
-	// to refuse. Judge the same thing the non-streaming path judges:
-	// whether an assistant actually said or did anything.
-	if strings.TrimSpace(contentBuilder.String()) == "" && len(toolCalls) == 0 {
-		return nil, fmt.Errorf("%s returned an empty stream for model %q (frames=%d)", c.provider, requestedModel, chunks)
-	}
-
-	// Content alone does not mean the answer finished. A proxy or runner
-	// that dies mid-generation closes the connection cleanly, so the
-	// scanner sees an ordinary EOF and everything received so far looks
-	// like a completion — a truncated answer presented as a whole one,
-	// which is the same lie as a fabricated success wearing better
-	// clothes. Require the server to have said it was done: either the
-	// [DONE] sentinel or a finish_reason on some choice. Servers vary in
-	// which they send, so either suffices; neither is silence.
-	if !done && finishReason == "" {
-		return nil, fmt.Errorf("%s ended the stream for model %q without a terminal marker after %d frames (truncated response)", c.provider, requestedModel, chunks)
-	}
-
-	result := &llm.ChatResponse{
-		Model:             model,
-		CreatedAt:         createdAt,
-		Done:              true,
-		StopReason:        finishReason,
-		UpstreamRequestID: upstreamID,
-		InputTokens:       usage.PromptTokens,
-		OutputTokens:      usage.CompletionTokens,
-		TotalDuration:     0,
-	}
-	result.Message.Role = normalizeOpenAICompatMessageRole(role)
-	result.Message.Content = contentBuilder.String()
-	result.Message.ToolCalls = toolCalls
-	if err := applyTextToolFallback(result, validToolNames); err != nil {
-		return nil, err
-	}
-
-	c.logger.Debug("stream complete",
-		"model", result.Model,
-		"input_tokens", result.InputTokens,
-		"output_tokens", result.OutputTokens,
-		"content_len", len(result.Message.Content),
-		"tool_calls", len(result.Message.ToolCalls),
-	)
-	c.logger.Log(ctx, llm.LevelTrace, "stream final content", "content", result.Message.Content)
-	return result, nil
 }
 
 func (c *OpenAICompatClient) chatResponseFromWire(wire *openAICompatChatResponse, validToolNames []string) (*llm.ChatResponse, error) {
@@ -474,4 +335,22 @@ func (c *OpenAICompatClient) SetStreamIdleTimeout(d time.Duration) {
 		return
 	}
 	c.streamIdleTimeout = d
+}
+
+// callLogger returns the logger for one request, preferring the
+// request-scoped logger the caller put on the context so provider lines
+// carry request_id, conversation_id, and session_id and can be grepped
+// as one cycle. The client's own identity is re-applied on top, because
+// the caller's logger knows the request and this client knows which
+// endpoint is answering it — a line needs both to be worth reading.
+func (c *OpenAICompatClient) callLogger(ctx context.Context) *slog.Logger {
+	log := logging.Logger(ctx)
+	if log == nil {
+		log = c.logger
+	}
+	log = log.With("provider", c.provider)
+	if c.resource != "" {
+		log = log.With("resource", c.resource)
+	}
+	return log
 }

--- a/internal/model/fleet/providers/openaicompat.go
+++ b/internal/model/fleet/providers/openaicompat.go
@@ -169,20 +169,30 @@ func (c *OpenAICompatClient) ChatStream(ctx context.Context, model string, messa
 		return nil, fmt.Errorf("marshal request: %w", err)
 	}
 
-	c.logger.Debug("preparing request",
-		"model", model,
+	// Built before the first line this call writes, so every one of them
+	// carries the same identity — the request and the endpoint together.
+	// A logger created after the early lines leaves them orphaned from
+	// the turn that produced them, which is the gap this change exists
+	// to close.
+	log := c.callLogger(ctx).With("model", model, "stream", stream)
+	started := time.Now()
+
+	log.Debug("preparing request",
 		"messages", len(messages),
 		"tools", len(tools),
-		"stream", stream,
 		"idle_ttl_seconds", c.idleTTLSeconds,
+		"max_tokens", req.MaxTokens,
 	)
-	c.logger.Log(ctx, llm.LevelTrace, "request payload", "json", string(jsonData))
+	log.Log(ctx, llm.LevelTrace, "request payload", "json", string(jsonData))
 
 	// The request context must be cancellable before the request is
 	// built: the idle guard unblocks a stalled read by cancelling this
 	// request, and cancelling any later-derived context would leave the
-	// read exactly where it was.
-	reqCtx, cancelReq := context.WithCancel(ctx)
+	// read exactly where it was. The call logger rides along on it, so
+	// the retry transport — which only ever sees the request — logs with
+	// the same attributes rather than falling back to whatever handler
+	// it was constructed with.
+	reqCtx, cancelReq := context.WithCancel(logging.WithLogger(ctx, log))
 	httpReq, err := http.NewRequestWithContext(reqCtx, "POST", c.baseURL+"/v1/chat/completions", bytes.NewReader(jsonData))
 	if err != nil {
 		cancelReq()
@@ -194,13 +204,9 @@ func (c *OpenAICompatClient) ChatStream(ctx context.Context, model string, messa
 	// layer never receives a server-side id, and that is exactly the
 	// failure worth correlating; a header the caller set is the only
 	// handle that exists on both sides of it.
-	clientRequestID := logging.RequestIDFromContext(ctx)
-	if clientRequestID != "" {
+	if clientRequestID := logging.RequestIDFromContext(ctx); clientRequestID != "" {
 		httpReq.Header.Set("X-Client-Request-Id", clientRequestID)
 	}
-
-	log := c.callLogger(ctx).With("model", model, "stream", stream)
-	started := time.Now()
 
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
@@ -256,7 +262,7 @@ func (c *OpenAICompatClient) ChatStream(ctx context.Context, model string, messa
 			"upstream_request_id", result.UpstreamRequestID,
 			"total_ms", time.Since(started).Milliseconds(),
 		)
-		c.logger.Log(ctx, llm.LevelTrace, "response content", "content", result.Message.Content)
+		log.Log(ctx, llm.LevelTrace, "response content", "content", result.Message.Content)
 		return result, nil
 	}
 

--- a/internal/model/fleet/providers/openaicompat_stream.go
+++ b/internal/model/fleet/providers/openaicompat_stream.go
@@ -1,0 +1,236 @@
+package providers
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/model/llm"
+)
+
+// This file owns reading one OpenAI-compatible SSE stream: turning a
+// sequence of frames into a completion, and refusing to turn a sequence
+// of frames into a completion that never happened. The request that
+// produced the stream is assembled in openaicompat.go.
+
+// streamTrace carries what the caller already knows about a request
+// into the streaming reader, so the completion line can report the whole
+// call rather than only the part the reader witnessed.
+type streamTrace struct {
+	log        *slog.Logger
+	started    time.Time
+	upstreamID string
+}
+
+func (c *OpenAICompatClient) handleStreaming(ctx context.Context, requestedModel string, validToolNames []string, body io.Reader, callback llm.StreamCallback, trace streamTrace) (*llm.ChatResponse, error) {
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 2*1024*1024)
+
+	var (
+		eventLines     []string
+		contentBuilder strings.Builder
+		model          = requestedModel
+		role           = "assistant"
+		createdAt      time.Time
+		usage          openAICompatUsage
+		toolAcc        = make(map[int]*openAICompatToolAccumulator)
+		done           bool
+		chunks         int
+		finishReason   string
+		upstreamID     string
+		firstToken     time.Time
+	)
+
+	processEvent := func(data string) error {
+		if data == "" {
+			return nil
+		}
+		if data == "[DONE]" {
+			return io.EOF
+		}
+		// An error frame decodes cleanly into openAICompatChatResponse — every
+		// field it carries is unknown to that type — so it would otherwise
+		// pass through as a chunk contributing nothing, turning an upstream
+		// failure into a silently empty completion. Check for it first.
+		if errText := openAICompatStreamErrorText(data); errText != "" {
+			return fmt.Errorf("stream error: %s", errText)
+		}
+
+		var chunk openAICompatChatResponse
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			return fmt.Errorf("decode stream chunk: %w", err)
+		}
+		chunks++
+		if chunk.Model != "" {
+			model = chunk.Model
+		}
+		if chunk.ID != "" {
+			upstreamID = chunk.ID
+		}
+		if chunk.Created > 0 {
+			createdAt = time.Unix(chunk.Created, 0).UTC()
+		}
+		if chunk.Usage != nil {
+			usage = *chunk.Usage
+		}
+		for _, choice := range chunk.Choices {
+			// The terminating frame carries finish_reason with an empty
+			// delta, so read it before the delta guard skips the choice.
+			// This is the provider's own termination signal — "length",
+			// "tool_calls", "stop", and the pause_turn family — which
+			// the iteration layer records and operators read to tell a
+			// truncated answer from a complete one.
+			if choice.FinishReason != nil && strings.TrimSpace(*choice.FinishReason) != "" {
+				finishReason = strings.TrimSpace(*choice.FinishReason)
+			}
+			if choice.Delta == nil {
+				continue
+			}
+			if choice.Delta.Role != "" {
+				role = choice.Delta.Role
+			}
+			if choice.Delta.Content != "" {
+				// First content, not first frame: the role-only opener
+				// says the server accepted the request, while this says
+				// it started answering. The gap between the request and
+				// this instant is prefill plus queueing — which is the
+				// measurement that separates a runner that is slow from
+				// one that is merely busy, and the one nothing recorded
+				// when the fleet's throughput was last in question.
+				if firstToken.IsZero() {
+					firstToken = time.Now()
+				}
+				contentBuilder.WriteString(choice.Delta.Content)
+				callback(llm.StreamEvent{Kind: llm.KindToken, Token: choice.Delta.Content})
+			}
+			for _, tc := range choice.Delta.ToolCalls {
+				acc := toolAcc[tc.Index]
+				if acc == nil {
+					acc = &openAICompatToolAccumulator{}
+					toolAcc[tc.Index] = acc
+				}
+				if tc.ID != "" {
+					acc.ID = tc.ID
+				}
+				if tc.Function.Name != "" {
+					acc.Name = tc.Function.Name
+				}
+				if tc.Function.Arguments != "" {
+					acc.Args.WriteString(tc.Function.Arguments)
+				}
+			}
+		}
+		return nil
+	}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case line == "":
+			if len(eventLines) == 0 {
+				continue
+			}
+			err := processEvent(strings.Join(eventLines, "\n"))
+			eventLines = eventLines[:0]
+			if err == io.EOF {
+				done = true
+				break
+			}
+			if err != nil {
+				return nil, err
+			}
+		case strings.HasPrefix(line, "data:"):
+			eventLines = append(eventLines, strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+		}
+		if done {
+			break
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read stream: %w", err)
+	}
+	if len(eventLines) > 0 {
+		if err := processEvent(strings.Join(eventLines, "\n")); err != nil && err != io.EOF {
+			return nil, err
+		}
+	}
+
+	toolCalls, err := decodeOpenAICompatToolCalls(toolAcc)
+	if err != nil {
+		return nil, err
+	}
+
+	// Frame count is not evidence of a completion. A role-only opening
+	// frame or a usage-only trailer both increment it, so a stream that
+	// carried nothing but scaffolding and then closed cleanly would pass
+	// a chunks>0 check and return Done:true with no content, no tool
+	// calls, and zero tokens — the fabricated success this client exists
+	// to refuse. Judge the same thing the non-streaming path judges:
+	// whether an assistant actually said or did anything.
+	if strings.TrimSpace(contentBuilder.String()) == "" && len(toolCalls) == 0 {
+		return nil, fmt.Errorf("%s returned an empty stream for model %q (frames=%d)", c.provider, requestedModel, chunks)
+	}
+
+	// Content alone does not mean the answer finished. A proxy or runner
+	// that dies mid-generation closes the connection cleanly, so the
+	// scanner sees an ordinary EOF and everything received so far looks
+	// like a completion — a truncated answer presented as a whole one,
+	// which is the same lie as a fabricated success wearing better
+	// clothes. Require the server to have said it was done: either the
+	// [DONE] sentinel or a finish_reason on some choice. Servers vary in
+	// which they send, so either suffices; neither is silence.
+	if !done && finishReason == "" {
+		return nil, fmt.Errorf("%s ended the stream for model %q without a terminal marker after %d frames (truncated response)", c.provider, requestedModel, chunks)
+	}
+
+	result := &llm.ChatResponse{
+		Model:             model,
+		CreatedAt:         createdAt,
+		Done:              true,
+		StopReason:        finishReason,
+		UpstreamRequestID: upstreamID,
+		InputTokens:       usage.PromptTokens,
+		OutputTokens:      usage.CompletionTokens,
+		TotalDuration:     0,
+	}
+	if trace.upstreamID != "" {
+		result.UpstreamRequestID = trace.upstreamID
+	}
+	result.Message.Role = normalizeOpenAICompatMessageRole(role)
+	result.Message.Content = contentBuilder.String()
+	result.Message.ToolCalls = toolCalls
+	if err := applyTextToolFallback(result, validToolNames); err != nil {
+		return nil, err
+	}
+
+	attrs := []any{
+		"model", result.Model,
+		"input_tokens", result.InputTokens,
+		"output_tokens", result.OutputTokens,
+		"content_len", len(result.Message.Content),
+		"tool_calls", len(result.Message.ToolCalls),
+		"finish_reason", result.StopReason,
+		"upstream_request_id", result.UpstreamRequestID,
+		"total_ms", time.Since(trace.started).Milliseconds(),
+	}
+	// Reported separately, and only when content actually arrived: a
+	// turn that produced nothing but tool calls has no first token, and
+	// a zero would read as an instant one. Time-to-first-token is what
+	// distinguishes a queued request from a slow generation — the two
+	// look identical in total duration, and only one of them is fixed by
+	// a faster model.
+	if !firstToken.IsZero() {
+		attrs = append(attrs,
+			"first_token_ms", firstToken.Sub(trace.started).Milliseconds(),
+			"generation_ms", time.Since(firstToken).Milliseconds(),
+		)
+	}
+	trace.log.Debug("stream complete", attrs...)
+	trace.log.Log(ctx, llm.LevelTrace, "stream final content", "content", result.Message.Content)
+	return result, nil
+}

--- a/internal/model/fleet/providers/openaicompat_test.go
+++ b/internal/model/fleet/providers/openaicompat_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/model/llm"
+	"github.com/nugget/thane-ai-agent/internal/platform/logging"
 )
 
 // TestOpenAICompatStreamErrorIsNotSuccess pins the defect that motivated
@@ -43,7 +44,7 @@ func TestOpenAICompatStreamErrorIsNotSuccess(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			c := NewOpenAICompatClient(srv.URL, "", "test", nil, 0)
+			c := NewOpenAICompatClient(srv.URL, "", "test", "res", nil, 0)
 			resp, err := c.ChatStream(context.Background(), "m", []llm.Message{{Role: "user", Content: "hi"}}, nil, func(llm.StreamEvent) {})
 			if err == nil {
 				t.Fatalf("ChatStream returned success on an error frame: %#v", resp)
@@ -72,7 +73,7 @@ func TestOpenAICompatRequestsUsageAndOmitsTTL(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewOpenAICompatClient(srv.URL, "", "test", nil, 0)
+	c := NewOpenAICompatClient(srv.URL, "", "test", "res", nil, 0)
 	if _, err := c.ChatStream(context.Background(), "m", []llm.Message{{Role: "user", Content: "hi"}}, nil, func(llm.StreamEvent) {}); err != nil {
 		t.Fatalf("ChatStream: %v", err)
 	}
@@ -167,7 +168,7 @@ func TestOpenAICompatEmptyStreamIsNotSuccess(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			c := NewOpenAICompatClient(srv.URL, "", "test", nil, 0)
+			c := NewOpenAICompatClient(srv.URL, "", "test", "res", nil, 0)
 			resp, err := c.ChatStream(context.Background(), "m", []llm.Message{{Role: "user", Content: "hi"}}, nil, func(llm.StreamEvent) {})
 			if tt.wantOK {
 				if err != nil {
@@ -198,7 +199,7 @@ func TestOpenAICompatCapturesFinishReason(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewOpenAICompatClient(srv.URL, "", "test", nil, 0)
+	c := NewOpenAICompatClient(srv.URL, "", "test", "res", nil, 0)
 	resp, err := c.ChatStream(context.Background(), "m", []llm.Message{{Role: "user", Content: "hi"}}, nil, func(llm.StreamEvent) {})
 	if err != nil {
 		t.Fatalf("ChatStream: %v", err)
@@ -232,7 +233,7 @@ func TestOpenAICompatParallelToolCallsNonStreaming(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewOpenAICompatClient(srv.URL, "", "test", nil, 0)
+	c := NewOpenAICompatClient(srv.URL, "", "test", "res", nil, 0)
 	resp, err := c.Chat(context.Background(), "m", []llm.Message{{Role: "user", Content: "hi"}}, nil)
 	if err != nil {
 		t.Fatalf("Chat: %v", err)
@@ -294,7 +295,7 @@ func TestOpenAICompatTruncatedStreamIsNotSuccess(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			c := NewOpenAICompatClient(srv.URL, "", "test", nil, 0)
+			c := NewOpenAICompatClient(srv.URL, "", "test", "res", nil, 0)
 			resp, err := c.ChatStream(context.Background(), "m", []llm.Message{{Role: "user", Content: "hi"}}, nil, func(llm.StreamEvent) {})
 			if tt.wantOK {
 				if err != nil {
@@ -388,7 +389,7 @@ func TestOpenAICompatSendsRemainingBudget(t *testing.T) {
 			defer srv.Close()
 
 			ctx := llm.WithMaxOutputTokens(context.Background(), tt.budget)
-			c := NewOpenAICompatClient(srv.URL, "", "test", nil, 0)
+			c := NewOpenAICompatClient(srv.URL, "", "test", "res", nil, 0)
 			if _, err := c.Chat(ctx, "m", []llm.Message{{Role: "user", Content: "hi"}}, nil); err != nil {
 				t.Fatalf("Chat: %v", err)
 			}
@@ -430,7 +431,7 @@ func TestOpenAICompatStreamIdleTimeout(t *testing.T) {
 	defer srv.Close()
 	defer close(release)
 
-	c := NewOpenAICompatClient(srv.URL, "", "test", nil, 0)
+	c := NewOpenAICompatClient(srv.URL, "", "test", "res", nil, 0)
 	c.SetStreamIdleTimeout(150 * time.Millisecond)
 
 	done := make(chan error, 1)
@@ -472,7 +473,7 @@ func TestOpenAICompatStreamIdleAllowsSlowGeneration(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewOpenAICompatClient(srv.URL, "", "test", nil, 0)
+	c := NewOpenAICompatClient(srv.URL, "", "test", "res", nil, 0)
 	c.SetStreamIdleTimeout(150 * time.Millisecond)
 
 	resp, err := c.ChatStream(context.Background(), "m", []llm.Message{{Role: "user", Content: "hi"}}, nil, func(llm.StreamEvent) {})
@@ -481,5 +482,65 @@ func TestOpenAICompatStreamIdleAllowsSlowGeneration(t *testing.T) {
 	}
 	if resp.Message.Content != "toktoktoktoktoktok" {
 		t.Errorf("content = %q, want all six tokens", resp.Message.Content)
+	}
+}
+
+// TestOpenAICompatRequestTraceability pins what a provider call now says
+// about itself. The measurements that drove the spark analysis — how
+// long a call took, and how much of that was spent before the first
+// token — had to be reconstructed from event JSONL because none of it
+// was logged at the provider. The identifiers matter for the same
+// reason: a failure at the network layer has no response body to carry
+// a server-side id, so the only handle that exists on both sides is the
+// one the client claimed on the way out.
+func TestOpenAICompatRequestTraceability(t *testing.T) {
+	t.Parallel()
+
+	var gotClientID string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotClientID = r.Header.Get("X-Client-Request-Id")
+		w.Header().Set("x-request-id", "srv-req-42")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-body-id","model":"m","choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`))
+	}))
+	defer srv.Close()
+
+	ctx := logging.WithRequestID(context.Background(), "r_abc123")
+	c := NewOpenAICompatClient(srv.URL, "", "test", "res", nil, 0)
+	resp, err := c.Chat(ctx, "m", []llm.Message{{Role: "user", Content: "hi"}}, nil)
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	if gotClientID != "r_abc123" {
+		t.Errorf("X-Client-Request-Id = %q, want the caller's request id", gotClientID)
+	}
+	// The header wins over the completion body's id: it is present on
+	// error responses too, where there is no completion object at all.
+	if resp.UpstreamRequestID != "srv-req-42" {
+		t.Errorf("UpstreamRequestID = %q, want the x-request-id header", resp.UpstreamRequestID)
+	}
+}
+
+// TestOpenAICompatOmitsClientRequestIDWhenUnset pins that an absent id
+// stays absent. A fabricated identifier matching nothing on either side
+// is worse than no header — it invites correlation that cannot succeed.
+func TestOpenAICompatOmitsClientRequestIDWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	var present bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, present = r.Header["X-Client-Request-Id"]
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"model":"m","choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`))
+	}))
+	defer srv.Close()
+
+	c := NewOpenAICompatClient(srv.URL, "", "test", "res", nil, 0)
+	if _, err := c.Chat(context.Background(), "m", []llm.Message{{Role: "user", Content: "hi"}}, nil); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if present {
+		t.Error("X-Client-Request-Id sent without a request id in context")
 	}
 }

--- a/internal/model/fleet/providers/openaicompat_test.go
+++ b/internal/model/fleet/providers/openaicompat_test.go
@@ -1,8 +1,10 @@
 package providers
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -542,5 +544,81 @@ func TestOpenAICompatOmitsClientRequestIDWhenUnset(t *testing.T) {
 	}
 	if present {
 		t.Error("X-Client-Request-Id sent without a request id in context")
+	}
+}
+
+// TestOpenAICompatStreamLatencyMetrics pins the measurement this change
+// exists for. Total duration cannot separate a runner that is slow from
+// one that is busy — they look identical — so the completion line
+// reports first-token separately from generation. It also pins the
+// absence: a tool-call-only stream never produced a first token, and
+// emitting a zero there would read as an instant one.
+func TestOpenAICompatStreamLatencyMetrics(t *testing.T) {
+	t.Parallel()
+
+	contentFrames := []string{
+		`{"choices":[{"delta":{"role":"assistant"}}]}`,
+		`{"choices":[{"delta":{"content":"hello"}}]}`,
+		`{"choices":[{"delta":{},"finish_reason":"stop"}]}`,
+		"[DONE]",
+	}
+	toolFrames := []string{
+		`{"choices":[{"delta":{"role":"assistant"}}]}`,
+		`{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"ha_get_state","arguments":"{}"}}]}}]}`,
+		`{"choices":[{"delta":{},"finish_reason":"tool_calls"}]}`,
+		"[DONE]",
+	}
+
+	tests := []struct {
+		name          string
+		frames        []string
+		wantFirstToke bool
+	}{
+		{name: "content stream reports first token", frames: contentFrames, wantFirstToke: true},
+		{name: "tool-only stream has no first token", frames: toolFrames},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				f, _ := w.(http.Flusher)
+				for _, fr := range tt.frames {
+					_, _ = w.Write([]byte("data: " + fr + "\n\n"))
+					if f != nil {
+						f.Flush()
+					}
+				}
+			}))
+			defer srv.Close()
+
+			buf := &bytes.Buffer{}
+			logger := slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			ctx := logging.WithLogger(context.Background(), logger)
+
+			c := NewOpenAICompatClient(srv.URL, "", "test", "res", nil, 0)
+			if _, err := c.ChatStream(ctx, "m", []llm.Message{{Role: "user", Content: "hi"}}, nil, func(llm.StreamEvent) {}); err != nil {
+				t.Fatalf("ChatStream: %v", err)
+			}
+
+			out := buf.String()
+			if !strings.Contains(out, `"msg":"stream complete"`) {
+				t.Fatalf("no completion line logged\n%s", out)
+			}
+			// The request-scoped logger must reach provider lines, or
+			// they cannot be grepped alongside the turn that caused them.
+			for _, want := range []string{`"total_ms"`, `"provider":"test"`, `"resource":"res"`, `"model":"m"`} {
+				if !strings.Contains(out, want) {
+					t.Errorf("completion line missing %s\n%s", want, out)
+				}
+			}
+			hasFirst := strings.Contains(out, `"first_token_ms"`)
+			hasGen := strings.Contains(out, `"generation_ms"`)
+			if hasFirst != tt.wantFirstToke || hasGen != tt.wantFirstToke {
+				t.Errorf("first_token_ms=%t generation_ms=%t, want both %t\n%s", hasFirst, hasGen, tt.wantFirstToke, out)
+			}
+		})
 	}
 }

--- a/internal/model/fleet/runtime_test.go
+++ b/internal/model/fleet/runtime_test.go
@@ -223,7 +223,7 @@ func TestRuntime_SetLogger_RebindsAllProviderClients(t *testing.T) {
 			"deepslate": modelproviders.NewLMStudioClient("http://127.0.0.1:1234", "", bootLogger.With("resource", "deepslate")),
 		},
 		OpenAICompatClients: map[string]*modelproviders.OpenAICompatClient{
-			"spark": modelproviders.NewOpenAICompatClient("http://127.0.0.1:8000", "", "openai_compat", bootLogger.With("resource", "spark"), 0),
+			"spark": modelproviders.NewOpenAICompatClient("http://127.0.0.1:8000", "", "openai_compat", "res", bootLogger.With("resource", "spark"), 0),
 		},
 		AnthropicClient: modelproviders.NewAnthropicClient("k", bootLogger),
 	}

--- a/internal/platform/httpkit/httpkit.go
+++ b/internal/platform/httpkit/httpkit.go
@@ -464,7 +464,11 @@ func ReadErrorBody(rc io.ReadCloser, limit int64) string {
 // told about either.
 func (t *retryTransport) requestLogger(req *http.Request) *slog.Logger {
 	if req != nil {
-		if log := logging.Logger(req.Context()); log != nil {
+		// LoggerFrom, not Logger: the latter substitutes slog.Default
+		// when the context carries nothing, which would route every
+		// plain-context request away from the handler and attributes
+		// this transport was configured with.
+		if log, ok := logging.LoggerFrom(req.Context()); ok {
 			return log
 		}
 	}

--- a/internal/platform/httpkit/httpkit.go
+++ b/internal/platform/httpkit/httpkit.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/platform/buildinfo"
+	"github.com/nugget/thane-ai-agent/internal/platform/logging"
 )
 
 // Default timeouts and connection pool limits for the shared transport.
@@ -332,7 +333,7 @@ func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 			}
 		}
 
-		if t.logger != nil {
+		if log := t.requestLogger(req); log != nil {
 			attrs := []any{
 				"method", req.Method,
 				"url", req.URL.String(),
@@ -342,10 +343,10 @@ func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 			}
 			if statusRetry {
 				attrs = append(attrs, "status", resp.StatusCode)
-				t.logger.Debug("retrying request after transient HTTP status", attrs...)
+				log.Debug("retrying request after transient HTTP status", attrs...)
 			} else {
 				attrs = append(attrs, "error", err)
-				t.logger.Debug("retrying request after transient error", attrs...)
+				log.Debug("retrying request after transient error", attrs...)
 			}
 		}
 
@@ -449,4 +450,23 @@ func ReadErrorBody(rc io.ReadCloser, limit int64) string {
 		return fmt.Sprintf("(failed to read error body: %v)", err)
 	}
 	return string(body)
+}
+
+// requestLogger prefers the request-scoped logger the caller attached to
+// the context, falling back to the logger this transport was built with.
+//
+// Retries are among the log lines most worth correlating and were the
+// hardest to: the transport captured a logger once at construction, so
+// it kept writing to the bootstrap handler after the process swapped to
+// its real one, and its lines carried no request_id because it had never
+// seen the request. Reading the context gets both the current handler
+// and the caller's trace fields, without the transport needing to be
+// told about either.
+func (t *retryTransport) requestLogger(req *http.Request) *slog.Logger {
+	if req != nil {
+		if log := logging.Logger(req.Context()); log != nil {
+			return log
+		}
+	}
+	return t.logger
 }

--- a/internal/platform/logging/context.go
+++ b/internal/platform/logging/context.go
@@ -65,10 +65,31 @@ func WithLogger(ctx context.Context, logger *slog.Logger) context.Context {
 // logger is present (or nil was stored), it returns [slog.Default]
 // as a safe fallback so callers never need nil checks.
 func Logger(ctx context.Context) *slog.Logger {
-	if l, ok := ctx.Value(contextKey{}).(*slog.Logger); ok && l != nil {
+	if l, ok := LoggerFrom(ctx); ok {
 		return l
 	}
 	return slog.Default()
+}
+
+// LoggerFrom returns the logger stored by [WithLogger] and whether one
+// was actually there.
+//
+// [Logger] answers "give me something I can log to", which is what
+// almost every caller wants. This answers "did the caller attach one",
+// which is a different question and the only one a component holding its
+// own configured logger can act on: without the distinction it cannot
+// tell a request carrying trace fields from a bare context, and
+// preferring slog.Default over its own handler silently discards the
+// configuration it was built with.
+func LoggerFrom(ctx context.Context) (*slog.Logger, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+	l, ok := ctx.Value(contextKey{}).(*slog.Logger)
+	if !ok || l == nil {
+		return nil, false
+	}
+	return l, true
 }
 
 // requestIDKey carries the agent's request identifier.

--- a/internal/platform/logging/context.go
+++ b/internal/platform/logging/context.go
@@ -34,6 +34,7 @@ package logging
 import (
 	"context"
 	"log/slog"
+	"strings"
 )
 
 // contextKey is an unexported type to avoid collisions with other
@@ -68,4 +69,32 @@ func Logger(ctx context.Context) *slog.Logger {
 		return l
 	}
 	return slog.Default()
+}
+
+// requestIDKey carries the agent's request identifier.
+type requestIDKey struct{}
+
+// WithRequestID stores the identifier for the current request→response
+// cycle so code far from the entry point can name it.
+//
+// The context logger already carries request_id as an attribute, which
+// is enough to correlate log lines but not to put the identifier
+// anywhere else — an slog.Logger will not give its attributes back. A
+// provider that wants to send the id upstream as a client request
+// header, so a failure can be matched against the server's own logs,
+// needs the value rather than a logger that happens to mention it.
+func WithRequestID(ctx context.Context, id string) context.Context {
+	if strings.TrimSpace(id) == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, requestIDKey{}, id)
+}
+
+// RequestIDFromContext returns the current request identifier, or "" when
+// the caller set none. Callers should treat the empty string as "do not
+// claim an identity" rather than inventing one: a fabricated id that
+// matches nothing on either side is worse than an absent header.
+func RequestIDFromContext(ctx context.Context) string {
+	id, _ := ctx.Value(requestIDKey{}).(string)
+	return id
 }

--- a/internal/platform/logging/context_test.go
+++ b/internal/platform/logging/context_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"log/slog"
 	"testing"
 )
@@ -77,5 +78,33 @@ func TestWithLogger_FieldsPropagated(t *testing.T) {
 		if got != want {
 			t.Errorf("key %q = %q, want %q", key, got, want)
 		}
+	}
+}
+
+// TestLoggerFromDistinguishesAbsence pins the difference Logger cannot
+// express. A component holding its own configured logger has to know
+// whether the caller attached one; without that it cannot tell a request
+// carrying trace fields from a bare context, and substituting
+// slog.Default silently discards the handler it was built with.
+func TestLoggerFromDistinguishesAbsence(t *testing.T) {
+	t.Parallel()
+
+	if _, ok := LoggerFrom(context.Background()); ok {
+		t.Error("LoggerFrom reported a logger on a bare context")
+	}
+	if got := Logger(context.Background()); got == nil {
+		t.Error("Logger returned nil instead of a usable default")
+	}
+
+	attached := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	ctx := WithLogger(context.Background(), attached)
+	got, ok := LoggerFrom(ctx)
+	if !ok || got != attached {
+		t.Errorf("LoggerFrom = (%v, %t), want the attached logger", got, ok)
+	}
+
+	// A nil stored logger is an absence, not a logger.
+	if _, ok := LoggerFrom(WithLogger(context.Background(), nil)); ok {
+		t.Error("LoggerFrom reported a nil logger as present")
 	}
 }

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -1557,6 +1557,11 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 		"conversation_id", convID,
 	)
 	ctx = logging.WithLogger(ctx, log)
+	// The id travels as a value as well as a log attribute: providers
+	// send it upstream as a client request header, which is what lets a
+	// network-level failure — the case with no response body to carry a
+	// server id — be matched against the server's own record.
+	ctx = logging.WithRequestID(ctx, requestID)
 	runStarted := time.Now()
 	defer func() {
 		attrs := []any{


### PR DESCRIPTION
Closes the traceability item in #1406.

## The number that would have settled the spark question

The measurements that decided the serving analysis — **42.7s median per call, 9.4 output tok/s** — had to be reconstructed from event JSONL after the fact, because the provider logged almost nothing about the call it had just made. And the one measurement that would have settled it outright was recorded nowhere: **time to first token**.

Total duration cannot distinguish a runner that is *slow* from one that is *busy*. They look identical, and only one of them is fixed by a faster model. A completion line now reports:

```
first_token_ms=8420 generation_ms=34280 total_ms=42700
model=gpt-oss:120b finish_reason=stop
upstream_request_id=... input_tokens=... output_tokens=...
```

First-token is reported **only when content actually arrived** — a turn producing nothing but tool calls has no first token, and a zero there would read as an instant one.

## Identity was equally thin

Provider lines went through the client's own logger, which knows the endpoint and nothing about the request, so they couldn't be grepped alongside the turn that caused them. They now go through the request-scoped logger the agent already builds — `request_id`, `session_id`, `conversation_id` — with the client's endpoint identity re-applied on top. One line needs both halves to be worth reading.

## Claiming an identity instead of hoping for one

The client now sends `X-Client-Request-Id` from the agent's own request id. This matters exactly where the existing handle fails: **a request that dies at the network layer receives no response**, so there is no server-assigned id to correlate against, and the only shared handle is the one the client set on the way out. That is the timeout case — the one worth correlating.

When no request id is in context the header is omitted. An invented identifier matching nothing on either side invites a correlation that cannot succeed.

Coming back, the `x-request-id` **response header now wins over the completion body's id**, because it is present on error responses too, where there is no completion object at all.

Carrying the id needed a home: `logging.WithRequestID` / `RequestIDFromContext`. The context logger has always had it as an *attribute*, which is enough to correlate log lines and useless for anything else — an `slog.Logger` will not give its attributes back.

## The retry transport had the same disease, worse

It captured a logger once at construction, so it kept writing to the **bootstrap handler** long after the process swapped to its real one, and its lines carried no `request_id` because it had never seen the request. It reads the request context now, which gets both the current handler and the caller's trace fields.

## Two guardrails caught this, both correctly

- **`set_mutators`** objected to another setter. It was right: resource identity is known when the client is built, so it belongs in the constructor, not a mutation afterward. `SetResource` is gone.
- **`large_files`** objected to the file's size, so the stream reader moved to `openaicompat_stream.go` — a cleaner seam regardless: one file assembles a request, the other decides whether a sequence of frames amounts to a completion.

Both metrics are back at baseline; neither was bumped.

## Test plan

- [x] `just ci` green, architecture metrics at baseline
- [x] `X-Client-Request-Id` carries the caller's request id
- [x] The header is omitted when no request id is in context
- [x] `x-request-id` response header wins over the completion body's id
- [x] Existing LM Studio and OpenAI-compat suites pass against the reshaped constructor
- [ ] Production: confirm `first_token_ms` separates queueing from generation on spark

That last one is the whole point — with it, the "is spark slow or serialized?" question that motivated #1334's engine evaluation becomes a log query instead of a research project.

Refs #1406. Remaining there: inventory deadlines with parallel probes, and the per-resource capability/dialect policy.