### PR TITLE
Render calendar events in the household zone, not UTC

### DIFF
--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -223,6 +223,19 @@ func (a *App) initServers(s *newState) error {
 	// to connect and register capabilities for bidirectional service dispatch.
 	if cfg.Companion.Configured() {
 		a.companionRegistry = companion.NewRegistry(logger)
+
+		// Calendar output is rendered in the household zone, not the
+		// host's, and not UTC. Already validated by config.Validate, so a
+		// load failure here can only mean the zone database is missing;
+		// time.Local is the honest fallback.
+		companionHome := time.Local
+		if cfg.Timezone != "" {
+			if loc, err := time.LoadLocation(cfg.Timezone); err == nil {
+				companionHome = loc
+			}
+		}
+		a.loop.Tools().SetTimezone(cfg.Timezone)
+
 		// Legacy floor: the hand-coded macos_calendar_events tool keeps
 		// working against older Macs that advertise only methods (no
 		// authored tool defs).
@@ -234,7 +247,7 @@ func (a *App) initServers(s *newState) error {
 		// whenever a companion connects, re-registers, or drops — so a
 		// laptop popping on/off line surfaces and retracts its tools
 		// mid-session. A Mac-authored tool shadows the legacy floor by name.
-		registrar := tools.NewCompanionRegistrar(a.companionRegistry, logger)
+		registrar := tools.NewCompanionRegistrar(a.companionRegistry, companionHome, logger)
 		a.loop.SetDynamicToolSource(registrar)
 		a.companionRegistry.SetOnChange(registrar.Rebuild)
 

--- a/internal/model/promptfmt/timefmt.go
+++ b/internal/model/promptfmt/timefmt.go
@@ -193,3 +193,44 @@ func parseDeltaTerms(s string) (time.Duration, error) {
 	}
 	return total, nil
 }
+
+// FormatDayDelta renders the distance between two calendar days as the
+// word a reader would use, falling back to a signed day count past the
+// range words have: "today", "tomorrow", "yesterday", "+5d", "-3d".
+//
+// Unlike [FormatDeltaOnly] this takes whole days rather than an instant
+// offset, because its subject is a date rather than a moment. An all-day
+// calendar event occupies a day, not a point on the clock; saying it
+// starts in "+14h29m" invents a precision the source never had and reads
+// as though there were a time to be early or late for.
+//
+// Both arguments are interpreted in their own locations, so callers must
+// pass times already converted to the frame the reader thinks in.
+func FormatDayDelta(day, today time.Time) string {
+	d := daysBetween(today, day)
+	switch d {
+	case 0:
+		return "today"
+	case 1:
+		return "tomorrow"
+	case -1:
+		return "yesterday"
+	}
+	if d > 0 {
+		return fmt.Sprintf("+%dd", d)
+	}
+	return fmt.Sprintf("-%dd", -d)
+}
+
+// daysBetween counts whole calendar days from one date to another,
+// ignoring both clock times and the locations the two carry. Truncating
+// each to midnight UTC before subtracting keeps the count immune to the
+// 23- and 25-hour days a DST transition produces: a plain Sub on two
+// local midnights either side of a spring-forward reports 23h, which
+// integer-divides to zero days and would render an event "today" on the
+// morning it is actually tomorrow.
+func daysBetween(from, to time.Time) int {
+	a := time.Date(from.Year(), from.Month(), from.Day(), 0, 0, 0, 0, time.UTC)
+	b := time.Date(to.Year(), to.Month(), to.Day(), 0, 0, 0, 0, time.UTC)
+	return int(b.Sub(a) / (24 * time.Hour))
+}

--- a/internal/model/promptfmt/timefmt_test.go
+++ b/internal/model/promptfmt/timefmt_test.go
@@ -321,3 +321,64 @@ func TestFormatDurationRoundTripsThroughParseDuration(t *testing.T) {
 		}
 	}
 }
+
+func TestFormatDayDelta(t *testing.T) {
+	chicago, err := time.LoadLocation("America/Chicago")
+	if err != nil {
+		t.Fatalf("load America/Chicago: %v", err)
+	}
+	day := func(y int, m time.Month, d int) time.Time {
+		return time.Date(y, m, d, 0, 0, 0, 0, chicago)
+	}
+	today := time.Date(2026, time.August, 29, 10, 48, 0, 0, chicago)
+
+	tests := []struct {
+		name string
+		day  time.Time
+		want string
+	}{
+		{"same day", day(2026, time.August, 29), "today"},
+		{"next day", day(2026, time.August, 30), "tomorrow"},
+		{"previous day", day(2026, time.August, 28), "yesterday"},
+		{"a week out", day(2026, time.September, 5), "+7d"},
+		{"a week back", day(2026, time.August, 22), "-7d"},
+		{"across a year boundary", day(2027, time.January, 1), "+125d"},
+		{
+			// The clock time of either argument is irrelevant: a date is
+			// the whole subject, so late on the 29th and early on the 30th
+			// are still one day apart.
+			name: "clock times do not shift the count",
+			day:  time.Date(2026, time.August, 30, 23, 59, 0, 0, chicago),
+			want: "tomorrow",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := FormatDayDelta(tc.day, today); got != tc.want {
+				t.Errorf("FormatDayDelta() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFormatDayDeltaSurvivesDSTTransitions guards the reason daysBetween
+// normalises to UTC midnight before subtracting: the local days around a
+// transition are 23 and 25 hours long, and a plain division by 24h would
+// report the short one as no day at all.
+func TestFormatDayDeltaSurvivesDSTTransitions(t *testing.T) {
+	chicago, err := time.LoadLocation("America/Chicago")
+	if err != nil {
+		t.Fatalf("load America/Chicago: %v", err)
+	}
+
+	// 2026-03-08 springs forward; 2026-11-01 falls back.
+	springNow := time.Date(2026, time.March, 7, 10, 0, 0, 0, chicago)
+	if got := FormatDayDelta(time.Date(2026, time.March, 8, 0, 0, 0, 0, chicago), springNow); got != "tomorrow" {
+		t.Errorf("spring forward: got %q, want %q", got, "tomorrow")
+	}
+
+	fallNow := time.Date(2026, time.October, 31, 10, 0, 0, 0, chicago)
+	if got := FormatDayDelta(time.Date(2026, time.November, 1, 0, 0, 0, 0, chicago), fallNow); got != "tomorrow" {
+		t.Errorf("fall back: got %q, want %q", got, "tomorrow")
+	}
+}

--- a/internal/tools/companion_calendar_format.go
+++ b/internal/tools/companion_calendar_format.go
@@ -1,0 +1,360 @@
+package tools
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
+)
+
+// The layouts a companion may use for an event boundary. A timed event
+// carries a full RFC3339 timestamp with the offset of the zone the event
+// is scheduled in; an all-day event carries a bare calendar date, which
+// has no time and no zone by definition.
+const (
+	calendarDateLayout = "2006-01-02"
+
+	// Weekday-and-date shapes. The year appears only when the event does
+	// not fall in the reader's current year: on a calendar the near term
+	// is the common case, and "2026" on every line of a week's schedule
+	// is noise that pushes the parts that vary off to the right.
+	calendarDayLayout     = "Mon Jan 2"
+	calendarDayYearLayout = "Mon Jan 2 2006"
+
+	// Clock shapes. Seconds never appear — no calendar event means them,
+	// and rendering ":00" on every line invites the model to treat the
+	// precision as real.
+	calendarClockLayout     = "3:04PM MST"
+	calendarClockOnlyLayout = "3:04PM"
+)
+
+// calendarRenderer turns companion calendar events into the lines a model
+// reads. It resolves two frames for every event:
+//
+//   - home, the household zone from configuration, which is the frame the
+//     agent's own process reasons in and the one "is this soon?" is asked
+//     against;
+//   - the event's own zone, which on this operator's calendar is a
+//     statement of intent — an event recorded in Europe/Berlin means the
+//     operator expects to be in Berlin for it, so that reading is the
+//     wall clock they will actually live.
+//
+// Home is primary and every event is rendered in it. The event's own
+// reading is appended whenever the two disagree about what the clock says,
+// so neither frame has to be inferred.
+type calendarRenderer struct {
+	home *time.Location
+	now  time.Time
+}
+
+func newCalendarRenderer(home *time.Location, now time.Time) calendarRenderer {
+	if home == nil {
+		home = time.Local
+	}
+	return calendarRenderer{home: home, now: now.In(home)}
+}
+
+// calendarBoundary is a parsed start or end of an event.
+type calendarBoundary struct {
+	t time.Time
+
+	// dateOnly marks a boundary that named a calendar date rather than a
+	// moment. Its clock and zone are placeholders and must never be shown.
+	dateOnly bool
+}
+
+// parseCalendarBoundary reads one end of an event, preferring the date
+// form so an all-day event is recognised before its value is mistaken for
+// a midnight instant.
+//
+// This deliberately does not reuse database.ParseTimestamp: that is the
+// read-side salvage parser for SQLite TEXT columns and accepts eight
+// historical shapes, none of which a companion emits. Borrowing it here
+// would silently accept payloads the contract does not permit and hide
+// exactly the drift these formats exist to catch.
+func parseCalendarBoundary(value string) (calendarBoundary, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return calendarBoundary{}, false
+	}
+	if t, err := time.Parse(calendarDateLayout, value); err == nil {
+		return calendarBoundary{t: t, dateOnly: true}, true
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339} {
+		if t, err := time.Parse(layout, value); err == nil {
+			return calendarBoundary{t: t}, true
+		}
+	}
+	return calendarBoundary{}, false
+}
+
+// formatCompanionCalendarResponse renders the whole result set, headed by
+// the frame every line below it is written in. Stating the zone and the
+// current time once removes the arithmetic the model would otherwise have
+// to do per line to decide what is imminent.
+func formatCompanionCalendarResponse(response companionCalendarResponse, home *time.Location, now time.Time) string {
+	if len(response.Events) == 0 {
+		return "No macOS calendar events found in the requested window."
+	}
+
+	r := newCalendarRenderer(home, now)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Found %d macOS calendar events (times in %s; now %s):",
+		len(response.Events), r.homeZoneName(), r.now.Format(calendarDayLayout+" "+calendarClockLayout))
+	for _, event := range response.Events {
+		fmt.Fprintf(&b, "\n- %s | %s", r.formatRange(event), strings.TrimSpace(event.Title))
+		if event.Calendar != "" {
+			fmt.Fprintf(&b, " (%s)", event.Calendar)
+		}
+		if event.Location != "" {
+			fmt.Fprintf(&b, "\n  Location: %s", event.Location)
+		}
+		if event.NotesExcerpt != "" {
+			fmt.Fprintf(&b, "\n  Notes: %s", event.NotesExcerpt)
+		}
+		if event.URL != "" {
+			fmt.Fprintf(&b, "\n  URL: %s", event.URL)
+		}
+	}
+	formatted := b.String()
+	if len(formatted) <= maxCompanionCalendarResultBytes {
+		return formatted
+	}
+	const note = "\n\n[... output truncated; narrow the window, filters, or limit for more ...]"
+	allowed := maxCompanionCalendarResultBytes - len(note)
+	if allowed < 0 {
+		allowed = 0
+	}
+	return truncateUTF8(formatted, allowed) + note
+}
+
+// homeZoneName is the IANA name of the reader's frame where one exists.
+// A location loaded from configuration carries its name; time.Local does
+// not, and reports "Local", which tells a model nothing — fall back to the
+// zone abbreviation currently in effect, which at least anchors the offset.
+func (r calendarRenderer) homeZoneName() string {
+	name := r.home.String()
+	if name == "" || name == "Local" {
+		abbrev, _ := r.now.Zone()
+		return abbrev
+	}
+	return name
+}
+
+// formatRange renders the time portion of one event line.
+func (r calendarRenderer) formatRange(event companionCalendarEvent) string {
+	start, startOK := parseCalendarBoundary(event.Start)
+	end, endOK := parseCalendarBoundary(event.End)
+
+	// An unparseable start leaves nothing to reason from. Echo whatever the
+	// companion sent rather than dropping the event: a malformed timestamp
+	// is a bug worth seeing, and the title and location are still useful.
+	if !startOK {
+		if strings.TrimSpace(event.End) == "" {
+			return strings.TrimSpace(event.Start)
+		}
+		return strings.TrimSpace(event.Start) + " - " + strings.TrimSpace(event.End)
+	}
+
+	if event.AllDay {
+		return r.formatAllDay(start, end, endOK)
+	}
+	return r.formatTimed(event, start, end, endOK)
+}
+
+// formatAllDay renders a date range with no clock and no zone. An all-day
+// event is a property of a date in the place the operator will be, not an
+// interval on any particular clock, so imposing one would be a fiction.
+func (r calendarRenderer) formatAllDay(start, end calendarBoundary, endOK bool) string {
+	first := r.allDayDate(start)
+	delta := promptfmt.FormatDayDelta(first, r.now)
+
+	last := first
+	if endOK {
+		last = r.allDayLastDate(end, first)
+	}
+
+	if sameDay(first, last) {
+		return fmt.Sprintf("%s (all day, %s)", r.formatDay(first), delta)
+	}
+	return fmt.Sprintf("%s -> %s (all day, %s)", r.formatDay(first), r.formatDay(last), delta)
+}
+
+// allDayDate resolves the calendar date an all-day boundary names.
+//
+// The date form needs no interpretation. The instant form is what older
+// companions send: some zone's midnight, with the zone itself discarded
+// before it reached the wire, which is the bug this contract replaces.
+// Rounding to the nearest UTC midnight recovers the intended date for
+// every offset inside ±12h — the Chicago reading 05:00Z and the Berlin
+// reading 22:00Z of the previous day both round to the same date — which
+// covers every zone this household operates in. Offsets beyond ±12h
+// (Kiribati, Baker Island) would land a day out; they are unreachable
+// here, and a companion new enough to visit one sends the date form.
+func (r calendarRenderer) allDayDate(b calendarBoundary) time.Time {
+	if b.dateOnly {
+		return b.t
+	}
+	rounded := b.t.UTC().Round(24 * time.Hour)
+	return time.Date(rounded.Year(), rounded.Month(), rounded.Day(), 0, 0, 0, 0, time.UTC)
+}
+
+// allDayLastDate resolves the inclusive final day of an all-day event.
+//
+// The date form is already inclusive: the companion computed it against
+// the event's own calendar, which is the only place the answer is
+// knowable. The instant form is exclusive in EventKit's model, so the day
+// before it is the last one the event actually occupies.
+func (r calendarRenderer) allDayLastDate(end calendarBoundary, first time.Time) time.Time {
+	if end.dateOnly {
+		if end.t.Before(first) {
+			return first
+		}
+		return end.t
+	}
+	last := r.allDayDate(end).AddDate(0, 0, -1)
+	if last.Before(first) {
+		return first
+	}
+	return last
+}
+
+// formatTimed renders an event that occupies a span of clock time, in home
+// with the event's own reading appended when the two clocks disagree.
+func (r calendarRenderer) formatTimed(event companionCalendarEvent, start, end calendarBoundary, endOK bool) string {
+	homeStart := start.t.In(r.home)
+	line := fmt.Sprintf("%s (%s)",
+		r.formatSpan(homeStart, end.t.In(r.home), endOK, spanStyle{withDate: true, withZone: true}),
+		promptfmt.FormatDeltaOnly(start.t, r.now))
+
+	away, ok := r.eventLocation(event, start.t)
+	if !ok {
+		return line
+	}
+
+	// The away reading repeats the date only when it is a different one.
+	// A 9pm Berlin event is 2pm the same afternoon in Chicago and the date
+	// would be noise; an 11pm Chicago event is the following morning in
+	// Berlin, and there the date is the whole point.
+	awayStart := start.t.In(away)
+	return fmt.Sprintf("%s [%s %s]", line, r.eventZoneName(event, away, start.t),
+		r.formatSpan(awayStart, end.t.In(away), endOK, spanStyle{withDate: !sameDay(homeStart, awayStart)}))
+}
+
+// eventLocation returns the zone to render an event's own clock in, and
+// whether that clock differs from home at all.
+//
+// The comparison is on the offset in effect at the event, not on the zone
+// names: America/Chicago and America/Winnipeg keep the same clock, and
+// annotating one with the other would add a line of text that says nothing
+// a reader can act on. Only a genuinely different wall-clock reading earns
+// the annotation.
+func (r calendarRenderer) eventLocation(event companionCalendarEvent, at time.Time) (*time.Location, bool) {
+	loc := at.Location()
+	if name := strings.TrimSpace(event.TimeZone); name != "" {
+		if parsed, err := time.LoadLocation(name); err == nil {
+			loc = parsed
+		}
+	} else if _, offset := at.Zone(); offset == 0 {
+		// No declared zone and a bare Z offset is an absence of evidence,
+		// not evidence of UTC: companions predating the time_zone field
+		// forced every event to UTC no matter where it was scheduled.
+		// Annotating those as UTC events would invent the very fact the
+		// old wire format destroyed.
+		return nil, false
+	}
+
+	_, homeOffset := at.In(r.home).Zone()
+	_, eventOffset := at.In(loc).Zone()
+	if homeOffset == eventOffset {
+		return nil, false
+	}
+	return loc, true
+}
+
+// eventZoneName labels the event's own frame, preferring the IANA name the
+// companion declared. A timestamp offset alone has no name to report, so
+// fall back to the zone abbreviation, and then to the numeric offset when
+// even that is only a "+02" placeholder.
+func (r calendarRenderer) eventZoneName(event companionCalendarEvent, loc *time.Location, at time.Time) string {
+	if name := strings.TrimSpace(event.TimeZone); name != "" {
+		if _, err := time.LoadLocation(name); err == nil {
+			return name
+		}
+	}
+	abbrev, offset := at.In(loc).Zone()
+	if abbrev != "" && !strings.HasPrefix(abbrev, "+") && !strings.HasPrefix(abbrev, "-") {
+		return abbrev
+	}
+	return formatZoneOffset(offset)
+}
+
+// spanStyle selects which parts of a span are worth printing. The home
+// reading carries both the date and the zone; an away reading is already
+// introduced by its zone name and sits beside the home date, so it usually
+// needs neither.
+type spanStyle struct {
+	withDate bool
+	withZone bool
+}
+
+// formatSpan renders a start and end already converted to one location. A
+// span that stays inside a single day states the date once and drops it
+// from the end; one that crosses a day boundary states both regardless of
+// style, because a reader cannot supply the second date themselves. A
+// zero-length or unparseable end drops the end entirely.
+func (r calendarRenderer) formatSpan(start, end time.Time, endOK bool, style spanStyle) string {
+	clock := calendarClockOnlyLayout
+	if style.withZone {
+		clock = calendarClockLayout
+	}
+	day := func(t time.Time) string {
+		if !style.withDate {
+			return ""
+		}
+		return r.formatDay(t) + " "
+	}
+
+	if !endOK || !end.After(start) {
+		return day(start) + start.Format(clock)
+	}
+	if sameDay(start, end) {
+		return day(start) + start.Format(calendarClockOnlyLayout) + "-" + end.Format(clock)
+	}
+	return fmt.Sprintf("%s %s -> %s %s",
+		r.formatDay(start), start.Format(clock),
+		r.formatDay(end), end.Format(clock))
+}
+
+// formatDay renders a weekday and date, carrying the year only when the
+// event falls outside the reader's current one.
+func (r calendarRenderer) formatDay(t time.Time) string {
+	if t.Year() == r.now.Year() {
+		return t.Format(calendarDayLayout)
+	}
+	return t.Format(calendarDayYearLayout)
+}
+
+// formatZoneOffset renders a UTC offset as "UTC+2" or "UTC-5:30", the last
+// resort when a zone has neither an IANA name nor a usable abbreviation.
+func formatZoneOffset(seconds int) string {
+	sign := "+"
+	if seconds < 0 {
+		sign = "-"
+		seconds = -seconds
+	}
+	h, m := seconds/3600, (seconds%3600)/60
+	if m == 0 {
+		return fmt.Sprintf("UTC%s%d", sign, h)
+	}
+	return fmt.Sprintf("UTC%s%d:%02d", sign, h, m)
+}
+
+// sameDay reports whether two times fall on the same calendar day. Callers
+// pass times already in one location; comparing across locations would ask
+// a question with no answer.
+func sameDay(a, b time.Time) bool {
+	return a.Year() == b.Year() && a.YearDay() == b.YearDay()
+}

--- a/internal/tools/companion_calendar_format.go
+++ b/internal/tools/companion_calendar_format.go
@@ -229,66 +229,111 @@ func (r calendarRenderer) formatTimed(event companionCalendarEvent, start, end c
 		r.formatSpan(homeStart, end.t.In(r.home), endOK, spanStyle{withDate: true, withZone: true}),
 		promptfmt.FormatDeltaOnly(start.t, r.now))
 
-	away, ok := r.eventLocation(event, start.t)
-	if !ok {
-		return line
+	if away, ok := r.awayReading(event, start, end, endOK, homeStart); ok {
+		return line + " [" + away + "]"
 	}
-
-	// The away reading repeats the date only when it is a different one.
-	// A 9pm Berlin event is 2pm the same afternoon in Chicago and the date
-	// would be noise; an 11pm Chicago event is the following morning in
-	// Berlin, and there the date is the whole point.
-	awayStart := start.t.In(away)
-	return fmt.Sprintf("%s [%s %s]", line, r.eventZoneName(event, away, start.t),
-		r.formatSpan(awayStart, end.t.In(away), endOK, spanStyle{withDate: !sameDay(homeStart, awayStart)}))
+	return line
 }
 
-// eventLocation returns the zone to render an event's own clock in, and
-// whether that clock differs from home at all.
-//
-// The comparison is on the offset in effect at the event, not on the zone
-// names: America/Chicago and America/Winnipeg keep the same clock, and
-// annotating one with the other would add a line of text that says nothing
-// a reader can act on. Only a genuinely different wall-clock reading earns
-// the annotation.
-func (r calendarRenderer) eventLocation(event companionCalendarEvent, at time.Time) (*time.Location, bool) {
-	loc := at.Location()
-	if name := strings.TrimSpace(event.TimeZone); name != "" {
-		if parsed, err := time.LoadLocation(name); err == nil {
-			loc = parsed
-		}
-	} else if _, offset := at.Zone(); offset == 0 {
+// awayReading renders the event on its own clock, and reports whether that
+// reading says anything the home reading did not.
+func (r calendarRenderer) awayReading(event companionCalendarEvent, start, end calendarBoundary, endOK bool, homeStart time.Time) (string, bool) {
+	declared := declaredLocation(event)
+
+	// Resolve each boundary in the frame that actually governs it. With a
+	// declared zone that is the zone itself, transitions included. Without
+	// one, each timestamp's own offset is the only evidence there is, and
+	// the two ends can legitimately disagree across a transition the event
+	// spans — forcing the end into the start's offset would move it.
+	awayStart, awayEnd := start.t, end.t
+	if declared != nil {
+		awayStart, awayEnd = start.t.In(declared), end.t.In(declared)
+	} else if _, offset := start.t.Zone(); offset == 0 {
 		// No declared zone and a bare Z offset is an absence of evidence,
 		// not evidence of UTC: companions predating the time_zone field
 		// forced every event to UTC no matter where it was scheduled.
 		// Annotating those as UTC events would invent the very fact the
 		// old wire format destroyed.
-		return nil, false
+		return "", false
 	}
 
-	_, homeOffset := at.In(r.home).Zone()
-	_, eventOffset := at.In(loc).Zone()
-	if homeOffset == eventOffset {
-		return nil, false
+	if !r.divergesFromHome(awayStart, awayEnd, endOK) {
+		return "", false
 	}
-	return loc, true
+
+	// Label the frame once where a single one governs the whole span. When
+	// the ends sit at different offsets there is no one frame to name, so
+	// each end carries its own and the label is dropped rather than
+	// claiming the start's offset covers both.
+	zonesDiffer := endOK && !sameOffset(awayStart, awayEnd)
+	span := r.formatSpan(awayStart, awayEnd, endOK, spanStyle{
+		// The away reading repeats the date only when it is a different
+		// one. A 9pm Berlin event is 2pm the same afternoon in Chicago and
+		// the date would be noise; an 11pm Chicago event is the following
+		// morning in Berlin, and there the date is the whole point.
+		withDate: !sameDay(homeStart, awayStart),
+		withZone: zonesDiffer,
+	})
+
+	if zonesDiffer && declared == nil {
+		return span, true
+	}
+	return r.eventZoneName(event, awayStart) + " " + span, true
+}
+
+// divergesFromHome reports whether the event's own clock reads differently
+// from home at either end.
+//
+// The comparison is on the offsets in effect, not on the zone names:
+// America/Chicago and America/Winnipeg keep the same clock, and annotating
+// one with the other would add a line of text that says nothing a reader
+// can act on. Both ends are checked because two zones can share an offset
+// at the start and part before the end — America/Phoenix and
+// America/Los_Angeles agree all summer and diverge at the fall-back — and
+// an annotation suppressed on the strength of the start alone would drop
+// exactly the hour that made it worth printing.
+func (r calendarRenderer) divergesFromHome(awayStart, awayEnd time.Time, endOK bool) bool {
+	if !sameOffset(awayStart, awayStart.In(r.home)) {
+		return true
+	}
+	return endOK && !sameOffset(awayEnd, awayEnd.In(r.home))
+}
+
+// declaredLocation loads the zone the companion named, or nil when it named
+// none or named one this host cannot resolve.
+func declaredLocation(event companionCalendarEvent) *time.Location {
+	name := strings.TrimSpace(event.TimeZone)
+	if name == "" {
+		return nil
+	}
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		return nil
+	}
+	return loc
 }
 
 // eventZoneName labels the event's own frame, preferring the IANA name the
 // companion declared. A timestamp offset alone has no name to report, so
 // fall back to the zone abbreviation, and then to the numeric offset when
 // even that is only a "+02" placeholder.
-func (r calendarRenderer) eventZoneName(event companionCalendarEvent, loc *time.Location, at time.Time) string {
-	if name := strings.TrimSpace(event.TimeZone); name != "" {
-		if _, err := time.LoadLocation(name); err == nil {
-			return name
-		}
+func (r calendarRenderer) eventZoneName(event companionCalendarEvent, at time.Time) string {
+	if declaredLocation(event) != nil {
+		return strings.TrimSpace(event.TimeZone)
 	}
-	abbrev, offset := at.In(loc).Zone()
+	abbrev, offset := at.Zone()
 	if abbrev != "" && !strings.HasPrefix(abbrev, "+") && !strings.HasPrefix(abbrev, "-") {
 		return abbrev
 	}
 	return formatZoneOffset(offset)
+}
+
+// sameOffset reports whether two times sit at the same UTC offset. Two
+// readings that do are the same wall clock, whatever their zones are named.
+func sameOffset(a, b time.Time) bool {
+	_, ao := a.Zone()
+	_, bo := b.Zone()
+	return ao == bo
 }
 
 // spanStyle selects which parts of a span are worth printing. The home
@@ -321,6 +366,13 @@ func (r calendarRenderer) formatSpan(start, end time.Time, endOK bool, style spa
 		return day(start) + start.Format(clock)
 	}
 	if sameDay(start, end) {
+		// Fall back repeats an hour: 1:30AM CDT and 1:30AM CST are a real
+		// hour apart on the same date. Carrying the zone on the end alone
+		// would label the start with the end's zone and render that hour
+		// as a zero-length event.
+		if style.withZone && !sameOffset(start, end) {
+			return day(start) + start.Format(clock) + "-" + end.Format(clock)
+		}
 		return day(start) + start.Format(calendarClockOnlyLayout) + "-" + end.Format(clock)
 	}
 	return fmt.Sprintf("%s %s -> %s %s",

--- a/internal/tools/companion_calendar_format_test.go
+++ b/internal/tools/companion_calendar_format_test.go
@@ -213,6 +213,46 @@ func TestFormatCompanionCalendarRange(t *testing.T) {
 			want: "Sat Mar 7 11:00PM CST -> Sun Mar 8 3:00AM CDT (+13h)",
 		},
 		{
+			// Fall back in Chicago is 2026-11-01: 1:30AM happens twice, an
+			// hour apart. Printing the zone only on the end labels the
+			// start CST too, so a real hour reads as zero-length.
+			name: "a same-day span across fall-back labels both ends",
+			now:  "2026-11-01T00:00:00-05:00",
+			event: companionCalendarEvent{
+				Start: "2026-11-01T01:30:00-05:00",
+				End:   "2026-11-01T01:30:00-06:00",
+			},
+			want: "Sun Nov 1 1:30AM CDT-1:30AM CST (+1h30m)",
+		},
+		{
+			// Phoenix never leaves -07:00; Los Angeles shares it until the
+			// fall-back, then drops to -08:00. Comparing only the start
+			// instant finds them equal and drops an annotation the end
+			// needs.
+			name: "an away zone that diverges only by the end is still annotated",
+			now:  "2026-11-01T00:00:00-07:00",
+			event: companionCalendarEvent{
+				Start:    "2026-11-01T01:30:00-07:00",
+				End:      "2026-11-01T01:30:00-08:00",
+				TimeZone: "America/Los_Angeles",
+			},
+			want: "Sun Nov 1 2:30AM-3:30AM CST (+1h30m) [America/Los_Angeles 1:30AM PDT-1:30AM PST]",
+		},
+		{
+			// With no declared zone the only evidence is each timestamp's
+			// own offset. Converting the end into the start's offset moves
+			// it an hour and reports a 4am event as ending at 3am.
+			name: "an offset-only span keeps each end's own offset",
+			event: companionCalendarEvent{
+				Start: "2026-09-01T23:00:00+01:00",
+				End:   "2026-09-02T04:00:00+02:00",
+			},
+			// The end reads 4:00AM, not the 3:00AM that forcing it into the
+			// start's offset produced. No single frame governs the span, so
+			// each end carries its own offset and the label is dropped.
+			want: "Tue Sep 1 5:00PM-9:00PM CDT (+3d6h) [Tue Sep 1 11:00PM +0100 -> Wed Sep 2 4:00AM +0200]",
+		},
+		{
 			name: "a malformed start echoes what the companion sent",
 			event: companionCalendarEvent{
 				Start: "not a timestamp",

--- a/internal/tools/companion_calendar_format_test.go
+++ b/internal/tools/companion_calendar_format_test.go
@@ -1,0 +1,416 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// chicago is the household zone in production and the frame every
+// expectation below is written in.
+func chicago(t *testing.T) *time.Location {
+	t.Helper()
+	loc, err := time.LoadLocation("America/Chicago")
+	if err != nil {
+		t.Fatalf("load America/Chicago: %v", err)
+	}
+	return loc
+}
+
+func mustTime(t *testing.T, value string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		t.Fatalf("parse %q: %v", value, err)
+	}
+	return parsed
+}
+
+func TestFormatCompanionCalendarRange(t *testing.T) {
+	// A Saturday mid-morning in Chicago, during daylight time.
+	now := mustTime(t, "2026-08-29T10:48:00-05:00")
+
+	tests := []struct {
+		name  string
+		now   string
+		event companionCalendarEvent
+		want  string
+	}{
+		{
+			name: "timed event renders in the household zone, not UTC",
+			event: companionCalendarEvent{
+				Start: "2026-08-29T09:00:00-05:00",
+				End:   "2026-08-29T09:30:00-05:00",
+			},
+			want: "Sat Aug 29 9:00AM-9:30AM CDT (-1h48m)",
+		},
+		{
+			// A bare Z is an older companion discarding the zone, not an
+			// event scheduled on UTC's clock, so it earns no away reading.
+			name: "a UTC instant from an older companion converts to home",
+			event: companionCalendarEvent{
+				Start: "2026-08-29T14:00:00Z",
+				End:   "2026-08-29T14:30:00Z",
+			},
+			want: "Sat Aug 29 9:00AM-9:30AM CDT (-1h48m)",
+		},
+		{
+			name: "an event in another zone carries both readings",
+			event: companionCalendarEvent{
+				Start:    "2026-08-29T21:00:00+02:00",
+				End:      "2026-08-29T22:00:00+02:00",
+				TimeZone: "Europe/Berlin",
+			},
+			want: "Sat Aug 29 2:00PM-3:00PM CDT (+3h12m) [Europe/Berlin 9:00PM-10:00PM]",
+		},
+		{
+			name: "an offset with no declared zone still earns the second reading",
+			event: companionCalendarEvent{
+				Start: "2026-08-29T21:00:00+02:00",
+				End:   "2026-08-29T22:00:00+02:00",
+			},
+			want: "Sat Aug 29 2:00PM-3:00PM CDT (+3h12m) [UTC+2 9:00PM-10:00PM]",
+		},
+		{
+			name: "a zone that keeps the same clock as home is not annotated",
+			event: companionCalendarEvent{
+				Start:    "2026-08-29T14:00:00-05:00",
+				End:      "2026-08-29T15:00:00-05:00",
+				TimeZone: "America/Winnipeg",
+			},
+			want: "Sat Aug 29 2:00PM-3:00PM CDT (+3h12m)",
+		},
+		{
+			// The span crosses midnight in Chicago but not in Berlin, so
+			// the away reading collapses to the single date it occupies.
+			name: "an away reading on another date carries that date",
+			event: companionCalendarEvent{
+				Start:    "2026-08-29T23:00:00-05:00",
+				End:      "2026-08-30T00:00:00-05:00",
+				TimeZone: "Europe/Berlin",
+			},
+			want: "Sat Aug 29 11:00PM CDT -> Sun Aug 30 12:00AM CDT (+12h12m) " +
+				"[Europe/Berlin Sun Aug 30 6:00AM-7:00AM]",
+		},
+		{
+			name: "a span crossing midnight repeats the date on both ends",
+			event: companionCalendarEvent{
+				Start: "2026-08-29T23:00:00-05:00",
+				End:   "2026-08-30T01:00:00-05:00",
+			},
+			want: "Sat Aug 29 11:00PM CDT -> Sun Aug 30 1:00AM CDT (+12h12m)",
+		},
+		{
+			name: "an event outside the current year carries it",
+			event: companionCalendarEvent{
+				Start: "2027-01-04T09:00:00-06:00",
+				End:   "2027-01-04T10:00:00-06:00",
+			},
+			want: "Mon Jan 4 2027 9:00AM-10:00AM CST (+127d23h)",
+		},
+		{
+			name: "an event with no end renders a single instant",
+			event: companionCalendarEvent{
+				Start: "2026-08-29T09:00:00-05:00",
+			},
+			want: "Sat Aug 29 9:00AM CDT (-1h48m)",
+		},
+		{
+			name: "an all-day date renders without a clock or a zone",
+			event: companionCalendarEvent{
+				Start:  "2026-08-29",
+				End:    "2026-08-29",
+				AllDay: true,
+			},
+			want: "Sat Aug 29 (all day, today)",
+		},
+		{
+			name: "a multi-day all-day event names its inclusive last day",
+			event: companionCalendarEvent{
+				Start:  "2026-08-31",
+				End:    "2026-09-02",
+				AllDay: true,
+			},
+			want: "Mon Aug 31 -> Wed Sep 2 (all day, +2d)",
+		},
+		{
+			name: "tomorrow reads as a word rather than a count",
+			event: companionCalendarEvent{
+				Start:  "2026-08-30",
+				End:    "2026-08-30",
+				AllDay: true,
+			},
+			want: "Sun Aug 30 (all day, tomorrow)",
+		},
+		{
+			name: "yesterday reads as a word rather than a count",
+			event: companionCalendarEvent{
+				Start:  "2026-08-28",
+				End:    "2026-08-28",
+				AllDay: true,
+			},
+			want: "Fri Aug 28 (all day, yesterday)",
+		},
+		{
+			name: "an all-day event never shows an hours-and-minutes delta",
+			event: companionCalendarEvent{
+				Start:  "2026-09-05",
+				End:    "2026-09-05",
+				AllDay: true,
+			},
+			want: "Sat Sep 5 (all day, +7d)",
+		},
+		{
+			// The bug that started this: a Berlin all-day event is local
+			// midnight, which an older companion sent as the previous day
+			// in UTC. Rendering that instant literally lost a day.
+			name: "a legacy all-day instant east of UTC keeps its own date",
+			event: companionCalendarEvent{
+				Start:  "2026-08-28T22:00:00Z",
+				End:    "2026-08-29T22:00:00Z",
+				AllDay: true,
+			},
+			want: "Sat Aug 29 (all day, today)",
+		},
+		{
+			name: "a legacy all-day instant west of UTC keeps its own date",
+			event: companionCalendarEvent{
+				Start:  "2026-08-29T05:00:00Z",
+				End:    "2026-08-30T05:00:00Z",
+				AllDay: true,
+			},
+			want: "Sat Aug 29 (all day, today)",
+		},
+		{
+			name: "a legacy multi-day all-day end stays exclusive",
+			event: companionCalendarEvent{
+				Start:  "2026-08-31T05:00:00Z",
+				End:    "2026-09-03T05:00:00Z",
+				AllDay: true,
+			},
+			want: "Mon Aug 31 -> Wed Sep 2 (all day, +2d)",
+		},
+		{
+			// Spring forward in Chicago is 2026-03-08. A whole-day count
+			// taken by subtracting local midnights would see 23h here and
+			// call the 8th "today" on the 7th.
+			name: "a day delta survives the spring-forward short day",
+			now:  "2026-03-07T10:00:00-06:00",
+			event: companionCalendarEvent{
+				Start:  "2026-03-08",
+				End:    "2026-03-08",
+				AllDay: true,
+			},
+			want: "Sun Mar 8 (all day, tomorrow)",
+		},
+		{
+			name: "an event spanning the DST boundary keeps each end's own abbreviation",
+			now:  "2026-03-07T10:00:00-06:00",
+			event: companionCalendarEvent{
+				Start: "2026-03-07T23:00:00-06:00",
+				End:   "2026-03-08T03:00:00-05:00",
+			},
+			want: "Sat Mar 7 11:00PM CST -> Sun Mar 8 3:00AM CDT (+13h)",
+		},
+		{
+			name: "a malformed start echoes what the companion sent",
+			event: companionCalendarEvent{
+				Start: "not a timestamp",
+				End:   "also not one",
+			},
+			want: "not a timestamp - also not one",
+		},
+		{
+			name: "a malformed end still renders the start",
+			event: companionCalendarEvent{
+				Start: "2026-08-29T09:00:00-05:00",
+				End:   "garbage",
+			},
+			want: "Sat Aug 29 9:00AM CDT (-1h48m)",
+		},
+	}
+
+	home := chicago(t)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			at := now
+			if tc.now != "" {
+				at = mustTime(t, tc.now)
+			}
+			got := newCalendarRenderer(home, at).formatRange(tc.event)
+			if got != tc.want {
+				t.Errorf("formatRange()\n got: %s\nwant: %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormatCompanionCalendarResponseStatesItsFrame(t *testing.T) {
+	out := formatCompanionCalendarResponse(companionCalendarResponse{
+		Events: []companionCalendarEvent{{
+			Title:    "Design sync",
+			Calendar: "Work",
+			Start:    "2026-08-29T09:00:00-05:00",
+			End:      "2026-08-29T09:30:00-05:00",
+		}},
+	}, chicago(t), mustTime(t, "2026-08-29T10:48:00-05:00"))
+
+	want := "Found 1 macOS calendar events (times in America/Chicago; now Sat Aug 29 10:48AM CDT):" +
+		"\n- Sat Aug 29 9:00AM-9:30AM CDT (-1h48m) | Design sync (Work)"
+	if out != want {
+		t.Fatalf("response\n got: %s\nwant: %s", out, want)
+	}
+}
+
+func TestFormatCompanionCalendarResponseFallsBackToLocalZone(t *testing.T) {
+	// A nil home must not panic or silently render UTC; the host's local
+	// zone is the honest answer when nothing was configured.
+	out := formatCompanionCalendarResponse(companionCalendarResponse{
+		Events: []companionCalendarEvent{{
+			Title: "Anything",
+			Start: "2026-08-29T09:00:00-05:00",
+		}},
+	}, nil, mustTime(t, "2026-08-29T10:48:00-05:00"))
+
+	if !strings.HasPrefix(out, "Found 1 macOS calendar events (times in ") {
+		t.Fatalf("expected a stated frame, got: %s", out)
+	}
+}
+
+func TestFormatCompanionCalendarResponseEmpty(t *testing.T) {
+	out := formatCompanionCalendarResponse(companionCalendarResponse{}, chicago(t), time.Now())
+	if out != "No macOS calendar events found in the requested window." {
+		t.Fatalf("empty response: got %q", out)
+	}
+}
+
+func TestFormatCompanionCalendarResponseTruncatesOutput(t *testing.T) {
+	response := companionCalendarResponse{
+		Events: make([]companionCalendarEvent, 0, 80),
+	}
+	for i := 0; i < 80; i++ {
+		response.Events = append(response.Events, companionCalendarEvent{
+			Title:        strings.Repeat("Quarterly planning sync ", 8),
+			Calendar:     "Work",
+			Start:        "2026-04-02T09:00:00-05:00",
+			End:          "2026-04-02T10:00:00-05:00",
+			Location:     strings.Repeat("Conference Room A ", 6),
+			NotesExcerpt: strings.Repeat("Bring status notes. ", 12),
+		})
+	}
+
+	formatted := formatCompanionCalendarResponse(response, chicago(t), time.Now())
+	if len(formatted) > maxCompanionCalendarResultBytes {
+		t.Fatalf("formatted output exceeded hard cap: got %d, want <= %d", len(formatted), maxCompanionCalendarResultBytes)
+	}
+	if !strings.Contains(formatted, "[... output truncated;") {
+		t.Fatalf("expected truncated note, got: %s", formatted)
+	}
+}
+
+// TestFormatCompanionCalendarResponseMixedDay renders a whole result set
+// of the kinds this household actually keeps — same-zone meetings, a trip
+// abroad, a flight crossing both midnight and a zone, and all-day events —
+// so a change to any one rule shows up as a change to the thing a model
+// reads rather than to a fragment of it.
+func TestFormatCompanionCalendarResponseMixedDay(t *testing.T) {
+	out := formatCompanionCalendarResponse(companionCalendarResponse{Events: []companionCalendarEvent{
+		{
+			Title: "Standup", Calendar: "Work", TimeZone: "America/Chicago",
+			Start: "2026-08-29T09:00:00-05:00", End: "2026-08-29T09:30:00-05:00",
+		},
+		{
+			Title: "Berlin kickoff", Calendar: "Work", TimeZone: "Europe/Berlin",
+			Start: "2026-09-02T10:00:00+02:00", End: "2026-09-02T11:30:00+02:00",
+			NotesExcerpt: "Bring the deck.",
+		},
+		{
+			Title: "Flight to Berlin", Calendar: "Travel", TimeZone: "America/Chicago",
+			Start: "2026-09-01T18:35:00-05:00", End: "2026-09-02T10:05:00+02:00",
+		},
+		{Title: "Conference", Calendar: "Work", Start: "2026-09-02", End: "2026-09-04", AllDay: true},
+		{Title: "Trash day", Calendar: "Home", Start: "2026-08-30", End: "2026-08-30", AllDay: true},
+	}}, chicago(t), mustTime(t, "2026-08-29T10:48:00-05:00"))
+
+	want := strings.Join([]string{
+		"Found 5 macOS calendar events (times in America/Chicago; now Sat Aug 29 10:48AM CDT):",
+		"- Sat Aug 29 9:00AM-9:30AM CDT (-1h48m) | Standup (Work)",
+		"- Wed Sep 2 3:00AM-4:30AM CDT (+3d16h) [Europe/Berlin 10:00AM-11:30AM] | Berlin kickoff (Work)",
+		"  Notes: Bring the deck.",
+		"- Tue Sep 1 6:35PM CDT -> Wed Sep 2 3:05AM CDT (+3d7h) | Flight to Berlin (Travel)",
+		"- Wed Sep 2 -> Fri Sep 4 (all day, +4d) | Conference (Work)",
+		"- Sun Aug 30 (all day, tomorrow) | Trash day (Home)",
+	}, "\n")
+
+	if out != want {
+		t.Fatalf("mixed day\n got:\n%s\nwant:\n%s", out, want)
+	}
+}
+
+func TestParseCompanionTimeArg(t *testing.T) {
+	home := chicago(t)
+	fallback := mustTime(t, "2026-08-29T10:48:00-05:00")
+
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{
+			name:  "an offset is taken at face value",
+			value: "2026-08-29T14:00:00+02:00",
+			want:  "2026-08-29T07:00:00-05:00",
+		},
+		{
+			name:  "an explicit Z is taken at face value",
+			value: "2026-08-29T14:00:00Z",
+			want:  "2026-08-29T09:00:00-05:00",
+		},
+		{
+			// The bug: a zone-less parse defaults to UTC, shifting the
+			// requested window by the household offset.
+			name:  "a zone-less timestamp is read in the household zone",
+			value: "2026-08-29 14:00:00",
+			want:  "2026-08-29T14:00:00-05:00",
+		},
+		{
+			name:  "a zone-less timestamp may omit its seconds",
+			value: "2026-08-29 14:00",
+			want:  "2026-08-29T14:00:00-05:00",
+		},
+		{
+			name:  "a bare date is household midnight, not UTC midnight",
+			value: "2026-08-29",
+			want:  "2026-08-29T00:00:00-05:00",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseCompanionTimeArg(map[string]any{"start": tc.value}, "start", home, fallback)
+			if err != nil {
+				t.Fatalf("parseCompanionTimeArg(%q): %v", tc.value, err)
+			}
+			if !got.Equal(mustTime(t, tc.want)) {
+				t.Errorf("parseCompanionTimeArg(%q) = %s, want %s", tc.value, got.Format(time.RFC3339), tc.want)
+			}
+		})
+	}
+}
+
+func TestParseCompanionTimeArgDefaultsAndRejects(t *testing.T) {
+	home := chicago(t)
+	fallback := mustTime(t, "2026-08-29T10:48:00-05:00")
+
+	got, err := parseCompanionTimeArg(map[string]any{}, "start", home, fallback)
+	if err != nil {
+		t.Fatalf("missing value should fall back: %v", err)
+	}
+	if !got.Equal(fallback) {
+		t.Errorf("missing value = %s, want the fallback %s", got, fallback)
+	}
+
+	if _, err := parseCompanionTimeArg(map[string]any{"start": "next tuesday"}, "start", home, fallback); err == nil {
+		t.Fatal("expected an unparseable value to be rejected")
+	}
+}

--- a/internal/tools/companion_registrar.go
+++ b/internal/tools/companion_registrar.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/integrations/companion"
 )
@@ -64,6 +65,7 @@ type CompanionRegistrar struct {
 	list       companionProviderLister
 	call       companionCallFunc
 	logger     *slog.Logger
+	home       *time.Location
 	formatters map[string]companionResultFormatter
 
 	mu           sync.RWMutex
@@ -75,25 +77,31 @@ type CompanionRegistrar struct {
 // registry. Wire its Rebuild method to companion.Registry.SetOnChange and
 // install it via Loop.SetDynamicToolSource. The initial snapshot is empty
 // until a companion connects and registers capabilities.
-func NewCompanionRegistrar(registry *companion.Registry, logger *slog.Logger) *CompanionRegistrar {
-	return newCompanionRegistrar(registry.List, registry.Call, logger)
+// The home location is the household zone every calendar time is
+// rendered in; pass nil to fall back to the host's local zone.
+func NewCompanionRegistrar(registry *companion.Registry, home *time.Location, logger *slog.Logger) *CompanionRegistrar {
+	return newCompanionRegistrar(registry.List, registry.Call, home, logger)
 }
 
 // newCompanionRegistrar is the func-injected constructor used by tests to
 // supply a fake provider list and caller.
-func newCompanionRegistrar(list companionProviderLister, call companionCallFunc, logger *slog.Logger) *CompanionRegistrar {
+func newCompanionRegistrar(list companionProviderLister, call companionCallFunc, home *time.Location, logger *slog.Logger) *CompanionRegistrar {
 	if logger == nil {
 		logger = slog.Default()
+	}
+	if home == nil {
+		home = time.Local
 	}
 	cr := &CompanionRegistrar{
 		list:   list,
 		call:   call,
+		home:   home,
 		logger: logger.With("component", "companion_registrar"),
-		formatters: map[string]companionResultFormatter{
-			// Preserve the pretty calendar prose for the legacy tool name
-			// while everything else defaults to JSON passthrough.
-			"macos_calendar_events": calendarResultFormatter,
-		},
+	}
+	cr.formatters = map[string]companionResultFormatter{
+		// Preserve the pretty calendar prose for the legacy tool name
+		// while everything else defaults to JSON passthrough.
+		"macos_calendar_events": cr.calendarResultFormatter,
 	}
 	cr.Rebuild()
 	return cr
@@ -424,11 +432,12 @@ func jsonPassthroughFormatter(raw json.RawMessage) (string, error) {
 }
 
 // calendarResultFormatter preserves the human-readable calendar prose for
-// the legacy macos_calendar_events tool name.
-func calendarResultFormatter(raw json.RawMessage) (string, error) {
+// the legacy macos_calendar_events tool name, rendered in the household
+// zone the registrar was built with.
+func (cr *CompanionRegistrar) calendarResultFormatter(raw json.RawMessage) (string, error) {
 	var resp companionCalendarResponse
 	if err := json.Unmarshal(raw, &resp); err != nil {
 		return "", fmt.Errorf("decode companion calendar response: %w", err)
 	}
-	return formatCompanionCalendarResponse(resp), nil
+	return formatCompanionCalendarResponse(resp, cr.home, time.Now()), nil
 }

--- a/internal/tools/companion_registrar_test.go
+++ b/internal/tools/companion_registrar_test.go
@@ -62,7 +62,7 @@ func findTool(tools []*Tool, name string) *Tool {
 
 func TestCompanionRegistrar_Synthesize(t *testing.T) {
 	src := &fakeCompanionSource{infos: []companion.ProviderInfo{contactsProvider()}}
-	cr := newCompanionRegistrar(src.List, src.Call, nil)
+	cr := newCompanionRegistrar(src.List, src.Call, nil, nil)
 
 	synth, tagAdds := cr.Snapshot()
 	if len(synth) != 1 {
@@ -103,7 +103,7 @@ func TestCompanionRegistrar_DispatchRoutesAndStripsHints(t *testing.T) {
 		infos:  []companion.ProviderInfo{contactsProvider()},
 		result: json.RawMessage(`{"contacts":[{"name":"Bob"}]}`),
 	}
-	cr := newCompanionRegistrar(src.List, src.Call, nil)
+	cr := newCompanionRegistrar(src.List, src.Call, nil, nil)
 	synth, _ := cr.Snapshot()
 	tool := findTool(synth, "macos_search_contacts")
 
@@ -151,7 +151,7 @@ func TestCompanionRegistrar_DispatchSurfacesError(t *testing.T) {
 		infos: []companion.ProviderInfo{contactsProvider()},
 		err:   errors.New("provider_disconnected: companion app disconnected"),
 	}
-	cr := newCompanionRegistrar(src.List, src.Call, nil)
+	cr := newCompanionRegistrar(src.List, src.Call, nil, nil)
 	synth, _ := cr.Snapshot()
 	tool := findTool(synth, "macos_search_contacts")
 
@@ -177,7 +177,7 @@ func TestCompanionRegistrar_CalendarFormatter(t *testing.T) {
 		infos:  []companion.ProviderInfo{info},
 		result: json.RawMessage(`{"events":[{"title":"Standup","calendar":"Work","start":"2026-06-23T09:00:00Z","end":"2026-06-23T09:15:00Z"}]}`),
 	}
-	cr := newCompanionRegistrar(src.List, src.Call, nil)
+	cr := newCompanionRegistrar(src.List, src.Call, nil, nil)
 	synth, _ := cr.Snapshot()
 	tool := findTool(synth, "macos_calendar_events")
 
@@ -205,7 +205,7 @@ func TestCompanionRegistrar_DedupAcrossProviders(t *testing.T) {
 		}
 	}
 	src := &fakeCompanionSource{infos: []companion.ProviderInfo{mk("aimee", "first"), mk("nugget", "second")}}
-	cr := newCompanionRegistrar(src.List, src.Call, nil)
+	cr := newCompanionRegistrar(src.List, src.Call, nil, nil)
 	synth, tagAdds := cr.Snapshot()
 	if len(synth) != 1 {
 		t.Fatalf("dedup: got %d tools, want 1", len(synth))
@@ -218,7 +218,7 @@ func TestCompanionRegistrar_DedupAcrossProviders(t *testing.T) {
 
 func TestCompanionRegistrar_RebuildOnConnectAndDisconnect(t *testing.T) {
 	src := &fakeCompanionSource{}
-	cr := newCompanionRegistrar(src.List, src.Call, nil)
+	cr := newCompanionRegistrar(src.List, src.Call, nil, nil)
 
 	if synth, _ := cr.Snapshot(); len(synth) != 0 {
 		t.Fatalf("initial snapshot should be empty, got %d", len(synth))
@@ -401,7 +401,7 @@ func claimant(providerID, clientID, method string) companion.ProviderInfo {
 func winningMethod(t *testing.T, infos ...companion.ProviderInfo) string {
 	t.Helper()
 	src := &fakeCompanionSource{infos: infos, result: json.RawMessage(`{}`)}
-	cr := newCompanionRegistrar(src.List, src.Call, discardLogger())
+	cr := newCompanionRegistrar(src.List, src.Call, nil, discardLogger())
 	synth, _ := cr.Snapshot()
 	if len(synth) != 1 {
 		t.Fatalf("collision should yield 1 tool, got %d", len(synth))
@@ -419,7 +419,7 @@ func rebuildLogs(t *testing.T, infos ...companion.ProviderInfo) string {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	src := &fakeCompanionSource{infos: infos}
-	newCompanionRegistrar(src.List, src.Call, logger)
+	newCompanionRegistrar(src.List, src.Call, nil, logger)
 	return buf.String()
 }
 
@@ -435,7 +435,7 @@ func TestCompanionRegistrar_DispatchCapsResult(t *testing.T) {
 		infos:  []companion.ProviderInfo{contactsProvider()},
 		result: json.RawMessage(huge),
 	}
-	cr := newCompanionRegistrar(src.List, src.Call, nil)
+	cr := newCompanionRegistrar(src.List, src.Call, nil, nil)
 	synth, _ := cr.Snapshot()
 
 	out, err := findTool(synth, "macos_search_contacts").Handler(context.Background(), map[string]any{"query": "x"})

--- a/internal/tools/companion_tools.go
+++ b/internal/tools/companion_tools.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/integrations/companion"
-	"github.com/nugget/thane-ai-agent/internal/platform/database"
 )
 
 type companionCallFunc func(ctx context.Context, req companion.CallRequest) (json.RawMessage, error)
@@ -26,11 +25,17 @@ type companionCalendarResponse struct {
 }
 
 type companionCalendarEvent struct {
-	Title        string `json:"title"`
-	Calendar     string `json:"calendar"`
-	Start        string `json:"start"`
-	End          string `json:"end"`
-	AllDay       bool   `json:"all_day"`
+	Title    string `json:"title"`
+	Calendar string `json:"calendar"`
+	Start    string `json:"start"`
+	End      string `json:"end"`
+	AllDay   bool   `json:"all_day"`
+	// TimeZone is the IANA zone the event is scheduled in, when the
+	// companion knows one. On this operator's calendar it is a statement
+	// of intent rather than incidental metadata: an event recorded in
+	// Europe/Berlin means they expect to be in Berlin for it. Absent for
+	// floating events and for companions predating the field.
+	TimeZone     string `json:"time_zone,omitempty"`
 	Location     string `json:"location,omitempty"`
 	NotesExcerpt string `json:"notes_excerpt,omitempty"`
 	URL          string `json:"url,omitempty"`
@@ -70,11 +75,11 @@ func (r *Registry) registerCompanionTools() {
 				},
 				"start": map[string]any{
 					"type":        "string",
-					"description": "Inclusive start of the calendar window in RFC3339 format. Defaults to now.",
+					"description": "Inclusive start of the calendar window. RFC3339, or a bare YYYY-MM-DD[ HH:MM] read in the household timezone. Defaults to now.",
 				},
 				"end": map[string]any{
 					"type":        "string",
-					"description": "Exclusive end of the calendar window in RFC3339 format. Defaults to 24 hours after start.",
+					"description": "Exclusive end of the calendar window. RFC3339, or a bare YYYY-MM-DD[ HH:MM] read in the household timezone. Defaults to 24 hours after start.",
 				},
 				"calendar_names": map[string]any{
 					"type": "array",
@@ -102,12 +107,13 @@ func (r *Registry) handleMacOSCalendarEvents(ctx context.Context, args map[strin
 		return "", fmt.Errorf("no native companion caller configured")
 	}
 
-	now := time.Now()
-	start, err := parseCompanionTimeArg(args, "start", now)
+	home := r.HomeLocation()
+	now := time.Now().In(home)
+	start, err := parseCompanionTimeArg(args, "start", home, now)
 	if err != nil {
 		return "", err
 	}
-	end, err := parseCompanionTimeArg(args, "end", start.Add(24*time.Hour))
+	end, err := parseCompanionTimeArg(args, "end", home, start.Add(24*time.Hour))
 	if err != nil {
 		return "", err
 	}
@@ -158,20 +164,47 @@ func (r *Registry) handleMacOSCalendarEvents(ctx context.Context, args map[strin
 		return "", fmt.Errorf("decode companion calendar response: %w", err)
 	}
 
-	return formatCompanionCalendarResponse(response), nil
+	return formatCompanionCalendarResponse(response, home, now), nil
 }
 
-func parseCompanionTimeArg(args map[string]any, key string, fallback time.Time) (time.Time, error) {
+// companionTimeLayouts are the zone-less shapes accepted for a window
+// bound, tried after RFC3339 and interpreted in the household zone.
+//
+// A model asked "what is on my calendar this afternoon" writes the hour it
+// means, not the hour in UTC. Reading "2026-08-29 14:00:00" as UTC — which
+// is what a zone-less parse defaults to — silently shifts the window by the
+// household's offset and answers a question nobody asked.
+var companionTimeLayouts = []string{
+	"2006-01-02T15:04:05",
+	"2006-01-02 15:04:05",
+	"2006-01-02T15:04",
+	"2006-01-02 15:04",
+	"2006-01-02",
+}
+
+// parseCompanionTimeArg reads one end of the requested window. A value
+// carrying its own offset is taken at face value; one without is read in
+// home, the zone the model is reasoning in.
+func parseCompanionTimeArg(args map[string]any, key string, home *time.Location, fallback time.Time) (time.Time, error) {
 	value := strings.TrimSpace(stringArg(args, key))
 	if value == "" {
 		return fallback, nil
 	}
-
-	ts, err := database.ParseTimestamp(value)
-	if err != nil {
-		return time.Time{}, fmt.Errorf("%s must be a valid timestamp (RFC3339, RFC3339Nano, or YYYY-MM-DD HH:MM:SS) (got %q)", key, value)
+	if home == nil {
+		home = time.Local
 	}
-	return ts, nil
+
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339} {
+		if ts, err := time.Parse(layout, value); err == nil {
+			return ts, nil
+		}
+	}
+	for _, layout := range companionTimeLayouts {
+		if ts, err := time.ParseInLocation(layout, value, home); err == nil {
+			return ts, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("%s must be a valid timestamp (RFC3339, or YYYY-MM-DD[ HH:MM[:SS]] read in %s) (got %q)", key, home, value)
 }
 
 func stringSliceArg(args map[string]any, key string) []string {
@@ -195,85 +228,4 @@ func stringSliceArg(args map[string]any, key string) []string {
 		values = append(values, value)
 	}
 	return values
-}
-
-func formatCompanionCalendarResponse(response companionCalendarResponse) string {
-	if len(response.Events) == 0 {
-		return "No macOS calendar events found in the requested window."
-	}
-
-	var b strings.Builder
-	fmt.Fprintf(&b, "Found %d macOS calendar events:", len(response.Events))
-	for _, event := range response.Events {
-		fmt.Fprintf(&b, "\n- %s | %s", formatCompanionCalendarRange(event), strings.TrimSpace(event.Title))
-		if event.Calendar != "" {
-			fmt.Fprintf(&b, " (%s)", event.Calendar)
-		}
-		if event.Location != "" {
-			fmt.Fprintf(&b, "\n  Location: %s", event.Location)
-		}
-		if event.NotesExcerpt != "" {
-			fmt.Fprintf(&b, "\n  Notes: %s", event.NotesExcerpt)
-		}
-		if event.URL != "" {
-			fmt.Fprintf(&b, "\n  URL: %s", event.URL)
-		}
-	}
-	formatted := b.String()
-	if len(formatted) <= maxCompanionCalendarResultBytes {
-		return formatted
-	}
-	const note = "\n\n[... output truncated; narrow the window, filters, or limit for more ...]"
-	allowed := maxCompanionCalendarResultBytes - len(note)
-	if allowed < 0 {
-		allowed = 0
-	}
-	return truncateUTF8(formatted, allowed) + note
-}
-
-func formatCompanionCalendarRange(event companionCalendarEvent) string {
-	start, startErr := parseCalendarTimestamp(event.Start)
-	end, endErr := parseCalendarTimestamp(event.End)
-	if startErr != nil {
-		if event.End == "" {
-			return event.Start
-		}
-		return strings.TrimSpace(event.Start + " - " + event.End)
-	}
-
-	if event.AllDay {
-		return formatCompanionCalendarAllDayRange(start, end, endErr)
-	}
-
-	if endErr != nil || event.End == "" {
-		return start.Format("Mon Jan 2 3:04PM MST")
-	}
-	if start.YearDay() == end.YearDay() && start.Year() == end.Year() {
-		return fmt.Sprintf("%s-%s", start.Format("Mon Jan 2 3:04PM MST"), end.Format("3:04PM MST"))
-	}
-	return fmt.Sprintf("%s -> %s", start.Format("Mon Jan 2 3:04PM MST"), end.Format("Mon Jan 2 3:04PM MST"))
-}
-
-func formatCompanionCalendarAllDayRange(start, end time.Time, endErr error) string {
-	if endErr != nil || !end.After(start) {
-		return fmt.Sprintf("%s (all day)", start.Format("Mon Jan 2"))
-	}
-
-	// EventKit-style all-day events use an exclusive end date, so show
-	// the previous day when the range spans multiple days.
-	lastDay := end.Add(-24 * time.Hour)
-	if lastDay.Before(start) {
-		lastDay = start
-	}
-	if start.Year() == lastDay.Year() && start.YearDay() == lastDay.YearDay() {
-		return fmt.Sprintf("%s (all day)", start.Format("Mon Jan 2"))
-	}
-	return fmt.Sprintf("%s -> %s (all day)", start.Format("Mon Jan 2"), lastDay.Format("Mon Jan 2"))
-}
-
-func parseCalendarTimestamp(value string) (time.Time, error) {
-	if value == "" {
-		return time.Time{}, fmt.Errorf("empty timestamp")
-	}
-	return database.ParseTimestamp(value)
 }

--- a/internal/tools/companion_tools_test.go
+++ b/internal/tools/companion_tools_test.go
@@ -124,38 +124,3 @@ func TestMacOSCalendarEventsRejectsLimitOverMax(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
-
-func TestFormatCompanionCalendarResponseTruncatesOutput(t *testing.T) {
-	response := companionCalendarResponse{
-		Events: make([]companionCalendarEvent, 0, 80),
-	}
-	for i := 0; i < 80; i++ {
-		response.Events = append(response.Events, companionCalendarEvent{
-			Title:        strings.Repeat("Quarterly planning sync ", 8),
-			Calendar:     "Work",
-			Start:        "2026-04-02T09:00:00Z",
-			End:          "2026-04-02T10:00:00Z",
-			Location:     strings.Repeat("Conference Room A ", 6),
-			NotesExcerpt: strings.Repeat("Bring status notes. ", 12),
-		})
-	}
-
-	formatted := formatCompanionCalendarResponse(response)
-	if len(formatted) > maxCompanionCalendarResultBytes {
-		t.Fatalf("formatted output exceeded hard cap: got %d, want <= %d", len(formatted), maxCompanionCalendarResultBytes)
-	}
-	if !strings.Contains(formatted, "[... output truncated;") {
-		t.Fatalf("expected truncated note, got: %s", formatted)
-	}
-}
-
-func TestFormatCompanionCalendarRangeAllDayMultiDay(t *testing.T) {
-	got := formatCompanionCalendarRange(companionCalendarEvent{
-		Start:  "2026-04-02T00:00:00Z",
-		End:    "2026-04-05T00:00:00Z",
-		AllDay: true,
-	})
-	if got != "Thu Apr 2 -> Sat Apr 4 (all day)" {
-		t.Fatalf("all-day range: got %q", got)
-	}
-}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -82,6 +82,7 @@ type Registry struct {
 	usageStore         *usage.Store
 	lensStore          *LensStore
 	logIndexDB         *sql.DB
+	homeLocation       *time.Location
 	workingMemoryStore *memory.WorkingMemoryStore
 	archiveStore       *memory.ArchiveStore
 
@@ -153,6 +154,35 @@ func (r *Registry) log() *slog.Logger {
 		return r.logger
 	}
 	return slog.Default()
+}
+
+// SetTimezone records the household IANA timezone (config `timezone`) as
+// the frame tool output renders wall-clock times in. Invalid or empty
+// names leave the registry on the host's local zone, matching how the
+// same setting degrades everywhere else it is read.
+//
+// Tool output is read by a model that cannot see where the reader stands,
+// so a bare local time is only as good as the frame stated alongside it.
+func (r *Registry) SetTimezone(name string) {
+	if name == "" {
+		return
+	}
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		r.log().Warn("ignoring invalid timezone for tool output",
+			"timezone", name, "error", err)
+		return
+	}
+	r.homeLocation = loc
+}
+
+// HomeLocation is the zone tool output renders wall-clock times in,
+// falling back to the host's local zone when none was configured.
+func (r *Registry) HomeLocation() *time.Location {
+	if r.homeLocation == nil {
+		return time.Local
+	}
+	return r.homeLocation
 }
 
 // SetFactTools adds fact management tools to the registry.
@@ -1263,6 +1293,7 @@ func (r *Registry) derive(capacity int) *Registry {
 		tagIndex:        r.tagIndex,
 		logger:          r.logger,
 		policy:          r.sharedPolicy(),
+		homeLocation:    r.homeLocation,
 	}
 }
 

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=68
-interfaces=83
+interfaces=82
 large_files=57
-set_mutators=117
+set_mutators=118
 database_opens=9


### PR DESCRIPTION
## The defect

A calendar event reached the model as a bare UTC instant. `CalendarService` on the companion formats every timestamp with a default-constructed `ISO8601DateFormatter`, whose zone is GMT, and the Go renderer printed whatever zone the parsed value happened to carry. A 9:00 AM Chicago standup arrived like this:

```
- Sat Aug 29 2:00PM UTC-2:30PM UTC | Standup (Work)
```

Nothing in the output said the frame was UTC, so the model had no way to notice it was reading a shifted clock. Every answer built on it — is this soon, did this already happen, what is on my afternoon — inherited the shift silently.

The same missing zone cost a whole day on all-day events, which are local midnight and so land on the previous date east of UTC. A Berlin all-day event on the 29th rendered as `Fri Aug 28`.

## What it renders now

```
Found 5 macOS calendar events (times in America/Chicago; now Sat Aug 29 10:48AM CDT):
- Sat Aug 29 9:00AM-9:30AM CDT (-1h48m) | Standup (Work)
- Wed Sep 2 3:00AM-4:30AM CDT (+3d16h) [Europe/Berlin 10:00AM-11:30AM] | Berlin kickoff (Work)
  Notes: Bring the deck.
- Tue Sep 1 6:35PM CDT -> Wed Sep 2 3:05AM CDT (+3d7h) | Flight to Berlin (Travel)
- Wed Sep 2 -> Fri Sep 4 (all day, +4d) | Conference (Work)
- Sun Aug 30 (all day, tomorrow) | Trash day (Home)
```

**One stated frame.** Everything renders in the household zone from config `timezone`, named once in the header with the current time beside it, so no line has to be interpreted on its own.

**Two readings where they differ.** An event that declares its own zone gets that reading appended. On this operator's calendar `EKEvent.timeZone` is not incidental metadata — an event recorded in `Europe/Berlin` is a statement about where they expect to be standing, so it is the clock they will actually live, while the home reading stays the one the agent's own always-Chicago process reasons in. The annotation is suppressed when both zones agree on the wall clock; `America/Winnipeg` next to `America/Chicago` tells a reader nothing. It is also suppressed for a bare `Z` with no declared zone, because that is an older companion discarding the zone rather than an event scheduled on UTC's clock.

**Precision matched to the source.** Seconds are gone. The year appears only outside the current one. A span inside one day states its date once. An all-day event is a date with a whole-day delta — `today`, `tomorrow`, `+7d` — because saying it starts in `+14h29m` invents a precision the source never had. Every absolute time carries a delta, past and future both: this departs from `FormatDelta`'s past-only shape because on a calendar the wall clock always matters, and so does knowing how far off it is.

**Input had the mirror bug — on the legacy path.** A zone-less `2026-08-29 14:00:00` went through `database.ParseTimestamp`, which defaults to UTC, so a model asking about its own afternoon silently moved the window by the household offset. Zone-less bounds now read in home.

To be precise about reach: this fixes the hand-coded handler. When a Mac authors its own tool defs — the production path — the synthesized tool shadows that handler and forwards `start`/`end` untouched, and the shipped companion accepts only RFC3339. So a zone-less bound there fails loudly with `invalid_timestamp` rather than shifting silently. Teaching the Mac's own decoder to accept a bare date belongs in `nugget/thane-agent-macos#49`; doing it server-side would mean rewriting one named tool's params in the registrar, rebuilding the Go/Swift drift risk that component exists to prevent.

The wire parse no longer borrows `database.ParseTimestamp` at all — it accepts eight historical SQLite shapes no companion emits, which is exactly how a contract drifts unnoticed.

## Compatibility

The macOS half of the contract — offset-preserving timestamps, a `time_zone` field, and inclusive date-only all-day bounds — follows in `nugget/thane-agent-macos`. Both directions degrade honestly in the meantime:

- This renderer **already fixes timed events** from today's companions, by converting their `Z` instants to home.
- Legacy all-day instants are recovered by rounding to the nearest UTC midnight, which lands on the intended date for every offset inside ±12h — covering every zone this household operates in.
- An older server reading the new date-only form prints it verbatim rather than wrongly.

## Test plan

- [x] `just ci` green (exit 0), including the regenerated `scripts/architecture.baseline` (`set_mutators` 117→118 for the new `Registry.SetTimezone`)
- [x] Table-driven renderer tests: home conversion, both DST transitions, non-home annotation and its suppression cases, away readings that land on another date, all-day date-only and multi-day, legacy all-day instants east and west of UTC, same-day collapse, year suppression, malformed input
- [x] Review round 1 (f1b54816): three DST-boundary cases where one end of a span spoke for the other — a same-day fall-back span rendering as zero-length, an away annotation suppressed on a start-only comparison (Phoenix vs Los_Angeles), and an offset-only end forced into the start's offset. Each has a regression test written to fail against the prior commit first.
- [x] Golden test over a realistic mixed day (the block above) so a change to any one rule shows up as a change to what the model reads
- [x] `FormatDayDelta` tests including both DST transitions — the reason `daysBetween` normalises to UTC midnight is that a 23-hour local day divides to zero
- [x] Input-parse tests covering offset, `Z`, zone-less, bare date, default, and rejection
- [ ] Verified against production once deployed

Refs #1017
