### PR TITLE
One quiet runner should not hold up startup

### DIFF
--- a/internal/model/fleet/inventory.go
+++ b/internal/model/fleet/inventory.go
@@ -73,6 +73,11 @@ func DiscoverInventory(ctx context.Context, cat *Catalog, bundle *ClientBundle) 
 	var wg sync.WaitGroup
 	for i, res := range cat.Resources {
 		wg.Add(1)
+		// i and res are per-iteration variables (go.mod declares go
+		// 1.25; this has held since 1.22), so the closure captures a
+		// distinct pair each time and each goroutine writes a distinct
+		// element of results. Concurrent writes to different elements of
+		// one slice do not race — the header is never touched.
 		go func() {
 			defer wg.Done()
 			probeCtx, cancel := context.WithTimeout(ctx, resourceProbeTimeout)

--- a/internal/model/fleet/inventory.go
+++ b/internal/model/fleet/inventory.go
@@ -2,8 +2,8 @@ package fleet
 
 import (
 	"context"
-	"fmt"
 	"sort"
+	"sync"
 	"time"
 
 	modelproviders "github.com/nugget/thane-ai-agent/internal/model/fleet/providers"
@@ -62,418 +62,173 @@ func DiscoverInventory(ctx context.Context, cat *Catalog, bundle *ClientBundle) 
 		Resources: make([]ResourceInventory, 0, len(cat.Resources)),
 	}
 
-	for _, res := range cat.Resources {
-		ri := ResourceInventory{
-			ResourceID:   res.ID,
-			Provider:     res.Provider,
-			Capabilities: providerCapabilities(res.Provider, res.Capabilities),
-		}
+	// Probe every resource at once, each under its own deadline. Run
+	// sequentially, one unreachable-but-listening runner delayed every
+	// resource behind it and, at boot, the process itself — and the
+	// failure of one endpoint is no reason to learn nothing about the
+	// rest. Results are written by index so the inventory keeps catalog
+	// order regardless of which probe finishes first.
+	results := make([]ResourceInventory, len(cat.Resources))
+	keep := make([]bool, len(cat.Resources))
+	var wg sync.WaitGroup
+	for i, res := range cat.Resources {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			probeCtx, cancel := context.WithTimeout(ctx, resourceProbeTimeout)
+			defer cancel()
+			results[i], keep[i] = probeResource(probeCtx, res, bundle)
+		}()
+	}
+	wg.Wait()
 
-		switch res.Provider {
-		case "ollama":
-			ri.Attempted = true
-			client := bundle.OllamaClients[res.ID]
-			if client == nil {
-				ri.Error = "missing ollama client"
-				inv.Resources = append(inv.Resources, ri)
-				continue
-			}
-			models, err := client.ListModelInfos(ctx)
-			if err != nil {
-				ri.Error = err.Error()
-				inv.Resources = append(inv.Resources, ri)
-				continue
-			}
-			sort.Slice(models, func(i, j int) bool { return models[i].Name < models[j].Name })
-			for _, m := range models {
-				ri.Models = append(ri.Models, DiscoveredModel{
-					SupportsChat:      true,
-					Name:              m.Name,
-					Family:            m.Details.Family,
-					Families:          append([]string(nil), m.Details.Families...),
-					ParameterSize:     m.Details.ParameterSize,
-					Quantization:      m.Details.QuantizationLevel,
-					SupportsTools:     ri.Capabilities.SupportsTools,
-					SupportsStreaming: ri.Capabilities.SupportsStreaming,
-					SupportsImages: modelproviders.SupportsImagesForModel(
-						ri.Provider,
-						m.Name,
-						m.Details.Family,
-						m.Details.Families,
-						ri.Capabilities,
-					),
-				})
-			}
-		case "openai_compat":
-			ri.Attempted = true
-			client := bundle.OpenAICompatClients[res.ID]
-			if client == nil {
-				ri.Error = "missing openai_compat client"
-				inv.Resources = append(inv.Resources, ri)
-				continue
-			}
-			models, err := client.ListModelInfos(ctx)
-			if err != nil {
-				ri.Error = err.Error()
-				inv.Resources = append(inv.Resources, ri)
-				continue
-			}
-			sort.Slice(models, func(i, j int) bool { return models[i].ID < models[j].ID })
-			for _, m := range models {
-				// The OpenAI schema carries only an id, so most of this
-				// is what the server volunteered beyond it. A ceiling of
-				// zero means the server did not report one — the
-				// deployment then keeps its configured window rather
-				// than inheriting a fabricated zero.
-				ceiling := m.ContextCeiling()
-				ri.Models = append(ri.Models, DiscoveredModel{
-					SupportsChat:      modelproviders.SupportsChatForModel(ri.Provider, m.Type, ri.Capabilities),
-					Name:              m.ID,
-					Family:            m.Arch,
-					Quantization:      m.Quantization,
-					SupportsTools:     ri.Capabilities.SupportsTools,
-					SupportsStreaming: ri.Capabilities.SupportsStreaming,
-					SupportsImages: modelproviders.SupportsImagesForModel(
-						ri.Provider, m.ID, m.Arch, nil, ri.Capabilities,
-					),
-					ContextWindow:    ceiling,
-					MaxContextWindow: ceiling,
-				})
-			}
-		case "lmstudio":
-			ri.Attempted = true
-			client := bundle.LMStudioClients[res.ID]
-			if client == nil {
-				ri.Error = "missing lmstudio client"
-				inv.Resources = append(inv.Resources, ri)
-				continue
-			}
-			models, err := client.ListModelInfos(ctx)
-			if err != nil {
-				ri.Error = err.Error()
-				inv.Resources = append(inv.Resources, ri)
-				continue
-			}
-			sort.Slice(models, func(i, j int) bool { return models[i].ID < models[j].ID })
-			for _, m := range models {
-				supportsChat := modelproviders.SupportsChatForModel(ri.Provider, m.Type, ri.Capabilities)
-				contextWindow := m.LoadedContextLength
-				if contextWindow <= 0 {
-					contextWindow = m.MaxContextLength
-				}
-				ri.Models = append(ri.Models, DiscoveredModel{
-					SupportsChat:      supportsChat,
-					Name:              m.ID,
-					ModelType:         m.Type,
-					Publisher:         m.Publisher,
-					CompatibilityType: m.CompatibilityType,
-					State:             m.State,
-					Family:            m.Arch,
-					Quantization:      m.Quantization,
-					SupportsTools:     supportsChat && ri.Capabilities.SupportsTools,
-					TrainedForToolUse: m.TrainedForToolUse,
-					SupportsStreaming: supportsChat && ri.Capabilities.SupportsStreaming,
-					SupportsImages: (m.Vision || modelproviders.SupportsImagesForModel(
-						ri.Provider,
-						m.ID,
-						m.Arch,
-						nil,
-						modelproviders.Capabilities{
-							SupportsImages: supportsChat && ri.Capabilities.SupportsImages,
-						},
-					)) && supportsChat,
-					ContextWindow:       contextWindow,
-					MaxContextWindow:    m.MaxContextLength,
-					LoadedContextWindow: m.LoadedContextLength,
-					LoadedInstanceID:    m.LoadedInstanceID,
-				})
-			}
+	for i := range results {
+		if keep[i] {
+			inv.Resources = append(inv.Resources, results[i])
 		}
-
-		if !ri.Attempted {
-			continue
-		}
-		inv.Resources = append(inv.Resources, ri)
 	}
 
 	return inv
 }
 
-func discoveredModelSupportsChat(provider string, caps modelproviders.Capabilities, model DiscoveredModel) bool {
-	if model.SupportsChat {
-		return true
-	}
-	if model.ModelType != "" {
-		return modelproviders.SupportsChatForModel(provider, model.ModelType, caps)
-	}
-	return caps.SupportsChat
-}
+// resourceProbeTimeout bounds one resource's inventory probe.
+//
+// Discovery is a single cheap request per resource, so a healthy runner
+// answers in well under a second. The bound exists for the unhealthy
+// one: a server that completes its TCP handshake and then goes quiet
+// has nothing else stopping it, and before probes ran concurrently it
+// held up startup and every resource queued behind it. That is the same
+// failure the stream-idle guard closes during generation, reached one
+// loop earlier.
+const resourceProbeTimeout = 15 * time.Second
 
-// MergeInventory overlays discovered provider inventory on top of the
-// immutable config-defined catalog. Config deployments keep their IDs
-// and routing authority; discovered deployments are explicit-use only
-// until a later policy layer promotes them into routing.
-func MergeInventory(base *Catalog, inv *Inventory) (*Catalog, error) {
-	if base == nil {
-		return nil, fmt.Errorf("nil base catalog")
+// probeResource asks one resource what models it has. The bool reports
+// whether the result belongs in the inventory at all — a provider with
+// nothing to discover (anthropic) is not a failure, it is silent.
+func probeResource(ctx context.Context, res Resource, bundle *ClientBundle) (ResourceInventory, bool) {
+	ri := ResourceInventory{
+		ResourceID:   res.ID,
+		Provider:     res.Provider,
+		Capabilities: providerCapabilities(res.Provider, res.Capabilities),
 	}
-	if inv == nil {
-		out := *base
-		out.Resources = append([]Resource(nil), base.Resources...)
-		out.Deployments = cloneDeployments(base.Deployments)
-		if err := out.reindex(base.DefaultModel, base.RecoveryModel); err != nil {
-			return nil, err
+
+	switch res.Provider {
+	case "ollama":
+		ri.Attempted = true
+		client := bundle.OllamaClients[res.ID]
+		if client == nil {
+			ri.Error = "missing ollama client"
+			return ri, true
 		}
-		return &out, nil
-	}
-
-	out := &Catalog{
-		DefaultModel:  base.DefaultModel,
-		RecoveryModel: base.RecoveryModel,
-		LocalFirst:    base.LocalFirst,
-		Resources:     append([]Resource(nil), base.Resources...),
-		Deployments:   cloneDeployments(base.Deployments),
-	}
-
-	existingByResourceModel := make(map[string]bool, len(out.Deployments))
-	existingByID := make(map[string]bool, len(out.Deployments))
-	deploymentIndexByResourceModel := make(map[string]int, len(out.Deployments))
-	for i, dep := range out.Deployments {
-		existingByResourceModel[deploymentKey(dep.ResourceID, dep.ModelName)] = true
-		deploymentIndexByResourceModel[deploymentKey(dep.ResourceID, dep.ModelName)] = i
-		existingByID[dep.ID] = true
-	}
-
-	for _, ri := range inv.Resources {
-		if !ri.Attempted || ri.Error != "" {
-			continue
+		models, err := client.ListModelInfos(ctx)
+		if err != nil {
+			ri.Error = err.Error()
+			return ri, true
 		}
-		if _, ok := base.resourceBy[ri.ResourceID]; !ok {
-			continue
+		sort.Slice(models, func(i, j int) bool { return models[i].Name < models[j].Name })
+		for _, m := range models {
+			ri.Models = append(ri.Models, DiscoveredModel{
+				SupportsChat:      true,
+				Name:              m.Name,
+				Family:            m.Details.Family,
+				Families:          append([]string(nil), m.Details.Families...),
+				ParameterSize:     m.Details.ParameterSize,
+				Quantization:      m.Details.QuantizationLevel,
+				SupportsTools:     ri.Capabilities.SupportsTools,
+				SupportsStreaming: ri.Capabilities.SupportsStreaming,
+				SupportsImages: modelproviders.SupportsImagesForModel(
+					ri.Provider,
+					m.Name,
+					m.Details.Family,
+					m.Details.Families,
+					ri.Capabilities,
+				),
+			})
 		}
-		caps := providerCapabilities(ri.Provider, ri.Capabilities)
-		for _, m := range ri.Models {
-			if !discoveredModelSupportsChat(ri.Provider, caps, m) {
-				continue
+	case "openai_compat":
+		ri.Attempted = true
+		client := bundle.OpenAICompatClients[res.ID]
+		if client == nil {
+			ri.Error = "missing openai_compat client"
+			return ri, true
+		}
+		models, err := client.ListModelInfos(ctx)
+		if err != nil {
+			ri.Error = err.Error()
+			return ri, true
+		}
+		sort.Slice(models, func(i, j int) bool { return models[i].ID < models[j].ID })
+		for _, m := range models {
+			// The OpenAI schema carries only an id, so most of this
+			// is what the server volunteered beyond it. A ceiling of
+			// zero means the server did not report one — the
+			// deployment then keeps its configured window rather
+			// than inheriting a fabricated zero.
+			ceiling := m.ContextCeiling()
+			ri.Models = append(ri.Models, DiscoveredModel{
+				SupportsChat:      modelproviders.SupportsChatForModel(ri.Provider, m.Type, ri.Capabilities),
+				Name:              m.ID,
+				Family:            m.Arch,
+				Quantization:      m.Quantization,
+				SupportsTools:     ri.Capabilities.SupportsTools,
+				SupportsStreaming: ri.Capabilities.SupportsStreaming,
+				SupportsImages: modelproviders.SupportsImagesForModel(
+					ri.Provider, m.ID, m.Arch, nil, ri.Capabilities,
+				),
+				ContextWindow:    ceiling,
+				MaxContextWindow: ceiling,
+			})
+		}
+	case "lmstudio":
+		ri.Attempted = true
+		client := bundle.LMStudioClients[res.ID]
+		if client == nil {
+			ri.Error = "missing lmstudio client"
+			return ri, true
+		}
+		models, err := client.ListModelInfos(ctx)
+		if err != nil {
+			ri.Error = err.Error()
+			return ri, true
+		}
+		sort.Slice(models, func(i, j int) bool { return models[i].ID < models[j].ID })
+		for _, m := range models {
+			supportsChat := modelproviders.SupportsChatForModel(ri.Provider, m.Type, ri.Capabilities)
+			contextWindow := m.LoadedContextLength
+			if contextWindow <= 0 {
+				contextWindow = m.MaxContextLength
 			}
-			key := deploymentKey(ri.ResourceID, m.Name)
-			if idx, ok := deploymentIndexByResourceModel[key]; ok {
-				dep := out.Deployments[idx]
-				mergeDiscoveredDeployment(&dep, m, caps)
-				out.Deployments[idx] = dep
-				continue
-			}
-			id := ri.ResourceID + "/" + m.Name
-			if existingByID[id] {
-				continue
-			}
-			dep := newDiscoveredDeployment(base, ri, m, caps, id)
-			out.Deployments = append(out.Deployments, dep)
-			existingByResourceModel[key] = true
-			deploymentIndexByResourceModel[key] = len(out.Deployments) - 1
-			existingByID[id] = true
+			ri.Models = append(ri.Models, DiscoveredModel{
+				SupportsChat:      supportsChat,
+				Name:              m.ID,
+				ModelType:         m.Type,
+				Publisher:         m.Publisher,
+				CompatibilityType: m.CompatibilityType,
+				State:             m.State,
+				Family:            m.Arch,
+				Quantization:      m.Quantization,
+				SupportsTools:     supportsChat && ri.Capabilities.SupportsTools,
+				TrainedForToolUse: m.TrainedForToolUse,
+				SupportsStreaming: supportsChat && ri.Capabilities.SupportsStreaming,
+				SupportsImages: (m.Vision || modelproviders.SupportsImagesForModel(
+					ri.Provider,
+					m.ID,
+					m.Arch,
+					nil,
+					modelproviders.Capabilities{
+						SupportsImages: supportsChat && ri.Capabilities.SupportsImages,
+					},
+				)) && supportsChat,
+				ContextWindow:       contextWindow,
+				MaxContextWindow:    m.MaxContextLength,
+				LoadedContextWindow: m.LoadedContextLength,
+				LoadedInstanceID:    m.LoadedInstanceID,
+			})
 		}
 	}
 
-	if err := out.reindex(base.DefaultModel, base.RecoveryModel); err != nil {
-		return nil, err
+	if !ri.Attempted {
+		return ri, false
 	}
-	return out, nil
-}
-
-func mergeDiscoveredDeployment(dep *Deployment, model DiscoveredModel, caps modelproviders.Capabilities) {
-	if dep == nil {
-		return
-	}
-	if model.ModelType != "" {
-		dep.ModelType = model.ModelType
-	}
-	if model.Publisher != "" {
-		dep.Publisher = model.Publisher
-	}
-	if model.CompatibilityType != "" {
-		dep.CompatibilityType = model.CompatibilityType
-	}
-	if model.State != "" {
-		dep.RunnerState = model.State
-	}
-	if model.Family != "" {
-		dep.Family = model.Family
-	}
-	if len(model.Families) > 0 {
-		dep.Families = append([]string(nil), model.Families...)
-	}
-	if model.ParameterSize != "" {
-		dep.ParameterSize = model.ParameterSize
-	}
-	if model.Quantization != "" {
-		dep.Quantization = model.Quantization
-	}
-	dep.ObservedSupportsTools = observedBoolCapability(model.SupportsTools, caps.SupportsTools)
-	dep.ObservedSupportsStreaming = observedBoolCapability(model.SupportsStreaming, caps.SupportsStreaming)
-	if model.ContextWindow > 0 {
-		dep.ObservedContextWindow = model.ContextWindow
-	}
-	if model.MaxContextWindow > 0 {
-		dep.MaxContextWindow = model.MaxContextWindow
-	}
-	if model.LoadedContextWindow > 0 {
-		dep.LoadedContextWindow = model.LoadedContextWindow
-	}
-	if model.LoadedInstanceID != "" {
-		dep.LoadedInstanceID = model.LoadedInstanceID
-	}
-	dep.SupportsImages = dep.SupportsImages || model.SupportsImages
-	if model.TrainedForToolUse {
-		dep.TrainedForToolUse = true
-	}
-	applyObservedCapabilities(dep, caps)
-}
-
-func newDiscoveredDeployment(base *Catalog, ri ResourceInventory, model DiscoveredModel, caps modelproviders.Capabilities, id string) Deployment {
-	dep := Deployment{
-		ID:                        id,
-		ModelName:                 model.Name,
-		ModelType:                 model.ModelType,
-		Publisher:                 model.Publisher,
-		Provider:                  ri.Provider,
-		ResourceID:                ri.ResourceID,
-		Server:                    ri.ResourceID,
-		CompatibilityType:         model.CompatibilityType,
-		RunnerState:               model.State,
-		ObservedSupportsTools:     observedBoolCapability(model.SupportsTools, caps.SupportsTools),
-		TrainedForToolUse:         model.TrainedForToolUse,
-		ObservedSupportsStreaming: observedBoolCapability(model.SupportsStreaming, caps.SupportsStreaming),
-		SupportsImages:            model.SupportsImages,
-		ObservedContextWindow:     firstPositiveInt(model.ContextWindow, base.ContextWindowForModel(model.Name, 0)),
-		MaxContextWindow:          model.MaxContextWindow,
-		LoadedContextWindow:       model.LoadedContextWindow,
-		LoadedInstanceID:          model.LoadedInstanceID,
-		Speed:                     5,
-		Quality:                   5,
-		CostTier:                  defaultCostTier(ri.Provider),
-		Source:                    DeploymentSourceDiscovered,
-		Routable:                  false,
-		Family:                    model.Family,
-		Families:                  append([]string(nil), model.Families...),
-		ParameterSize:             model.ParameterSize,
-		Quantization:              model.Quantization,
-	}
-	applyObservedCapabilities(&dep, caps)
-	return dep
-}
-
-func observedBoolCapability(modelValue, providerValue bool) bool {
-	return modelValue || providerValue
-}
-
-func firstPositiveInt(values ...int) int {
-	for _, v := range values {
-		if v > 0 {
-			return v
-		}
-	}
-	return 0
-}
-
-func cloneDeployments(in []Deployment) []Deployment {
-	out := make([]Deployment, len(in))
-	for i, dep := range in {
-		dep.Families = append([]string(nil), dep.Families...)
-		out[i] = dep
-	}
-	return out
-}
-
-func applyResourcePolicies(cat *Catalog, policies map[string]ResourcePolicy) (*Catalog, error) {
-	if cat == nil {
-		return nil, fmt.Errorf("nil model catalog")
-	}
-
-	out := *cat
-	out.Resources = append([]Resource(nil), cat.Resources...)
-	out.Deployments = cloneDeployments(cat.Deployments)
-	for i := range out.Resources {
-		out.Resources[i].PolicyState = DeploymentPolicyStateActive
-		out.Resources[i].PolicySource = DeploymentPolicySourceDefault
-		out.Resources[i].PolicyReason = ""
-		out.Resources[i].PolicyUpdatedAt = time.Time{}
-		if policy, ok := policies[out.Resources[i].ID]; ok {
-			out.Resources[i].PolicyState = policy.State
-			out.Resources[i].PolicySource = DeploymentPolicySourceOverlay
-			out.Resources[i].PolicyReason = policy.Reason
-			out.Resources[i].PolicyUpdatedAt = policy.UpdatedAt
-		}
-	}
-	resourceByID := make(map[string]Resource, len(out.Resources))
-	for _, res := range out.Resources {
-		resourceByID[res.ID] = res
-	}
-	for i := range out.Deployments {
-		out.Deployments[i].ResourcePolicyState = DeploymentPolicyStateActive
-		out.Deployments[i].ResourcePolicySource = DeploymentPolicySourceDefault
-		out.Deployments[i].ResourcePolicyReason = ""
-		out.Deployments[i].ResourcePolicyUpdatedAt = time.Time{}
-		if res, ok := resourceByID[out.Deployments[i].ResourceID]; ok {
-			out.Deployments[i].ResourcePolicyState = res.PolicyState
-			out.Deployments[i].ResourcePolicySource = res.PolicySource
-			out.Deployments[i].ResourcePolicyReason = res.PolicyReason
-			out.Deployments[i].ResourcePolicyUpdatedAt = res.PolicyUpdatedAt
-		}
-	}
-	if err := out.reindex(cat.DefaultModel, cat.RecoveryModel); err != nil {
-		return nil, err
-	}
-	return &out, nil
-}
-
-func applyDeploymentPolicies(cat *Catalog, policies map[string]DeploymentPolicy) (*Catalog, error) {
-	if cat == nil {
-		return nil, fmt.Errorf("nil model catalog")
-	}
-
-	out := *cat
-	out.Resources = append([]Resource(nil), cat.Resources...)
-	out.Deployments = cloneDeployments(cat.Deployments)
-	for i := range out.Deployments {
-		out.Deployments[i].PolicyState = DeploymentPolicyStateActive
-		out.Deployments[i].PolicySource = DeploymentPolicySourceDefault
-		out.Deployments[i].PolicyReason = ""
-		out.Deployments[i].PolicyUpdatedAt = time.Time{}
-		out.Deployments[i].RoutableSource = DeploymentPolicySourceDefault
-		if policy, ok := policies[out.Deployments[i].ID]; ok {
-			if policy.State != "" {
-				out.Deployments[i].PolicyState = policy.State
-			}
-			out.Deployments[i].PolicySource = DeploymentPolicySourceOverlay
-			out.Deployments[i].PolicyReason = policy.Reason
-			out.Deployments[i].PolicyUpdatedAt = policy.UpdatedAt
-			if policy.Routable != nil {
-				out.Deployments[i].Routable = *policy.Routable
-				out.Deployments[i].RoutableSource = DeploymentPolicySourceOverlay
-			}
-		}
-	}
-	if err := out.reindex(cat.DefaultModel, cat.RecoveryModel); err != nil {
-		return nil, err
-	}
-	return &out, nil
-}
-
-func deploymentKey(resourceID, modelName string) string {
-	return resourceID + "\x00" + modelName
-}
-
-func defaultCostTier(provider string) int {
-	switch provider {
-	case "ollama", "lmstudio", "openai_compat":
-		// Self-hosted: no per-token price. An openai_compat resource
-		// pointed at a paid API should set cost_tier explicitly on its
-		// models rather than inherit this.
-		return 0
-	case "anthropic", "openai":
-		return 3
-	default:
-		return 1
-	}
+	return ri, true
 }

--- a/internal/model/fleet/inventory_merge.go
+++ b/internal/model/fleet/inventory_merge.go
@@ -1,0 +1,293 @@
+package fleet
+
+import (
+	"fmt"
+	"time"
+
+	modelproviders "github.com/nugget/thane-ai-agent/internal/model/fleet/providers"
+)
+
+// This file folds what discovery found into the configured catalog.
+// inventory.go owns the probing; everything here decides what a probe
+// result is allowed to change — config deployments keep their IDs and
+// routing authority, and discovered ones stay explicit-use only until a
+// policy layer promotes them.
+
+func discoveredModelSupportsChat(provider string, caps modelproviders.Capabilities, model DiscoveredModel) bool {
+	if model.SupportsChat {
+		return true
+	}
+	if model.ModelType != "" {
+		return modelproviders.SupportsChatForModel(provider, model.ModelType, caps)
+	}
+	return caps.SupportsChat
+}
+
+// MergeInventory overlays discovered provider inventory on top of the
+// immutable config-defined catalog. Config deployments keep their IDs
+// and routing authority; discovered deployments are explicit-use only
+// until a later policy layer promotes them into routing.
+func MergeInventory(base *Catalog, inv *Inventory) (*Catalog, error) {
+	if base == nil {
+		return nil, fmt.Errorf("nil base catalog")
+	}
+	if inv == nil {
+		out := *base
+		out.Resources = append([]Resource(nil), base.Resources...)
+		out.Deployments = cloneDeployments(base.Deployments)
+		if err := out.reindex(base.DefaultModel, base.RecoveryModel); err != nil {
+			return nil, err
+		}
+		return &out, nil
+	}
+
+	out := &Catalog{
+		DefaultModel:  base.DefaultModel,
+		RecoveryModel: base.RecoveryModel,
+		LocalFirst:    base.LocalFirst,
+		Resources:     append([]Resource(nil), base.Resources...),
+		Deployments:   cloneDeployments(base.Deployments),
+	}
+
+	existingByResourceModel := make(map[string]bool, len(out.Deployments))
+	existingByID := make(map[string]bool, len(out.Deployments))
+	deploymentIndexByResourceModel := make(map[string]int, len(out.Deployments))
+	for i, dep := range out.Deployments {
+		existingByResourceModel[deploymentKey(dep.ResourceID, dep.ModelName)] = true
+		deploymentIndexByResourceModel[deploymentKey(dep.ResourceID, dep.ModelName)] = i
+		existingByID[dep.ID] = true
+	}
+
+	for _, ri := range inv.Resources {
+		if !ri.Attempted || ri.Error != "" {
+			continue
+		}
+		if _, ok := base.resourceBy[ri.ResourceID]; !ok {
+			continue
+		}
+		caps := providerCapabilities(ri.Provider, ri.Capabilities)
+		for _, m := range ri.Models {
+			if !discoveredModelSupportsChat(ri.Provider, caps, m) {
+				continue
+			}
+			key := deploymentKey(ri.ResourceID, m.Name)
+			if idx, ok := deploymentIndexByResourceModel[key]; ok {
+				dep := out.Deployments[idx]
+				mergeDiscoveredDeployment(&dep, m, caps)
+				out.Deployments[idx] = dep
+				continue
+			}
+			id := ri.ResourceID + "/" + m.Name
+			if existingByID[id] {
+				continue
+			}
+			dep := newDiscoveredDeployment(base, ri, m, caps, id)
+			out.Deployments = append(out.Deployments, dep)
+			existingByResourceModel[key] = true
+			deploymentIndexByResourceModel[key] = len(out.Deployments) - 1
+			existingByID[id] = true
+		}
+	}
+
+	if err := out.reindex(base.DefaultModel, base.RecoveryModel); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func mergeDiscoveredDeployment(dep *Deployment, model DiscoveredModel, caps modelproviders.Capabilities) {
+	if dep == nil {
+		return
+	}
+	if model.ModelType != "" {
+		dep.ModelType = model.ModelType
+	}
+	if model.Publisher != "" {
+		dep.Publisher = model.Publisher
+	}
+	if model.CompatibilityType != "" {
+		dep.CompatibilityType = model.CompatibilityType
+	}
+	if model.State != "" {
+		dep.RunnerState = model.State
+	}
+	if model.Family != "" {
+		dep.Family = model.Family
+	}
+	if len(model.Families) > 0 {
+		dep.Families = append([]string(nil), model.Families...)
+	}
+	if model.ParameterSize != "" {
+		dep.ParameterSize = model.ParameterSize
+	}
+	if model.Quantization != "" {
+		dep.Quantization = model.Quantization
+	}
+	dep.ObservedSupportsTools = observedBoolCapability(model.SupportsTools, caps.SupportsTools)
+	dep.ObservedSupportsStreaming = observedBoolCapability(model.SupportsStreaming, caps.SupportsStreaming)
+	if model.ContextWindow > 0 {
+		dep.ObservedContextWindow = model.ContextWindow
+	}
+	if model.MaxContextWindow > 0 {
+		dep.MaxContextWindow = model.MaxContextWindow
+	}
+	if model.LoadedContextWindow > 0 {
+		dep.LoadedContextWindow = model.LoadedContextWindow
+	}
+	if model.LoadedInstanceID != "" {
+		dep.LoadedInstanceID = model.LoadedInstanceID
+	}
+	dep.SupportsImages = dep.SupportsImages || model.SupportsImages
+	if model.TrainedForToolUse {
+		dep.TrainedForToolUse = true
+	}
+	applyObservedCapabilities(dep, caps)
+}
+
+func newDiscoveredDeployment(base *Catalog, ri ResourceInventory, model DiscoveredModel, caps modelproviders.Capabilities, id string) Deployment {
+	dep := Deployment{
+		ID:                        id,
+		ModelName:                 model.Name,
+		ModelType:                 model.ModelType,
+		Publisher:                 model.Publisher,
+		Provider:                  ri.Provider,
+		ResourceID:                ri.ResourceID,
+		Server:                    ri.ResourceID,
+		CompatibilityType:         model.CompatibilityType,
+		RunnerState:               model.State,
+		ObservedSupportsTools:     observedBoolCapability(model.SupportsTools, caps.SupportsTools),
+		TrainedForToolUse:         model.TrainedForToolUse,
+		ObservedSupportsStreaming: observedBoolCapability(model.SupportsStreaming, caps.SupportsStreaming),
+		SupportsImages:            model.SupportsImages,
+		ObservedContextWindow:     firstPositiveInt(model.ContextWindow, base.ContextWindowForModel(model.Name, 0)),
+		MaxContextWindow:          model.MaxContextWindow,
+		LoadedContextWindow:       model.LoadedContextWindow,
+		LoadedInstanceID:          model.LoadedInstanceID,
+		Speed:                     5,
+		Quality:                   5,
+		CostTier:                  defaultCostTier(ri.Provider),
+		Source:                    DeploymentSourceDiscovered,
+		Routable:                  false,
+		Family:                    model.Family,
+		Families:                  append([]string(nil), model.Families...),
+		ParameterSize:             model.ParameterSize,
+		Quantization:              model.Quantization,
+	}
+	applyObservedCapabilities(&dep, caps)
+	return dep
+}
+
+func observedBoolCapability(modelValue, providerValue bool) bool {
+	return modelValue || providerValue
+}
+
+func firstPositiveInt(values ...int) int {
+	for _, v := range values {
+		if v > 0 {
+			return v
+		}
+	}
+	return 0
+}
+
+func cloneDeployments(in []Deployment) []Deployment {
+	out := make([]Deployment, len(in))
+	for i, dep := range in {
+		dep.Families = append([]string(nil), dep.Families...)
+		out[i] = dep
+	}
+	return out
+}
+
+func applyResourcePolicies(cat *Catalog, policies map[string]ResourcePolicy) (*Catalog, error) {
+	if cat == nil {
+		return nil, fmt.Errorf("nil model catalog")
+	}
+
+	out := *cat
+	out.Resources = append([]Resource(nil), cat.Resources...)
+	out.Deployments = cloneDeployments(cat.Deployments)
+	for i := range out.Resources {
+		out.Resources[i].PolicyState = DeploymentPolicyStateActive
+		out.Resources[i].PolicySource = DeploymentPolicySourceDefault
+		out.Resources[i].PolicyReason = ""
+		out.Resources[i].PolicyUpdatedAt = time.Time{}
+		if policy, ok := policies[out.Resources[i].ID]; ok {
+			out.Resources[i].PolicyState = policy.State
+			out.Resources[i].PolicySource = DeploymentPolicySourceOverlay
+			out.Resources[i].PolicyReason = policy.Reason
+			out.Resources[i].PolicyUpdatedAt = policy.UpdatedAt
+		}
+	}
+	resourceByID := make(map[string]Resource, len(out.Resources))
+	for _, res := range out.Resources {
+		resourceByID[res.ID] = res
+	}
+	for i := range out.Deployments {
+		out.Deployments[i].ResourcePolicyState = DeploymentPolicyStateActive
+		out.Deployments[i].ResourcePolicySource = DeploymentPolicySourceDefault
+		out.Deployments[i].ResourcePolicyReason = ""
+		out.Deployments[i].ResourcePolicyUpdatedAt = time.Time{}
+		if res, ok := resourceByID[out.Deployments[i].ResourceID]; ok {
+			out.Deployments[i].ResourcePolicyState = res.PolicyState
+			out.Deployments[i].ResourcePolicySource = res.PolicySource
+			out.Deployments[i].ResourcePolicyReason = res.PolicyReason
+			out.Deployments[i].ResourcePolicyUpdatedAt = res.PolicyUpdatedAt
+		}
+	}
+	if err := out.reindex(cat.DefaultModel, cat.RecoveryModel); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func applyDeploymentPolicies(cat *Catalog, policies map[string]DeploymentPolicy) (*Catalog, error) {
+	if cat == nil {
+		return nil, fmt.Errorf("nil model catalog")
+	}
+
+	out := *cat
+	out.Resources = append([]Resource(nil), cat.Resources...)
+	out.Deployments = cloneDeployments(cat.Deployments)
+	for i := range out.Deployments {
+		out.Deployments[i].PolicyState = DeploymentPolicyStateActive
+		out.Deployments[i].PolicySource = DeploymentPolicySourceDefault
+		out.Deployments[i].PolicyReason = ""
+		out.Deployments[i].PolicyUpdatedAt = time.Time{}
+		out.Deployments[i].RoutableSource = DeploymentPolicySourceDefault
+		if policy, ok := policies[out.Deployments[i].ID]; ok {
+			if policy.State != "" {
+				out.Deployments[i].PolicyState = policy.State
+			}
+			out.Deployments[i].PolicySource = DeploymentPolicySourceOverlay
+			out.Deployments[i].PolicyReason = policy.Reason
+			out.Deployments[i].PolicyUpdatedAt = policy.UpdatedAt
+			if policy.Routable != nil {
+				out.Deployments[i].Routable = *policy.Routable
+				out.Deployments[i].RoutableSource = DeploymentPolicySourceOverlay
+			}
+		}
+	}
+	if err := out.reindex(cat.DefaultModel, cat.RecoveryModel); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func deploymentKey(resourceID, modelName string) string {
+	return resourceID + "\x00" + modelName
+}
+
+func defaultCostTier(provider string) int {
+	switch provider {
+	case "ollama", "lmstudio", "openai_compat":
+		// Self-hosted: no per-token price. An openai_compat resource
+		// pointed at a paid API should set cost_tier explicitly on its
+		// models rather than inherit this.
+		return 0
+	case "anthropic", "openai":
+		return 3
+	default:
+		return 1
+	}
+}

--- a/internal/model/fleet/inventory_test.go
+++ b/internal/model/fleet/inventory_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	modelproviders "github.com/nugget/thane-ai-agent/internal/model/fleet/providers"
 )
@@ -183,5 +184,71 @@ func TestDiscoverInventory_OpenAICompat(t *testing.T) {
 	}
 	if !byName["gpt-oss:120b"].SupportsStreaming {
 		t.Error("discovered model should inherit streaming support from the provider capabilities")
+	}
+}
+
+// TestDiscoverInventory_SlowResourceDoesNotStarveOthers pins the two
+// properties that make discovery survivable at boot: one unreachable
+// resource is bounded rather than unbounded, and it does not delay the
+// resources behind it. Sequential probing gave a runner that completes
+// its handshake and then goes quiet the power to hold up startup
+// entirely — the failure the stream-idle guard closes during
+// generation, one loop earlier.
+func TestDiscoverInventory_SlowResourceDoesNotStarveOthers(t *testing.T) {
+	t.Parallel()
+
+	// Defer order matters: httptest.Close waits for in-flight handlers,
+	// so the handler must be released before the server is closed. LIFO
+	// means close(release) has to be deferred last.
+	release := make(chan struct{})
+	stalled := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		<-release
+	}))
+	defer stalled.Close()
+	defer close(release)
+
+	healthy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"live-model"}]}`))
+	}))
+	defer healthy.Close()
+
+	cat := &Catalog{Resources: []Resource{
+		{ID: "stalled", Provider: "openai_compat", URL: stalled.URL},
+		{ID: "healthy", Provider: "openai_compat", URL: healthy.URL},
+	}}
+	bundle := &ClientBundle{OpenAICompatClients: map[string]*modelproviders.OpenAICompatClient{
+		"stalled": modelproviders.NewOpenAICompatClient(stalled.URL, "", "openai_compat", "stalled", nil, 0),
+		"healthy": modelproviders.NewOpenAICompatClient(healthy.URL, "", "openai_compat", "healthy", nil, 0),
+	}}
+
+	// A deadline well under resourceProbeTimeout stands in for it, so the
+	// test asserts the bound without waiting for the production one.
+	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
+	defer cancel()
+
+	done := make(chan *Inventory, 1)
+	go func() { done <- DiscoverInventory(ctx, cat, bundle) }()
+
+	var inv *Inventory
+	select {
+	case inv = <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("discovery never returned — a stalled resource blocked the pass")
+	}
+
+	if len(inv.Resources) != 2 {
+		t.Fatalf("resources = %d, want both probed", len(inv.Resources))
+	}
+	// Catalog order is preserved regardless of completion order.
+	if inv.Resources[0].ResourceID != "stalled" || inv.Resources[1].ResourceID != "healthy" {
+		t.Errorf("resource order = %q, %q; want catalog order", inv.Resources[0].ResourceID, inv.Resources[1].ResourceID)
+	}
+	if inv.Resources[0].Error == "" {
+		t.Error("stalled resource reported no error")
+	}
+	// The healthy resource is not punished for its neighbor.
+	if len(inv.Resources[1].Models) != 1 || inv.Resources[1].Models[0].Name != "live-model" {
+		t.Errorf("healthy resource models = %#v, want the one it serves", inv.Resources[1].Models)
 	}
 }

--- a/internal/model/fleet/inventory_test.go
+++ b/internal/model/fleet/inventory_test.go
@@ -224,7 +224,11 @@ func TestDiscoverInventory_SlowResourceDoesNotStarveOthers(t *testing.T) {
 
 	// A deadline well under resourceProbeTimeout stands in for it, so the
 	// test asserts the bound without waiting for the production one.
-	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
+	// Generous enough that a loaded CI box cannot cancel the healthy
+	// probe by accident: what is under test is that the stall is
+	// bounded and does not starve its neighbor, not how quickly a
+	// local httptest server answers.
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
 	done := make(chan *Inventory, 1)


### PR DESCRIPTION
Refs #1406. The inventory half of that issue's "nothing bounds silence" item.

## The gap

`DiscoverInventory` probed resources **one at a time with no per-resource deadline**. A server that completes its TCP handshake and then goes quiet had nothing stopping it:

- **at boot**, it stalls the process
- **on refresh**, it stalls every resource queued behind it

So the fleet learns nothing about endpoints that were answering perfectly well. This is the same failure the stream-idle guard closes during generation, reached one loop earlier — and with more to lose, because at boot there is no fleet yet to route around the gap. It is also the 2026-07-30 incident in #1334 one layer down: sound machinery below, nothing bounding it above.

## The change

Probes run concurrently, each under its own `resourceProbeTimeout` (15s — a healthy runner answers a `/v1/models` in well under a second; the bound exists for the unhealthy one).

Results are written **by index** rather than appended, so the inventory keeps catalog order however the probes interleave. Order is part of the contract for anything reading the list, and making it depend on which runner answered first would trade one nondeterminism for another.

Extracting `probeResource` is what made concurrency possible at all: the old loop body appended to the shared inventory from inside its provider branches, so the work could not leave the goroutine that owned the slice. It now returns its result plus a flag for whether the resource belongs in the inventory — a provider with nothing to discover (anthropic) is not a failure, it is silent.

## The size guardrail had a point

It fired after the extraction, and it was right that the file was doing two jobs. Discovery stays in `inventory.go`; the merge half — deciding what a probe result may change about the configured catalog — moves to `inventory_merge.go`. Metrics back at baseline, no bump.

## Test plan

- [x] `just ci` green, architecture metrics at baseline
- [x] `go test -race` clean on the concurrent path
- [x] A stalled resource is bounded rather than unbounded
- [x] A healthy resource beside it is probed and returned regardless
- [x] Catalog order is preserved independent of completion order
- [x] Existing discovery tests (ollama, lmstudio, openai_compat, unsupported providers) unchanged

## A note for the next test author here

`httptest.Close` waits for in-flight handlers, so a deliberately stalled handler must be released **before** the server is closed. Defers run LIFO, which means the release has to be deferred *last*. I got it backwards first and it deadlocked the test rather than failing it — worth the comment I left in the test.

## Remaining in #1406

Per-resource capability/dialect policy: the capability table is keyed by *provider*, and `openai_compat` is not a provider — it is the absence of one, so every server that declines to be special shares a single row. Not urgent while spark is the only candidate; load-bearing the moment a second generic endpoint joins with different capabilities.