### PR TITLE
Render calendar results as framed JSON, one event per line

### DIFF
--- a/internal/tools/companion_calendar_format.go
+++ b/internal/tools/companion_calendar_format.go
@@ -12,37 +12,25 @@ import (
 // carries a full RFC3339 timestamp with the offset of the zone the event
 // is scheduled in; an all-day event carries a bare calendar date, which
 // has no time and no zone by definition.
-const (
-	calendarDateLayout = "2006-01-02"
+const calendarDateLayout = "2006-01-02"
 
-	// Weekday-and-date shapes. The year appears only when the event does
-	// not fall in the reader's current year: on a calendar the near term
-	// is the common case, and "2026" on every line of a week's schedule
-	// is noise that pushes the parts that vary off to the right.
-	calendarDayLayout     = "Mon Jan 2"
-	calendarDayYearLayout = "Mon Jan 2 2006"
-
-	// Clock shapes. Seconds never appear — no calendar event means them,
-	// and rendering ":00" on every line invites the model to treat the
-	// precision as real.
-	calendarClockLayout     = "3:04PM MST"
-	calendarClockOnlyLayout = "3:04PM"
-)
-
-// calendarRenderer turns companion calendar events into the lines a model
-// reads. It resolves two frames for every event:
+// calendarRenderer turns companion calendar events into what the model
+// reads: a one-line framing header stating the frame, then one JSON
+// object per event (docs/model-facing-context.md — generated runtime
+// data defaults to JSON; one object per line for homogeneous lists).
+//
+// The value of rendering server-side is derivation, not prose. Every
+// event resolves against two frames:
 //
 //   - home, the household zone from configuration, which is the frame the
 //     agent's own process reasons in and the one "is this soon?" is asked
-//     against;
+//     against — start/end are re-expressed in it, and every event carries
+//     a delta so the model never does timestamp arithmetic;
 //   - the event's own zone, which on this operator's calendar is a
 //     statement of intent — an event recorded in Europe/Berlin means the
 //     operator expects to be in Berlin for it, so that reading is the
-//     wall clock they will actually live.
-//
-// Home is primary and every event is rendered in it. The event's own
-// reading is appended whenever the two disagree about what the clock says,
-// so neither frame has to be inferred.
+//     wall clock they will actually live. It is emitted as
+//     event_local_start/end whenever it disagrees with home's clock.
 type calendarRenderer struct {
 	home *time.Location
 	now  time.Time
@@ -89,6 +77,58 @@ func parseCalendarBoundary(value string) (calendarBoundary, bool) {
 	return calendarBoundary{}, false
 }
 
+// calendarEventJSON is one event as the model reads it. Timed events use
+// start/end (RFC3339 in the household zone, end exclusive); all-day
+// events use first_day/last_day (bare dates, both inclusive) — distinct
+// field names because the two kinds answer inclusivity differently, and
+// a reader should never have to know which convention start/end is in.
+type calendarEventJSON struct {
+	Title    string `json:"title"`
+	Calendar string `json:"calendar,omitempty"`
+	AllDay   bool   `json:"all_day,omitempty"`
+
+	// Day is the weekday the event starts, in the household frame.
+	// Derivable from the date in principle, but models are bad at
+	// calendar arithmetic and "what's on Wednesday" is a first-class
+	// calendar question.
+	Day string `json:"day,omitempty"`
+
+	Start    string `json:"start,omitempty"`
+	End      string `json:"end,omitempty"`
+	FirstDay string `json:"first_day,omitempty"`
+	LastDay  string `json:"last_day,omitempty"`
+
+	// StartDelta is the signed distance from now to the start —
+	// "-1h48m", "+3d16h" — or a day word for all-day events ("today",
+	// "tomorrow", "+4d"), which occupy a date rather than a moment and
+	// must not be rendered as though there were a clock to be early for.
+	StartDelta string `json:"start_delta,omitempty"`
+
+	// EventZone is the IANA zone the event declares, present only when
+	// the companion named one that reads differently from home. An
+	// event's own zone is intent on this calendar: where the operator
+	// expects to be standing.
+	EventZone string `json:"event_zone,omitempty"`
+
+	// EventLocalStart/End re-express the span on the event's own clock,
+	// present only when that clock disagrees with home's at either end.
+	// Each carries its boundary's own offset, so a span crossing a DST
+	// transition — local or remote — shows both offsets rather than
+	// forcing one end into the other's.
+	EventLocalStart string `json:"event_local_start,omitempty"`
+	EventLocalEnd   string `json:"event_local_end,omitempty"`
+
+	Location string `json:"location,omitempty"`
+	Notes    string `json:"notes,omitempty"`
+	URL      string `json:"url,omitempty"`
+
+	// Unparsed marks an event whose boundaries did not parse; start/end
+	// then echo the companion's bytes verbatim. A malformed timestamp is
+	// a bug worth seeing, and the title and location are still useful —
+	// but nothing downstream should read those strings as times.
+	Unparsed bool `json:"unparsed,omitempty"`
+}
+
 // formatCompanionCalendarResponse renders the whole result set, headed by
 // the frame every line below it is written in. Stating the zone and the
 // current time once removes the arithmetic the model would otherwise have
@@ -101,23 +141,14 @@ func formatCompanionCalendarResponse(response companionCalendarResponse, home *t
 	r := newCalendarRenderer(home, now)
 
 	var b strings.Builder
-	fmt.Fprintf(&b, "Found %d macOS calendar events (times in %s; now %s):",
-		len(response.Events), r.homeZoneName(), r.now.Format(calendarDayLayout+" "+calendarClockLayout))
+	fmt.Fprintf(&b, "Found %d macOS calendar events (times in %s; now %s %s):",
+		len(response.Events), r.homeZoneName(),
+		r.now.Format("Mon"), r.now.Format(time.RFC3339))
 	for _, event := range response.Events {
-		fmt.Fprintf(&b, "\n- %s | %s", r.formatRange(event), strings.TrimSpace(event.Title))
-		if event.Calendar != "" {
-			fmt.Fprintf(&b, " (%s)", event.Calendar)
-		}
-		if event.Location != "" {
-			fmt.Fprintf(&b, "\n  Location: %s", event.Location)
-		}
-		if event.NotesExcerpt != "" {
-			fmt.Fprintf(&b, "\n  Notes: %s", event.NotesExcerpt)
-		}
-		if event.URL != "" {
-			fmt.Fprintf(&b, "\n  URL: %s", event.URL)
-		}
+		b.WriteString("\n")
+		b.WriteString(promptfmt.MarshalCompact(r.renderEvent(event)))
 	}
+
 	// A capped result must say so on the line the reader finishes on.
 	// Twenty events with nothing appended reads as "there are twenty",
 	// and a calendar answer that quietly omits the rest is worse than one
@@ -126,10 +157,9 @@ func formatCompanionCalendarResponse(response companionCalendarResponse, home *t
 	// Built as a suffix rather than written into the body, because the
 	// byte cap below slices from the tail — the exact place this marker
 	// has to survive. A result can be capped by count and oversized in
-	// bytes at once (a hundred events with fat notes clears the ceiling
-	// easily), and losing the marker to the size cut would defeat the
-	// reason it is carried. When both fire, the size note comes first and
-	// the capped-events marker keeps the final word.
+	// bytes at once, and losing the marker to the size cut would defeat
+	// the reason it is carried. When both fire, the size note comes first
+	// and the capped-events marker keeps the final word.
 	const cappedNote = "\n\n[the window held more events than were returned; narrow it, filter by calendar, or raise limit]"
 	const sizeNote = "\n\n[... output truncated; narrow the window, filters, or limit for more ...]"
 
@@ -163,43 +193,135 @@ func (r calendarRenderer) homeZoneName() string {
 	return name
 }
 
-// formatRange renders the time portion of one event line.
-func (r calendarRenderer) formatRange(event companionCalendarEvent) string {
+// renderEvent derives one event's JSON object.
+func (r calendarRenderer) renderEvent(event companionCalendarEvent) calendarEventJSON {
+	out := calendarEventJSON{
+		Title:    strings.TrimSpace(event.Title),
+		Calendar: event.Calendar,
+		Location: event.Location,
+		Notes:    event.NotesExcerpt,
+		URL:      event.URL,
+	}
+
 	start, startOK := parseCalendarBoundary(event.Start)
 	end, endOK := parseCalendarBoundary(event.End)
 
-	// An unparseable start leaves nothing to reason from. Echo whatever the
-	// companion sent rather than dropping the event: a malformed timestamp
-	// is a bug worth seeing, and the title and location are still useful.
 	if !startOK {
-		if strings.TrimSpace(event.End) == "" {
-			return strings.TrimSpace(event.Start)
-		}
-		return strings.TrimSpace(event.Start) + " - " + strings.TrimSpace(event.End)
+		out.Start = strings.TrimSpace(event.Start)
+		out.End = strings.TrimSpace(event.End)
+		out.Unparsed = true
+		return out
 	}
 
 	if event.AllDay {
-		return r.formatAllDay(start, end, endOK)
+		r.renderAllDay(&out, start, end, endOK)
+		return out
 	}
-	return r.formatTimed(event, start, end, endOK)
+	r.renderTimed(&out, event, start, end, endOK)
+	return out
 }
 
-// formatAllDay renders a date range with no clock and no zone. An all-day
-// event is a property of a date in the place the operator will be, not an
-// interval on any particular clock, so imposing one would be a fiction.
-func (r calendarRenderer) formatAllDay(start, end calendarBoundary, endOK bool) string {
+// renderAllDay fills the date fields. An all-day event is a property of a
+// date in the place the operator will be, not an interval on any
+// particular clock, so it carries no times and no zone.
+func (r calendarRenderer) renderAllDay(out *calendarEventJSON, start, end calendarBoundary, endOK bool) {
 	first := r.allDayDate(start)
-	delta := promptfmt.FormatDayDelta(first, r.now)
-
 	last := first
 	if endOK {
 		last = r.allDayLastDate(end, first)
 	}
 
-	if sameDay(first, last) {
-		return fmt.Sprintf("%s (all day, %s)", r.formatDay(first), delta)
+	out.AllDay = true
+	out.Day = first.Format("Mon")
+	out.FirstDay = first.Format(calendarDateLayout)
+	out.LastDay = last.Format(calendarDateLayout)
+	out.StartDelta = promptfmt.FormatDayDelta(first, r.now)
+}
+
+// renderTimed fills the instant fields, in home with the event's own
+// reading added when the two clocks disagree.
+func (r calendarRenderer) renderTimed(out *calendarEventJSON, event companionCalendarEvent, start, end calendarBoundary, endOK bool) {
+	homeStart := start.t.In(r.home)
+	out.Day = homeStart.Format("Mon")
+	out.Start = homeStart.Format(time.RFC3339)
+	if endOK && end.t.After(start.t) {
+		out.End = end.t.In(r.home).Format(time.RFC3339)
 	}
-	return fmt.Sprintf("%s -> %s (all day, %s)", r.formatDay(first), r.formatDay(last), delta)
+	out.StartDelta = promptfmt.FormatDeltaOnly(start.t, r.now)
+
+	awayStart, awayEnd, ok := r.awayReading(event, start, end, endOK)
+	if !ok {
+		return
+	}
+	if declaredLocation(event) != nil {
+		out.EventZone = strings.TrimSpace(event.TimeZone)
+	}
+	// Each boundary keeps its own offset. With a declared zone both were
+	// converted into it, transitions included; without one, each
+	// timestamp's embedded offset is the only evidence there is, and the
+	// two can legitimately differ across a transition the event spans.
+	out.EventLocalStart = awayStart.Format(time.RFC3339)
+	if endOK && end.t.After(start.t) {
+		out.EventLocalEnd = awayEnd.Format(time.RFC3339)
+	}
+}
+
+// awayReading resolves the event on its own clock, and reports whether
+// that reading says anything the home reading did not.
+func (r calendarRenderer) awayReading(event companionCalendarEvent, start, end calendarBoundary, endOK bool) (time.Time, time.Time, bool) {
+	declared := declaredLocation(event)
+
+	// Resolve each boundary in the frame that actually governs it. With a
+	// declared zone that is the zone itself, transitions included. Without
+	// one, each timestamp's own offset is the only evidence there is.
+	awayStart, awayEnd := start.t, end.t
+	if declared != nil {
+		awayStart, awayEnd = start.t.In(declared), end.t.In(declared)
+	} else if _, offset := start.t.Zone(); offset == 0 {
+		// No declared zone and a bare Z offset is an absence of evidence,
+		// not evidence of UTC: companions predating the time_zone field
+		// forced every event to UTC no matter where it was scheduled.
+		// Annotating those as UTC events would invent the very fact the
+		// old wire format destroyed.
+		return time.Time{}, time.Time{}, false
+	}
+
+	if !r.divergesFromHome(awayStart, awayEnd, endOK) {
+		return time.Time{}, time.Time{}, false
+	}
+	return awayStart, awayEnd, true
+}
+
+// divergesFromHome reports whether the event's own clock reads differently
+// from home at either end.
+//
+// The comparison is on the offsets in effect, not on the zone names:
+// America/Chicago and America/Winnipeg keep the same clock, and annotating
+// one with the other would add fields that say nothing a reader can act
+// on. Both ends are checked because two zones can share an offset at the
+// start and part before the end — America/Phoenix and America/Los_Angeles
+// agree all summer and diverge at the fall-back — and a reading suppressed
+// on the strength of the start alone would drop exactly the hour that made
+// it worth emitting.
+func (r calendarRenderer) divergesFromHome(awayStart, awayEnd time.Time, endOK bool) bool {
+	if !sameOffset(awayStart, awayStart.In(r.home)) {
+		return true
+	}
+	return endOK && !sameOffset(awayEnd, awayEnd.In(r.home))
+}
+
+// declaredLocation loads the zone the companion named, or nil when it named
+// none or named one this host cannot resolve.
+func declaredLocation(event companionCalendarEvent) *time.Location {
+	name := strings.TrimSpace(event.TimeZone)
+	if name == "" {
+		return nil
+	}
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		return nil
+	}
+	return loc
 }
 
 // allDayDate resolves the calendar date an all-day boundary names.
@@ -241,192 +363,10 @@ func (r calendarRenderer) allDayLastDate(end calendarBoundary, first time.Time) 
 	return last
 }
 
-// formatTimed renders an event that occupies a span of clock time, in home
-// with the event's own reading appended when the two clocks disagree.
-func (r calendarRenderer) formatTimed(event companionCalendarEvent, start, end calendarBoundary, endOK bool) string {
-	homeStart := start.t.In(r.home)
-	line := fmt.Sprintf("%s (%s)",
-		r.formatSpan(homeStart, end.t.In(r.home), endOK, spanStyle{withDate: true, withZone: true}),
-		promptfmt.FormatDeltaOnly(start.t, r.now))
-
-	if away, ok := r.awayReading(event, start, end, endOK, homeStart); ok {
-		return line + " [" + away + "]"
-	}
-	return line
-}
-
-// awayReading renders the event on its own clock, and reports whether that
-// reading says anything the home reading did not.
-func (r calendarRenderer) awayReading(event companionCalendarEvent, start, end calendarBoundary, endOK bool, homeStart time.Time) (string, bool) {
-	declared := declaredLocation(event)
-
-	// Resolve each boundary in the frame that actually governs it. With a
-	// declared zone that is the zone itself, transitions included. Without
-	// one, each timestamp's own offset is the only evidence there is, and
-	// the two ends can legitimately disagree across a transition the event
-	// spans — forcing the end into the start's offset would move it.
-	awayStart, awayEnd := start.t, end.t
-	if declared != nil {
-		awayStart, awayEnd = start.t.In(declared), end.t.In(declared)
-	} else if _, offset := start.t.Zone(); offset == 0 {
-		// No declared zone and a bare Z offset is an absence of evidence,
-		// not evidence of UTC: companions predating the time_zone field
-		// forced every event to UTC no matter where it was scheduled.
-		// Annotating those as UTC events would invent the very fact the
-		// old wire format destroyed.
-		return "", false
-	}
-
-	if !r.divergesFromHome(awayStart, awayEnd, endOK) {
-		return "", false
-	}
-
-	// Label the frame once where a single one governs the whole span. When
-	// the ends sit at different offsets there is no one frame to name, so
-	// each end carries its own and the label is dropped rather than
-	// claiming the start's offset covers both.
-	zonesDiffer := endOK && !sameOffset(awayStart, awayEnd)
-	span := r.formatSpan(awayStart, awayEnd, endOK, spanStyle{
-		// The away reading repeats the date only when it is a different
-		// one. A 9pm Berlin event is 2pm the same afternoon in Chicago and
-		// the date would be noise; an 11pm Chicago event is the following
-		// morning in Berlin, and there the date is the whole point.
-		withDate: !sameDay(homeStart, awayStart),
-		withZone: zonesDiffer,
-	})
-
-	if zonesDiffer && declared == nil {
-		return span, true
-	}
-	return r.eventZoneName(event, awayStart) + " " + span, true
-}
-
-// divergesFromHome reports whether the event's own clock reads differently
-// from home at either end.
-//
-// The comparison is on the offsets in effect, not on the zone names:
-// America/Chicago and America/Winnipeg keep the same clock, and annotating
-// one with the other would add a line of text that says nothing a reader
-// can act on. Both ends are checked because two zones can share an offset
-// at the start and part before the end — America/Phoenix and
-// America/Los_Angeles agree all summer and diverge at the fall-back — and
-// an annotation suppressed on the strength of the start alone would drop
-// exactly the hour that made it worth printing.
-func (r calendarRenderer) divergesFromHome(awayStart, awayEnd time.Time, endOK bool) bool {
-	if !sameOffset(awayStart, awayStart.In(r.home)) {
-		return true
-	}
-	return endOK && !sameOffset(awayEnd, awayEnd.In(r.home))
-}
-
-// declaredLocation loads the zone the companion named, or nil when it named
-// none or named one this host cannot resolve.
-func declaredLocation(event companionCalendarEvent) *time.Location {
-	name := strings.TrimSpace(event.TimeZone)
-	if name == "" {
-		return nil
-	}
-	loc, err := time.LoadLocation(name)
-	if err != nil {
-		return nil
-	}
-	return loc
-}
-
-// eventZoneName labels the event's own frame, preferring the IANA name the
-// companion declared. A timestamp offset alone has no name to report, so
-// fall back to the zone abbreviation, and then to the numeric offset when
-// even that is only a "+02" placeholder.
-func (r calendarRenderer) eventZoneName(event companionCalendarEvent, at time.Time) string {
-	if declaredLocation(event) != nil {
-		return strings.TrimSpace(event.TimeZone)
-	}
-	abbrev, offset := at.Zone()
-	if abbrev != "" && !strings.HasPrefix(abbrev, "+") && !strings.HasPrefix(abbrev, "-") {
-		return abbrev
-	}
-	return formatZoneOffset(offset)
-}
-
 // sameOffset reports whether two times sit at the same UTC offset. Two
 // readings that do are the same wall clock, whatever their zones are named.
 func sameOffset(a, b time.Time) bool {
 	_, ao := a.Zone()
 	_, bo := b.Zone()
 	return ao == bo
-}
-
-// spanStyle selects which parts of a span are worth printing. The home
-// reading carries both the date and the zone; an away reading is already
-// introduced by its zone name and sits beside the home date, so it usually
-// needs neither.
-type spanStyle struct {
-	withDate bool
-	withZone bool
-}
-
-// formatSpan renders a start and end already converted to one location. A
-// span that stays inside a single day states the date once and drops it
-// from the end; one that crosses a day boundary states both regardless of
-// style, because a reader cannot supply the second date themselves. A
-// zero-length or unparseable end drops the end entirely.
-func (r calendarRenderer) formatSpan(start, end time.Time, endOK bool, style spanStyle) string {
-	clock := calendarClockOnlyLayout
-	if style.withZone {
-		clock = calendarClockLayout
-	}
-	day := func(t time.Time) string {
-		if !style.withDate {
-			return ""
-		}
-		return r.formatDay(t) + " "
-	}
-
-	if !endOK || !end.After(start) {
-		return day(start) + start.Format(clock)
-	}
-	if sameDay(start, end) {
-		// Fall back repeats an hour: 1:30AM CDT and 1:30AM CST are a real
-		// hour apart on the same date. Carrying the zone on the end alone
-		// would label the start with the end's zone and render that hour
-		// as a zero-length event.
-		if style.withZone && !sameOffset(start, end) {
-			return day(start) + start.Format(clock) + "-" + end.Format(clock)
-		}
-		return day(start) + start.Format(calendarClockOnlyLayout) + "-" + end.Format(clock)
-	}
-	return fmt.Sprintf("%s %s -> %s %s",
-		r.formatDay(start), start.Format(clock),
-		r.formatDay(end), end.Format(clock))
-}
-
-// formatDay renders a weekday and date, carrying the year only when the
-// event falls outside the reader's current one.
-func (r calendarRenderer) formatDay(t time.Time) string {
-	if t.Year() == r.now.Year() {
-		return t.Format(calendarDayLayout)
-	}
-	return t.Format(calendarDayYearLayout)
-}
-
-// formatZoneOffset renders a UTC offset as "UTC+2" or "UTC-5:30", the last
-// resort when a zone has neither an IANA name nor a usable abbreviation.
-func formatZoneOffset(seconds int) string {
-	sign := "+"
-	if seconds < 0 {
-		sign = "-"
-		seconds = -seconds
-	}
-	h, m := seconds/3600, (seconds%3600)/60
-	if m == 0 {
-		return fmt.Sprintf("UTC%s%d", sign, h)
-	}
-	return fmt.Sprintf("UTC%s%d:%02d", sign, h, m)
-}
-
-// sameDay reports whether two times fall on the same calendar day. Callers
-// pass times already in one location; comparing across locations would ask
-// a question with no answer.
-func sameDay(a, b time.Time) bool {
-	return a.Year() == b.Year() && a.YearDay() == b.YearDay()
 }

--- a/internal/tools/companion_calendar_format.go
+++ b/internal/tools/companion_calendar_format.go
@@ -177,7 +177,17 @@ func formatCompanionCalendarResponse(response companionCalendarResponse, home *t
 	if allowed < 0 {
 		allowed = 0
 	}
-	return truncateUTF8(body, allowed) + suffix
+	cut := truncateUTF8(body, allowed)
+	// Trim back to the last complete line. The body is one JSON object per
+	// line, and a byte-positioned cut would almost always leave a partial
+	// object right before the marker — breaking the very contract the
+	// header advertises, and doing it precisely on the large responses
+	// where a reader most needs the lines to parse. Dropping the split
+	// line costs one event that was already being cut; the marker says so.
+	if i := strings.LastIndexByte(cut, '\n'); i > 0 {
+		cut = cut[:i]
+	}
+	return cut + suffix
 }
 
 // homeZoneName is the IANA name of the reader's frame where one exists.
@@ -206,7 +216,12 @@ func (r calendarRenderer) renderEvent(event companionCalendarEvent) calendarEven
 	start, startOK := parseCalendarBoundary(event.Start)
 	end, endOK := parseCalendarBoundary(event.End)
 
-	if !startOK {
+	// An empty end is a legitimate omission; a non-empty end that does not
+	// parse is companion drift, and folding it into "no end" would render
+	// a confident one-day or open-ended event from data that is actually
+	// broken. Either way the boundaries are echoed verbatim and marked, so
+	// nothing downstream reads them as times.
+	if !startOK || (!endOK && strings.TrimSpace(event.End) != "") {
 		out.Start = strings.TrimSpace(event.Start)
 		out.End = strings.TrimSpace(event.End)
 		out.Unparsed = true

--- a/internal/tools/companion_calendar_format_test.go
+++ b/internal/tools/companion_calendar_format_test.go
@@ -27,7 +27,7 @@ func mustTime(t *testing.T, value string) time.Time {
 	return parsed
 }
 
-func TestFormatCompanionCalendarRange(t *testing.T) {
+func TestRenderCalendarEvent(t *testing.T) {
 	// A Saturday mid-morning in Chicago, during daylight time.
 	now := mustTime(t, "2026-08-29T10:48:00-05:00")
 
@@ -35,239 +35,227 @@ func TestFormatCompanionCalendarRange(t *testing.T) {
 		name  string
 		now   string
 		event companionCalendarEvent
-		want  string
+		want  calendarEventJSON
 	}{
 		{
-			name: "timed event renders in the household zone, not UTC",
+			name: "a home-zone event carries home instants and a delta, nothing more",
 			event: companionCalendarEvent{
+				Title: "Standup", Calendar: "Work",
 				Start: "2026-08-29T09:00:00-05:00",
 				End:   "2026-08-29T09:30:00-05:00",
 			},
-			want: "Sat Aug 29 9:00AM-9:30AM CDT (-1h48m)",
+			want: calendarEventJSON{
+				Title: "Standup", Calendar: "Work", Day: "Sat",
+				Start: "2026-08-29T09:00:00-05:00", End: "2026-08-29T09:30:00-05:00",
+				StartDelta: "-1h48m",
+			},
 		},
 		{
 			// A bare Z is an older companion discarding the zone, not an
-			// event scheduled on UTC's clock, so it earns no away reading.
+			// event scheduled on UTC's clock: it converts to home and earns
+			// no event-local reading.
 			name: "a UTC instant from an older companion converts to home",
 			event: companionCalendarEvent{
+				Title: "Standup",
 				Start: "2026-08-29T14:00:00Z",
 				End:   "2026-08-29T14:30:00Z",
 			},
-			want: "Sat Aug 29 9:00AM-9:30AM CDT (-1h48m)",
-		},
-		{
-			name: "an event in another zone carries both readings",
-			event: companionCalendarEvent{
-				Start:    "2026-08-29T21:00:00+02:00",
-				End:      "2026-08-29T22:00:00+02:00",
-				TimeZone: "Europe/Berlin",
+			want: calendarEventJSON{
+				Title: "Standup", Day: "Sat",
+				Start: "2026-08-29T09:00:00-05:00", End: "2026-08-29T09:30:00-05:00",
+				StartDelta: "-1h48m",
 			},
-			want: "Sat Aug 29 2:00PM-3:00PM CDT (+3h12m) [Europe/Berlin 9:00PM-10:00PM]",
 		},
 		{
-			name: "an offset with no declared zone still earns the second reading",
+			name: "an event in a declared zone carries both readings",
 			event: companionCalendarEvent{
+				Title: "Berlin kickoff", TimeZone: "Europe/Berlin",
 				Start: "2026-08-29T21:00:00+02:00",
 				End:   "2026-08-29T22:00:00+02:00",
 			},
-			want: "Sat Aug 29 2:00PM-3:00PM CDT (+3h12m) [UTC+2 9:00PM-10:00PM]",
+			want: calendarEventJSON{
+				Title: "Berlin kickoff", Day: "Sat",
+				Start: "2026-08-29T14:00:00-05:00", End: "2026-08-29T15:00:00-05:00",
+				StartDelta:      "+3h12m",
+				EventZone:       "Europe/Berlin",
+				EventLocalStart: "2026-08-29T21:00:00+02:00",
+				EventLocalEnd:   "2026-08-29T22:00:00+02:00",
+			},
 		},
 		{
-			name: "a zone that keeps the same clock as home is not annotated",
+			// No declared zone: the embedded offsets are the only evidence,
+			// so the local reading keeps them and no zone is named.
+			name: "an offset-only event keeps its offsets and names no zone",
 			event: companionCalendarEvent{
-				Start:    "2026-08-29T14:00:00-05:00",
-				End:      "2026-08-29T15:00:00-05:00",
-				TimeZone: "America/Winnipeg",
+				Title: "Somewhere east",
+				Start: "2026-08-29T21:00:00+02:00",
+				End:   "2026-08-29T22:00:00+02:00",
 			},
-			want: "Sat Aug 29 2:00PM-3:00PM CDT (+3h12m)",
+			want: calendarEventJSON{
+				Title: "Somewhere east", Day: "Sat",
+				Start: "2026-08-29T14:00:00-05:00", End: "2026-08-29T15:00:00-05:00",
+				StartDelta:      "+3h12m",
+				EventLocalStart: "2026-08-29T21:00:00+02:00",
+				EventLocalEnd:   "2026-08-29T22:00:00+02:00",
+			},
 		},
 		{
-			// The span crosses midnight in Chicago but not in Berlin, so
-			// the away reading collapses to the single date it occupies.
-			name: "an away reading on another date carries that date",
+			name: "a zone that keeps the same clock as home adds nothing",
 			event: companionCalendarEvent{
-				Start:    "2026-08-29T23:00:00-05:00",
-				End:      "2026-08-30T00:00:00-05:00",
-				TimeZone: "Europe/Berlin",
+				Title: "Winnipeg call", TimeZone: "America/Winnipeg",
+				Start: "2026-08-29T14:00:00-05:00",
+				End:   "2026-08-29T15:00:00-05:00",
 			},
-			want: "Sat Aug 29 11:00PM CDT -> Sun Aug 30 12:00AM CDT (+12h12m) " +
-				"[Europe/Berlin Sun Aug 30 6:00AM-7:00AM]",
-		},
-		{
-			name: "a span crossing midnight repeats the date on both ends",
-			event: companionCalendarEvent{
-				Start: "2026-08-29T23:00:00-05:00",
-				End:   "2026-08-30T01:00:00-05:00",
+			want: calendarEventJSON{
+				Title: "Winnipeg call", Day: "Sat",
+				Start: "2026-08-29T14:00:00-05:00", End: "2026-08-29T15:00:00-05:00",
+				StartDelta: "+3h12m",
 			},
-			want: "Sat Aug 29 11:00PM CDT -> Sun Aug 30 1:00AM CDT (+12h12m)",
-		},
-		{
-			name: "an event outside the current year carries it",
-			event: companionCalendarEvent{
-				Start: "2027-01-04T09:00:00-06:00",
-				End:   "2027-01-04T10:00:00-06:00",
-			},
-			want: "Mon Jan 4 2027 9:00AM-10:00AM CST (+127d23h)",
-		},
-		{
-			name: "an event with no end renders a single instant",
-			event: companionCalendarEvent{
-				Start: "2026-08-29T09:00:00-05:00",
-			},
-			want: "Sat Aug 29 9:00AM CDT (-1h48m)",
-		},
-		{
-			name: "an all-day date renders without a clock or a zone",
-			event: companionCalendarEvent{
-				Start:  "2026-08-29",
-				End:    "2026-08-29",
-				AllDay: true,
-			},
-			want: "Sat Aug 29 (all day, today)",
-		},
-		{
-			name: "a multi-day all-day event names its inclusive last day",
-			event: companionCalendarEvent{
-				Start:  "2026-08-31",
-				End:    "2026-09-02",
-				AllDay: true,
-			},
-			want: "Mon Aug 31 -> Wed Sep 2 (all day, +2d)",
-		},
-		{
-			name: "tomorrow reads as a word rather than a count",
-			event: companionCalendarEvent{
-				Start:  "2026-08-30",
-				End:    "2026-08-30",
-				AllDay: true,
-			},
-			want: "Sun Aug 30 (all day, tomorrow)",
-		},
-		{
-			name: "yesterday reads as a word rather than a count",
-			event: companionCalendarEvent{
-				Start:  "2026-08-28",
-				End:    "2026-08-28",
-				AllDay: true,
-			},
-			want: "Fri Aug 28 (all day, yesterday)",
-		},
-		{
-			name: "an all-day event never shows an hours-and-minutes delta",
-			event: companionCalendarEvent{
-				Start:  "2026-09-05",
-				End:    "2026-09-05",
-				AllDay: true,
-			},
-			want: "Sat Sep 5 (all day, +7d)",
-		},
-		{
-			// The bug that started this: a Berlin all-day event is local
-			// midnight, which an older companion sent as the previous day
-			// in UTC. Rendering that instant literally lost a day.
-			name: "a legacy all-day instant east of UTC keeps its own date",
-			event: companionCalendarEvent{
-				Start:  "2026-08-28T22:00:00Z",
-				End:    "2026-08-29T22:00:00Z",
-				AllDay: true,
-			},
-			want: "Sat Aug 29 (all day, today)",
-		},
-		{
-			name: "a legacy all-day instant west of UTC keeps its own date",
-			event: companionCalendarEvent{
-				Start:  "2026-08-29T05:00:00Z",
-				End:    "2026-08-30T05:00:00Z",
-				AllDay: true,
-			},
-			want: "Sat Aug 29 (all day, today)",
-		},
-		{
-			name: "a legacy multi-day all-day end stays exclusive",
-			event: companionCalendarEvent{
-				Start:  "2026-08-31T05:00:00Z",
-				End:    "2026-09-03T05:00:00Z",
-				AllDay: true,
-			},
-			want: "Mon Aug 31 -> Wed Sep 2 (all day, +2d)",
-		},
-		{
-			// Spring forward in Chicago is 2026-03-08. A whole-day count
-			// taken by subtracting local midnights would see 23h here and
-			// call the 8th "today" on the 7th.
-			name: "a day delta survives the spring-forward short day",
-			now:  "2026-03-07T10:00:00-06:00",
-			event: companionCalendarEvent{
-				Start:  "2026-03-08",
-				End:    "2026-03-08",
-				AllDay: true,
-			},
-			want: "Sun Mar 8 (all day, tomorrow)",
-		},
-		{
-			name: "an event spanning the DST boundary keeps each end's own abbreviation",
-			now:  "2026-03-07T10:00:00-06:00",
-			event: companionCalendarEvent{
-				Start: "2026-03-07T23:00:00-06:00",
-				End:   "2026-03-08T03:00:00-05:00",
-			},
-			want: "Sat Mar 7 11:00PM CST -> Sun Mar 8 3:00AM CDT (+13h)",
-		},
-		{
-			// Fall back in Chicago is 2026-11-01: 1:30AM happens twice, an
-			// hour apart. Printing the zone only on the end labels the
-			// start CST too, so a real hour reads as zero-length.
-			name: "a same-day span across fall-back labels both ends",
-			now:  "2026-11-01T00:00:00-05:00",
-			event: companionCalendarEvent{
-				Start: "2026-11-01T01:30:00-05:00",
-				End:   "2026-11-01T01:30:00-06:00",
-			},
-			want: "Sun Nov 1 1:30AM CDT-1:30AM CST (+1h30m)",
 		},
 		{
 			// Phoenix never leaves -07:00; Los Angeles shares it until the
 			// fall-back, then drops to -08:00. Comparing only the start
-			// instant finds them equal and drops an annotation the end
-			// needs.
-			name: "an away zone that diverges only by the end is still annotated",
+			// would find them equal and suppress a reading the end needs.
+			name: "a zone that diverges only by the end is still emitted",
 			now:  "2026-11-01T00:00:00-07:00",
 			event: companionCalendarEvent{
-				Start:    "2026-11-01T01:30:00-07:00",
-				End:      "2026-11-01T01:30:00-08:00",
-				TimeZone: "America/Los_Angeles",
+				Title: "LA overnight", TimeZone: "America/Los_Angeles",
+				Start: "2026-11-01T01:30:00-07:00",
+				End:   "2026-11-01T01:30:00-08:00",
 			},
-			want: "Sun Nov 1 2:30AM-3:30AM CST (+1h30m) [America/Los_Angeles 1:30AM PDT-1:30AM PST]",
+			want: calendarEventJSON{
+				Title: "LA overnight", Day: "Sun",
+				Start: "2026-11-01T02:30:00-06:00", End: "2026-11-01T03:30:00-06:00",
+				StartDelta:      "+1h30m",
+				EventZone:       "America/Los_Angeles",
+				EventLocalStart: "2026-11-01T01:30:00-07:00",
+				EventLocalEnd:   "2026-11-01T01:30:00-08:00",
+			},
 		},
 		{
-			// With no declared zone the only evidence is each timestamp's
-			// own offset. Converting the end into the start's offset moves
-			// it an hour and reports a 4am event as ending at 3am.
-			name: "an offset-only span keeps each end's own offset",
+			// A span across a remote transition: each end keeps its own
+			// embedded offset rather than being forced into the other's,
+			// so the 4:00 AM end stays 4:00 AM.
+			name: "an offset-only span across a remote transition keeps both offsets",
 			event: companionCalendarEvent{
+				Title: "Overnight abroad",
 				Start: "2026-09-01T23:00:00+01:00",
 				End:   "2026-09-02T04:00:00+02:00",
 			},
-			// The end reads 4:00AM, not the 3:00AM that forcing it into the
-			// start's offset produced. No single frame governs the span, so
-			// each end carries its own offset and the label is dropped.
-			want: "Tue Sep 1 5:00PM-9:00PM CDT (+3d6h) [Tue Sep 1 11:00PM +0100 -> Wed Sep 2 4:00AM +0200]",
-		},
-		{
-			name: "a malformed start echoes what the companion sent",
-			event: companionCalendarEvent{
-				Start: "not a timestamp",
-				End:   "also not one",
+			want: calendarEventJSON{
+				Title: "Overnight abroad", Day: "Tue",
+				Start: "2026-09-01T17:00:00-05:00", End: "2026-09-01T21:00:00-05:00",
+				StartDelta:      "+3d6h",
+				EventLocalStart: "2026-09-01T23:00:00+01:00",
+				EventLocalEnd:   "2026-09-02T04:00:00+02:00",
 			},
-			want: "not a timestamp - also not one",
 		},
 		{
-			name: "a malformed end still renders the start",
+			// Fall back in Chicago: the home instants themselves carry the
+			// two offsets, -05:00 then -06:00, with no labeling to get wrong.
+			name: "a span across home's fall-back shows both home offsets",
+			now:  "2026-11-01T00:00:00-05:00",
 			event: companionCalendarEvent{
+				Title: "Repeated hour",
+				Start: "2026-11-01T01:30:00-05:00",
+				End:   "2026-11-01T01:30:00-06:00",
+			},
+			want: calendarEventJSON{
+				Title: "Repeated hour", Day: "Sun",
+				Start: "2026-11-01T01:30:00-05:00", End: "2026-11-01T01:30:00-06:00",
+				StartDelta: "+1h30m",
+			},
+		},
+		{
+			name: "an event with no end omits end fields",
+			event: companionCalendarEvent{
+				Title: "Ping",
 				Start: "2026-08-29T09:00:00-05:00",
-				End:   "garbage",
 			},
-			want: "Sat Aug 29 9:00AM CDT (-1h48m)",
+			want: calendarEventJSON{
+				Title: "Ping", Day: "Sat",
+				Start:      "2026-08-29T09:00:00-05:00",
+				StartDelta: "-1h48m",
+			},
+		},
+		{
+			name: "an all-day date renders as inclusive dates with a day word",
+			event: companionCalendarEvent{
+				Title: "Trash day", Calendar: "Home", AllDay: true,
+				Start: "2026-08-30", End: "2026-08-30",
+			},
+			want: calendarEventJSON{
+				Title: "Trash day", Calendar: "Home", AllDay: true, Day: "Sun",
+				FirstDay: "2026-08-30", LastDay: "2026-08-30",
+				StartDelta: "tomorrow",
+			},
+		},
+		{
+			name: "a multi-day all-day event keeps its inclusive last day",
+			event: companionCalendarEvent{
+				Title: "Conference", AllDay: true,
+				Start: "2026-08-31", End: "2026-09-02",
+			},
+			want: calendarEventJSON{
+				Title: "Conference", AllDay: true, Day: "Mon",
+				FirstDay: "2026-08-31", LastDay: "2026-09-02",
+				StartDelta: "+2d",
+			},
+		},
+		{
+			// The bug that started the arc: a Berlin all-day event is local
+			// midnight, which an older companion sent as the previous day
+			// in UTC. The rounding recovery keeps its own date.
+			name: "a legacy all-day instant east of UTC keeps its own date",
+			event: companionCalendarEvent{
+				Title: "Berlin holiday", AllDay: true,
+				Start: "2026-08-28T22:00:00Z", End: "2026-08-29T22:00:00Z",
+			},
+			want: calendarEventJSON{
+				Title: "Berlin holiday", AllDay: true, Day: "Sat",
+				FirstDay: "2026-08-29", LastDay: "2026-08-29",
+				StartDelta: "today",
+			},
+		},
+		{
+			name: "a legacy multi-day all-day end stays exclusive",
+			event: companionCalendarEvent{
+				Title: "Long weekend", AllDay: true,
+				Start: "2026-08-31T05:00:00Z", End: "2026-09-03T05:00:00Z",
+			},
+			want: calendarEventJSON{
+				Title: "Long weekend", AllDay: true, Day: "Mon",
+				FirstDay: "2026-08-31", LastDay: "2026-09-02",
+				StartDelta: "+2d",
+			},
+		},
+		{
+			// Spring forward: a whole-day count taken by subtracting local
+			// midnights would see 23h and call the 8th "today" on the 7th.
+			name: "a day delta survives the spring-forward short day",
+			now:  "2026-03-07T10:00:00-06:00",
+			event: companionCalendarEvent{
+				Title: "Next day", AllDay: true,
+				Start: "2026-03-08", End: "2026-03-08",
+			},
+			want: calendarEventJSON{
+				Title: "Next day", AllDay: true, Day: "Sun",
+				FirstDay: "2026-03-08", LastDay: "2026-03-08",
+				StartDelta: "tomorrow",
+			},
+		},
+		{
+			name: "a malformed boundary is echoed and marked, never read as a time",
+			event: companionCalendarEvent{
+				Title: "Broken",
+				Start: "not a timestamp", End: "also not one",
+			},
+			want: calendarEventJSON{
+				Title:    "Broken",
+				Start:    "not a timestamp",
+				End:      "also not one",
+				Unparsed: true,
+			},
 		},
 	}
 
@@ -278,28 +266,61 @@ func TestFormatCompanionCalendarRange(t *testing.T) {
 			if tc.now != "" {
 				at = mustTime(t, tc.now)
 			}
-			got := newCalendarRenderer(home, at).formatRange(tc.event)
+			got := newCalendarRenderer(home, at).renderEvent(tc.event)
 			if got != tc.want {
-				t.Errorf("formatRange()\n got: %s\nwant: %s", got, tc.want)
+				t.Errorf("renderEvent()\n got: %+v\nwant: %+v", got, tc.want)
 			}
 		})
 	}
 }
 
-func TestFormatCompanionCalendarResponseStatesItsFrame(t *testing.T) {
-	out := formatCompanionCalendarResponse(companionCalendarResponse{
-		Events: []companionCalendarEvent{{
-			Title:    "Design sync",
-			Calendar: "Work",
-			Start:    "2026-08-29T09:00:00-05:00",
-			End:      "2026-08-29T09:30:00-05:00",
-		}},
-	}, chicago(t), mustTime(t, "2026-08-29T10:48:00-05:00"))
+// TestFormatCompanionCalendarResponseMixedDay locks the full output shape —
+// framing header, one JSON object per event, deterministic field order —
+// so a change to any one rule shows up as a change to the thing a model
+// reads rather than to a fragment of it.
+func TestFormatCompanionCalendarResponseMixedDay(t *testing.T) {
+	out := formatCompanionCalendarResponse(companionCalendarResponse{Events: []companionCalendarEvent{
+		{
+			Title: "Standup", Calendar: "Work", TimeZone: "America/Chicago",
+			Start: "2026-08-29T09:00:00-05:00", End: "2026-08-29T09:30:00-05:00",
+		},
+		{
+			Title: "Berlin kickoff", Calendar: "Work", TimeZone: "Europe/Berlin",
+			Start: "2026-09-02T10:00:00+02:00", End: "2026-09-02T11:30:00+02:00",
+			NotesExcerpt: "Bring the deck.",
+		},
+		{Title: "Conference", Calendar: "Work", AllDay: true, Start: "2026-09-02", End: "2026-09-04"},
+	}}, chicago(t), mustTime(t, "2026-08-29T10:48:00-05:00"))
 
-	want := "Found 1 macOS calendar events (times in America/Chicago; now Sat Aug 29 10:48AM CDT):" +
-		"\n- Sat Aug 29 9:00AM-9:30AM CDT (-1h48m) | Design sync (Work)"
+	want := strings.Join([]string{
+		"Found 3 macOS calendar events (times in America/Chicago; now Sat 2026-08-29T10:48:00-05:00):",
+		`{"title":"Standup","calendar":"Work","day":"Sat","start":"2026-08-29T09:00:00-05:00","end":"2026-08-29T09:30:00-05:00","start_delta":"-1h48m"}`,
+		`{"title":"Berlin kickoff","calendar":"Work","day":"Wed","start":"2026-09-02T03:00:00-05:00","end":"2026-09-02T04:30:00-05:00","start_delta":"+3d16h","event_zone":"Europe/Berlin","event_local_start":"2026-09-02T10:00:00+02:00","event_local_end":"2026-09-02T11:30:00+02:00","notes":"Bring the deck."}`,
+		`{"title":"Conference","calendar":"Work","all_day":true,"day":"Wed","first_day":"2026-09-02","last_day":"2026-09-04","start_delta":"+4d"}`,
+	}, "\n")
+
 	if out != want {
-		t.Fatalf("response\n got: %s\nwant: %s", out, want)
+		t.Fatalf("mixed day\n got:\n%s\nwant:\n%s", out, want)
+	}
+}
+
+// TestRenderedEventsAreValidJSONLines guards the contract the header
+// implies: every non-header line parses as a standalone JSON object.
+func TestRenderedEventsAreValidJSONLines(t *testing.T) {
+	out := formatCompanionCalendarResponse(companionCalendarResponse{Events: []companionCalendarEvent{
+		{Title: "A \"quoted\" title\nwith a newline", Start: "2026-08-29T09:00:00-05:00", End: "2026-08-29T10:00:00-05:00"},
+		{Title: "All-day", AllDay: true, Start: "2026-08-30", End: "2026-08-30"},
+	}}, chicago(t), mustTime(t, "2026-08-29T10:48:00-05:00"))
+
+	lines := strings.Split(out, "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected header + 2 event lines, got %d:\n%s", len(lines), out)
+	}
+	for _, line := range lines[1:] {
+		var decoded map[string]any
+		if err := json.Unmarshal([]byte(line), &decoded); err != nil {
+			t.Errorf("line is not valid JSON: %v\n%s", err, line)
+		}
 	}
 }
 
@@ -325,11 +346,9 @@ func TestFormatCompanionCalendarResponseEmpty(t *testing.T) {
 	}
 }
 
-func TestFormatCompanionCalendarResponseTruncatesOutput(t *testing.T) {
-	response := companionCalendarResponse{
-		Events: make([]companionCalendarEvent, 0, 80),
-	}
-	for i := 0; i < 80; i++ {
+func oversizedCalendarResponse() companionCalendarResponse {
+	response := companionCalendarResponse{}
+	for i := 0; i < 100; i++ {
 		response.Events = append(response.Events, companionCalendarEvent{
 			Title:        strings.Repeat("Quarterly planning sync ", 8),
 			Calendar:     "Work",
@@ -339,52 +358,85 @@ func TestFormatCompanionCalendarResponseTruncatesOutput(t *testing.T) {
 			NotesExcerpt: strings.Repeat("Bring status notes. ", 12),
 		})
 	}
+	return response
+}
 
-	formatted := formatCompanionCalendarResponse(response, chicago(t), time.Now())
+func TestFormatCompanionCalendarResponseTruncatesOutput(t *testing.T) {
+	formatted := formatCompanionCalendarResponse(oversizedCalendarResponse(), chicago(t), time.Now())
 	if len(formatted) > maxCompanionCalendarResultBytes {
 		t.Fatalf("formatted output exceeded hard cap: got %d, want <= %d", len(formatted), maxCompanionCalendarResultBytes)
 	}
 	if !strings.Contains(formatted, "[... output truncated;") {
-		t.Fatalf("expected truncated note, got: %s", formatted)
+		t.Fatalf("expected truncated note, got: %s", formatted[len(formatted)-200:])
 	}
 }
 
-// TestFormatCompanionCalendarResponseMixedDay renders a whole result set
-// of the kinds this household actually keeps — same-zone meetings, a trip
-// abroad, a flight crossing both midnight and a zone, and all-day events —
-// so a change to any one rule shows up as a change to the thing a model
-// reads rather than to a fragment of it.
-func TestFormatCompanionCalendarResponseMixedDay(t *testing.T) {
-	out := formatCompanionCalendarResponse(companionCalendarResponse{Events: []companionCalendarEvent{
-		{
-			Title: "Standup", Calendar: "Work", TimeZone: "America/Chicago",
-			Start: "2026-08-29T09:00:00-05:00", End: "2026-08-29T09:30:00-05:00",
-		},
-		{
-			Title: "Berlin kickoff", Calendar: "Work", TimeZone: "Europe/Berlin",
-			Start: "2026-09-02T10:00:00+02:00", End: "2026-09-02T11:30:00+02:00",
-			NotesExcerpt: "Bring the deck.",
-		},
-		{
-			Title: "Flight to Berlin", Calendar: "Travel", TimeZone: "America/Chicago",
-			Start: "2026-09-01T18:35:00-05:00", End: "2026-09-02T10:05:00+02:00",
-		},
-		{Title: "Conference", Calendar: "Work", Start: "2026-09-02", End: "2026-09-04", AllDay: true},
-		{Title: "Trash day", Calendar: "Home", Start: "2026-08-30", End: "2026-08-30", AllDay: true},
-	}}, chicago(t), mustTime(t, "2026-08-29T10:48:00-05:00"))
+func TestFormatCompanionCalendarResponseReportsTruncation(t *testing.T) {
+	events := []companionCalendarEvent{{
+		Title:    "Standup",
+		Calendar: "Work",
+		Start:    "2026-08-29T09:00:00-05:00",
+		End:      "2026-08-29T09:30:00-05:00",
+	}}
+	now := mustTime(t, "2026-08-29T10:48:00-05:00")
+	const note = "the window held more events than were returned"
 
-	want := strings.Join([]string{
-		"Found 5 macOS calendar events (times in America/Chicago; now Sat Aug 29 10:48AM CDT):",
-		"- Sat Aug 29 9:00AM-9:30AM CDT (-1h48m) | Standup (Work)",
-		"- Wed Sep 2 3:00AM-4:30AM CDT (+3d16h) [Europe/Berlin 10:00AM-11:30AM] | Berlin kickoff (Work)",
-		"  Notes: Bring the deck.",
-		"- Tue Sep 1 6:35PM CDT -> Wed Sep 2 3:05AM CDT (+3d7h) | Flight to Berlin (Travel)",
-		"- Wed Sep 2 -> Fri Sep 4 (all day, +4d) | Conference (Work)",
-		"- Sun Aug 30 (all day, tomorrow) | Trash day (Home)",
-	}, "\n")
+	complete := formatCompanionCalendarResponse(
+		companionCalendarResponse{Events: events}, chicago(t), now)
+	if strings.Contains(complete, note) {
+		t.Errorf("a complete result must not claim truncation:\n%s", complete)
+	}
 
-	if out != want {
-		t.Fatalf("mixed day\n got:\n%s\nwant:\n%s", out, want)
+	capped := formatCompanionCalendarResponse(
+		companionCalendarResponse{Events: events, Truncated: true}, chicago(t), now)
+	if !strings.Contains(capped, note) {
+		t.Errorf("a capped result must say so:\n%s", capped)
+	}
+	// The note has to be the last thing read; a reader that stops at the
+	// final event is exactly the reader this is for.
+	if !strings.HasSuffix(strings.TrimSpace(capped), "narrow it, filter by calendar, or raise limit]") {
+		t.Errorf("truncation note should close the output:\n%s", capped)
+	}
+}
+
+func TestFormatCompanionCalendarResponseKeepsTheCappedMarkerWhenBytesAlsoOverflow(t *testing.T) {
+	// A result can be capped by count and oversized in bytes at once — a
+	// hundred capped events with fat notes clears the byte ceiling easily.
+	// The byte cut slices from the tail, which is exactly where the capped
+	// marker lives; it must survive the cut and keep the final word.
+	response := oversizedCalendarResponse()
+	response.Truncated = true
+
+	out := formatCompanionCalendarResponse(response, chicago(t), mustTime(t, "2026-08-29T10:48:00-05:00"))
+
+	if len(out) > maxCompanionCalendarResultBytes {
+		t.Fatalf("output exceeded the byte cap: %d", len(out))
+	}
+	if !strings.Contains(out, "[... output truncated;") {
+		t.Errorf("expected the size note to be present:\n...%s", out[len(out)-300:])
+	}
+	if !strings.HasSuffix(strings.TrimSpace(out), "narrow it, filter by calendar, or raise limit]") {
+		t.Errorf("the capped-events marker must keep the final word:\n...%s", out[len(out)-300:])
+	}
+}
+
+func TestCompanionCalendarResponseDecodesTruncated(t *testing.T) {
+	var resp companionCalendarResponse
+	if err := json.Unmarshal([]byte(`{"events":[],"truncated":true}`), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !resp.Truncated {
+		t.Error("truncated should decode as true")
+	}
+
+	// A companion predating the field leaves it absent, which must read as
+	// "not told", never as a positive claim of completeness.
+	var legacy companionCalendarResponse
+	if err := json.Unmarshal([]byte(`{"events":[]}`), &legacy); err != nil {
+		t.Fatalf("unmarshal legacy: %v", err)
+	}
+	if legacy.Truncated {
+		t.Error("an absent field must not decode as truncated")
 	}
 }
 
@@ -453,82 +505,5 @@ func TestParseCompanionTimeArgDefaultsAndRejects(t *testing.T) {
 
 	if _, err := parseCompanionTimeArg(map[string]any{"start": "next tuesday"}, "start", home, fallback); err == nil {
 		t.Fatal("expected an unparseable value to be rejected")
-	}
-}
-
-func TestFormatCompanionCalendarResponseReportsTruncation(t *testing.T) {
-	events := []companionCalendarEvent{{
-		Title:    "Standup",
-		Calendar: "Work",
-		Start:    "2026-08-29T09:00:00-05:00",
-		End:      "2026-08-29T09:30:00-05:00",
-	}}
-	now := mustTime(t, "2026-08-29T10:48:00-05:00")
-	const note = "the window held more events than were returned"
-
-	complete := formatCompanionCalendarResponse(
-		companionCalendarResponse{Events: events}, chicago(t), now)
-	if strings.Contains(complete, note) {
-		t.Errorf("a complete result must not claim truncation:\n%s", complete)
-	}
-
-	capped := formatCompanionCalendarResponse(
-		companionCalendarResponse{Events: events, Truncated: true}, chicago(t), now)
-	if !strings.Contains(capped, note) {
-		t.Errorf("a capped result must say so:\n%s", capped)
-	}
-	// The note has to be the last thing read; a reader that stops at the
-	// final event is exactly the reader this is for.
-	if !strings.HasSuffix(strings.TrimSpace(capped), "narrow it, filter by calendar, or raise limit]") {
-		t.Errorf("truncation note should close the output:\n%s", capped)
-	}
-}
-
-func TestCompanionCalendarResponseDecodesTruncated(t *testing.T) {
-	var resp companionCalendarResponse
-	if err := json.Unmarshal([]byte(`{"events":[],"truncated":true}`), &resp); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if !resp.Truncated {
-		t.Error("truncated should decode as true")
-	}
-
-	// A companion predating the field leaves it absent, which must read as
-	// "not told", never as a positive claim of completeness.
-	var legacy companionCalendarResponse
-	if err := json.Unmarshal([]byte(`{"events":[]}`), &legacy); err != nil {
-		t.Fatalf("unmarshal legacy: %v", err)
-	}
-	if legacy.Truncated {
-		t.Error("an absent field must not decode as truncated")
-	}
-}
-
-func TestFormatCompanionCalendarResponseKeepsTheCappedMarkerWhenBytesAlsoOverflow(t *testing.T) {
-	// A result can be capped by count and oversized in bytes at once — a
-	// hundred capped events with fat notes clears the byte ceiling easily.
-	// The byte cut slices from the tail, which is exactly where the capped
-	// marker lives; it must survive the cut and keep the final word.
-	response := companionCalendarResponse{Truncated: true}
-	for i := 0; i < 100; i++ {
-		response.Events = append(response.Events, companionCalendarEvent{
-			Title:        strings.Repeat("Quarterly planning sync ", 8),
-			Calendar:     "Work",
-			Start:        "2026-04-02T09:00:00-05:00",
-			End:          "2026-04-02T10:00:00-05:00",
-			NotesExcerpt: strings.Repeat("Bring status notes. ", 12),
-		})
-	}
-
-	out := formatCompanionCalendarResponse(response, chicago(t), mustTime(t, "2026-08-29T10:48:00-05:00"))
-
-	if len(out) > maxCompanionCalendarResultBytes {
-		t.Fatalf("output exceeded the byte cap: %d", len(out))
-	}
-	if !strings.Contains(out, "[... output truncated;") {
-		t.Errorf("expected the size note to be present:\n...%s", out[len(out)-300:])
-	}
-	if !strings.HasSuffix(strings.TrimSpace(out), "narrow it, filter by calendar, or raise limit]") {
-		t.Errorf("the capped-events marker must keep the final word:\n...%s", out[len(out)-300:])
 	}
 }

--- a/internal/tools/companion_calendar_format_test.go
+++ b/internal/tools/companion_calendar_format_test.go
@@ -245,6 +245,35 @@ func TestRenderCalendarEvent(t *testing.T) {
 			},
 		},
 		{
+			// A non-empty end that does not parse is drift, not an omission:
+			// folding it into "no end" would render a confident open-ended
+			// event from broken data.
+			name: "a malformed end marks the whole event unparsed",
+			event: companionCalendarEvent{
+				Title: "Half broken",
+				Start: "2026-08-29T09:00:00-05:00", End: "garbage",
+			},
+			want: calendarEventJSON{
+				Title:    "Half broken",
+				Start:    "2026-08-29T09:00:00-05:00",
+				End:      "garbage",
+				Unparsed: true,
+			},
+		},
+		{
+			name: "a malformed all-day end marks the whole event unparsed",
+			event: companionCalendarEvent{
+				Title: "Broken holiday", AllDay: true,
+				Start: "2026-08-29", End: "not-a-date",
+			},
+			want: calendarEventJSON{
+				Title:    "Broken holiday",
+				Start:    "2026-08-29",
+				End:      "not-a-date",
+				Unparsed: true,
+			},
+		},
+		{
 			name: "a malformed boundary is echoed and marked, never read as a time",
 			event: companionCalendarEvent{
 				Title: "Broken",
@@ -369,6 +398,29 @@ func TestFormatCompanionCalendarResponseTruncatesOutput(t *testing.T) {
 	if !strings.Contains(formatted, "[... output truncated;") {
 		t.Fatalf("expected truncated note, got: %s", formatted[len(formatted)-200:])
 	}
+	assertEventLinesParse(t, formatted)
+}
+
+// assertEventLinesParse holds the one-object-per-line contract the header
+// advertises: every event line in the output — including the last one
+// before a truncation marker, which a byte-positioned cut would break —
+// must be a complete JSON object.
+func assertEventLinesParse(t *testing.T, out string) {
+	t.Helper()
+	kept := 0
+	for _, line := range strings.Split(out, "\n")[1:] {
+		if line == "" || strings.HasPrefix(line, "[") {
+			continue
+		}
+		var decoded map[string]any
+		if err := json.Unmarshal([]byte(line), &decoded); err != nil {
+			t.Errorf("event line is not a complete JSON object: %v\n%s", err, line)
+		}
+		kept++
+	}
+	if kept == 0 {
+		t.Error("expected at least one surviving event line")
+	}
 }
 
 func TestFormatCompanionCalendarResponseReportsTruncation(t *testing.T) {
@@ -418,6 +470,7 @@ func TestFormatCompanionCalendarResponseKeepsTheCappedMarkerWhenBytesAlsoOverflo
 	if !strings.HasSuffix(strings.TrimSpace(out), "narrow it, filter by calendar, or raise limit]") {
 		t.Errorf("the capped-events marker must keep the final word:\n...%s", out[len(out)-300:])
 	}
+	assertEventLinesParse(t, out)
 }
 
 func TestCompanionCalendarResponseDecodesTruncated(t *testing.T) {

--- a/internal/tools/companion_registrar.go
+++ b/internal/tools/companion_registrar.go
@@ -46,7 +46,7 @@ type companionProviderLister func() []companion.ProviderInfo
 
 // companionResultFormatter renders a raw companion result into the string
 // the model sees. The default is JSON passthrough; named formatters exist
-// only to preserve prose output for specific legacy tools.
+// where the server adds derivation the raw payload lacks.
 type companionResultFormatter func(json.RawMessage) (string, error)
 
 // CompanionRegistrar synthesizes model-facing tools from the tool
@@ -99,8 +99,10 @@ func newCompanionRegistrar(list companionProviderLister, call companionCallFunc,
 		logger: logger.With("component", "companion_registrar"),
 	}
 	cr.formatters = map[string]companionResultFormatter{
-		// Preserve the pretty calendar prose for the legacy tool name
-		// while everything else defaults to JSON passthrough.
+		// Calendar results are re-derived rather than passed through: the
+		// wire carries event-zone instants and dates, and the server owns
+		// the household frame, the deltas, and the divergence readings the
+		// model needs (see companion_calendar_format.go).
 		"macos_calendar_events": cr.calendarResultFormatter,
 	}
 	cr.Rebuild()
@@ -431,9 +433,9 @@ func jsonPassthroughFormatter(raw json.RawMessage) (string, error) {
 	return string(raw), nil
 }
 
-// calendarResultFormatter preserves the human-readable calendar prose for
-// the legacy macos_calendar_events tool name, rendered in the household
-// zone the registrar was built with.
+// calendarResultFormatter re-derives calendar results in the household
+// zone the registrar was built with: a framing header plus one JSON
+// object per event, with deltas and event-local readings attached.
 func (cr *CompanionRegistrar) calendarResultFormatter(raw json.RawMessage) (string, error) {
 	var resp companionCalendarResponse
 	if err := json.Unmarshal(raw, &resp); err != nil {


### PR DESCRIPTION
Follow-up to the timezone arc, closing the output-shape question. Doctrine (docs/model-facing-context.md §5) says generated runtime data defaults to typed JSON — prose for framing only — and explicitly claims *"any payload we may later diff, cache, trim, or suppress by policy."* Calendar results are now squarely that payload, and `macos_calendar_events` was the registrar's **only** named prose formatter — a legacy carve-out, not a decision anyone made for calendars.

## What the model reads now

```
Found 3 macOS calendar events (times in America/Chicago; now Sat 2026-08-29T10:48:00-05:00):
{"title":"Standup","calendar":"Work","day":"Sat","start":"2026-08-29T09:00:00-05:00","end":"2026-08-29T09:30:00-05:00","start_delta":"-1h48m"}
{"title":"Berlin kickoff","calendar":"Work","day":"Wed","start":"2026-09-02T03:00:00-05:00","end":"2026-09-02T04:30:00-05:00","start_delta":"+3d16h","event_zone":"Europe/Berlin","event_local_start":"2026-09-02T10:00:00+02:00","event_local_end":"2026-09-02T11:30:00+02:00","notes":"Bring the deck."}
{"title":"Conference","calendar":"Work","all_day":true,"day":"Wed","first_day":"2026-09-02","last_day":"2026-09-04","start_delta":"+4d"}
```

**Every derivation survives as a field.** Home-zone instants, `start_delta` (so the model never does timestamp arithmetic; day-granular for all-day events), the weekday, and `event_zone` + `event_local_start/end` whenever the event's own clock disagrees with home's at either end — the intent-carrying second reading from #1427, intact.

**All-day events use `first_day`/`last_day`** — bare inclusive dates, distinct field names, because timed `end` is exclusive and all-day is inclusive, and a reader should never have to know which convention `start`/`end` is in on a given line.

**Malformed boundaries** are echoed verbatim under `"unparsed":true` — visible as the bug they are, never read as a time.

The framing header states the zone and current instant once; the capped-events and byte-cap markers keep their reserved-suffix behavior from #1429.

## The satisfying part

RFC3339-per-boundary dissolves most of what the prose span machinery existed to reconstruct. Same-day collapse, year suppression, per-end zone labels across DST spans, the away reading's date rules — three review rounds hardened those, and every one was compensating for prose discarding offsets that RFC3339 simply carries. ~150 lines of span formatting deleted; **every behavioral scenario kept as a test**: divergence at either end (Phoenix/LA), offset-only spans across remote transitions, legacy bare-Z suppression, legacy all-day recovery east and west of UTC, both home DST transitions, the combined truncation overflow.

## Cost

~1.8× tokens per event versus the prose lines, accepted deliberately. What buys it back: one shape for tool output and the (future) cached context block alike, fields a policy layer can trim without re-parsing prose, and a deterministic contract (struct field order, `omitempty` throughout).

## Test plan

- [x] `just ci` green (exit 0)
- [x] 15-case table over `renderEvent` covering every scenario the prose renderer's review rounds produced
- [x] Golden mixed-day locking header + exact JSON lines + field order
- [x] Every non-header line parses as standalone JSON (quoted/newline titles included)
- [x] Truncation trio unchanged: complete, capped, capped+oversized (marker keeps the final word)
- [x] Legacy decode: absent `truncated` ≠ claim of completeness
- [x] Review round 1 (58589f51), both real: a malformed non-empty end was folded into "no end" — confident output from broken data, now `unparsed` with verbatim echo; and the byte cap cut mid-object, breaking one-object-per-line exactly on large responses — now trimmed to the last complete line, with `assertEventLinesParse` over both oversized outputs. Both verified failing against the prior commit.
- [ ] Verified against production once deployed

Refs #1017
