### PR TITLE
Bound a dispatch to a companion that stops answering

### DIFF
--- a/internal/tools/companion_call_test.go
+++ b/internal/tools/companion_call_test.go
@@ -1,0 +1,117 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/companion"
+)
+
+// hangingCaller models the failure this bound exists for: a companion that
+// is connected and never answers, the shape a Mac takes while it waits for
+// someone to dismiss a permission prompt.
+func hangingCaller(ctx context.Context, _ companion.CallRequest) (json.RawMessage, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func TestCallCompanionBoundsAHangingProvider(t *testing.T) {
+	// The real bound is 30s; drive it through an already-short parent so the
+	// test proves the deadline is applied without waiting for one.
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := callCompanion(ctx, hangingCaller, companion.CallRequest{
+		Capability: "macos.calendar",
+		Method:     "list_events",
+	})
+
+	if err == nil {
+		t.Fatal("expected a hanging companion to produce an error")
+	}
+	if elapsed := time.Since(start); elapsed > companionCallTimeout {
+		t.Fatalf("call outlived the bound: %s", elapsed)
+	}
+}
+
+func TestCallCompanionExplainsItsOwnDeadline(t *testing.T) {
+	// A caller with no deadline of its own — an ordinary conversational
+	// turn — is the case that previously hung outright.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	deadlined := func(callCtx context.Context, _ companion.CallRequest) (json.RawMessage, error) {
+		if _, ok := callCtx.Deadline(); !ok {
+			t.Error("expected callCompanion to impose a deadline on a context that had none")
+		}
+		return nil, context.DeadlineExceeded
+	}
+
+	_, err := callCompanion(ctx, deadlined, companion.CallRequest{
+		Capability: "macos.calendar",
+		Method:     "list_events",
+	})
+
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	for _, want := range []string{
+		"macos.calendar/list_events",
+		"connected but not answering",
+		"permission prompt",
+		"Report this rather than retrying",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should mention %q, got: %v", want, err)
+		}
+	}
+}
+
+func TestCallCompanionDoesNotClaimTheCallersDeadline(t *testing.T) {
+	// When the turn's own context expired, blaming the companion would send
+	// the model chasing the wrong fault.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := callCompanion(ctx, func(context.Context, companion.CallRequest) (json.RawMessage, error) {
+		return nil, context.DeadlineExceeded
+	}, companion.CallRequest{Capability: "macos.calendar", Method: "list_events"})
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("caller's own deadline should pass through unchanged, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "connected but not answering") {
+		t.Errorf("should not blame the companion for the caller's deadline: %v", err)
+	}
+}
+
+func TestCallCompanionPassesOtherErrorsThrough(t *testing.T) {
+	sentinel := errors.New("no connected companion app supports macos.calendar/list_events")
+
+	_, err := callCompanion(context.Background(), func(context.Context, companion.CallRequest) (json.RawMessage, error) {
+		return nil, sentinel
+	}, companion.CallRequest{Capability: "macos.calendar", Method: "list_events"})
+
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("unrelated errors must pass through unchanged, got: %v", err)
+	}
+}
+
+func TestCallCompanionReturnsResultUnchanged(t *testing.T) {
+	want := json.RawMessage(`{"events":[]}`)
+
+	got, err := callCompanion(context.Background(), func(context.Context, companion.CallRequest) (json.RawMessage, error) {
+		return want, nil
+	}, companion.CallRequest{Capability: "macos.calendar", Method: "list_events"})
+	if err != nil {
+		t.Fatalf("callCompanion: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("result = %s, want %s", got, want)
+	}
+}

--- a/internal/tools/companion_call_test.go
+++ b/internal/tools/companion_call_test.go
@@ -11,6 +11,15 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/integrations/companion"
 )
 
+// testCompanionTimeout stands in for companionCallTimeout so a test can
+// reach a genuine expiry without waiting thirty seconds for one.
+const testCompanionTimeout = 40 * time.Millisecond
+
+var testCalendarCall = companion.CallRequest{
+	Capability: "macos.calendar",
+	Method:     "list_events",
+}
+
 // hangingCaller models the failure this bound exists for: a companion that
 // is connected and never answers, the shape a Mac takes while it waits for
 // someone to dismiss a permission prompt.
@@ -20,46 +29,28 @@ func hangingCaller(ctx context.Context, _ companion.CallRequest) (json.RawMessag
 }
 
 func TestCallCompanionBoundsAHangingProvider(t *testing.T) {
-	// The real bound is 30s; drive it through an already-short parent so the
-	// test proves the deadline is applied without waiting for one.
 	start := time.Now()
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
-	defer cancel()
 
-	_, err := callCompanion(ctx, hangingCaller, companion.CallRequest{
-		Capability: "macos.calendar",
-		Method:     "list_events",
-	})
+	_, err := callCompanionWithin(context.Background(), testCompanionTimeout, hangingCaller, testCalendarCall)
 
 	if err == nil {
 		t.Fatal("expected a hanging companion to produce an error")
 	}
-	if elapsed := time.Since(start); elapsed > companionCallTimeout {
-		t.Fatalf("call outlived the bound: %s", elapsed)
+	// The caller had no deadline of its own — an ordinary conversational
+	// turn — which is the case that previously hung outright.
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("call outlived its bound: %s", elapsed)
 	}
 }
 
-func TestCallCompanionExplainsItsOwnDeadline(t *testing.T) {
-	// A caller with no deadline of its own — an ordinary conversational
-	// turn — is the case that previously hung outright.
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	deadlined := func(callCtx context.Context, _ companion.CallRequest) (json.RawMessage, error) {
-		if _, ok := callCtx.Deadline(); !ok {
-			t.Error("expected callCompanion to impose a deadline on a context that had none")
-		}
-		return nil, context.DeadlineExceeded
-	}
-
-	_, err := callCompanion(ctx, deadlined, companion.CallRequest{
-		Capability: "macos.calendar",
-		Method:     "list_events",
-	})
-
+func TestCallCompanionExplainsAnExpiredBound(t *testing.T) {
+	// A real expiry, not a synthesized sentinel: the caller blocks until the
+	// bound fires, so the message is only produced if the bound truly did.
+	_, err := callCompanionWithin(context.Background(), testCompanionTimeout, hangingCaller, testCalendarCall)
 	if err == nil {
 		t.Fatal("expected an error")
 	}
+
 	for _, want := range []string{
 		"macos.calendar/list_events",
 		"connected but not answering",
@@ -72,30 +63,80 @@ func TestCallCompanionExplainsItsOwnDeadline(t *testing.T) {
 	}
 }
 
+func TestCallCompanionImposesABoundOnAnUnboundedCaller(t *testing.T) {
+	var hadDeadline bool
+
+	_, _ = callCompanionWithin(context.Background(), testCompanionTimeout,
+		func(callCtx context.Context, _ companion.CallRequest) (json.RawMessage, error) {
+			_, hadDeadline = callCtx.Deadline()
+			return json.RawMessage(`{}`), nil
+		}, testCalendarCall)
+
+	if !hadDeadline {
+		t.Fatal("a caller with no deadline of its own should still be given one")
+	}
+}
+
+func TestCallCompanionDoesNotInventATimeoutThatDidNotHappen(t *testing.T) {
+	// A companion may hand back DeadlineExceeded from somewhere else
+	// entirely — an inner bound of its own, a wrapped transport error —
+	// while this bound still has almost all of its window left. Reporting
+	// that as "silent for the full window" would state a fact that never
+	// occurred.
+	_, err := callCompanionWithin(context.Background(), time.Minute,
+		func(context.Context, companion.CallRequest) (json.RawMessage, error) {
+			return nil, context.DeadlineExceeded
+		}, testCalendarCall)
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("the caller's own error should pass through, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "connected but not answering") {
+		t.Errorf("should not claim a timeout that never expired: %v", err)
+	}
+}
+
 func TestCallCompanionDoesNotClaimTheCallersDeadline(t *testing.T) {
 	// When the turn's own context expired, blaming the companion would send
 	// the model chasing the wrong fault.
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	time.Sleep(5 * time.Millisecond)
 
-	_, err := callCompanion(ctx, func(context.Context, companion.CallRequest) (json.RawMessage, error) {
-		return nil, context.DeadlineExceeded
-	}, companion.CallRequest{Capability: "macos.calendar", Method: "list_events"})
+	_, err := callCompanionWithin(ctx, time.Minute, hangingCaller, testCalendarCall)
 
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("caller's own deadline should pass through unchanged, got: %v", err)
+	if err == nil {
+		t.Fatal("expected an error")
 	}
 	if strings.Contains(err.Error(), "connected but not answering") {
 		t.Errorf("should not blame the companion for the caller's deadline: %v", err)
 	}
 }
 
+func TestCallCompanionReportsARacingDisconnectAsADisconnect(t *testing.T) {
+	// If the provider drops at the moment the bound fires, the disconnect is
+	// the more useful fact — it tells the model the Mac is gone rather than
+	// merely slow.
+	disconnected := errors.New("companion provider disconnected")
+
+	_, err := callCompanionWithin(context.Background(), testCompanionTimeout,
+		func(callCtx context.Context, _ companion.CallRequest) (json.RawMessage, error) {
+			<-callCtx.Done()
+			return nil, disconnected
+		}, testCalendarCall)
+
+	if !errors.Is(err, disconnected) {
+		t.Fatalf("a racing disconnect should be reported as itself, got: %v", err)
+	}
+}
+
 func TestCallCompanionPassesOtherErrorsThrough(t *testing.T) {
 	sentinel := errors.New("no connected companion app supports macos.calendar/list_events")
 
-	_, err := callCompanion(context.Background(), func(context.Context, companion.CallRequest) (json.RawMessage, error) {
-		return nil, sentinel
-	}, companion.CallRequest{Capability: "macos.calendar", Method: "list_events"})
+	_, err := callCompanionWithin(context.Background(), time.Minute,
+		func(context.Context, companion.CallRequest) (json.RawMessage, error) {
+			return nil, sentinel
+		}, testCalendarCall)
 
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("unrelated errors must pass through unchanged, got: %v", err)
@@ -105,13 +146,31 @@ func TestCallCompanionPassesOtherErrorsThrough(t *testing.T) {
 func TestCallCompanionReturnsResultUnchanged(t *testing.T) {
 	want := json.RawMessage(`{"events":[]}`)
 
-	got, err := callCompanion(context.Background(), func(context.Context, companion.CallRequest) (json.RawMessage, error) {
-		return want, nil
-	}, companion.CallRequest{Capability: "macos.calendar", Method: "list_events"})
+	got, err := callCompanionWithin(context.Background(), time.Minute,
+		func(context.Context, companion.CallRequest) (json.RawMessage, error) {
+			return want, nil
+		}, testCalendarCall)
 	if err != nil {
 		t.Fatalf("callCompanion: %v", err)
 	}
 	if string(got) != string(want) {
 		t.Fatalf("result = %s, want %s", got, want)
+	}
+}
+
+func TestCallCompanionUsesTheProductionBound(t *testing.T) {
+	// The exported path must carry the real constant, or every test above
+	// verifies a bound nothing in production uses.
+	var deadline time.Time
+
+	_, _ = callCompanion(context.Background(),
+		func(callCtx context.Context, _ companion.CallRequest) (json.RawMessage, error) {
+			deadline, _ = callCtx.Deadline()
+			return json.RawMessage(`{}`), nil
+		}, testCalendarCall)
+
+	remaining := time.Until(deadline)
+	if remaining <= companionCallTimeout-time.Second || remaining > companionCallTimeout {
+		t.Fatalf("expected roughly %s of budget, got %s", companionCallTimeout, remaining)
 	}
 }

--- a/internal/tools/companion_registrar.go
+++ b/internal/tools/companion_registrar.go
@@ -341,7 +341,7 @@ func (cr *CompanionRegistrar) dispatch(ctx context.Context, capability, method s
 		return "", fmt.Errorf("marshal companion request: %w", err)
 	}
 
-	result, err := cr.call(ctx, companion.CallRequest{
+	result, err := callCompanion(ctx, cr.call, companion.CallRequest{
 		Account:    account,
 		ClientID:   clientID,
 		Capability: capability,

--- a/internal/tools/companion_tools.go
+++ b/internal/tools/companion_tools.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -11,6 +12,58 @@ import (
 )
 
 type companionCallFunc func(ctx context.Context, req companion.CallRequest) (json.RawMessage, error)
+
+// companionCallTimeout bounds a single dispatch to a connected companion.
+//
+// [companion.Registry.Call] deliberately imposes no deadline of its own —
+// it waits on the caller's context, or on the provider disconnecting. That
+// is the right division, but on an ordinary conversational turn there is no
+// deadline to wait on: delegate profiles and loop definitions set
+// ToolTimeout, while a Signal message or a web-console turn leaves it zero,
+// and the loop only applies one when it is positive. A companion that is
+// connected but not answering therefore hangs the turn outright.
+//
+// That state is not hypothetical. A Mac blocks inside EventKit until
+// someone dismisses the macOS permission prompt, which on a laptop that is
+// closed, locked, or simply elsewhere is never. A disconnect is already
+// handled; being present and unresponsive was not.
+//
+// Thirty seconds is far longer than any real query — EventKit answers a
+// window query in well under a second — and short enough that a wedged turn
+// recovers on its own. It is deliberately not configurable: the value only
+// has to separate "working" from "wedged", and a real query approaching it
+// is a problem to surface rather than a number to tune.
+const companionCallTimeout = 30 * time.Second
+
+// callCompanion dispatches one request to a connected companion under
+// [companionCallTimeout], translating a deadline this bound imposed into
+// something the model can act on.
+//
+// A bare "context deadline exceeded" tells the model nothing it can use. It
+// needs to know the Mac is reachable but silent, that a permission prompt
+// is the usual reason, and that retrying immediately will not help — so it
+// reports the situation rather than burning the turn on retries.
+func callCompanion(ctx context.Context, call companionCallFunc, req companion.CallRequest) (json.RawMessage, error) {
+	callCtx, cancel := context.WithTimeout(ctx, companionCallTimeout)
+	defer cancel()
+
+	result, err := call(callCtx, req)
+	if err == nil {
+		return result, nil
+	}
+
+	// Only claim the timeout when it was ours. A caller whose own context
+	// expired gets its error unchanged; blaming the companion for the
+	// turn's deadline would send the model chasing the wrong fault.
+	if errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
+		return nil, fmt.Errorf(
+			"companion did not respond to %s/%s within %s; it is connected but not answering, "+
+				"which usually means the Mac is asleep, locked, or waiting on a macOS permission prompt. "+
+				"Report this rather than retrying — the next call will wait the same %s",
+			req.Capability, req.Method, companionCallTimeout, companionCallTimeout)
+	}
+	return nil, err
+}
 
 type companionCalendarRequest struct {
 	Start         string   `json:"start"`
@@ -148,7 +201,7 @@ func (r *Registry) handleMacOSCalendarEvents(ctx context.Context, args map[strin
 		return "", fmt.Errorf("marshal calendar request: %w", err)
 	}
 
-	result, err := r.companionCaller(ctx, companion.CallRequest{
+	result, err := callCompanion(ctx, r.companionCaller, companion.CallRequest{
 		Account:    strings.TrimSpace(stringArg(args, "account")),
 		ClientID:   strings.TrimSpace(stringArg(args, "client_id")),
 		Capability: "macos.calendar",

--- a/internal/tools/companion_tools.go
+++ b/internal/tools/companion_tools.go
@@ -44,7 +44,15 @@ const companionCallTimeout = 30 * time.Second
 // is the usual reason, and that retrying immediately will not help — so it
 // reports the situation rather than burning the turn on retries.
 func callCompanion(ctx context.Context, call companionCallFunc, req companion.CallRequest) (json.RawMessage, error) {
-	callCtx, cancel := context.WithTimeout(ctx, companionCallTimeout)
+	return callCompanionWithin(ctx, companionCallTimeout, call, req)
+}
+
+// callCompanionWithin is callCompanion with the bound supplied, so a test
+// can drive a real expiry in milliseconds instead of standing in for one.
+// The production bound stays the constant: this exists for tests, not for
+// operators, and no caller outside them passes anything else.
+func callCompanionWithin(ctx context.Context, timeout time.Duration, call companionCallFunc, req companion.CallRequest) (json.RawMessage, error) {
+	callCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	result, err := call(callCtx, req)
@@ -52,15 +60,28 @@ func callCompanion(ctx context.Context, call companionCallFunc, req companion.Ca
 		return result, nil
 	}
 
-	// Only claim the timeout when it was ours. A caller whose own context
-	// expired gets its error unchanged; blaming the companion for the
-	// turn's deadline would send the model chasing the wrong fault.
-	if errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
+	// Claim the timeout only when this bound is demonstrably the reason.
+	// All three conditions carry their own weight:
+	//
+	//   - the returned error is deadline-shaped, so a disconnect that raced
+	//     the deadline is still reported as the disconnect it was;
+	//   - this call's own context expired, so a caller that hands back
+	//     DeadlineExceeded from somewhere else entirely — its own inner
+	//     bound, a wrapped transport error — is not turned into a claim
+	//     that a Mac sat silent for the full window;
+	//   - the parent is still healthy, so a turn that ran out of time gets
+	//     its own error back rather than the companion taking the blame.
+	//
+	// The middle one is the difference between reporting a fact and
+	// inferring one from a error value that happens to match.
+	if errors.Is(err, context.DeadlineExceeded) &&
+		errors.Is(callCtx.Err(), context.DeadlineExceeded) &&
+		ctx.Err() == nil {
 		return nil, fmt.Errorf(
 			"companion did not respond to %s/%s within %s; it is connected but not answering, "+
 				"which usually means the Mac is asleep, locked, or waiting on a macOS permission prompt. "+
 				"Report this rather than retrying — the next call will wait the same %s",
-			req.Capability, req.Method, companionCallTimeout, companionCallTimeout)
+			req.Capability, req.Method, timeout, timeout)
 	}
 	return nil, err
 }


### PR DESCRIPTION
First of three hardening PRs from the calendar audit. Independent of the others.

## The gap

`companion.Registry.Call` imposes no deadline of its own — by design. Its doc says so plainly: it waits on the caller's context, or on the provider disconnecting.

That division is right. The problem is that on an ordinary conversational turn there is no deadline to wait on:

- Delegate profiles set `ToolTimeout` (`delegate/profile.go:135`) — bounded.
- Loop definitions may set `tool_timeout` — bounded when they do.
- A Signal message or a web-console turn leaves it zero (`agent_loop_bridge.go:53`), and `loop.go:2372` applies a timeout only when it is positive — **unbounded**.

So every companion dispatch on the main path had nothing stopping it.

## Why it isn't a corner case

Reaching it needs a companion that is *connected and silent*, which sounds unlikely until you notice a Mac blocks inside EventKit until somebody dismisses the macOS permission prompt. On a laptop that is closed, locked, or in another timezone, nobody does. Disconnection was always handled — `provider.done` fires and the call returns. Presence without response was not, and it took the whole turn with it.

## The fix

Both dispatch sites go through a new `callCompanion`, bounded at 30s. That covers **every** companion tool, not just calendar — the registrar's `dispatch` serves contacts and reminders through the same path.

**Not configurable, deliberately.** The bound only has to separate "working" from "wedged". EventKit answers a window query in well under a second, so 30s clears any real query by two orders of magnitude; a real one approaching it is a fact to surface, not a number to tune away.

**What the model is told matters as much as the bound.** A bare `context deadline exceeded` is unactionable. The timeout instead reports that the Mac is reachable but silent, names the permission prompt as the usual cause, and says not to retry — because the next call waits exactly as long, and a retry loop here burns the turn to no purpose.

A deadline belonging to the *caller* passes through untouched. Claiming it as the companion's would send the model chasing the wrong fault.

## Scope

Narrow on purpose. The broader finding — that **every** tool is unbounded on the main conversational path, not just companion calls — is real and deserves its own design conversation rather than riding in on a calendar fix. Not filed yet.

## Test plan

- [x] `just ci` green (exit 0)
- [x] A hanging provider is bounded rather than waiting forever
- [x] A caller with no deadline of its own gets one imposed, and the resulting error names the capability/method, the connected-but-silent state, the permission prompt, and the don't-retry guidance
- [x] A caller whose own context expired gets its own error back, with no companion blame attached
- [x] Unrelated errors and successful results pass through untouched
- [x] Review round 1 (921b89a0): the timeout was claimed from an error value matching `DeadlineExceeded` without checking that *this* bound expired, so a companion's own inner deadline became a claim that a Mac sat silent for thirty seconds. The check now requires `callCtx` to be deadline-expired too, and a disconnect racing the deadline is reported as the disconnect. Tests drive real expiries via `callCompanionWithin` rather than synthesizing the sentinel — a seam for tests, not an operator knob, with `TestCallCompanionUsesTheProductionBound` asserting the exported path still carries the constant. Verified failing against the prior condition first.
- [ ] Verified against production once deployed

Refs #1017
