### PR TITLE
feat: add production model evaluation snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,11 @@ talents/my-*
 
 # Built dev-tool binary (cmd/prewarm-replay)
 /prewarm-replay
+/model-eval
+
+# Production-derived model-evaluation artifacts are private runtime data.
+*.thane-eval.json
+*.thane-eval-report.json
 
 # Runtime state written by a local `thane serve` or `thane init` run in
 # the repo root. These are workspace artifacts, not source: the archive

--- a/cmd/model-eval/doc.go
+++ b/cmd/model-eval/doc.go
@@ -1,0 +1,4 @@
+// Command model-eval captures private production-derived model-call snapshots
+// and replays them against OpenAI-compatible model deployments without
+// executing tools.
+package main

--- a/cmd/model-eval/files.go
+++ b/cmd/model-eval/files.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
+)
+
+func defaultEvalDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "Thane/evals"
+	}
+	return filepath.Join(home, "Thane", "evals")
+}
+
+func openLogsReadOnly(path string) (*sql.DB, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve logs database: %w", err)
+	}
+	if _, err := os.Stat(abs); err != nil {
+		return nil, fmt.Errorf("logs database unavailable at %s: %w", abs, err)
+	}
+	dsnURL := url.URL{Scheme: "file", Path: abs}
+	query := dsnURL.Query()
+	query.Set("mode", "ro")
+	query.Set("_pragma", "busy_timeout(5000)")
+	dsnURL.RawQuery = query.Encode()
+	dsn := dsnURL.String()
+	db, err := sql.Open(database.DriverName, dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open logs database: %w", err)
+	}
+	db.SetMaxOpenConns(1)
+	if err := db.Ping(); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("read logs database: %w", err)
+	}
+	return db, nil
+}
+
+func writePrivateJSON(path string, value any, overwrite bool) error {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("resolve output path: %w", err)
+	}
+	inside, root, err := insideGitWorktree(abs)
+	if err != nil {
+		return err
+	}
+	if inside {
+		return fmt.Errorf("refusing to write production-derived data inside Git worktree %s; choose a private path such as %s", root, defaultEvalDir())
+	}
+	if err := os.MkdirAll(filepath.Dir(abs), 0o700); err != nil {
+		return fmt.Errorf("create private output directory: %w", err)
+	}
+	flags := os.O_WRONLY | os.O_CREATE
+	if overwrite {
+		flags |= os.O_TRUNC
+	} else {
+		flags |= os.O_EXCL
+	}
+	file, err := os.OpenFile(abs, flags, 0o600)
+	if err != nil {
+		return fmt.Errorf("create private output %s: %w", abs, err)
+	}
+	if err := file.Chmod(0o600); err != nil {
+		file.Close()
+		return fmt.Errorf("secure private output %s: %w", abs, err)
+	}
+	encoder := json.NewEncoder(file)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	encodeErr := encoder.Encode(value)
+	closeErr := file.Close()
+	if encodeErr != nil {
+		return fmt.Errorf("encode private output: %w", encodeErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close private output: %w", closeErr)
+	}
+	return nil
+}
+
+func insideGitWorktree(path string) (bool, string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return false, "", fmt.Errorf("resolve working directory: %w", err)
+	}
+	root := cwd
+	for {
+		if _, err := os.Stat(filepath.Join(root, ".git")); err == nil {
+			break
+		} else if !os.IsNotExist(err) {
+			return false, "", fmt.Errorf("inspect Git worktree: %w", err)
+		}
+		parent := filepath.Dir(root)
+		if parent == root {
+			return false, "", nil
+		}
+		root = parent
+	}
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return false, "", fmt.Errorf("resolve Git worktree root: %w", err)
+	}
+	rel, err := filepath.Rel(absRoot, path)
+	if err != nil {
+		return false, "", fmt.Errorf("compare output with Git worktree: %w", err)
+	}
+	inside := rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+	return inside, absRoot, nil
+}
+
+type stringList []string
+
+func (s *stringList) String() string { return strings.Join(*s, ",") }
+
+func (s *stringList) Set(value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fmt.Errorf("value must not be empty")
+	}
+	*s = append(*s, value)
+	return nil
+}

--- a/cmd/model-eval/main.go
+++ b/cmd/model-eval/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, "model-eval:", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string) error {
+	if len(args) == 0 {
+		printUsage()
+		return fmt.Errorf("a subcommand is required")
+	}
+	switch args[0] {
+	case "snapshot":
+		return cmdSnapshot(args[1:])
+	case "run":
+		return cmdRun(args[1:])
+	case "help", "-h", "--help":
+		printUsage()
+		return nil
+	default:
+		return fmt.Errorf("unknown subcommand %q (try snapshot or run)", args[0])
+	}
+}
+
+func printUsage() {
+	fmt.Fprintln(os.Stderr, `model-eval — replay production model decisions without executing tools.
+
+USAGE
+    model-eval snapshot [flags]
+    model-eval run [flags]
+
+SUBCOMMANDS
+    snapshot   export recent retained model calls to a private 0600 artifact
+    run        replay a snapshot against one OpenAI-compatible model
+
+Snapshots contain production prompts, messages, and tool results. They are
+written outside Git worktrees by default and must be treated as sensitive.`)
+}

--- a/cmd/model-eval/main_test.go
+++ b/cmd/model-eval/main_test.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/model/llm"
+	"github.com/nugget/thane-ai-agent/internal/model/modeleval"
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
+	"github.com/nugget/thane-ai-agent/internal/platform/logging"
+)
+
+func TestSnapshotAndReplayWorkflow(t *testing.T) {
+	t.Parallel()
+
+	privateDir := t.TempDir()
+	logsPath := filepath.Join(privateDir, "logs.db")
+	seedRetainedModelCall(t, logsPath)
+
+	snapshotPath := filepath.Join(privateDir, "production.thane-eval.json")
+	if err := cmdSnapshot([]string{
+		"-logs-db", logsPath,
+		"-output", snapshotPath,
+		"-request-id", "r_eval_workflow",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	assertPrivateFile(t, snapshotPath)
+
+	snapshot, err := loadSnapshot(snapshotPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot.Cases) != 1 || snapshot.Cases[0].Expected.ToolCalls[0].Function.Name != "search" {
+		t.Fatalf("snapshot cases = %#v", snapshot.Cases)
+	}
+
+	requestBodies := make(chan map[string]any, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		requestBodies <- body
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"chatcmpl_eval",
+			"model":"candidate",
+			"choices":[{"message":{"role":"assistant","content":"","tool_calls":[{
+				"id":"candidate_call","type":"function","function":{"name":"search","arguments":"{\"query\":\"weather\"}"}
+			}]},"finish_reason":"tool_calls"}],
+			"usage":{"prompt_tokens":50,"completion_tokens":8}
+		}`)
+	}))
+	defer server.Close()
+
+	reportPath := filepath.Join(privateDir, "candidate.thane-eval-report.json")
+	if err := cmdRun([]string{
+		"-snapshot", snapshotPath,
+		"-base-url", server.URL,
+		"-model", "candidate",
+		"-stream=false",
+		"-tool-contract=exact",
+		"-output", reportPath,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	assertPrivateFile(t, reportPath)
+
+	body := <-requestBodies
+	if body["model"] != "candidate" {
+		t.Fatalf("request model = %#v", body["model"])
+	}
+	tools, ok := body["tools"].([]any)
+	if !ok || len(tools) != 1 {
+		t.Fatalf("request tools = %#v", body["tools"])
+	}
+
+	file, err := os.Open(reportPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	var report evalReport
+	if err := json.NewDecoder(file).Decode(&report); err != nil {
+		t.Fatal(err)
+	}
+	if report.Summary.ReferenceMatches != 1 || report.Summary.Errors != 0 {
+		t.Fatalf("report summary = %#v", report.Summary)
+	}
+}
+
+func seedRetainedModelCall(t *testing.T, path string) {
+	t.Helper()
+	db, err := database.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := logging.Migrate(db); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	writer, err := logging.NewContentWriter(db, 64<<10, logger)
+	if err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+
+	messages := []llm.Message{
+		{Role: "system", Content: "You are a tool-using assistant."},
+		{Role: "user", Content: "Check the weather."},
+	}
+	tools := []map[string]any{{
+		"type": "function",
+		"function": map[string]any{
+			"name":        "search",
+			"description": "Search for current information.",
+			"parameters": map[string]any{
+				"type":       "object",
+				"properties": map[string]any{"query": map[string]any{"type": "string"}},
+				"required":   []string{"query"},
+			},
+		},
+	}}
+	call := logging.NewModelCallContent(0, "reference", messages, tools)
+	call.Complete(&llm.ChatResponse{
+		Model:      "reference",
+		Message:    llm.Message{Role: "assistant", ToolCalls: []llm.ToolCall{newToolCall("reference_call", "search", map[string]any{"query": "weather"})}},
+		StopReason: "tool_calls",
+	})
+	writer.WriteRequest(context.Background(), logging.RequestContent{
+		RequestID:    "r_eval_workflow",
+		SystemPrompt: messages[0].Content,
+		Model:        "reference",
+		Messages:     messages,
+		ModelCalls:   []logging.ModelCallContent{call},
+	})
+	if err := writer.Close(); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func newToolCall(id, name string, arguments map[string]any) llm.ToolCall {
+	call := llm.ToolCall{ID: id}
+	call.Function.Name = name
+	call.Function.Arguments = arguments
+	return call
+}
+
+func assertPrivateFile(t *testing.T, path string) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("permissions = %o, want 600", got)
+	}
+}
+
+func TestLoadSnapshotRejectsTrailingJSON(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "bad.thane-eval.json")
+	snapshot := modeleval.Snapshot{
+		SchemaVersion: modeleval.SnapshotSchemaVersion,
+		Cases: []modeleval.Case{{
+			ID:       "r/0",
+			Messages: []llm.Message{{Role: "user", Content: "hi"}},
+		}},
+	}
+	data, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, append(data, []byte(` {}`)...), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadSnapshot(path); err == nil {
+		t.Fatal("snapshot with trailing JSON passed validation")
+	}
+}
+
+func TestWritePrivateJSONSecuresOverwrittenFile(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "report.thane-eval-report.json")
+	if err := os.WriteFile(path, []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := writePrivateJSON(path, map[string]any{"private": true}, true); err != nil {
+		t.Fatal(err)
+	}
+	assertPrivateFile(t, path)
+}

--- a/cmd/model-eval/run.go
+++ b/cmd/model-eval/run.go
@@ -1,0 +1,283 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/model/fleet/providers"
+	"github.com/nugget/thane-ai-agent/internal/model/llm"
+	"github.com/nugget/thane-ai-agent/internal/model/modeleval"
+)
+
+type evalReport struct {
+	SchemaVersion          int              `json:"schema_version"`
+	CreatedAt              string           `json:"created_at"`
+	ContainsProductionData bool             `json:"contains_production_data"`
+	Notice                 string           `json:"notice"`
+	SnapshotPath           string           `json:"snapshot_path"`
+	Target                 evalTarget       `json:"target"`
+	Summary                evalSummary      `json:"summary"`
+	Cases                  []evalCaseResult `json:"cases"`
+}
+
+type evalTarget struct {
+	BaseURL            string `json:"base_url"`
+	Model              string `json:"model"`
+	Provider           string `json:"provider,omitempty"`
+	Family             string `json:"family,omitempty"`
+	TrainedForToolUse  bool   `json:"trained_for_tool_use"`
+	ToolContractMode   string `json:"tool_contract_mode"`
+	InteractionProfile string `json:"interaction_profile"`
+	Streaming          bool   `json:"streaming"`
+	MaxOutputTokens    int    `json:"max_output_tokens"`
+}
+
+type evalSummary struct {
+	Cases               int   `json:"cases"`
+	Responses           int   `json:"responses"`
+	Errors              int   `json:"errors"`
+	DecisionMatches     int   `json:"decision_matches"`
+	ToolNameMatches     int   `json:"tool_name_matches"`
+	ToolArgumentMatches int   `json:"tool_argument_matches"`
+	ReferenceMatches    int   `json:"reference_matches"`
+	PromptAdaptedCases  int   `json:"prompt_adapted_cases"`
+	TotalDurationMS     int64 `json:"total_duration_ms"`
+}
+
+type evalCaseResult struct {
+	CaseID         string          `json:"case_id"`
+	ReferenceModel string          `json:"reference_model"`
+	CandidateModel string          `json:"candidate_model,omitempty"`
+	PromptAdapted  bool            `json:"prompt_adapted"`
+	Score          modeleval.Score `json:"score"`
+	Expected       llm.Message     `json:"expected"`
+	Actual         llm.Message     `json:"actual"`
+	StopReason     string          `json:"stop_reason,omitempty"`
+	InputTokens    int             `json:"input_tokens,omitempty"`
+	OutputTokens   int             `json:"output_tokens,omitempty"`
+	DurationMS     int64           `json:"duration_ms"`
+	Error          string          `json:"error,omitempty"`
+}
+
+func cmdRun(args []string) error {
+	fs := flag.NewFlagSet("run", flag.ContinueOnError)
+	snapshotPath := fs.String("snapshot", "", "private snapshot to replay (required)")
+	baseURL := fs.String("base-url", "", "OpenAI-compatible server base URL (required)")
+	model := fs.String("model", "", "model identifier sent to the server (required)")
+	output := fs.String("output", "", "private report path (default: beside snapshot)")
+	apiKeyEnv := fs.String("api-key-env", "", "environment variable containing the optional API key")
+	provider := fs.String("provider", "openai_compat", "provider/family hint for prompt adaptation")
+	family := fs.String("family", "", "model-family hint for prompt adaptation")
+	trainedForToolUse := fs.Bool("trained-for-tool-use", true, "declare native provider tool-call training")
+	contractMode := fs.String("tool-contract", "auto", "tool contract: auto | exact | native | raw-text")
+	streaming := fs.Bool("stream", true, "exercise the streaming parser path")
+	caseTimeout := fs.Duration("case-timeout", 10*time.Minute, "deadline for each replay case")
+	maxOutputTokens := fs.Int("max-output-tokens", 1024, "per-case output ceiling")
+	limit := fs.Int("limit", 0, "optional maximum number of cases (0 = all)")
+	overwrite := fs.Bool("overwrite", false, "replace an existing private report")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if strings.TrimSpace(*snapshotPath) == "" || strings.TrimSpace(*baseURL) == "" || strings.TrimSpace(*model) == "" {
+		return fmt.Errorf("run requires -snapshot, -base-url, and -model")
+	}
+	if *caseTimeout <= 0 {
+		return fmt.Errorf("case-timeout must be positive")
+	}
+	if *maxOutputTokens <= 0 {
+		return fmt.Errorf("max-output-tokens must be positive")
+	}
+	if *limit < 0 {
+		return fmt.Errorf("limit must not be negative")
+	}
+
+	snapshot, err := loadSnapshot(*snapshotPath)
+	if err != nil {
+		return err
+	}
+	if *limit > 0 && *limit < len(snapshot.Cases) {
+		snapshot.Cases = snapshot.Cases[:*limit]
+	}
+	profile, err := interactionProfile(*contractMode, llm.ModelProfileInput{
+		Provider:          *provider,
+		Model:             *model,
+		Family:            *family,
+		TrainedForToolUse: *trainedForToolUse,
+	})
+	if err != nil {
+		return err
+	}
+
+	apiKey := ""
+	if *apiKeyEnv != "" {
+		apiKey = os.Getenv(*apiKeyEnv)
+		if apiKey == "" {
+			return fmt.Errorf("API key environment variable %q is empty", *apiKeyEnv)
+		}
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	client := providers.NewOpenAICompatClient(*baseURL, apiKey, *provider, "model-eval", logger, 0)
+
+	report := evalReport{
+		SchemaVersion:          1,
+		CreatedAt:              time.Now().UTC().Format(time.RFC3339Nano),
+		ContainsProductionData: true,
+		Notice:                 productionDataNotice,
+		SnapshotPath:           *snapshotPath,
+		Target: evalTarget{
+			BaseURL:            *baseURL,
+			Model:              *model,
+			Provider:           *provider,
+			Family:             *family,
+			TrainedForToolUse:  *trainedForToolUse,
+			ToolContractMode:   *contractMode,
+			InteractionProfile: profile.Name,
+			Streaming:          *streaming,
+			MaxOutputTokens:    *maxOutputTokens,
+		},
+		Cases: make([]evalCaseResult, 0, len(snapshot.Cases)),
+	}
+
+	for _, case_ := range snapshot.Cases {
+		messages := case_.Messages
+		adapted := false
+		if *contractMode != "exact" {
+			messages, adapted = modeleval.ApplyToolCallingProfile(case_.Messages, case_.PromptSections, profile)
+		}
+		result := evalCaseResult{
+			CaseID:         case_.ID,
+			ReferenceModel: case_.ReferenceModel,
+			PromptAdapted:  adapted,
+			Expected:       case_.Expected,
+		}
+		started := time.Now()
+		ctx, cancel := context.WithTimeout(context.Background(), *caseTimeout)
+		ctx = llm.WithMaxOutputTokens(ctx, *maxOutputTokens)
+		var response *llm.ChatResponse
+		if *streaming {
+			response, err = client.ChatStream(ctx, *model, messages, case_.Tools, func(llm.StreamEvent) {})
+		} else {
+			response, err = client.Chat(ctx, *model, messages, case_.Tools)
+		}
+		cancel()
+		result.DurationMS = time.Since(started).Milliseconds()
+		if err != nil {
+			result.Error = err.Error()
+			report.Summary.Errors++
+		} else {
+			result.CandidateModel = response.Model
+			result.Actual = response.Message
+			result.StopReason = response.StopReason
+			result.InputTokens = response.InputTokens
+			result.OutputTokens = response.OutputTokens
+			result.Score = modeleval.Evaluate(case_.Expected, response.Message)
+			report.Summary.Responses++
+			if result.Score.DecisionMatch {
+				report.Summary.DecisionMatches++
+			}
+			if result.Score.ToolNamesMatch {
+				report.Summary.ToolNameMatches++
+			}
+			if result.Score.ToolArgumentsMatch {
+				report.Summary.ToolArgumentMatches++
+			}
+			if result.Score.ReferenceMatch {
+				report.Summary.ReferenceMatches++
+			}
+		}
+		if adapted {
+			report.Summary.PromptAdaptedCases++
+		}
+		report.Summary.TotalDurationMS += result.DurationMS
+		report.Cases = append(report.Cases, result)
+	}
+	report.Summary.Cases = len(report.Cases)
+
+	if *output == "" {
+		base := strings.TrimSuffix(filepath.Base(*snapshotPath), filepath.Ext(*snapshotPath))
+		*output = filepath.Join(filepath.Dir(*snapshotPath), base+"-"+safeFilename(*model)+".thane-eval-report.json")
+	}
+	if err := writePrivateJSON(*output, report, *overwrite); err != nil {
+		return err
+	}
+	absOutput, _ := filepath.Abs(*output)
+	fmt.Fprintf(os.Stderr, "Replayed %d cases against %s: responses=%d errors=%d decision_match=%d reference_match=%d report=%s\n",
+		report.Summary.Cases, *model, report.Summary.Responses, report.Summary.Errors,
+		report.Summary.DecisionMatches, report.Summary.ReferenceMatches, absOutput)
+	return nil
+}
+
+func loadSnapshot(path string) (modeleval.Snapshot, error) {
+	const maxSnapshotSize = 512 << 20
+
+	file, err := os.Open(path)
+	if err != nil {
+		return modeleval.Snapshot{}, fmt.Errorf("open snapshot: %w", err)
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return modeleval.Snapshot{}, fmt.Errorf("stat snapshot: %w", err)
+	}
+	if info.Size() > maxSnapshotSize {
+		return modeleval.Snapshot{}, fmt.Errorf("snapshot is %d bytes; maximum is %d", info.Size(), maxSnapshotSize)
+	}
+	var snapshot modeleval.Snapshot
+	decoder := json.NewDecoder(io.LimitReader(file, maxSnapshotSize))
+	if err := decoder.Decode(&snapshot); err != nil {
+		return modeleval.Snapshot{}, fmt.Errorf("decode snapshot: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return modeleval.Snapshot{}, fmt.Errorf("decode snapshot: unexpected trailing JSON value")
+		}
+		return modeleval.Snapshot{}, fmt.Errorf("decode snapshot trailing data: %w", err)
+	}
+	if err := snapshot.Validate(); err != nil {
+		return modeleval.Snapshot{}, err
+	}
+	return snapshot, nil
+}
+
+func interactionProfile(mode string, input llm.ModelProfileInput) (llm.ModelInteractionProfile, error) {
+	switch mode {
+	case "auto":
+		return llm.ProfileForModel(input), nil
+	case "exact":
+		return llm.DefaultModelInteractionProfile(), nil
+	case "native":
+		return llm.DefaultModelInteractionProfile(), nil
+	case "raw-text":
+		profile := llm.DefaultModelInteractionProfile()
+		profile.Name = "forced_raw_text_tools"
+		profile.ToolCallStyle = llm.ToolCallStyleRawTextJSON
+		return profile, nil
+	default:
+		return llm.ModelInteractionProfile{}, fmt.Errorf("tool-contract must be auto, exact, native, or raw-text")
+	}
+}
+
+func safeFilename(value string) string {
+	var out strings.Builder
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_', r == '.':
+			out.WriteRune(r)
+		default:
+			out.WriteByte('_')
+		}
+	}
+	if out.Len() == 0 {
+		return "model"
+	}
+	return out.String()
+}

--- a/cmd/model-eval/snapshot.go
+++ b/cmd/model-eval/snapshot.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/model/modeleval"
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
+	"github.com/nugget/thane-ai-agent/internal/platform/logging"
+)
+
+const productionDataNotice = "Contains private production prompts, messages, and tool results. Best-effort retention limits are not redaction. Do not publish or commit this artifact."
+
+func cmdSnapshot(args []string) error {
+	fs := flag.NewFlagSet("snapshot", flag.ContinueOnError)
+	defaultDB := filepath.Join(filepath.Dir(defaultEvalDir()), "archive", "logs.db")
+	logsDB := fs.String("logs-db", defaultDB, "path to production logs.db")
+	output := fs.String("output", "", "private snapshot path (default: ~/Thane/evals/snapshot-<time>.thane-eval.json)")
+	since := fs.Duration("since", 7*24*time.Hour, "include requests retained within this window")
+	limit := fs.Int("limit", 100, "maximum retained requests to inspect")
+	model := fs.String("model", "", "optional reference-model filter")
+	includeExhausted := fs.Bool("include-exhausted", false, "include requests that exhausted their run budget")
+	overwrite := fs.Bool("overwrite", false, "replace an existing private output file")
+	var requestIDs stringList
+	fs.Var(&requestIDs, "request-id", "specific request ID to export (repeatable; bypasses since/model selection)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *limit <= 0 || *limit > 1000 {
+		return fmt.Errorf("snapshot limit must be between 1 and 1000")
+	}
+	if *since <= 0 {
+		return fmt.Errorf("snapshot since window must be positive")
+	}
+	if *output == "" {
+		*output = filepath.Join(defaultEvalDir(), "snapshot-"+time.Now().UTC().Format("20060102T150405Z")+".thane-eval.json")
+	}
+
+	db, err := openLogsReadOnly(*logsDB)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	if !database.HasColumn(db, "log_request_content", "model_calls_json") {
+		return fmt.Errorf("logs database predates model-call capture; deploy this build and collect new retained requests before exporting")
+	}
+
+	ids := []string(requestIDs)
+	if len(ids) == 0 {
+		ids, err = logging.QueryRecentModelCallRequestIDs(context.Background(), db, time.Now().Add(-*since), *model, *limit)
+		if err != nil {
+			return err
+		}
+	}
+	if len(ids) == 0 {
+		return fmt.Errorf("no retained model calls matched; deploy capture support and verify logging.retain_content is enabled")
+	}
+
+	snapshot := modeleval.Snapshot{
+		SchemaVersion:          modeleval.SnapshotSchemaVersion,
+		CreatedAt:              time.Now().UTC().Format(time.RFC3339Nano),
+		ContainsProductionData: true,
+		Notice:                 productionDataNotice,
+		Cases:                  []modeleval.Case{},
+	}
+	skippedTruncated := 0
+	skippedImages := 0
+	skippedExhausted := 0
+	skippedMissing := 0
+	for _, requestID := range ids {
+		detail, err := logging.QueryRequestDetail(db, requestID)
+		if err != nil {
+			return fmt.Errorf("query request %s: %w", requestID, err)
+		}
+		if detail == nil || len(detail.ModelCalls) == 0 {
+			skippedMissing++
+			continue
+		}
+		if detail.Exhausted && !*includeExhausted {
+			skippedExhausted += len(detail.ModelCalls)
+			continue
+		}
+		for _, call := range detail.ModelCalls {
+			case_, err := modeleval.CaseFromModelCall(requestID, call)
+			switch {
+			case errors.Is(err, modeleval.ErrTruncatedInput):
+				skippedTruncated++
+				continue
+			case errors.Is(err, modeleval.ErrImageInput):
+				skippedImages++
+				continue
+			case err != nil:
+				return fmt.Errorf("build case %s/%d: %w", requestID, call.Iteration, err)
+			}
+			snapshot.Cases = append(snapshot.Cases, case_)
+		}
+	}
+	if err := snapshot.Validate(); err != nil {
+		return err
+	}
+	if err := writePrivateJSON(*output, snapshot, *overwrite); err != nil {
+		return err
+	}
+	absOutput, _ := filepath.Abs(*output)
+	fmt.Fprintf(os.Stderr, "Wrote %d private model-call cases to %s (skipped: truncated=%d images=%d exhausted=%d missing=%d)\n",
+		len(snapshot.Cases), absOutput, skippedTruncated, skippedImages, skippedExhausted, skippedMissing)
+	return nil
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,8 @@ complete onboarding guide for Home Assistant users.
   macOS and Linux
 - **[Release Engineering](operating/release-engineering.md)** — Preferred
   macOS workflows for GitHub releases and pkg-based live-host deploys
+- **[Model Evaluation](operating/model-evaluation.md)** — Capture private
+  production model-call snapshots and replay them against local deployments
 
 ## Reference
 

--- a/docs/operating/model-evaluation.md
+++ b/docs/operating/model-evaluation.md
@@ -1,0 +1,123 @@
+# Model Evaluation
+
+`model-eval` captures the exact provider-neutral inputs and reference decision
+for each model call in a production request, then replays those calls against an
+OpenAI-compatible deployment without executing any tools. It is intended for
+comparing local models against production workloads rather than generic
+benchmark prompts.
+
+## Safety boundary
+
+Snapshots contain production system prompts, conversation history, tool
+results, and schemas. They are private operational data, not repository
+fixtures. The command:
+
+- writes snapshots and reports with mode `0600`
+- defaults to `~/Thane/evals`, outside the source tree
+- refuses to write an artifact inside the current Git worktree
+- accepts API credentials only through a named environment variable
+- never executes a captured tool
+
+Retention limits are not redaction. Do not commit or publish snapshots even if
+they look harmless after casual inspection.
+
+## Enable capture
+
+Per-iteration capture follows the existing retained-content policy. Enable it
+in the production configuration:
+
+```yaml
+logging:
+  retain_content: true
+  # Increase this if production tool results exceed the normal 4096-character
+  # forensic-retention ceiling. Truncated calls are never exported.
+  max_content_length: 65536
+```
+
+Restart Thane after changing the setting. Requests recorded before a build with
+model-call capture support do not contain the exact per-iteration tool surface
+and cannot be exported as evaluation cases.
+
+Each captured call contains:
+
+- the exact message array supplied to the model
+- the tool schemas visible on that iteration
+- semantic system-prompt section boundaries
+- the model response before any tool executes
+- provider stop reason, token counts, and latency
+
+Large message bodies still follow `logging.max_content_length`; choose a bound
+large enough for the contexts under evaluation while accounting for the added
+private storage. The exporter skips any case whose input was truncated, as well
+as image-bearing cases whose media bytes were intentionally not retained.
+
+## Capture a snapshot
+
+Capture up to 100 requests from the last seven days:
+
+```sh
+just model-eval snapshot
+```
+
+Common selection controls:
+
+```sh
+just model-eval snapshot --since 24h --limit 50
+just model-eval snapshot --model spark/gpt-oss:120b
+just model-eval snapshot --request-id r_123 --request-id r_456
+```
+
+The command reports how many cases were skipped because they were truncated,
+contained images, exhausted, or lacked model-call capture. Exhausted requests
+are excluded by default; use `--include-exhausted` when failure recovery is the
+behavior under study.
+
+## Replay one model
+
+Point the runner at any server implementing OpenAI chat completions. Streaming
+is on by default so the same tool-call accumulation and termination checks used
+in production are exercised.
+
+```sh
+just model-eval run \
+  --snapshot ~/Thane/evals/snapshot-20260820T180000Z.thane-eval.json \
+  --base-url http://spark:8000/v1 \
+  --model Qwen3.5-122B-A10B
+```
+
+If the endpoint requires authentication, name the environment variable rather
+than putting a token on the command line:
+
+```sh
+just model-eval run \
+  --snapshot ~/Thane/evals/snapshot-20260820T180000Z.thane-eval.json \
+  --base-url https://runner.example/v1 \
+  --model local-model \
+  --api-key-env LOCAL_MODEL_API_KEY
+```
+
+`--tool-contract auto` is the default. It replaces only the captured
+model-family tool-calling contract using Thane's current interaction profile
+for the target model; the rest of the production prompt remains unchanged.
+Use `--tool-contract exact` to test a literal drop-in replacement, or `native`
+and `raw-text` to compare those two contracts deliberately. `--provider`,
+`--family`, and `--trained-for-tool-use` supply the same profile hints used by
+the runtime catalog.
+
+## Reading a report
+
+The report separates transport reliability from semantic agreement:
+
+- `responses` versus `errors` shows whether the deployment completed the call
+- `decision_matches` compares text versus tool-call decisions
+- `tool_name_matches` ignores parallel-call ordering
+- `tool_argument_matches` compares names and semantic JSON arguments while
+  ignoring provider-assigned correlation IDs
+- `reference_matches` is exact deterministic agreement for tool decisions and
+  decision-kind agreement for text responses
+
+Reference agreement is not a quality oracle. Production can choose a merely
+acceptable path, and two correct plans can use different tools. Text response
+quality is intentionally left ungraded. Use the deterministic report to find
+divergent cases, then curate those cases or add a separate judge before making
+a production routing decision.

--- a/internal/model/modeleval/doc.go
+++ b/internal/model/modeleval/doc.go
@@ -1,0 +1,3 @@
+// Package modeleval defines portable, production-derived model-call fixtures
+// and deterministic tool-decision scoring for offline model evaluation.
+package modeleval

--- a/internal/model/modeleval/prompt.go
+++ b/internal/model/modeleval/prompt.go
@@ -1,0 +1,93 @@
+package modeleval
+
+import (
+	"strings"
+
+	"github.com/nugget/thane-ai-agent/internal/model/llm"
+)
+
+// ApplyToolCallingProfile replaces only the model-family tool-calling
+// contract inside a captured system prompt. It returns changed=false when
+// section boundaries are unavailable or invalid, leaving the exact captured
+// prompt untouched.
+func ApplyToolCallingProfile(messages []llm.Message, sections []PromptSection, profile llm.ModelInteractionProfile) ([]llm.Message, bool) {
+	out := cloneMessages(messages)
+	if len(out) == 0 || out[0].Role != "system" || len(sections) == 0 {
+		return out, false
+	}
+	prompt := out[0].Content
+	if !validSections(prompt, sections) {
+		return out, false
+	}
+
+	contract := strings.TrimSpace(profile.ToolCallingContract())
+	contractContent := ""
+	if contract != "" {
+		contractContent = "## Tool Calling Contract\n\n" + contract + "\n"
+	}
+
+	var contractSection *PromptSection
+	var runtimeSection *PromptSection
+	for _, section := range sections {
+		if section.Name == "TOOL CALLING CONTRACT" {
+			copy := section
+			contractSection = &copy
+		}
+		if section.Name == "RUNTIME CONTRACT" {
+			copy := section
+			runtimeSection = &copy
+		}
+	}
+	if contractSection == nil && contractContent == "" {
+		return out, false
+	}
+	if contractSection != nil && prompt[contractSection.Start:contractSection.End] == contractContent {
+		return out, false
+	}
+	if contractSection == nil && runtimeSection == nil {
+		return out, false
+	}
+	if contractSection != nil {
+		before := prompt[:contractSection.Start]
+		after := prompt[contractSection.End:]
+		if contractContent == "" && strings.HasPrefix(after, "\n\n") {
+			after = after[2:]
+		}
+		out[0].Content = before + contractContent + after
+	} else {
+		out[0].Content = prompt[:runtimeSection.End] + "\n\n" + contractContent + prompt[runtimeSection.End:]
+	}
+	out[0].Sections = nil
+	return out, true
+}
+
+func validSections(prompt string, sections []PromptSection) bool {
+	previousEnd := 0
+	for i, section := range sections {
+		if section.Start < 0 || section.End <= section.Start || section.End > len(prompt) {
+			return false
+		}
+		if i > 0 && section.Start < previousEnd {
+			return false
+		}
+		previousEnd = section.End
+	}
+	return true
+}
+
+func cloneMessages(src []llm.Message) []llm.Message {
+	dst := make([]llm.Message, len(src))
+	for i := range src {
+		dst[i] = src[i]
+		dst[i].Images = append([]llm.ImageContent(nil), src[i].Images...)
+		dst[i].Sections = append([]llm.PromptSection(nil), src[i].Sections...)
+		if src[i].ToolCalls != nil {
+			dst[i].ToolCalls = make([]llm.ToolCall, len(src[i].ToolCalls))
+			for callIndex := range src[i].ToolCalls {
+				dst[i].ToolCalls[callIndex] = src[i].ToolCalls[callIndex]
+				dst[i].ToolCalls[callIndex].Function.Arguments = cloneJSONMap(src[i].ToolCalls[callIndex].Function.Arguments)
+			}
+		}
+	}
+	return dst
+}

--- a/internal/model/modeleval/prompt_test.go
+++ b/internal/model/modeleval/prompt_test.go
@@ -1,0 +1,74 @@
+package modeleval
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/model/llm"
+)
+
+func TestApplyToolCallingProfile(t *testing.T) {
+	t.Parallel()
+
+	runtime := "runtime"
+	oldContract := "## Tool Calling Contract\n\nold\n"
+	talent := "talent"
+	prompt := strings.Join([]string{runtime, oldContract, talent}, "\n\n")
+	sections := sectionsFor(prompt, []struct{ name, content string }{
+		{"RUNTIME CONTRACT", runtime},
+		{"TOOL CALLING CONTRACT", oldContract},
+		{"TALENTS ALWAYS ON", talent},
+	})
+	messages := []llm.Message{{Role: "system", Content: prompt}}
+
+	native, changed := ApplyToolCallingProfile(messages, sections, llm.DefaultModelInteractionProfile())
+	if !changed || strings.Contains(native[0].Content, "old") || native[0].Content != runtime+"\n\n"+talent {
+		t.Fatalf("native prompt = %q, changed=%v", native[0].Content, changed)
+	}
+
+	raw := llm.DefaultModelInteractionProfile()
+	raw.ToolCallStyle = llm.ToolCallStyleRawTextJSON
+	rewritten, changed := ApplyToolCallingProfile(messages, sections, raw)
+	if !changed || !strings.Contains(rewritten[0].Content, "emit only one compact JSON object") || strings.Contains(rewritten[0].Content, "\nold\n") {
+		t.Fatalf("raw prompt = %q, changed=%v", rewritten[0].Content, changed)
+	}
+}
+
+func TestApplyToolCallingProfileInsertsAfterRuntime(t *testing.T) {
+	t.Parallel()
+
+	prompt := "runtime\n\ntalent"
+	sections := sectionsFor(prompt, []struct{ name, content string }{
+		{"RUNTIME CONTRACT", "runtime"},
+		{"TALENTS ALWAYS ON", "talent"},
+	})
+	profile := llm.DefaultModelInteractionProfile()
+	profile.ToolCallStyle = llm.ToolCallStyleRawTextJSON
+	got, changed := ApplyToolCallingProfile([]llm.Message{{Role: "system", Content: prompt}}, sections, profile)
+	if !changed || !strings.HasPrefix(got[0].Content, "runtime\n\n## Tool Calling Contract") || !strings.HasSuffix(got[0].Content, "\n\ntalent") {
+		t.Fatalf("prompt = %q, changed=%v", got[0].Content, changed)
+	}
+}
+
+func TestApplyToolCallingProfileNoOp(t *testing.T) {
+	t.Parallel()
+
+	messages := []llm.Message{{Role: "system", Content: "runtime"}}
+	got, changed := ApplyToolCallingProfile(messages, []PromptSection{{Name: "RUNTIME CONTRACT", Start: 0, End: 7}}, llm.DefaultModelInteractionProfile())
+	if changed || got[0].Content != "runtime" {
+		t.Fatalf("prompt = %q, changed=%v", got[0].Content, changed)
+	}
+}
+
+func sectionsFor(prompt string, inputs []struct{ name, content string }) []PromptSection {
+	cursor := 0
+	out := make([]PromptSection, 0, len(inputs))
+	for _, input := range inputs {
+		rel := strings.Index(prompt[cursor:], input.content)
+		start := cursor + rel
+		end := start + len(input.content)
+		out = append(out, PromptSection{Name: input.name, Start: start, End: end})
+		cursor = end
+	}
+	return out
+}

--- a/internal/model/modeleval/score.go
+++ b/internal/model/modeleval/score.go
@@ -1,0 +1,79 @@
+package modeleval
+
+import (
+	"encoding/json"
+	"sort"
+
+	"github.com/nugget/thane-ai-agent/internal/model/llm"
+)
+
+// Score describes deterministic agreement between a reference decision and a
+// candidate response. Text quality is intentionally not judged semantically.
+type Score struct {
+	ExpectedKind       string `json:"expected_kind"`
+	ActualKind         string `json:"actual_kind"`
+	DecisionMatch      bool   `json:"decision_match"`
+	ToolNamesMatch     bool   `json:"tool_names_match"`
+	ToolArgumentsMatch bool   `json:"tool_arguments_match"`
+	ReferenceMatch     bool   `json:"reference_match"`
+}
+
+// Evaluate compares response kind and tool calls while ignoring provider-
+// assigned correlation IDs and the order of parallel calls.
+func Evaluate(expected llm.Message, actual llm.Message) Score {
+	expectedKind := decisionKind(expected)
+	actualKind := decisionKind(actual)
+	score := Score{
+		ExpectedKind:  expectedKind,
+		ActualKind:    actualKind,
+		DecisionMatch: expectedKind == actualKind,
+	}
+	if expectedKind != "tool_calls" || actualKind != "tool_calls" {
+		score.ToolNamesMatch = len(expected.ToolCalls) == 0 && len(actual.ToolCalls) == 0
+		score.ToolArgumentsMatch = score.ToolNamesMatch
+		score.ReferenceMatch = score.DecisionMatch
+		return score
+	}
+
+	expectedNames, expectedCalls := canonicalCalls(expected.ToolCalls)
+	actualNames, actualCalls := canonicalCalls(actual.ToolCalls)
+	score.ToolNamesMatch = equalStrings(expectedNames, actualNames)
+	score.ToolArgumentsMatch = equalStrings(expectedCalls, actualCalls)
+	score.ReferenceMatch = score.DecisionMatch && score.ToolArgumentsMatch
+	return score
+}
+
+func decisionKind(message llm.Message) string {
+	if len(message.ToolCalls) > 0 {
+		return "tool_calls"
+	}
+	if message.Content != "" {
+		return "text"
+	}
+	return "empty"
+}
+
+func canonicalCalls(calls []llm.ToolCall) ([]string, []string) {
+	names := make([]string, 0, len(calls))
+	full := make([]string, 0, len(calls))
+	for _, call := range calls {
+		arguments, _ := json.Marshal(call.Function.Arguments)
+		names = append(names, call.Function.Name)
+		full = append(full, call.Function.Name+"\x00"+string(arguments))
+	}
+	sort.Strings(names)
+	sort.Strings(full)
+	return names, full
+}
+
+func equalStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/model/modeleval/score_test.go
+++ b/internal/model/modeleval/score_test.go
@@ -1,0 +1,45 @@
+package modeleval
+
+import (
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/model/llm"
+)
+
+func TestEvaluateToolCallsIgnoresParallelOrderAndIDs(t *testing.T) {
+	t.Parallel()
+
+	expected := llm.Message{ToolCalls: []llm.ToolCall{
+		toolCall("reference-a", "first", map[string]any{"value": 1}),
+		toolCall("reference-b", "second", map[string]any{"value": 2}),
+	}}
+	actual := llm.Message{ToolCalls: []llm.ToolCall{
+		toolCall("candidate-x", "second", map[string]any{"value": 2}),
+		toolCall("candidate-y", "first", map[string]any{"value": 1}),
+	}}
+	score := Evaluate(expected, actual)
+	if !score.DecisionMatch || !score.ToolNamesMatch || !score.ToolArgumentsMatch || !score.ReferenceMatch {
+		t.Fatalf("score = %#v", score)
+	}
+}
+
+func TestEvaluateDistinguishesNamesAndArguments(t *testing.T) {
+	t.Parallel()
+
+	expected := llm.Message{ToolCalls: []llm.ToolCall{toolCall("a", "search", map[string]any{"q": "one"})}}
+	wrongArgs := Evaluate(expected, llm.Message{ToolCalls: []llm.ToolCall{toolCall("b", "search", map[string]any{"q": "two"})}})
+	if !wrongArgs.ToolNamesMatch || wrongArgs.ToolArgumentsMatch || wrongArgs.ReferenceMatch {
+		t.Fatalf("wrong-args score = %#v", wrongArgs)
+	}
+	wrongDecision := Evaluate(expected, llm.Message{Content: "I would search."})
+	if wrongDecision.DecisionMatch || wrongDecision.ReferenceMatch {
+		t.Fatalf("wrong-decision score = %#v", wrongDecision)
+	}
+}
+
+func toolCall(id, name string, arguments map[string]any) llm.ToolCall {
+	call := llm.ToolCall{ID: id}
+	call.Function.Name = name
+	call.Function.Arguments = arguments
+	return call
+}

--- a/internal/model/modeleval/snapshot.go
+++ b/internal/model/modeleval/snapshot.go
@@ -1,0 +1,209 @@
+package modeleval
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/nugget/thane-ai-agent/internal/model/llm"
+	"github.com/nugget/thane-ai-agent/internal/platform/logging"
+)
+
+// SnapshotSchemaVersion is the current on-disk production snapshot contract.
+const SnapshotSchemaVersion = 1
+
+var (
+	// ErrTruncatedInput means content retention clipped part of a model input.
+	ErrTruncatedInput = errors.New("model input was truncated during retention")
+	// ErrImageInput means a call depended on image bytes that retention omits.
+	ErrImageInput = errors.New("model input contains omitted image data")
+)
+
+// Snapshot is a local-only collection of production-derived model decisions.
+// It intentionally carries an explicit sensitivity marker because automatic
+// redaction cannot make arbitrary prompts or tool results safe to publish.
+type Snapshot struct {
+	SchemaVersion          int    `json:"schema_version"`
+	CreatedAt              string `json:"created_at"`
+	ContainsProductionData bool   `json:"contains_production_data"`
+	Notice                 string `json:"notice"`
+	Cases                  []Case `json:"cases"`
+}
+
+// Case captures the complete input and reference output for one logical model
+// call. Replaying a case never executes the recorded tools.
+type Case struct {
+	ID                  string           `json:"id"`
+	SourceRequestID     string           `json:"source_request_id"`
+	Iteration           int              `json:"iteration"`
+	ReferenceModel      string           `json:"reference_model"`
+	Messages            []llm.Message    `json:"messages"`
+	Tools               []map[string]any `json:"tools"`
+	PromptSections      []PromptSection  `json:"prompt_sections,omitempty"`
+	Expected            llm.Message      `json:"expected"`
+	ReferenceStopReason string           `json:"reference_stop_reason,omitempty"`
+	ReferenceDurationMS int64            `json:"reference_duration_ms,omitempty"`
+}
+
+// PromptSection identifies one semantic range inside the system prompt.
+type PromptSection struct {
+	Name     string `json:"name"`
+	Start    int    `json:"start"`
+	End      int    `json:"end"`
+	CacheTTL string `json:"cache_ttl,omitempty"`
+}
+
+// CaseFromModelCall converts retained logging detail into a replayable case.
+// It refuses truncated or image-bearing inputs because replaying either would
+// silently evaluate a different request from the one production sent.
+func CaseFromModelCall(requestID string, call logging.ModelCallDetail) (Case, error) {
+	messages, err := messagesFromDetails(call.Messages)
+	if err != nil {
+		return Case{}, fmt.Errorf("input messages: %w", err)
+	}
+	expected, err := messageFromDetail(call.Response)
+	if err != nil {
+		return Case{}, fmt.Errorf("reference response: %w", err)
+	}
+	sections := make([]PromptSection, len(call.PromptSections))
+	for i, section := range call.PromptSections {
+		sections[i] = PromptSection{
+			Name:     section.Name,
+			Start:    section.Start,
+			End:      section.End,
+			CacheTTL: section.CacheTTL,
+		}
+	}
+	return Case{
+		ID:                  fmt.Sprintf("%s/%d", requestID, call.Iteration),
+		SourceRequestID:     requestID,
+		Iteration:           call.Iteration,
+		ReferenceModel:      call.Model,
+		Messages:            messages,
+		Tools:               cloneToolDefinitions(call.Tools),
+		PromptSections:      sections,
+		Expected:            expected,
+		ReferenceStopReason: call.StopReason,
+		ReferenceDurationMS: call.DurationMS,
+	}, nil
+}
+
+// Validate checks the snapshot's version and each case's required replay data.
+func (s Snapshot) Validate() error {
+	if s.SchemaVersion != SnapshotSchemaVersion {
+		return fmt.Errorf("snapshot schema_version = %d, want %d", s.SchemaVersion, SnapshotSchemaVersion)
+	}
+	if len(s.Cases) == 0 {
+		return fmt.Errorf("snapshot contains no cases")
+	}
+	seen := make(map[string]struct{}, len(s.Cases))
+	for i, c := range s.Cases {
+		if strings.TrimSpace(c.ID) == "" {
+			return fmt.Errorf("case %d has no id", i)
+		}
+		if _, duplicate := seen[c.ID]; duplicate {
+			return fmt.Errorf("duplicate case id %q", c.ID)
+		}
+		seen[c.ID] = struct{}{}
+		if len(c.Messages) == 0 {
+			return fmt.Errorf("case %q has no messages", c.ID)
+		}
+	}
+	return nil
+}
+
+func messagesFromDetails(details []logging.MessageDetail) ([]llm.Message, error) {
+	messages := make([]llm.Message, len(details))
+	for i, detail := range details {
+		message, err := messageFromDetail(detail)
+		if err != nil {
+			return nil, fmt.Errorf("message %d: %w", i, err)
+		}
+		messages[i] = message
+	}
+	return messages, nil
+}
+
+func messageFromDetail(detail logging.MessageDetail) (llm.Message, error) {
+	if detail.ContentTruncated {
+		return llm.Message{}, ErrTruncatedInput
+	}
+	if len(detail.Images) > 0 {
+		return llm.Message{}, ErrImageInput
+	}
+	message := llm.Message{
+		Role:       detail.Role,
+		Content:    detail.Content,
+		ToolCallID: detail.ToolCallID,
+	}
+	if len(detail.ToolCalls) > 0 {
+		message.ToolCalls = make([]llm.ToolCall, len(detail.ToolCalls))
+		for i, retained := range detail.ToolCalls {
+			if retained.ArgumentsTruncated {
+				return llm.Message{}, ErrTruncatedInput
+			}
+			arguments, err := decodeArguments(retained.Arguments)
+			if err != nil {
+				return llm.Message{}, fmt.Errorf("tool call %q arguments: %w", retained.Name, err)
+			}
+			message.ToolCalls[i].ID = retained.ID
+			message.ToolCalls[i].Function.Name = retained.Name
+			message.ToolCalls[i].Function.Arguments = arguments
+		}
+	}
+	return message, nil
+}
+
+func decodeArguments(raw string) (map[string]any, error) {
+	if strings.TrimSpace(raw) == "" {
+		return map[string]any{}, nil
+	}
+	var arguments map[string]any
+	if err := json.Unmarshal([]byte(raw), &arguments); err != nil {
+		return nil, err
+	}
+	if arguments == nil {
+		arguments = map[string]any{}
+	}
+	return arguments, nil
+}
+
+func cloneToolDefinitions(src []map[string]any) []map[string]any {
+	if src == nil {
+		return nil
+	}
+	dst := make([]map[string]any, len(src))
+	for i := range src {
+		dst[i] = cloneJSONMap(src[i])
+	}
+	return dst
+}
+
+func cloneJSONMap(src map[string]any) map[string]any {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[string]any, len(src))
+	for key, value := range src {
+		dst[key] = cloneJSONValue(value)
+	}
+	return dst
+}
+
+func cloneJSONValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		return cloneJSONMap(typed)
+	case []any:
+		out := make([]any, len(typed))
+		for i := range typed {
+			out[i] = cloneJSONValue(typed[i])
+		}
+		return out
+	case []string:
+		return append([]string(nil), typed...)
+	default:
+		return value
+	}
+}

--- a/internal/model/modeleval/snapshot_test.go
+++ b/internal/model/modeleval/snapshot_test.go
@@ -1,0 +1,81 @@
+package modeleval
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/model/llm"
+	"github.com/nugget/thane-ai-agent/internal/platform/logging"
+)
+
+func TestCaseFromModelCall(t *testing.T) {
+	t.Parallel()
+
+	call := logging.ModelCallDetail{
+		Iteration: 2,
+		Model:     "reference",
+		Messages: []logging.MessageDetail{
+			{Index: 0, Role: "system", Content: "system"},
+			{Index: 1, Role: "user", Content: "find it"},
+		},
+		Tools: []map[string]any{{"type": "function", "function": map[string]any{"name": "search"}}},
+		Response: logging.MessageDetail{
+			Role: "assistant",
+			ToolCalls: []logging.MessageToolCallDetail{{
+				ID: "call_ref", Name: "search", Arguments: `{"query":"it"}`,
+			}},
+		},
+	}
+	case_, err := CaseFromModelCall("r_1", call)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if case_.ID != "r_1/2" || case_.Expected.ToolCalls[0].Function.Name != "search" {
+		t.Fatalf("case = %#v", case_)
+	}
+	if case_.Expected.ToolCalls[0].Function.Arguments["query"] != "it" {
+		t.Fatalf("arguments = %#v", case_.Expected.ToolCalls[0].Function.Arguments)
+	}
+}
+
+func TestCaseFromModelCallRejectsIncompleteInputs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		detail logging.MessageDetail
+		want   error
+	}{
+		{name: "content truncated", detail: logging.MessageDetail{Role: "user", ContentTruncated: true}, want: ErrTruncatedInput},
+		{name: "arguments truncated", detail: logging.MessageDetail{Role: "assistant", ToolCalls: []logging.MessageToolCallDetail{{Name: "x", ArgumentsTruncated: true}}}, want: ErrTruncatedInput},
+		{name: "image omitted", detail: logging.MessageDetail{Role: "user", Images: []logging.MessageImageDetail{{MediaType: "image/png"}}}, want: ErrImageInput},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := CaseFromModelCall("r", logging.ModelCallDetail{
+				Messages: []logging.MessageDetail{tt.detail},
+				Response: logging.MessageDetail{Role: "assistant", Content: "done"},
+			})
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("error = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestSnapshotValidate(t *testing.T) {
+	t.Parallel()
+
+	valid := Snapshot{
+		SchemaVersion: SnapshotSchemaVersion,
+		Cases:         []Case{{ID: "r/0", Messages: []llm.Message{{Role: "user", Content: "hi"}}}},
+	}
+	if err := valid.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	valid.Cases = append(valid.Cases, valid.Cases[0])
+	if err := valid.Validate(); err == nil {
+		t.Fatal("duplicate case ID passed validation")
+	}
+}

--- a/internal/platform/logging/content.go
+++ b/internal/platform/logging/content.go
@@ -40,8 +40,8 @@ func NewContentWriter(db *sql.DB, maxLen int, logger *slog.Logger) (*ContentWrit
 	insertRequest, err := db.Prepare(`INSERT OR REPLACE INTO log_request_content
 		(request_id, prompt_hash, user_content, assistant_content, model,
 		 iteration_count, input_tokens, output_tokens, tools_used, messages_json,
-		 exhausted, exhaust_reason, created_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		 model_calls_json, exhausted, exhaust_reason, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		upsertPrompt.Close()
 		return nil, fmt.Errorf("prepare insert request: %w", err)
@@ -103,6 +103,11 @@ type RequestContent struct {
 	// Full message history sent to the model, retained for forensics and
 	// tool-call extraction. Image bytes are omitted from retained detail.
 	Messages []llm.Message
+
+	// ModelCalls preserves each logical model decision with the exact messages
+	// and tool schemas offered on that iteration. It powers offline evaluation
+	// without executing production tools.
+	ModelCalls []ModelCallContent
 }
 
 // WriteRequest persists a completed request's content. The system
@@ -135,6 +140,22 @@ func (w *ContentWriter) WriteRequest(ctx context.Context, rc RequestContent) {
 			"error", err,
 		)
 	}
+	modelCallsJSON, modelCallPrompts, err := marshalRetainedModelCalls(rc.ModelCalls, w.maxLen)
+	if err != nil {
+		w.logger.Warn("content retention: failed to marshal model calls",
+			"request_id", rc.RequestID,
+			"error", err,
+		)
+	}
+	for hash, prompt := range modelCallPrompts {
+		if _, err := w.stmtUpsertPrompt.ExecContext(ctx, hash, prompt, now); err != nil {
+			w.logger.Warn("content retention: failed to store model-call prompt",
+				"request_id", rc.RequestID,
+				"prompt_hash", hash,
+				"error", err,
+			)
+		}
+	}
 
 	// Store request-level content.
 	if _, err := w.stmtInsertRequest.ExecContext(ctx,
@@ -148,6 +169,7 @@ func (w *ContentWriter) WriteRequest(ctx context.Context, rc RequestContent) {
 		rc.OutputTokens,
 		nullStr(toolsUsedJSON),
 		nullStr(messagesJSON),
+		nullStr(modelCallsJSON),
 		rc.Exhausted,
 		nullStr(rc.ExhaustReason),
 		now,

--- a/internal/platform/logging/content_messages.go
+++ b/internal/platform/logging/content_messages.go
@@ -43,15 +43,17 @@ func retainedToolCalls(calls []llm.ToolCall, maxLen int) []MessageToolCallDetail
 	for _, call := range calls {
 		argsJSON, err := json.Marshal(call.Function.Arguments)
 		args := ""
+		truncated := false
 		if err != nil {
 			args = retainedToolCallMarshalError(err, maxLen)
 		} else {
-			args = truncateRetainedContent(string(argsJSON), maxLen)
+			args, truncated = truncateRetainedContentWithFlag(string(argsJSON), maxLen)
 		}
 		retained = append(retained, MessageToolCallDetail{
-			ID:        call.ID,
-			Name:      call.Function.Name,
-			Arguments: args,
+			ID:                 call.ID,
+			Name:               call.Function.Name,
+			Arguments:          args,
+			ArgumentsTruncated: truncated,
 		})
 	}
 	return retained

--- a/internal/platform/logging/content_query.go
+++ b/internal/platform/logging/content_query.go
@@ -6,26 +6,29 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
+	"time"
 )
 
 // RequestDetail holds the full content retained for a single request,
 // ready for JSON serialization by the web API.
 type RequestDetail struct {
-	RequestID        string          `json:"request_id"`
-	PromptHash       string          `json:"prompt_hash,omitempty"`
-	SystemPrompt     string          `json:"system_prompt,omitempty"`
-	Messages         []MessageDetail `json:"messages"`
-	UserContent      string          `json:"user_content,omitempty"`
-	AssistantContent string          `json:"assistant_content,omitempty"`
-	Model            string          `json:"model,omitempty"`
-	IterationCount   int             `json:"iteration_count"`
-	InputTokens      int             `json:"input_tokens"`
-	OutputTokens     int             `json:"output_tokens"`
-	ToolsUsed        map[string]int  `json:"tools_used,omitempty"`
-	Exhausted        bool            `json:"exhausted"`
-	ExhaustReason    string          `json:"exhaust_reason,omitempty"`
-	CreatedAt        string          `json:"created_at"`
-	ToolCalls        []ToolDetail    `json:"tool_calls"`
+	RequestID        string            `json:"request_id"`
+	PromptHash       string            `json:"prompt_hash,omitempty"`
+	SystemPrompt     string            `json:"system_prompt,omitempty"`
+	Messages         []MessageDetail   `json:"messages"`
+	UserContent      string            `json:"user_content,omitempty"`
+	AssistantContent string            `json:"assistant_content,omitempty"`
+	Model            string            `json:"model,omitempty"`
+	IterationCount   int               `json:"iteration_count"`
+	InputTokens      int               `json:"input_tokens"`
+	OutputTokens     int               `json:"output_tokens"`
+	ToolsUsed        map[string]int    `json:"tools_used,omitempty"`
+	Exhausted        bool              `json:"exhausted"`
+	ExhaustReason    string            `json:"exhaust_reason,omitempty"`
+	CreatedAt        string            `json:"created_at"`
+	ToolCalls        []ToolDetail      `json:"tool_calls"`
+	ModelCalls       []ModelCallDetail `json:"model_calls,omitempty"`
 }
 
 // ToolDetail holds the retained content for a single tool invocation.
@@ -53,9 +56,10 @@ type MessageDetail struct {
 // MessageToolCallDetail describes a tool call embedded in an assistant
 // message from the retained chat payload.
 type MessageToolCallDetail struct {
-	ID        string `json:"id,omitempty"`
-	Name      string `json:"name"`
-	Arguments string `json:"arguments,omitempty"`
+	ID                 string `json:"id,omitempty"`
+	Name               string `json:"name"`
+	Arguments          string `json:"arguments,omitempty"`
+	ArgumentsTruncated bool   `json:"arguments_truncated,omitempty"`
 }
 
 // MessageImageDetail describes a retained image attachment without storing
@@ -71,6 +75,50 @@ func QueryRequestDetail(db *sql.DB, requestID string) (*RequestDetail, error) {
 	return queryRequestDetailCtx(context.Background(), db, requestID)
 }
 
+// QueryRecentModelCallRequestIDs returns newest-first retained request IDs that
+// contain replayable per-iteration model-call capture. A non-empty model
+// filters on the deployment recorded for any captured call. Limit must be positive.
+func QueryRecentModelCallRequestIDs(ctx context.Context, db *sql.DB, since time.Time, model string, limit int) ([]string, error) {
+	if limit <= 0 {
+		return nil, fmt.Errorf("model-call request limit must be positive")
+	}
+	query := `SELECT request_id FROM log_request_content
+		WHERE model_calls_json IS NOT NULL
+		  AND model_calls_json <> ''
+		  AND model_calls_json <> '[]'
+		  AND created_at >= ?`
+	args := []any{since.UTC().Format(time.RFC3339Nano)}
+	if model = strings.TrimSpace(model); model != "" {
+		query += ` AND json_valid(model_calls_json)
+			AND EXISTS (
+				SELECT 1 FROM json_each(model_calls_json) AS model_call
+				WHERE json_extract(model_call.value, '$.model') = ?
+			)`
+		args = append(args, model)
+	}
+	query += ` ORDER BY created_at DESC LIMIT ?`
+	args = append(args, limit)
+
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query retained model-call requests: %w", err)
+	}
+	defer rows.Close()
+
+	ids := make([]string, 0, limit)
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan retained model-call request: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate retained model-call requests: %w", err)
+	}
+	return ids, nil
+}
+
 // queryRequestDetailCtx is the context-aware implementation shared by
 // QueryRequestDetail and the Archiver.
 func queryRequestDetailCtx(ctx context.Context, db *sql.DB, requestID string) (*RequestDetail, error) {
@@ -78,7 +126,8 @@ func queryRequestDetailCtx(ctx context.Context, db *sql.DB, requestID string) (*
 		rd                             RequestDetail
 		promptHash, userContent        sql.NullString
 		assistantContent, model        sql.NullString
-		messagesJSON, toolsUsed        sql.NullString
+		messagesJSON, modelCallsJSON   sql.NullString
+		toolsUsed                      sql.NullString
 		exhaustReason                  sql.NullString
 		iterCount, inputTok, outputTok sql.NullInt64
 		exhausted                      sql.NullBool
@@ -86,12 +135,12 @@ func queryRequestDetailCtx(ctx context.Context, db *sql.DB, requestID string) (*
 	)
 
 	err := db.QueryRowContext(ctx, `SELECT request_id, prompt_hash, user_content, assistant_content,
-		model, iteration_count, input_tokens, output_tokens, tools_used, messages_json,
+		model, iteration_count, input_tokens, output_tokens, tools_used, messages_json, model_calls_json,
 		exhausted, exhaust_reason, created_at
 		FROM log_request_content WHERE request_id = ?`, requestID).Scan(
 		&rd.RequestID, &promptHash, &userContent, &assistantContent,
 		&model, &iterCount, &inputTok, &outputTok, &toolsUsed,
-		&messagesJSON, &exhausted, &exhaustReason, &createdAt,
+		&messagesJSON, &modelCallsJSON, &exhausted, &exhaustReason, &createdAt,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
@@ -124,6 +173,14 @@ func queryRequestDetailCtx(ctx context.Context, db *sql.DB, requestID string) (*
 	}
 	if rd.Messages == nil {
 		rd.Messages = []MessageDetail{}
+	}
+	if modelCallsJSON.Valid && modelCallsJSON.String != "" {
+		if err := json.Unmarshal([]byte(modelCallsJSON.String), &rd.ModelCalls); err != nil {
+			return &rd, fmt.Errorf("decode retained model calls: %w", err)
+		}
+		if err := resolveModelCallPrompts(ctx, db, rd.ModelCalls); err != nil {
+			return &rd, err
+		}
 	}
 
 	// Resolve system prompt content from the prompts table.

--- a/internal/platform/logging/indexer.go
+++ b/internal/platform/logging/indexer.go
@@ -427,6 +427,7 @@ func Migrate(db *sql.DB) error {
 		output_tokens INTEGER,
 		tools_used TEXT,
 		messages_json TEXT,
+		model_calls_json TEXT,
 		exhausted BOOLEAN DEFAULT FALSE,
 		exhaust_reason TEXT,
 		created_at TEXT NOT NULL
@@ -452,6 +453,9 @@ func Migrate(db *sql.DB) error {
 	}
 	if err := database.AddColumn(db, "log_request_content", "messages_json", "TEXT"); err != nil {
 		return fmt.Errorf("migrate content messages: %w", err)
+	}
+	if err := database.AddColumn(db, "log_request_content", "model_calls_json", "TEXT"); err != nil {
+		return fmt.Errorf("migrate retained model calls: %w", err)
 	}
 
 	return nil

--- a/internal/platform/logging/live_requests.go
+++ b/internal/platform/logging/live_requests.go
@@ -125,6 +125,7 @@ func (s *LiveRequestStore) QueryRequestDetail(requestID string) (*RequestDetail,
 }
 
 func buildLiveRequestDetail(rc RequestContent, maxLen int, now time.Time) *RequestDetail {
+	modelCalls, _ := retainedModelCalls(rc.ModelCalls, maxLen, true)
 	detail := &RequestDetail{
 		RequestID:        rc.RequestID,
 		PromptHash:       hashPrompt(rc.SystemPrompt),
@@ -140,6 +141,7 @@ func buildLiveRequestDetail(rc RequestContent, maxLen int, now time.Time) *Reque
 		CreatedAt:        now.Format(time.RFC3339Nano),
 		Messages:         retainedMessages(rc.Messages, maxLen),
 		ToolCalls:        extractToolDetails(rc.Messages, maxLen),
+		ModelCalls:       modelCalls,
 	}
 	if len(rc.ToolsUsed) > 0 {
 		detail.ToolsUsed = make(map[string]int, len(rc.ToolsUsed))
@@ -167,6 +169,7 @@ func cloneRequestDetail(src *RequestDetail) *RequestDetail {
 		dst.ToolCalls = append([]ToolDetail(nil), src.ToolCalls...)
 	}
 	dst.Messages = cloneMessageDetails(src.Messages)
+	dst.ModelCalls = cloneModelCallDetails(src.ModelCalls)
 	return &dst
 }
 

--- a/internal/platform/logging/model_calls.go
+++ b/internal/platform/logging/model_calls.go
@@ -1,0 +1,295 @@
+package logging
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/model/llm"
+)
+
+// ModelCallContent captures one logical provider call before and after model
+// inference. It is retained only when request content retention is enabled.
+// Tool execution is deliberately outside this record: the response is the
+// model's decision, while later tool messages remain inputs to the next call.
+type ModelCallContent struct {
+	// Iteration is the zero-based agent-loop iteration that made this call.
+	Iteration int `json:"iteration"`
+	// Model is the resolved deployment used for the successful response.
+	Model string `json:"model"`
+	// Messages is the exact provider-neutral message history supplied to the model.
+	Messages []llm.Message `json:"messages"`
+	// Tools is the exact OpenAI-style tool-definition surface supplied to the model.
+	Tools []map[string]any `json:"tools"`
+	// Response is the model decision returned before any tool executes.
+	Response llm.Message `json:"response"`
+	// StopReason is the provider's normalized termination signal.
+	StopReason string `json:"stop_reason,omitempty"`
+	// InputTokens is the provider-reported input-token count for this call.
+	InputTokens int `json:"input_tokens,omitempty"`
+	// OutputTokens is the provider-reported output-token count for this call.
+	OutputTokens int `json:"output_tokens,omitempty"`
+	// DurationMS is elapsed wall time for the logical call, including provider recovery.
+	DurationMS int64 `json:"duration_ms,omitempty"`
+
+	startedAt time.Time
+	discarded bool
+}
+
+// UseAttempt replaces the captured input with the exact physical attempt now
+// being made by retry or recovery logic. It preserves the original start time
+// so DurationMS continues to describe the complete logical call.
+func (c *ModelCallContent) UseAttempt(model string, messages []llm.Message, tools []map[string]any) {
+	if c == nil {
+		return
+	}
+	c.Model = model
+	c.Messages = cloneLLMMessages(messages)
+	c.Tools = cloneToolDefinitions(tools)
+}
+
+// Discard excludes a logical call whose apparent response was synthesized by
+// runtime recovery rather than returned by a model provider.
+func (c *ModelCallContent) Discard() {
+	if c != nil {
+		c.discarded = true
+	}
+}
+
+// NewModelCallContent takes a detached snapshot of one provider call's inputs.
+// The returned value can be completed later with [ModelCallContent.Complete].
+func NewModelCallContent(iteration int, model string, messages []llm.Message, tools []map[string]any) ModelCallContent {
+	return ModelCallContent{
+		Iteration: iteration,
+		Model:     model,
+		Messages:  cloneLLMMessages(messages),
+		Tools:     cloneToolDefinitions(tools),
+		startedAt: time.Now(),
+	}
+}
+
+// Complete records the successful provider response for a captured call.
+// A nil response leaves the call incomplete and is ignored.
+func (c *ModelCallContent) Complete(response *llm.ChatResponse) {
+	if c == nil || response == nil {
+		return
+	}
+	if response.Model != "" {
+		c.Model = response.Model
+	}
+	c.Response = cloneLLMMessage(response.Message)
+	c.StopReason = response.StopReason
+	c.InputTokens = response.InputTokens
+	c.OutputTokens = response.OutputTokens
+	if !c.startedAt.IsZero() {
+		c.DurationMS = time.Since(c.startedAt).Milliseconds()
+	}
+}
+
+// ModelCallDetail is the retained, JSON-facing representation of one model
+// call. System-message content is resolved through PromptHash when read from
+// SQLite, allowing repeated prompts to stay content-addressed on disk.
+type ModelCallDetail struct {
+	Iteration      int                   `json:"iteration"`
+	Model          string                `json:"model"`
+	PromptHash     string                `json:"prompt_hash,omitempty"`
+	PromptSections []PromptSectionDetail `json:"prompt_sections,omitempty"`
+	Messages       []MessageDetail       `json:"messages"`
+	Tools          []map[string]any      `json:"tools"`
+	Response       MessageDetail         `json:"response"`
+	StopReason     string                `json:"stop_reason,omitempty"`
+	InputTokens    int                   `json:"input_tokens,omitempty"`
+	OutputTokens   int                   `json:"output_tokens,omitempty"`
+	DurationMS     int64                 `json:"duration_ms,omitempty"`
+}
+
+// PromptSectionDetail locates one semantic system-prompt section inside the
+// resolved prompt. The offsets let an evaluator replace only model-family
+// contracts while preserving the production context around them.
+type PromptSectionDetail struct {
+	Name     string `json:"name"`
+	Start    int    `json:"start"`
+	End      int    `json:"end"`
+	CacheTTL string `json:"cache_ttl,omitempty"`
+}
+
+func retainedModelCalls(calls []ModelCallContent, maxLen int, preserveSystem bool) ([]ModelCallDetail, map[string]string) {
+	details := make([]ModelCallDetail, 0, len(calls))
+	prompts := make(map[string]string)
+	for _, call := range calls {
+		if call.discarded || call.Response.Role == "" {
+			continue
+		}
+		messages := retainedMessages(call.Messages, maxLen)
+		detail := ModelCallDetail{
+			Iteration:    call.Iteration,
+			Model:        call.Model,
+			Messages:     messages,
+			Tools:        cloneToolDefinitions(call.Tools),
+			Response:     retainedMessages([]llm.Message{call.Response}, maxLen)[0],
+			StopReason:   call.StopReason,
+			InputTokens:  call.InputTokens,
+			OutputTokens: call.OutputTokens,
+			DurationMS:   call.DurationMS,
+		}
+		for i := range messages {
+			if messages[i].Role != "system" {
+				continue
+			}
+			original := call.Messages[i].Content
+			detail.PromptHash = hashPrompt(original)
+			prompts[detail.PromptHash] = original
+			detail.PromptSections = locatePromptSections(original, call.Messages[i].Sections)
+			if preserveSystem {
+				messages[i].Content = original
+				messages[i].ContentTruncated = false
+			} else {
+				messages[i].Content = ""
+				messages[i].ContentTruncated = false
+			}
+			break
+		}
+		details = append(details, detail)
+	}
+	return details, prompts
+}
+
+func marshalRetainedModelCalls(calls []ModelCallContent, maxLen int) (string, map[string]string, error) {
+	details, prompts := retainedModelCalls(calls, maxLen, false)
+	data, err := json.Marshal(details)
+	if err != nil {
+		return "", nil, err
+	}
+	return string(data), prompts, nil
+}
+
+func resolveModelCallPrompts(ctx context.Context, db *sql.DB, calls []ModelCallDetail) error {
+	for i := range calls {
+		if calls[i].PromptHash == "" {
+			continue
+		}
+		var content string
+		if err := db.QueryRowContext(ctx, `SELECT content FROM log_prompts WHERE hash = ?`, calls[i].PromptHash).Scan(&content); err != nil {
+			return fmt.Errorf("resolve model-call prompt %s: %w", calls[i].PromptHash, err)
+		}
+		for j := range calls[i].Messages {
+			if calls[i].Messages[j].Role == "system" {
+				calls[i].Messages[j].Content = content
+				calls[i].Messages[j].ContentTruncated = false
+				break
+			}
+		}
+	}
+	return nil
+}
+
+func cloneLLMMessages(src []llm.Message) []llm.Message {
+	if src == nil {
+		return nil
+	}
+	dst := make([]llm.Message, len(src))
+	for i := range src {
+		dst[i] = cloneLLMMessage(src[i])
+	}
+	return dst
+}
+
+func cloneLLMMessage(src llm.Message) llm.Message {
+	dst := src
+	dst.Images = append([]llm.ImageContent(nil), src.Images...)
+	dst.Sections = append([]llm.PromptSection(nil), src.Sections...)
+	if src.ToolCalls != nil {
+		dst.ToolCalls = make([]llm.ToolCall, len(src.ToolCalls))
+		for i := range src.ToolCalls {
+			dst.ToolCalls[i] = src.ToolCalls[i]
+			dst.ToolCalls[i].Function.Arguments = cloneAnyMap(src.ToolCalls[i].Function.Arguments)
+		}
+	}
+	return dst
+}
+
+func cloneToolDefinitions(src []map[string]any) []map[string]any {
+	if src == nil {
+		return nil
+	}
+	dst := make([]map[string]any, len(src))
+	for i := range src {
+		dst[i] = cloneAnyMap(src[i])
+	}
+	return dst
+}
+
+func cloneModelCallDetails(src []ModelCallDetail) []ModelCallDetail {
+	if src == nil {
+		return nil
+	}
+	dst := make([]ModelCallDetail, len(src))
+	for i := range src {
+		dst[i] = src[i]
+		dst[i].PromptSections = append([]PromptSectionDetail(nil), src[i].PromptSections...)
+		dst[i].Messages = cloneMessageDetails(src[i].Messages)
+		dst[i].Tools = cloneToolDefinitions(src[i].Tools)
+		dst[i].Response = cloneMessageDetails([]MessageDetail{src[i].Response})[0]
+	}
+	return dst
+}
+
+func locatePromptSections(prompt string, sections []llm.PromptSection) []PromptSectionDetail {
+	if prompt == "" || len(sections) == 0 {
+		return nil
+	}
+	cursor := 0
+	out := make([]PromptSectionDetail, 0, len(sections))
+	for _, section := range sections {
+		if section.Content == "" {
+			continue
+		}
+		relative := strings.Index(prompt[cursor:], section.Content)
+		if relative < 0 {
+			return nil
+		}
+		start := cursor + relative
+		end := start + len(section.Content)
+		out = append(out, PromptSectionDetail{
+			Name:     section.Name,
+			Start:    start,
+			End:      end,
+			CacheTTL: section.CacheTTL,
+		})
+		cursor = end
+	}
+	return out
+}
+
+func cloneAnyMap(src map[string]any) map[string]any {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[string]any, len(src))
+	for key, value := range src {
+		dst[key] = cloneAnyValue(value)
+	}
+	return dst
+}
+
+func cloneAnyValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		return cloneAnyMap(typed)
+	case []any:
+		out := make([]any, len(typed))
+		for i := range typed {
+			out[i] = cloneAnyValue(typed[i])
+		}
+		return out
+	case []map[string]any:
+		return cloneToolDefinitions(typed)
+	case []string:
+		return append([]string(nil), typed...)
+	default:
+		return value
+	}
+}

--- a/internal/platform/logging/model_calls_test.go
+++ b/internal/platform/logging/model_calls_test.go
@@ -1,0 +1,162 @@
+package logging
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/model/llm"
+)
+
+func TestContentWriterRetainsReplayableModelCalls(t *testing.T) {
+	t.Parallel()
+
+	db := openTestDB(t)
+	writer, err := NewContentWriter(db, 4096, slog.Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writer.Close()
+
+	const systemPrompt = "persona\n\nruntime contract\n\ntool contract"
+	messages := []llm.Message{
+		{
+			Role:    "system",
+			Content: systemPrompt,
+			Sections: []llm.PromptSection{
+				{Name: "PERSONA", Content: "persona"},
+				{Name: "RUNTIME CONTRACT", Content: "runtime contract"},
+				{Name: "TOOL CALLING CONTRACT", Content: "tool contract"},
+			},
+		},
+		{Role: "user", Content: "turn on the office light"},
+	}
+	call := NewModelCallContent(0, "reference-model", messages, []map[string]any{{
+		"type": "function",
+		"function": map[string]any{
+			"name": "ha_control_device",
+			"parameters": map[string]any{
+				"type": "object",
+			},
+		},
+	}})
+	response := &llm.ChatResponse{Model: "reference-model", StopReason: "tool_calls", InputTokens: 42, OutputTokens: 7}
+	response.Message.Role = "assistant"
+	response.Message.ToolCalls = []llm.ToolCall{{
+		ID: "call_ref",
+		Function: struct {
+			Name      string         `json:"name"`
+			Arguments map[string]any `json:"arguments"`
+		}{Name: "ha_control_device", Arguments: map[string]any{"entity_id": "light.office", "action": "turn_on"}},
+	}}
+	call.Complete(response)
+
+	writer.WriteRequest(context.Background(), RequestContent{
+		RequestID:    "r_eval",
+		SystemPrompt: systemPrompt,
+		Model:        "request-summary-model",
+		Messages:     messages,
+		ModelCalls:   []ModelCallContent{call},
+	})
+
+	var stored string
+	if err := db.QueryRow(`SELECT model_calls_json FROM log_request_content WHERE request_id = ?`, "r_eval").Scan(&stored); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(stored, systemPrompt) {
+		t.Fatal("model_calls_json duplicated the content-addressed system prompt")
+	}
+
+	detail, err := QueryRequestDetail(db, "r_eval")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if detail == nil || len(detail.ModelCalls) != 1 {
+		t.Fatalf("ModelCalls = %#v, want one call", detail)
+	}
+	got := detail.ModelCalls[0]
+	if got.Messages[0].Content != systemPrompt {
+		t.Fatalf("resolved system prompt = %q", got.Messages[0].Content)
+	}
+	if len(got.PromptSections) != 3 {
+		t.Fatalf("PromptSections = %#v", got.PromptSections)
+	}
+	contract := got.PromptSections[2]
+	if got.Messages[0].Content[contract.Start:contract.End] != "tool contract" {
+		t.Fatalf("tool contract range = %q", got.Messages[0].Content[contract.Start:contract.End])
+	}
+	if got.Response.ToolCalls[0].Name != "ha_control_device" {
+		t.Fatalf("response tool = %#v", got.Response.ToolCalls)
+	}
+	if got.Tools[0]["type"] != "function" {
+		t.Fatalf("tools = %#v", got.Tools)
+	}
+
+	ids, err := QueryRecentModelCallRequestIDs(context.Background(), db, time.Now().Add(-time.Hour), "reference-model", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ids) != 1 || ids[0] != "r_eval" {
+		t.Fatalf("request IDs = %#v, want r_eval", ids)
+	}
+}
+
+func TestRetainedToolCallMarksTruncatedArguments(t *testing.T) {
+	t.Parallel()
+
+	call := llm.ToolCall{ID: "call_1"}
+	call.Function.Name = "search"
+	call.Function.Arguments = map[string]any{"query": "long search phrase"}
+	details := retainedToolCalls([]llm.ToolCall{call}, 8)
+	if len(details) != 1 || !details[0].ArgumentsTruncated {
+		t.Fatalf("retained tool call = %#v, want arguments_truncated", details)
+	}
+}
+
+func TestLiveRequestStoreModelCallsAreDefensiveCopies(t *testing.T) {
+	t.Parallel()
+
+	store := NewLiveRequestStore(2, 4096)
+	call := NewModelCallContent(0, "m", []llm.Message{{Role: "system", Content: "system"}}, []map[string]any{{
+		"type":     "function",
+		"function": map[string]any{"name": "tool_a"},
+	}})
+	call.Complete(&llm.ChatResponse{Message: llm.Message{Role: "assistant", Content: "done"}})
+	store.WriteRequest(context.Background(), RequestContent{RequestID: "r", ModelCalls: []ModelCallContent{call}})
+
+	first, err := store.QueryRequestDetail("r")
+	if err != nil {
+		t.Fatal(err)
+	}
+	first.ModelCalls[0].Messages[0].Content = "mutated"
+	first.ModelCalls[0].Tools[0]["type"] = "mutated"
+	second, err := store.QueryRequestDetail("r")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.ModelCalls[0].Messages[0].Content != "system" || second.ModelCalls[0].Tools[0]["type"] != "function" {
+		t.Fatalf("stored model call was aliased: %#v", second.ModelCalls[0])
+	}
+}
+
+func TestRetainedModelCallsExcludeIncompleteAndDiscardedCalls(t *testing.T) {
+	t.Parallel()
+
+	incomplete := NewModelCallContent(0, "model", []llm.Message{{Role: "user", Content: "hello"}}, nil)
+	discarded := NewModelCallContent(1, "model", []llm.Message{{Role: "user", Content: "hello"}}, nil)
+	discarded.Complete(&llm.ChatResponse{Message: llm.Message{Role: "assistant", Content: "synthetic"}})
+	discarded.Discard()
+	complete := NewModelCallContent(2, "model", []llm.Message{{Role: "user", Content: "hello"}}, nil)
+	complete.UseAttempt("recovery-model", []llm.Message{{Role: "user", Content: "recovery input"}}, nil)
+	complete.Complete(&llm.ChatResponse{Message: llm.Message{Role: "assistant", Content: "provider response"}})
+
+	details, _ := retainedModelCalls([]ModelCallContent{incomplete, discarded, complete}, 4096, true)
+	if len(details) != 1 {
+		t.Fatalf("retained calls = %#v, want only completed provider call", details)
+	}
+	if details[0].Model != "recovery-model" || details[0].Messages[0].Content != "recovery input" {
+		t.Fatalf("retained recovery attempt = %#v", details[0])
+	}
+}

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -2072,6 +2072,21 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 
 	// Track whether the error handler triggered timeout recovery.
 	var timeoutRecovered bool
+	var modelCalls []logging.ModelCallContent
+	captureModelCalls := l.requestRecorder != nil || l.liveRequestRecorder != nil
+	captureHooks := modelCallCaptureHooks{}
+	if captureModelCalls {
+		captureHooks.recordAttempt = func(model string, messages []llm.Message, tools []map[string]any) {
+			if len(modelCalls) > 0 {
+				modelCalls[len(modelCalls)-1].UseAttempt(model, messages, tools)
+			}
+		}
+		captureHooks.discard = func() {
+			if len(modelCalls) > 0 {
+				modelCalls[len(modelCalls)-1].Discard()
+			}
+		}
+	}
 
 	// Optional per-tool timeout wrapper for request-scoped runs such as
 	// delegates. Cancelled after each tool completes.
@@ -2250,7 +2265,7 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 		},
 
 		// Iteration lifecycle callbacks.
-		OnIterationStart: func(iterCtx context.Context, i int, currentModel string, msgs []llm.Message, _ []map[string]any) {
+		OnIterationStart: func(iterCtx context.Context, i int, currentModel string, msgs []llm.Message, toolDefs []map[string]any) {
 			iterLog := logging.Logger(iterCtx)
 
 			// Rebuild system prompt each iteration so that:
@@ -2269,6 +2284,9 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 			}
 
 			msgSnapshot := append([]llm.Message(nil), msgs...)
+			if captureModelCalls {
+				modelCalls = append(modelCalls, logging.NewModelCallContent(i, currentModel, msgs, toolDefs))
+			}
 			liveStreamMu.Lock()
 			liveStreamModel = currentModel
 			liveStreamIteration = i
@@ -2317,6 +2335,12 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 		},
 
 		OnLLMResponse: func(iterCtx context.Context, llmResp *llm.ChatResponse, i int) {
+			for callIndex := len(modelCalls) - 1; callIndex >= 0; callIndex-- {
+				if modelCalls[callIndex].Iteration == i {
+					modelCalls[callIndex].Complete(llmResp)
+					break
+				}
+			}
 			if stream != nil {
 				stream(llm.StreamEvent{
 					Kind:     llm.KindLLMResponse,
@@ -2338,7 +2362,7 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 		},
 
 		// Error handling: timeout retry, recovery model, failover.
-		OnLLMError: l.buildLLMErrorHandler(ctx, stream, model, req, &timeoutRecovered),
+		OnLLMError: l.buildLLMErrorHandler(ctx, stream, model, req, &timeoutRecovered, captureHooks),
 
 		// Enrich context before each tool execution.
 		OnBeforeToolExec: func(iterCtx context.Context, i int, tc llm.ToolCall) context.Context {
@@ -2586,7 +2610,7 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 		LoadedCapabilities:       toolcatalog.BuildLoadedCapabilityEntries(l.capSurface, activeTags),
 	}
 
-	l.recordLiveRequestDetail(ctx, requestID, systemPrompt, userMessage, iterResult)
+	l.recordLiveRequestDetail(ctx, requestID, systemPrompt, userMessage, iterResult, modelCalls)
 
 	l.recordUsage(ctx, req, iterResult.Model, iterResult.InputTokens, iterResult.OutputTokens, iterResult.CacheCreationInputTokens, iterResult.CacheCreation5mInputTokens, iterResult.CacheCreation1hInputTokens, iterResult.CacheReadInputTokens, convID, sessionTag, requestID, iterResult.UpstreamRequestID)
 	l.archiveIterations(log, convID, iterResult.Iterations)
@@ -2596,7 +2620,7 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 	go func() {
 		bgCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		l.retainContent(bgCtx, requestID, systemPrompt, userMessage, iterResult)
+		l.retainContent(bgCtx, requestID, systemPrompt, userMessage, iterResult, modelCalls)
 	}()
 
 	return resp, nil
@@ -2623,7 +2647,24 @@ func (l *Loop) conversationChannelBinding(conversationID string) *memory.Channel
 
 // buildLLMErrorHandler returns the OnLLMError callback that implements
 // the agent's timeout retry, recovery model downshift, and failover logic.
-func (l *Loop) buildLLMErrorHandler(ctx context.Context, stream llm.StreamCallback, defaultModel string, req *Request, timeoutRecovered *bool) func(context.Context, error, string, []llm.Message, []map[string]any, llm.StreamCallback) (*llm.ChatResponse, string, error) {
+type modelCallCaptureHooks struct {
+	recordAttempt func(model string, messages []llm.Message, tools []map[string]any)
+	discard       func()
+}
+
+func (h modelCallCaptureHooks) attempt(model string, messages []llm.Message, tools []map[string]any) {
+	if h.recordAttempt != nil {
+		h.recordAttempt(model, messages, tools)
+	}
+}
+
+func (h modelCallCaptureHooks) discardSynthetic() {
+	if h.discard != nil {
+		h.discard()
+	}
+}
+
+func (l *Loop) buildLLMErrorHandler(ctx context.Context, stream llm.StreamCallback, defaultModel string, req *Request, timeoutRecovered *bool, capture modelCallCaptureHooks) func(context.Context, error, string, []llm.Message, []map[string]any, llm.StreamCallback) (*llm.ChatResponse, string, error) {
 	explicitModelRequested := strings.TrimSpace(req.Model) != ""
 
 	return func(iterCtx context.Context, err error, model string,
@@ -2655,6 +2696,7 @@ func (l *Loop) buildLLMErrorHandler(ctx context.Context, stream llm.StreamCallba
 					return nil, "", ctx.Err()
 				case <-time.After(backoff):
 				}
+				capture.attempt(model, msgs, toolDefs)
 				resp, retryErr := l.llm.ChatStream(iterCtx, model, msgs, toolDefs, stream)
 				if retryErr == nil {
 					iterLog.Info("LLM retry succeeded", "retry", retry, "model", model)
@@ -2680,6 +2722,7 @@ func (l *Loop) buildLLMErrorHandler(ctx context.Context, stream llm.StreamCallba
 				// generation is bounded like every other call.
 				recoveryBase := llm.WithMaxOutputTokens(context.Background(), llm.MaxOutputTokensFromContext(iterCtx))
 				recoveryCtx, recoveryCancel := context.WithTimeout(recoveryBase, timeoutRecoveryDeadline)
+				capture.attempt(l.recoveryModel, recoveryMessages, nil)
 				resp, recoveryErr := l.llm.ChatStream(recoveryCtx, l.recoveryModel, recoveryMessages, nil, stream)
 				recoveryCancel()
 				if recoveryErr != nil {
@@ -2688,6 +2731,7 @@ func (l *Loop) buildLLMErrorHandler(ctx context.Context, stream llm.StreamCallba
 						"recovery_model", l.recoveryModel,
 					)
 					// Return a static recovery response as content.
+					capture.discardSynthetic()
 					return &llm.ChatResponse{
 						Model:   l.recoveryModel,
 						Message: llm.Message{Role: "assistant", Content: prompts.TimeoutRecoveryEmpty},
@@ -2703,6 +2747,7 @@ func (l *Loop) buildLLMErrorHandler(ctx context.Context, stream llm.StreamCallba
 			// No recovery model — return a static fallback response
 			// so the user sees something rather than an error.
 			iterLog.Error("LLM timeout with no recovery model, returning static fallback")
+			capture.discardSynthetic()
 			*timeoutRecovered = true
 			used := toolsUsedFromMessages(msgs)
 			names := make([]string, 0, len(used))
@@ -2735,7 +2780,7 @@ func (l *Loop) buildLLMErrorHandler(ctx context.Context, stream llm.StreamCallba
 		}
 
 		if explicitModelRequested {
-			if resp, recoveredModel, recoveryErr, handled := l.maybeRetryExplicitModelAfterProviderContextError(iterCtx, model, err, msgs, toolDefs, stream); handled {
+			if resp, recoveredModel, recoveryErr, handled := l.maybeRetryExplicitModelAfterProviderContextError(iterCtx, model, err, msgs, toolDefs, stream, capture); handled {
 				if recoveryErr != nil {
 					iterLog.Warn("explicit model context recovery failed", "model", model, "error", recoveryErr)
 					return nil, "", recoveryErr
@@ -2770,6 +2815,7 @@ func (l *Loop) buildLLMErrorHandler(ctx context.Context, stream llm.StreamCallba
 					iterLog.Warn("failover handler failed", "error", ferr)
 				}
 			}
+			capture.attempt(fallbackModel, msgs, toolDefs)
 			resp, failErr := l.llm.ChatStream(iterCtx, fallbackModel, msgs, toolDefs, stream)
 			if failErr != nil {
 				iterLog.Error("failover also failed", "error", failErr, "model", fallbackModel)
@@ -2826,7 +2872,7 @@ func (l *Loop) archiveIterations(log *slog.Logger, convID string, iterations []i
 
 // retainContent captures request-level content (system prompt, tool call
 // details, messages) for live inspection and optional persistence.
-func (l *Loop) retainContent(ctx context.Context, requestID, systemPrompt, userMessage string, result *iterate.Result) {
+func (l *Loop) retainContent(ctx context.Context, requestID, systemPrompt, userMessage string, result *iterate.Result, modelCalls []logging.ModelCallContent) {
 	if l.requestRecorder == nil {
 		return
 	}
@@ -2843,10 +2889,11 @@ func (l *Loop) retainContent(ctx context.Context, requestID, systemPrompt, userM
 		Exhausted:        result.Exhausted,
 		ExhaustReason:    result.ExhaustReason,
 		Messages:         result.Messages,
+		ModelCalls:       modelCalls,
 	})
 }
 
-func (l *Loop) recordLiveRequestDetail(ctx context.Context, requestID, systemPrompt, userMessage string, result *iterate.Result) {
+func (l *Loop) recordLiveRequestDetail(ctx context.Context, requestID, systemPrompt, userMessage string, result *iterate.Result, modelCalls []logging.ModelCallContent) {
 	if l.liveRequestRecorder == nil || result == nil {
 		return
 	}
@@ -2863,6 +2910,7 @@ func (l *Loop) recordLiveRequestDetail(ctx context.Context, requestID, systemPro
 		Exhausted:        result.Exhausted,
 		ExhaustReason:    result.ExhaustReason,
 		Messages:         result.Messages,
+		ModelCalls:       modelCalls,
 	})
 }
 

--- a/internal/runtime/agent/model_context_recovery.go
+++ b/internal/runtime/agent/model_context_recovery.go
@@ -18,6 +18,7 @@ func (l *Loop) maybeRetryExplicitModelAfterProviderContextError(
 	msgs []llm.Message,
 	toolDefs []map[string]any,
 	stream llm.StreamCallback,
+	capture modelCallCaptureHooks,
 ) (*llm.ChatResponse, string, error, bool) {
 	if l == nil || l.modelRuntime == nil || err == nil {
 		return nil, "", nil, false
@@ -119,6 +120,7 @@ func (l *Loop) maybeRetryExplicitModelAfterProviderContextError(
 	}
 
 	retryCall := func(tools []map[string]any) (*llm.ChatResponse, error) {
+		capture.attempt(retryModel, msgs, tools)
 		if retryUpstreamModel != "" {
 			if client := l.modelRuntime.LMStudioClient(dep.ResourceID); client != nil {
 				resp, err := client.ChatStream(ctx, retryUpstreamModel, msgs, tools, stream)

--- a/internal/runtime/agent/timeout_recovery_test.go
+++ b/internal/runtime/agent/timeout_recovery_test.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/model/llm"
+	"github.com/nugget/thane-ai-agent/internal/model/prompts"
+	"github.com/nugget/thane-ai-agent/internal/platform/logging"
 )
 
 // --- isTimeout tests ---
@@ -289,6 +291,10 @@ func TestTimeoutRecovery_DownshiftsToRecoveryModel(t *testing.T) {
 
 	loop := buildTestLoopWithLLM(mock, []string{"recall_fact"})
 	loop.recoveryModel = "recovery-model"
+	var retained logging.RequestContent
+	loop.UseLiveRequestRecorder(func(_ context.Context, content logging.RequestContent) {
+		retained = content
+	})
 
 	resp, err := loop.Run(context.Background(), &Request{
 		Messages: []Message{{Role: "user", Content: "recall something"}},
@@ -311,6 +317,16 @@ func TestTimeoutRecovery_DownshiftsToRecoveryModel(t *testing.T) {
 	mock.mu.Unlock()
 	if lastCall.Model != "recovery-model" {
 		t.Errorf("last call model = %q, want recovery-model", lastCall.Model)
+	}
+	if len(retained.ModelCalls) != 2 {
+		t.Fatalf("retained model calls = %#v, want initial and recovery calls", retained.ModelCalls)
+	}
+	recoveryCall := retained.ModelCalls[1]
+	if recoveryCall.Model != "recovery-model" || len(recoveryCall.Tools) != 0 {
+		t.Fatalf("retained recovery call = %#v", recoveryCall)
+	}
+	if len(recoveryCall.Messages) != 2 || recoveryCall.Messages[0].Content != prompts.TimeoutRecoverySystem {
+		t.Fatalf("retained recovery messages = %#v", recoveryCall.Messages)
 	}
 }
 
@@ -349,6 +365,12 @@ func TestTimeoutRecovery_StaticFallbackWhenNoRecoveryModel(t *testing.T) {
 
 	loop := buildTestLoopWithLLM(mock, []string{"recall_fact"})
 	// No recovery model set
+	store := logging.NewLiveRequestStore(4, 64<<10)
+	var retainedRequestID string
+	loop.UseLiveRequestRecorder(func(_ context.Context, content logging.RequestContent) {
+		retainedRequestID = content.RequestID
+		store.WriteRequest(context.Background(), content)
+	})
 
 	resp, err := loop.Run(context.Background(), &Request{
 		Messages: []Message{{Role: "user", Content: "recall something"}},
@@ -359,6 +381,13 @@ func TestTimeoutRecovery_StaticFallbackWhenNoRecoveryModel(t *testing.T) {
 
 	if resp.FinishReason != "timeout_recovery" {
 		t.Errorf("FinishReason = %q, want timeout_recovery", resp.FinishReason)
+	}
+	retained, err := store.QueryRequestDetail(retainedRequestID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retained == nil || len(retained.ModelCalls) != 1 {
+		t.Fatalf("static timeout fallback was not excluded from capture: %#v", retained)
 	}
 
 	if !strings.Contains(resp.Content, "tool call") {
@@ -444,7 +473,7 @@ func TestCanceledContext_DoesNotFailOver(t *testing.T) {
 	cancelIter()
 
 	timeoutRecovered := false
-	handler := loop.buildLLMErrorHandler(reqCtx, nil, loop.model, &Request{}, &timeoutRecovered)
+	handler := loop.buildLLMErrorHandler(reqCtx, nil, loop.model, &Request{}, &timeoutRecovered, modelCallCaptureHooks{})
 
 	_, _, err := handler(
 		iterCtx,

--- a/internal/server/openapi/native.yaml
+++ b/internal/server/openapi/native.yaml
@@ -2368,6 +2368,11 @@ components:
           items: { $ref: "#/components/schemas/ToolDetail" }
           description: Tool invocations performed while handling the request.
           readOnly: true
+        model_calls:
+          type: array
+          items: { $ref: "#/components/schemas/ModelCallDetail" }
+          description: Exact per-iteration model inputs and reference decisions retained for private offline evaluation.
+          readOnly: true
       required: [request_id, messages, iteration_count, input_tokens, output_tokens, exhausted, created_at, tool_calls]
       example:
         request_id: "019e7469-3abf-7e6b-ae38-85b5e34915ac"
@@ -2446,7 +2451,86 @@ components:
           description: JSON-encoded arguments passed to the tool call.
           readOnly: true
           example: "{\"location\":\"Austin, TX\"}"
+        arguments_truncated:
+          type: boolean
+          description: Whether retained arguments were truncated and therefore cannot be replayed exactly.
+          readOnly: true
+          example: false
       required: [name]
+    ModelCallDetail:
+      type: object
+      description: One retained logical provider call, including its exact message and tool surface plus the reference response before tool execution.
+      properties:
+        iteration:
+          type: integer
+          description: Zero-based agent-loop iteration that made the provider call.
+          readOnly: true
+        model:
+          type: string
+          description: Resolved deployment that produced the retained response.
+          readOnly: true
+        prompt_hash:
+          type: string
+          description: Content hash used to resolve the system prompt without duplicating it on disk.
+          readOnly: true
+        prompt_sections:
+          type: array
+          items: { $ref: "#/components/schemas/PromptSectionDetail" }
+          description: Semantic ranges within the resolved system prompt, used for model-family contract substitution.
+          readOnly: true
+        messages:
+          type: array
+          items: { $ref: "#/components/schemas/MessageDetail" }
+          description: Exact provider-neutral input messages for this call.
+          readOnly: true
+        tools:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+          description: Exact OpenAI-style tool definitions offered on this call.
+          readOnly: true
+        response:
+          $ref: "#/components/schemas/MessageDetail"
+        stop_reason:
+          type: string
+          description: Provider termination signal normalized by Thane.
+          readOnly: true
+        input_tokens:
+          type: integer
+          description: Provider-reported input tokens for this call.
+          readOnly: true
+        output_tokens:
+          type: integer
+          description: Provider-reported output tokens for this call.
+          readOnly: true
+        duration_ms:
+          type: integer
+          format: int64
+          description: Logical provider-call duration in milliseconds, including recovery.
+          readOnly: true
+      required: [iteration, model, messages, tools, response]
+    PromptSectionDetail:
+      type: object
+      description: Byte range and cache metadata for one semantic system-prompt section.
+      properties:
+        name:
+          type: string
+          description: Stable semantic section name.
+          readOnly: true
+        start:
+          type: integer
+          description: Inclusive byte offset in the resolved system prompt.
+          readOnly: true
+        end:
+          type: integer
+          description: Exclusive byte offset in the resolved system prompt.
+          readOnly: true
+        cache_ttl:
+          type: string
+          description: Optional provider cache hint captured with the section.
+          readOnly: true
+      required: [name, start, end]
     MessageImageDetail:
       type: object
       description: Metadata for a retained image attachment, without the base64 image payload.

--- a/justfile
+++ b/justfile
@@ -277,6 +277,11 @@ deploy-macos host target_arch=host_arch version="" remote_pkg_dir="/tmp/thane-re
 serve: build
     cd Thane && ../dist/thane-{{host_os}}-{{host_arch}} serve -workspace .
 
+[doc("Capture and replay private production model-evaluation snapshots")]
+[group('operations')]
+model-eval *args:
+    go run ./cmd/model-eval {{args}}
+
 # Tail live service logs (default: dev workdir). Follows the events
 # dataset and rolls to the next HH.jsonl segment automatically. Waits
 # patiently if no segment exists yet so this works on a fresh install.

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,4 +1,4 @@
-packages=68
+packages=69
 interfaces=83
 large_files=57
 set_mutators=117


### PR DESCRIPTION
## Summary

- retain each successful physical model attempt with the exact provider-neutral messages, tool schemas, reference decision, stop reason, tokens, and latency
- add a private `model-eval snapshot` / `model-eval run` workflow for replaying production-derived cases against OpenAI-compatible local deployments without executing tools
- add deterministic tool-decision scoring, model-family tool-contract adaptation, OpenAPI coverage, tests, and operator documentation

## Why

Generic benchmarks do not show whether a local model can operate Thane’s real context and internally exposed tool surface. This creates a production-shaped evaluation path while keeping snapshots explicitly private and treating reference agreement as diagnostic evidence rather than a quality oracle.

## User impact

When retained-content logging is enabled, newly completed requests include per-iteration model-call capture. Snapshots and reports default outside the Git worktree, use mode 0600, never execute captured tools, and exclude truncated, image-dependent, incomplete, and synthetic recovery cases. Streaming replay exercises the same provider parser and tool-call correlation path used by Thane.

## Test plan

- [x] `just ci`
- [x] end-to-end snapshot and non-streaming replay against a mock OpenAI-compatible endpoint
- [x] deterministic scoring and prompt-contract adaptation tests
- [x] timeout recovery records the actual recovery prompt/tool surface and excludes static fallbacks