### PR TITLE
Context advertisements: the contract and discriminator, without the rename

### DIFF
--- a/docs/model-facing-context.md
+++ b/docs/model-facing-context.md
@@ -310,6 +310,44 @@ instruction-document counterpart of the "cafeteria bullets" warning in
 Use brief framing when it removes ambiguity. Once the shape is clear,
 prefer compactness.
 
+## Context Advertisements
+
+Generated context is an attention market. A subsystem should offer what it
+has that matches the current request, then let one final discriminator rank,
+filter, and limit the combined set. It should not eagerly inject a payload or
+declare its own global importance.
+
+A context advertisement carries:
+
+- stable source identity and an optional document ref
+- the typed prompt bucket where selected content belongs
+- request-relative match evidence such as exact subject, alias, semantic,
+  lexical, or ambient relevance
+- the projections available for materialization, including their role,
+  format, and conservative byte estimate
+
+Projection roles describe what a consumer gets:
+
+- `signal` is the compact outward-facing reason to spend attention. A
+  document's `status_line` and `teaser` are different authored shapes with
+  this same role. Whether the signal is ambient or request-matched belongs to
+  the advertisement's evidence, not its prose.
+- `context` carries enough substance to use directly. A document `digest` is
+  the canonical form.
+- `detail` is the complete source. It is reached through an explicit read or
+  escalation, never selected automatically.
+
+Go owns evidence ordering, deduplication, projection choice, stable ties, and
+count and byte limits. Providers own domain matching and materialization. A
+model-authored facet can describe why it is useful, but it cannot grant itself
+injection or assign its own rank.
+
+Advertising should be cheaper than materializing. Do not read a full document
+or render an expensive view merely to discover that the discriminator will
+drop it. Estimates are admission hints, not permission to overflow: the
+materialized value must still fit whole and should be dropped rather than
+silently clipped when it does not.
+
 ## Anti-Patterns
 
 - Human-optimized terse names that make the model infer purpose
@@ -322,6 +360,8 @@ prefer compactness.
   clues
 - Presenting the same fact in multiple conflicting shapes
 - Silent truncation or unstable ordering
+- Providers that inject eagerly when they can advertise a bounded projection
+- Model-authored relevance scores treated as shared ranking authority
 - A "Guidelines" dumping ground where a hazard, a toolkit fact, and a
   style note share equal weight, far from the steps they govern
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -61,7 +61,7 @@ filesystem paths, signer principals, or the contents of `.allowed_signers`.
 | `GET` | `/v1/loops` | Running loop status snapshots. Optional `?state=` filter (`pending`, `sleeping`, `waiting`, `processing`, `error`, `stopped`). |
 | `GET` | `/v1/loops/{id}` | One running loop's status. |
 | `GET` | `/v1/loops/{id}/logs` | Structured logs for a running loop's recent conversation IDs (bare array, newest first; `?limit=` default 50, max 200). |
-| `GET` | `/v1/loops/{name}/outputs/{output}` | One declared loop output at a negotiated fidelity: `text/plain` = status_line, `application/json` = typed facets + full body, `text/markdown` (default) = document body. |
+| `GET` | `/v1/loops/{name}/outputs/{output}` | One declared loop output at a negotiated fidelity: `text/plain` = `status_line` when that signal shape is declared, `application/json` = typed facets + full body, `text/markdown` (default) = document body. A plain-only request is not acceptable for an output without `status_line`. |
 | `GET` | `/v1/loops/events` | SSE stream: initial loop snapshot, then loop and delegate events. |
 | `GET` | `/v1/schedules` | Scheduler tasks (`at`/`every`/`cron`) each with its next fire time. Optional `?enabled=true`. |
 | `GET` | `/v1/schedules/{id}` | One scheduled task. |

--- a/docs/reference/loop-definitions.md
+++ b/docs/reference/loop-definitions.md
@@ -74,7 +74,7 @@ validation from `loop_definition_lint` before anything persists.)
 
 | Key | Meaning |
 |---|---|
-| `outputs` | Durable documents the loop maintains through generated tools. Entry keys: `name`, `type` (`maintained_document`, or `working_notes` for the loop-private variant), `ref` (managed document ref like `self:ego.md`), `mode` (`replace`), `purpose` (model-facing guidance), `facets` (`status_line` / `teaser` / `digest` projections; declaring any swaps the write tool to `publish_output_*`), `audience` (`published` or `internal`) |
+| `outputs` | Durable documents the loop maintains through generated tools. Entry keys: `name`, `type` (`maintained_document`, or `working_notes` for the loop-private variant), `ref` (managed document ref like `self:ego.md`), `mode` (`replace`), `purpose` (model-facing guidance), `facets` (declare the needed `status_line` / `teaser` / `digest` projections; declaring any swaps the write tool to `publish_output_*`; `status_line` and `teaser` are both outward-facing signals with different shape budgets), `audience` (`published` or `internal`) |
 
 ## Watching
 

--- a/docs/understanding/agent-loop.md
+++ b/docs/understanding/agent-loop.md
@@ -123,7 +123,10 @@ Output shapes available today:
   body through a generated `publish_output_<name>` tool, one argument
   per projection. Thane renders the document's sections, enforces a
   per-projection size budget, and can parse the document back into the
-  projections it was published from.
+  projections it was published from. Declare only the projections the
+  document's consumers need: `status_line` and `teaser` are compact
+  outward-facing signals with different shape budgets, while `digest`
+  carries enough context to act.
 - **Working notes** outputs are a loop's private append-only process
   log. They are internal-audience: excluded from document search and
   from tagged-guidance injection, though the operator and the archive

--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -414,7 +414,9 @@ runtime tools:
   `facets`: one typed argument per published projection
   (`status_line`, `teaser`, `digest`) plus the full body, written
   together in a single call. Thane renders the document sections from
-  the payload, so the loop supplies content and never structure.
+  the payload, so the loop supplies content and never structure. Declare
+  only the projections the document's readers need; `status_line` and
+  `teaser` are two shapes of the same outward-facing signal role.
 
 The loop sees a matching context block with the current document content
 or recent journal tail, so the document itself remains the durable source

--- a/internal/app/new_awareness.go
+++ b/internal/app/new_awareness.go
@@ -213,10 +213,9 @@ func (a *App) initAwareness(s *newState) error {
 	// window's annunciator of facts (#1351). Always-on (ambient
 	// interactive awareness) — worker loops don't carry the fleet's
 	// verdict; quiet until the metacognitive document publishes facets.
-	// Registered BEFORE the state window on purpose: both write the
-	// Live State bucket, cap priority is registration order, and the
-	// one-line verdict must survive a busy unbounded window — not the
-	// other way around.
+	// The provider advertises this signal before reading it. The final
+	// discriminator selects it and prepends the materialized projection to
+	// Live State, so a busy eager state window cannot starve the verdict.
 	a.loop.RegisterAlwaysContextProvider(awareness.NewSystemSelfAssessmentProvider(a.readSystemSelfAssessmentDocument, logger))
 
 	stateWindowProvider := homeassistant.NewStateWindowProvider(

--- a/internal/runtime/agent/context_discriminator.go
+++ b/internal/runtime/agent/context_discriminator.go
@@ -1,0 +1,253 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+)
+
+// The advertisement budget is deliberately much smaller than the outer
+// generated-context cap. Advertisements are a competition for attention, not
+// another path to fill every bucket. Legacy eager providers remain under the
+// existing per-bucket limit while they migrate onto this contract.
+const (
+	maxSelectedContextAdvertisements = 8
+	maxAdvertisedContextBytes        = 16 * 1024
+	contextContentSeparatorBytes     = len("\n\n---\n\n")
+)
+
+type contextAdvertisementCandidate struct {
+	advertiser    ContextAdvertiser
+	advertisement agentctx.ContextAdvertisement
+}
+
+type contextAdvertisementSelection struct {
+	advertiser ContextAdvertiser
+	selection  agentctx.ContextSelection
+	match      agentctx.ContextMatchSignal
+}
+
+// selectContextAdvertisements is the deterministic discriminator. Providers
+// decide what they can offer and how the current request matches; this pass
+// owns cross-provider evidence ordering, deduplication, projection choice,
+// count, and byte limits. Complete detail is never selected automatically.
+func selectContextAdvertisements(candidates []contextAdvertisementCandidate) []contextAdvertisementSelection {
+	valid := make([]contextAdvertisementCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		if candidate.advertiser == nil || candidate.advertisement.Validate() != nil {
+			continue
+		}
+		valid = append(valid, candidate)
+	}
+	sort.Slice(valid, func(i, j int) bool {
+		left, right := valid[i], valid[j]
+		leftMatch, leftTier := bestContextMatch(left.advertisement.Matches)
+		rightMatch, rightTier := bestContextMatch(right.advertisement.Matches)
+		if leftTier != rightTier {
+			return leftTier > rightTier
+		}
+		if leftMatch.Strength != rightMatch.Strength {
+			return leftMatch.Strength > rightMatch.Strength
+		}
+		if left.advertisement.Source != right.advertisement.Source {
+			return left.advertisement.Source < right.advertisement.Source
+		}
+		if left.advertisement.ID != right.advertisement.ID {
+			return left.advertisement.ID < right.advertisement.ID
+		}
+		leftFingerprint := contextAdvertisementFingerprint(left.advertisement)
+		rightFingerprint := contextAdvertisementFingerprint(right.advertisement)
+		if leftFingerprint != rightFingerprint {
+			return leftFingerprint < rightFingerprint
+		}
+		return fmt.Sprintf("%T", left.advertiser) < fmt.Sprintf("%T", right.advertiser)
+	})
+
+	selected := make([]contextAdvertisementSelection, 0, min(len(valid), maxSelectedContextAdvertisements))
+	seen := make(map[string]struct{}, len(valid))
+	remaining := maxAdvertisedContextBytes
+	for _, candidate := range valid {
+		key := candidate.advertisement.Source + "\x00" + candidate.advertisement.ID
+		if _, duplicate := seen[key]; duplicate {
+			continue
+		}
+		seen[key] = struct{}{}
+		match, _ := bestContextMatch(candidate.advertisement.Matches)
+		separator := 0
+		if len(selected) > 0 {
+			separator = contextContentSeparatorBytes
+		}
+		projection, ok := chooseContextProjection(candidate.advertisement.Projections, match.Kind, remaining-separator)
+		if !ok {
+			continue
+		}
+		selected = append(selected, contextAdvertisementSelection{
+			advertiser: candidate.advertiser,
+			selection: agentctx.ContextSelection{
+				Advertisement: candidate.advertisement,
+				Projection:    projection,
+			},
+			match: match,
+		})
+		remaining -= separator + projection.EstimatedBytes
+		if len(selected) == maxSelectedContextAdvertisements || remaining <= 0 {
+			break
+		}
+	}
+	return selected
+}
+
+func bestContextMatch(matches []agentctx.ContextMatchSignal) (agentctx.ContextMatchSignal, int) {
+	var best agentctx.ContextMatchSignal
+	bestTier := 0
+	for _, match := range matches {
+		tier := contextMatchTier(match.Kind)
+		if tier > bestTier || (tier == bestTier && match.Strength > best.Strength) {
+			best, bestTier = match, tier
+		}
+	}
+	return best, bestTier
+}
+
+func contextMatchTier(kind agentctx.ContextMatchKind) int {
+	switch kind {
+	case agentctx.ContextMatchExactSubject:
+		return 5
+	case agentctx.ContextMatchAlias:
+		return 4
+	case agentctx.ContextMatchSemantic:
+		return 3
+	case agentctx.ContextMatchLexical:
+		return 2
+	case agentctx.ContextMatchAmbient:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func chooseContextProjection(projections []agentctx.ContextProjection, match agentctx.ContextMatchKind, remaining int) (agentctx.ContextProjection, bool) {
+	if remaining <= 0 {
+		return agentctx.ContextProjection{}, false
+	}
+	roles := []agentctx.ContextProjectionRole{agentctx.ContextRoleContext, agentctx.ContextRoleSignal}
+	preferSmall := false
+	if match == agentctx.ContextMatchAmbient {
+		roles = []agentctx.ContextProjectionRole{agentctx.ContextRoleSignal, agentctx.ContextRoleContext}
+		preferSmall = true
+	}
+	for _, role := range roles {
+		available := make([]agentctx.ContextProjection, 0, len(projections))
+		for _, projection := range projections {
+			if projection.Role == role && projection.EstimatedBytes <= remaining {
+				available = append(available, projection)
+			}
+		}
+		if len(available) == 0 {
+			continue
+		}
+		sort.Slice(available, func(i, j int) bool {
+			if available[i].EstimatedBytes != available[j].EstimatedBytes {
+				if preferSmall {
+					return available[i].EstimatedBytes < available[j].EstimatedBytes
+				}
+				return available[i].EstimatedBytes > available[j].EstimatedBytes
+			}
+			return available[i].Name < available[j].Name
+		})
+		return available[0], true
+	}
+	return agentctx.ContextProjection{}, false
+}
+
+func contextAdvertisementFingerprint(ad agentctx.ContextAdvertisement) string {
+	var out strings.Builder
+	fmt.Fprintf(&out, "%s\x00%s\x00%s\x00%s\x00", ad.Kind, ad.Ref, ad.Bucket, ad.Summary)
+	for _, match := range ad.Matches {
+		fmt.Fprintf(&out, "%s:%g\x00", match.Kind, match.Strength)
+	}
+	for _, projection := range ad.Projections {
+		fmt.Fprintf(&out, "%s:%s:%s:%d\x00", projection.Name, projection.Role, projection.Format, projection.EstimatedBytes)
+	}
+	return out.String()
+}
+
+// materializeContextAdvertisements renders selected projections under the
+// real byte budget. Estimates decide admission; actual output still has to fit
+// whole. An oversized projection is dropped rather than clipped into an
+// unmarked fragment.
+func (a *TagContextAssembler) materializeContextAdvertisements(ctx context.Context, req agentctx.ContextRequest, candidates []contextAdvertisementCandidate) map[agentctx.ContextBucket]string {
+	selected := selectContextAdvertisements(candidates)
+	if len(selected) == 0 {
+		return nil
+	}
+	buffers := make(map[agentctx.ContextBucket]*strings.Builder)
+	used := 0
+	for _, item := range selected {
+		started := time.Now()
+		content, err := item.advertiser.MaterializeContextAdvertisement(ctx, req, item.selection)
+		warnSlowContextSource(a.logger, "context_advertisement_materialization", item.selection.Advertisement.Source+"/"+item.selection.Advertisement.ID, started)
+		if err != nil {
+			a.logger.Warn("context advertisement materialization failed",
+				"source", item.selection.Advertisement.Source,
+				"id", item.selection.Advertisement.ID,
+				"projection", item.selection.Projection.Name,
+				"error", err)
+			continue
+		}
+		if content == "" {
+			continue
+		}
+		if len(content) > item.selection.Projection.EstimatedBytes {
+			a.logger.Warn("context advertisement exceeded its byte estimate",
+				"source", item.selection.Advertisement.Source,
+				"id", item.selection.Advertisement.ID,
+				"projection", item.selection.Projection.Name,
+				"estimated_bytes", item.selection.Projection.EstimatedBytes,
+				"actual_bytes", len(content))
+		}
+		bucket := item.selection.Advertisement.Bucket
+		buf := buffers[bucket]
+		separator := 0
+		if buf != nil && buf.Len() > 0 {
+			separator = contextContentSeparatorBytes
+		}
+		if used+separator+len(content) > maxAdvertisedContextBytes {
+			a.logger.Warn("context advertisement exceeded materialization budget",
+				"source", item.selection.Advertisement.Source,
+				"id", item.selection.Advertisement.ID,
+				"projection", item.selection.Projection.Name,
+				"estimated_bytes", item.selection.Projection.EstimatedBytes,
+				"actual_bytes", len(content),
+				"limit_bytes", maxAdvertisedContextBytes)
+			continue
+		}
+		if buf == nil {
+			buf = &strings.Builder{}
+			buffers[bucket] = buf
+		}
+		if separator > 0 {
+			buf.WriteString("\n\n---\n\n")
+		}
+		buf.WriteString(content)
+		used += separator + len(content)
+		a.logger.Debug("context advertisement materialized",
+			"source", item.selection.Advertisement.Source,
+			"id", item.selection.Advertisement.ID,
+			"projection", item.selection.Projection.Name,
+			"match_kind", item.match.Kind,
+			"match_strength", item.match.Strength,
+			"bytes", len(content))
+	}
+	out := make(map[agentctx.ContextBucket]string, len(buffers))
+	for bucket, buf := range buffers {
+		if buf.Len() > 0 {
+			out[bucket] = buf.String()
+		}
+	}
+	return out
+}

--- a/internal/runtime/agent/context_discriminator.go
+++ b/internal/runtime/agent/context_discriminator.go
@@ -75,7 +75,6 @@ func selectContextAdvertisements(candidates []contextAdvertisementCandidate) []c
 		if _, duplicate := seen[key]; duplicate {
 			continue
 		}
-		seen[key] = struct{}{}
 		match, _ := bestContextMatch(candidate.advertisement.Matches)
 		separator := 0
 		if len(selected) > 0 {
@@ -83,8 +82,14 @@ func selectContextAdvertisements(candidates []contextAdvertisementCandidate) []c
 		}
 		projection, ok := chooseContextProjection(candidate.advertisement.Projections, match.Kind, remaining-separator)
 		if !ok {
+			// Not marked seen: this claimant offered nothing selectable
+			// (detail-only, or nothing fits the remaining budget), and a
+			// lower-ranked claimant of the same identity may still carry a
+			// projection that does. Marking the identity here would let
+			// the emptiest offer suppress every usable one behind it.
 			continue
 		}
+		seen[key] = struct{}{}
 		selected = append(selected, contextAdvertisementSelection{
 			advertiser: candidate.advertiser,
 			selection: agentctx.ContextSelection{
@@ -203,12 +208,20 @@ func (a *TagContextAssembler) materializeContextAdvertisements(ctx context.Conte
 			continue
 		}
 		if len(content) > item.selection.Projection.EstimatedBytes {
-			a.logger.Warn("context advertisement exceeded its byte estimate",
+			// The estimate is what selection reserved; admitting a larger
+			// payload spends capacity that later, honestly-estimated
+			// winners were promised, and whether they then fit becomes an
+			// accident of materialization order. An offer that overruns
+			// its own declaration is dropped — the same policy as an
+			// oversized projection, and the pressure that keeps estimates
+			// honest.
+			a.logger.Warn("context advertisement dropped: exceeded its own byte estimate",
 				"source", item.selection.Advertisement.Source,
 				"id", item.selection.Advertisement.ID,
 				"projection", item.selection.Projection.Name,
 				"estimated_bytes", item.selection.Projection.EstimatedBytes,
 				"actual_bytes", len(content))
+			continue
 		}
 		bucket := item.selection.Advertisement.Bucket
 		buf := buffers[bucket]

--- a/internal/runtime/agent/context_discriminator_test.go
+++ b/internal/runtime/agent/context_discriminator_test.go
@@ -1,0 +1,210 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+)
+
+type testContextAdvertiser struct {
+	advertisements []agentctx.ContextAdvertisement
+	content        map[string]string
+	legacyCalls    int
+	materialized   []string
+}
+
+func (p *testContextAdvertiser) TagContext(context.Context, agentctx.ContextRequest) (string, error) {
+	p.legacyCalls++
+	return "LEGACY_ADVERTISER_PATH", nil
+}
+
+func (p *testContextAdvertiser) ContextAdvertisements(context.Context, agentctx.ContextRequest) ([]agentctx.ContextAdvertisement, error) {
+	return append([]agentctx.ContextAdvertisement(nil), p.advertisements...), nil
+}
+
+func (p *testContextAdvertiser) MaterializeContextAdvertisement(_ context.Context, _ agentctx.ContextRequest, selection agentctx.ContextSelection) (string, error) {
+	key := selection.Advertisement.Source + "/" + selection.Advertisement.ID + "/" + selection.Projection.Name
+	p.materialized = append(p.materialized, key)
+	return p.content[key], nil
+}
+
+func testAdvertisement(source, id string, match agentctx.ContextMatchKind, strength float64, projections ...agentctx.ContextProjection) agentctx.ContextAdvertisement {
+	return agentctx.ContextAdvertisement{
+		ID:          id,
+		Source:      source,
+		Kind:        "test",
+		Bucket:      agentctx.ContextBucketRelated,
+		Summary:     "test advertisement " + id,
+		Matches:     []agentctx.ContextMatchSignal{{Kind: match, Strength: strength}},
+		Projections: projections,
+	}
+}
+
+func testProjection(name string, role agentctx.ContextProjectionRole, bytes int) agentctx.ContextProjection {
+	return agentctx.ContextProjection{Name: name, Role: role, Format: "text/markdown", EstimatedBytes: bytes}
+}
+
+func TestSelectContextAdvertisementsRanksEvidenceDeterministically(t *testing.T) {
+	t.Parallel()
+
+	provider := &testContextAdvertiser{}
+	ads := []agentctx.ContextAdvertisement{
+		testAdvertisement("memory", "ambient", agentctx.ContextMatchAmbient, 1, testProjection("signal", agentctx.ContextRoleSignal, 100)),
+		testAdvertisement("memory", "semantic", agentctx.ContextMatchSemantic, 1, testProjection("digest", agentctx.ContextRoleContext, 100)),
+		testAdvertisement("memory", "exact", agentctx.ContextMatchExactSubject, 0.1, testProjection("digest", agentctx.ContextRoleContext, 100)),
+	}
+
+	orders := [][]agentctx.ContextAdvertisement{ads, {ads[2], ads[0], ads[1]}}
+	for i, order := range orders {
+		candidates := make([]contextAdvertisementCandidate, 0, len(order))
+		for _, ad := range order {
+			candidates = append(candidates, contextAdvertisementCandidate{advertiser: provider, advertisement: ad})
+		}
+		selected := selectContextAdvertisements(candidates)
+		if len(selected) != 3 {
+			t.Fatalf("order %d selected %d advertisements, want 3", i, len(selected))
+		}
+		got := []string{
+			selected[0].selection.Advertisement.ID,
+			selected[1].selection.Advertisement.ID,
+			selected[2].selection.Advertisement.ID,
+		}
+		if strings.Join(got, ",") != "exact,semantic,ambient" {
+			t.Fatalf("order %d selection = %v, want [exact semantic ambient]", i, got)
+		}
+	}
+}
+
+func TestSelectContextAdvertisementsChoosesProjectionForMatchAndBudget(t *testing.T) {
+	t.Parallel()
+
+	provider := &testContextAdvertiser{}
+	tests := []struct {
+		name  string
+		ad    agentctx.ContextAdvertisement
+		want  string
+		empty bool
+	}{
+		{
+			name: "request match gets actionable context",
+			ad: testAdvertisement("docs", "one", agentctx.ContextMatchSemantic, 0.8,
+				testProjection("signal", agentctx.ContextRoleSignal, 100),
+				testProjection("digest", agentctx.ContextRoleContext, 1000),
+				testProjection("full", agentctx.ContextRoleDetail, 2000)),
+			want: "digest",
+		},
+		{
+			name: "ambient match gets smallest signal",
+			ad: testAdvertisement("docs", "one", agentctx.ContextMatchAmbient, 1,
+				testProjection("teaser", agentctx.ContextRoleSignal, 500),
+				testProjection("status_line", agentctx.ContextRoleSignal, 120),
+				testProjection("digest", agentctx.ContextRoleContext, 1000)),
+			want: "status_line",
+		},
+		{
+			name: "request match gets roomiest signal when no digest exists",
+			ad: testAdvertisement("docs", "one", agentctx.ContextMatchLexical, 1,
+				testProjection("status_line", agentctx.ContextRoleSignal, 120),
+				testProjection("teaser", agentctx.ContextRoleSignal, 500)),
+			want: "teaser",
+		},
+		{
+			name: "oversized context falls back to signal",
+			ad: testAdvertisement("docs", "one", agentctx.ContextMatchExactSubject, 1,
+				testProjection("signal", agentctx.ContextRoleSignal, 200),
+				testProjection("digest", agentctx.ContextRoleContext, maxAdvertisedContextBytes+1)),
+			want: "signal",
+		},
+		{
+			name:  "detail is never automatic",
+			ad:    testAdvertisement("docs", "one", agentctx.ContextMatchExactSubject, 1, testProjection("full", agentctx.ContextRoleDetail, 100)),
+			empty: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			selected := selectContextAdvertisements([]contextAdvertisementCandidate{{advertiser: provider, advertisement: tt.ad}})
+			if tt.empty {
+				if len(selected) != 0 {
+					t.Fatalf("selected = %#v, want none", selected)
+				}
+				return
+			}
+			if len(selected) != 1 || selected[0].selection.Projection.Name != tt.want {
+				t.Fatalf("selected = %#v, want projection %q", selected, tt.want)
+			}
+		})
+	}
+}
+
+func TestSelectContextAdvertisementsDeduplicatesAndLimits(t *testing.T) {
+	t.Parallel()
+
+	provider := &testContextAdvertiser{}
+	duplicate := testAdvertisement("archive", "same", agentctx.ContextMatchExactSubject, 1, testProjection("signal", agentctx.ContextRoleSignal, 100))
+	candidates := []contextAdvertisementCandidate{
+		{advertiser: provider, advertisement: duplicate},
+		{advertiser: provider, advertisement: duplicate},
+	}
+	for i := 0; i < maxSelectedContextAdvertisements+3; i++ {
+		ad := testAdvertisement("archive", "subject-"+string(rune('a'+i)), agentctx.ContextMatchLexical, 0.5, testProjection("signal", agentctx.ContextRoleSignal, 100))
+		candidates = append(candidates, contextAdvertisementCandidate{advertiser: provider, advertisement: ad})
+	}
+
+	selected := selectContextAdvertisements(candidates)
+	if len(selected) != maxSelectedContextAdvertisements {
+		t.Fatalf("selected %d advertisements, want cap %d", len(selected), maxSelectedContextAdvertisements)
+	}
+	seenSame := 0
+	for _, item := range selected {
+		if item.selection.Advertisement.ID == "same" {
+			seenSame++
+		}
+	}
+	if seenSame != 1 {
+		t.Fatalf("duplicate selected %d times, want once", seenSame)
+	}
+}
+
+func TestTagContextAssemblerUsesAdvertisementPathAndPrependsSelection(t *testing.T) {
+	provider := &testContextAdvertiser{}
+	provider.advertisements = []agentctx.ContextAdvertisement{
+		testAdvertisement("metacognition", "self", agentctx.ContextMatchAmbient, 1, testProjection("status_line", agentctx.ContextRoleSignal, 256)),
+	}
+	provider.advertisements[0].Bucket = agentctx.ContextBucketLiveState
+	provider.content = map[string]string{"metacognition/self/status_line": "SELECTED_SELF_SIGNAL"}
+
+	assembler := NewTagContextAssembler(TagContextAssemblerConfig{})
+	assembler.RegisterAlwaysProvider(&mockTagProvider{
+		content: "LEGACY_LIVE_STATE" + strings.Repeat("L", maxTagContextBytes),
+		bucket:  agentctx.ContextBucketLiveState,
+	})
+	assembler.RegisterAlwaysProvider(provider)
+	sections := assembler.BuildSections(context.Background(), agentctx.ContextRequest{IncludeAlways: true})
+
+	var live string
+	for _, section := range sections {
+		if section.Bucket == agentctx.ContextBucketLiveState {
+			live = section.Content
+			break
+		}
+	}
+	if live == "" {
+		t.Fatal("Live State section missing")
+	}
+	if signal, legacy := strings.Index(live, "SELECTED_SELF_SIGNAL"), strings.Index(live, "LEGACY_LIVE_STATE"); signal < 0 || legacy < 0 || signal > legacy {
+		t.Fatalf("advertised signal should precede eager context:\n%s", live)
+	}
+	if !strings.Contains(live, "Live State truncated: exceeded 64 KB bucket limit") {
+		t.Fatal("selected signal should survive while oversized eager context remains honestly truncated")
+	}
+	if provider.legacyCalls != 0 {
+		t.Fatalf("legacy TagContext called %d times, want 0", provider.legacyCalls)
+	}
+	if len(provider.materialized) != 1 || provider.materialized[0] != "metacognition/self/status_line" {
+		t.Fatalf("materialized = %v, want selected status_line only", provider.materialized)
+	}
+}

--- a/internal/runtime/agent/context_discriminator_test.go
+++ b/internal/runtime/agent/context_discriminator_test.go
@@ -208,3 +208,61 @@ func TestTagContextAssemblerUsesAdvertisementPathAndPrependsSelection(t *testing
 		t.Fatalf("materialized = %v, want selected status_line only", provider.materialized)
 	}
 }
+
+func TestSelectContextAdvertisementsDuplicateWithoutProjectionDoesNotSuppressLaterClaimant(t *testing.T) {
+	t.Parallel()
+
+	provider := &testContextAdvertiser{}
+	// Two claimants of one identity. The higher-ranked one offers only
+	// detail, which automatic selection never chooses; the lower-ranked one
+	// carries a selectable signal. Marking the identity seen on the empty
+	// claimant would suppress the usable one and select nothing at all.
+	empty := testAdvertisement("memory", "same", agentctx.ContextMatchExactSubject, 1,
+		testProjection("full", agentctx.ContextRoleDetail, 100))
+	usable := testAdvertisement("memory", "same", agentctx.ContextMatchAmbient, 0.5,
+		testProjection("signal", agentctx.ContextRoleSignal, 100))
+
+	selected := selectContextAdvertisements([]contextAdvertisementCandidate{
+		{advertiser: provider, advertisement: empty},
+		{advertiser: provider, advertisement: usable},
+	})
+
+	if len(selected) != 1 {
+		t.Fatalf("selected %d advertisements, want 1", len(selected))
+	}
+	if got := selected[0].selection.Projection.Name; got != "signal" {
+		t.Fatalf("selected projection %q, want the later claimant's signal", got)
+	}
+}
+
+func TestMaterializeDropsPayloadExceedingItsOwnEstimate(t *testing.T) {
+	t.Parallel()
+
+	provider := &testContextAdvertiser{}
+	over := testAdvertisement("memory", "overrun", agentctx.ContextMatchExactSubject, 1,
+		testProjection("digest", agentctx.ContextRoleContext, 64))
+	honest := testAdvertisement("memory", "honest", agentctx.ContextMatchSemantic, 1,
+		testProjection("digest", agentctx.ContextRoleContext, 64))
+	provider.advertisements = []agentctx.ContextAdvertisement{over, honest}
+	provider.content = map[string]string{
+		// Selection reserved 64 bytes for each; the overrun delivers far
+		// more. Admitting it would spend capacity promised to later
+		// winners and make their fate order-dependent.
+		"memory/overrun/digest": strings.Repeat("x", 4096),
+		"memory/honest/digest":  "fits fine",
+	}
+
+	assembler := NewTagContextAssembler(TagContextAssemblerConfig{})
+	buckets := assembler.materializeContextAdvertisements(context.Background(), agentctx.ContextRequest{}, []contextAdvertisementCandidate{
+		{advertiser: provider, advertisement: over},
+		{advertiser: provider, advertisement: honest},
+	})
+
+	rendered := buckets[agentctx.ContextBucketRelated]
+	if strings.Contains(rendered, "xxxx") {
+		t.Fatalf("over-estimate payload must be dropped, got: %.80s", rendered)
+	}
+	if !strings.Contains(rendered, "fits fine") {
+		t.Fatalf("honest payload should survive, got: %q", rendered)
+	}
+}

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -232,6 +232,19 @@ type TagContextProvider interface {
 	TagContext(ctx context.Context, req agentctx.ContextRequest) (string, error)
 }
 
+// ContextAdvertiser offers cheap, structured candidates to prompt assembly
+// and materializes only the projection selected by the final discriminator.
+// During migration, advertisers also implement [TagContextProvider] so they
+// can use the existing tagged and gated registration paths; the assembler
+// prefers this contract when both are present.
+type ContextAdvertiser interface {
+	// ContextAdvertisements returns request-relative offers without reading or
+	// rendering their full payloads.
+	ContextAdvertisements(ctx context.Context, req agentctx.ContextRequest) ([]agentctx.ContextAdvertisement, error)
+	// MaterializeContextAdvertisement renders exactly the chosen projection.
+	MaterializeContextAdvertisement(ctx context.Context, req agentctx.ContextRequest, selection agentctx.ContextSelection) (string, error)
+}
+
 // SessionArchiver handles session lifecycle and message archiving.
 type SessionArchiver interface {
 	// ArchiveConversation archives all messages from a conversation before clearing.

--- a/internal/runtime/agent/tag_context.go
+++ b/internal/runtime/agent/tag_context.go
@@ -41,6 +41,12 @@ import (
 //     full-mode loop turns set both, task-mode turns set only
 //     loop-scoped, delegate runs set neither.
 //
+// Providers may instead implement [ContextAdvertiser]. Those providers offer
+// cheap request-relative candidates during the same walk; one deterministic
+// discriminator ranks, filters, and limits all offers before materializing
+// selected projections. Legacy eager providers keep rendering directly while
+// they migrate.
+//
 // Each rendered bucket has its own 64 KB cap and truncation marker.
 // A provider's class is encoded as how it registered, not as a
 // separate code path — one interleaved list preserves registration
@@ -382,6 +388,7 @@ func (a *TagContextAssembler) BuildSections(ctx context.Context, req agentctx.Co
 
 	seen := make(map[string]bool)
 	acc := newContextAccumulator()
+	var advertisements []contextAdvertisementCandidate
 
 	// Source 1: Tagged KB articles. Re-scanned and re-read each turn
 	// so frontmatter edits, additions, and deletions propagate
@@ -430,11 +437,14 @@ func (a *TagContextAssembler) BuildSections(ctx context.Context, req agentctx.Co
 			continue
 		}
 		pStart := time.Now()
-		content, err := p.TagContext(ctx, req)
+		content, advertised, err := a.contextFromProvider(ctx, req, p, &advertisements)
 		warnSlowContextSource(a.logger, "tagged_provider", tag, pStart)
 		if err != nil {
 			a.logger.Warn("tag context provider failed",
 				"tag", tag, "error", err)
+			continue
+		}
+		if advertised {
 			continue
 		}
 		if content == "" {
@@ -474,10 +484,13 @@ func (a *TagContextAssembler) BuildSections(ctx context.Context, req agentctx.Co
 			defaultBucket, source = agentctx.ContextBucketLiveState, "loop_scoped_provider"
 		}
 		pStart := time.Now()
-		content, err := gp.provider.TagContext(ctx, req)
+		content, advertised, err := a.contextFromProvider(ctx, req, gp.provider, &advertisements)
 		warnSlowContextSource(a.logger, source, fmt.Sprintf("%T", gp.provider), pStart)
 		if err != nil {
 			a.logger.Warn("gated context provider failed", "source", source, "error", err)
+			continue
+		}
+		if advertised {
 			continue
 		}
 		if content == "" {
@@ -491,7 +504,50 @@ func (a *TagContextAssembler) BuildSections(ctx context.Context, req agentctx.Co
 		}
 	}
 
+	// Advertised context wins the front of its bucket after the full offer
+	// set has competed. That keeps final rank independent of registration
+	// order and prevents a selected compact projection from being starved by
+	// an earlier legacy provider that filled the outer bucket cap.
+	for bucket, content := range a.materializeContextAdvertisements(ctx, req, advertisements) {
+		if acc.prepend(bucket, []byte(content)) {
+			a.logger.Warn("tag context bucket limit reached after advertised context selection",
+				"bucket", string(bucket), "bucket_title", bucket.Title(),
+				"source", "context_discriminator", "limit_bytes", maxTagContextBytes)
+		}
+	}
+
 	return acc.sections()
+}
+
+// contextFromProvider takes the advertisement path when a provider supports
+// it, otherwise preserving the legacy eager render contract. Invalid offers
+// are isolated to the producer that emitted them; other candidates still
+// compete normally.
+func (a *TagContextAssembler) contextFromProvider(ctx context.Context, req agentctx.ContextRequest, provider TagContextProvider, candidates *[]contextAdvertisementCandidate) (string, bool, error) {
+	advertiser, ok := provider.(ContextAdvertiser)
+	if !ok {
+		content, err := provider.TagContext(ctx, req)
+		return content, false, err
+	}
+	advertisements, err := advertiser.ContextAdvertisements(ctx, req)
+	if err != nil {
+		return "", true, err
+	}
+	for _, advertisement := range advertisements {
+		if err := advertisement.Validate(); err != nil {
+			a.logger.Warn("context advertisement rejected",
+				"provider", fmt.Sprintf("%T", provider),
+				"source", advertisement.Source,
+				"id", advertisement.ID,
+				"error", err)
+			continue
+		}
+		*candidates = append(*candidates, contextAdvertisementCandidate{
+			advertiser:    advertiser,
+			advertisement: advertisement,
+		})
+	}
+	return "", true, nil
 }
 
 // BuildRefs assembles exact managed document refs for origin-derived
@@ -647,6 +703,25 @@ func (a *contextAccumulator) append(bucket agentctx.ContextBucket, data []byte) 
 		return true
 	}
 	return false
+}
+
+func (a *contextAccumulator) prepend(bucket agentctx.ContextBucket, data []byte) bool {
+	bucket = bucket.OrDefault(agentctx.ContextBucketContinuity)
+	if len(data) == 0 {
+		return false
+	}
+	old := a.buffers[bucket]
+	buf := &strings.Builder{}
+	truncated := appendContextContent(buf, data, maxTagContextBytes, contextBucketTruncationMarker(bucket))
+	if !truncated && old != nil && old.Len() > 0 {
+		truncated = appendContextContent(buf, []byte(old.String()), maxTagContextBytes, contextBucketTruncationMarker(bucket))
+	}
+	if old == nil {
+		a.order = append(a.order, bucket)
+	}
+	a.buffers[bucket] = buf
+	a.capped[bucket] = truncated || a.capped[bucket]
+	return truncated
 }
 
 func (a *contextAccumulator) sections() []agentctx.ContextSection {

--- a/internal/runtime/agentctx/context_advertisement.go
+++ b/internal/runtime/agentctx/context_advertisement.go
@@ -1,0 +1,183 @@
+package agentctx
+
+import (
+	"fmt"
+	"math"
+	"strings"
+)
+
+// ContextProjectionRole describes how a projection participates in context
+// selection. The role is a consumer contract, not a relevance score: the
+// final discriminator combines it with request-relative match signals and
+// its own limits.
+type ContextProjectionRole string
+
+const (
+	// ContextRoleSignal is a compact outward-facing reason to spend more
+	// attention on an item. A document's status line and teaser are both
+	// signal-shaped: ambient-versus-request relevance belongs to match
+	// evidence, not to two different consumer roles.
+	ContextRoleSignal ContextProjectionRole = "signal"
+
+	// ContextRoleContext is a standalone payload with enough substance to
+	// use directly in a turn. A digest is the canonical example.
+	ContextRoleContext ContextProjectionRole = "context"
+
+	// ContextRoleDetail is the complete source material. Automatic context
+	// selection does not choose detail; it is reached through an explicit
+	// read or a later escalation path.
+	ContextRoleDetail ContextProjectionRole = "detail"
+)
+
+// Valid reports whether r is a recognized context projection role.
+func (r ContextProjectionRole) Valid() bool {
+	switch r {
+	case ContextRoleSignal, ContextRoleContext, ContextRoleDetail:
+		return true
+	default:
+		return false
+	}
+}
+
+// ContextMatchKind names one kind of request-relative evidence offered by a
+// context subsystem. Providers perform their domain-specific matching; the
+// discriminator owns the shared ordering between evidence kinds.
+type ContextMatchKind string
+
+const (
+	// ContextMatchExactSubject means the request names the advertised subject
+	// directly using its canonical identity.
+	ContextMatchExactSubject ContextMatchKind = "exact_subject"
+
+	// ContextMatchAlias means the request names a known alias for the
+	// advertised subject.
+	ContextMatchAlias ContextMatchKind = "alias"
+
+	// ContextMatchSemantic means domain retrieval found a semantic match.
+	ContextMatchSemantic ContextMatchKind = "semantic"
+
+	// ContextMatchLexical means domain retrieval found a token or full-text
+	// match.
+	ContextMatchLexical ContextMatchKind = "lexical"
+
+	// ContextMatchAmbient means the item is useful without matching the
+	// request, subject to the discriminator's ambient budget.
+	ContextMatchAmbient ContextMatchKind = "ambient"
+)
+
+// Valid reports whether k is a recognized context match kind.
+func (k ContextMatchKind) Valid() bool {
+	switch k {
+	case ContextMatchExactSubject, ContextMatchAlias, ContextMatchSemantic, ContextMatchLexical, ContextMatchAmbient:
+		return true
+	default:
+		return false
+	}
+}
+
+// ContextMatchSignal is provider-owned evidence that an advertisement fits
+// the current request. Strength is meaningful only within one evidence kind;
+// the discriminator decides how kinds compare.
+type ContextMatchSignal struct {
+	Kind     ContextMatchKind `json:"kind"`
+	Strength float64          `json:"strength"`
+}
+
+// ContextProjection describes one bounded representation that an advertiser
+// can materialize if selected. EstimatedBytes includes any framing the
+// materializer adds and lets the discriminator choose a projection without
+// first paying to render it.
+type ContextProjection struct {
+	Name           string                `json:"name"`
+	Role           ContextProjectionRole `json:"role"`
+	Format         string                `json:"format"`
+	EstimatedBytes int                   `json:"estimated_bytes"`
+}
+
+// ContextAdvertisement is a cheap, structured offer of model context. It
+// identifies the source, records why it matches this request, and lists the
+// projections that can be materialized. It intentionally carries no global
+// rank or injection flag; those are consumer policy owned by the final
+// discriminator.
+type ContextAdvertisement struct {
+	ID          string               `json:"id"`
+	Source      string               `json:"source"`
+	Kind        string               `json:"kind"`
+	Ref         string               `json:"ref,omitempty"`
+	Bucket      ContextBucket        `json:"bucket"`
+	Summary     string               `json:"summary"`
+	Matches     []ContextMatchSignal `json:"matches"`
+	Projections []ContextProjection  `json:"projections"`
+}
+
+// Validate checks that an advertisement is complete enough for deterministic
+// selection and bounded materialization.
+func (a ContextAdvertisement) Validate() error {
+	if strings.TrimSpace(a.ID) == "" {
+		return fmt.Errorf("id is required")
+	}
+	if a.ID != strings.TrimSpace(a.ID) || strings.ContainsRune(a.ID, '\x00') {
+		return fmt.Errorf("id must be a stable value without surrounding whitespace or NUL bytes")
+	}
+	if strings.TrimSpace(a.Source) == "" {
+		return fmt.Errorf("source is required")
+	}
+	if a.Source != strings.TrimSpace(a.Source) || strings.ContainsRune(a.Source, '\x00') {
+		return fmt.Errorf("source must be a stable value without surrounding whitespace or NUL bytes")
+	}
+	if strings.TrimSpace(a.Kind) == "" {
+		return fmt.Errorf("kind is required")
+	}
+	if !a.Bucket.Valid() {
+		return fmt.Errorf("bucket %q is not recognized", a.Bucket)
+	}
+	if strings.TrimSpace(a.Summary) == "" {
+		return fmt.Errorf("summary is required")
+	}
+	if len(a.Matches) == 0 {
+		return fmt.Errorf("at least one match signal is required")
+	}
+	for i, match := range a.Matches {
+		if !match.Kind.Valid() {
+			return fmt.Errorf("matches[%d]: kind %q is not recognized", i, match.Kind)
+		}
+		if math.IsNaN(match.Strength) || math.IsInf(match.Strength, 0) || match.Strength <= 0 || match.Strength > 1 {
+			return fmt.Errorf("matches[%d]: strength must be finite and greater than 0 through 1", i)
+		}
+	}
+	if len(a.Projections) == 0 {
+		return fmt.Errorf("at least one projection is required")
+	}
+	seen := make(map[string]struct{}, len(a.Projections))
+	for i, projection := range a.Projections {
+		name := strings.TrimSpace(projection.Name)
+		if name == "" {
+			return fmt.Errorf("projections[%d]: name is required", i)
+		}
+		if projection.Name != name || strings.ContainsRune(projection.Name, '\x00') {
+			return fmt.Errorf("projections[%d]: name must be stable without surrounding whitespace or NUL bytes", i)
+		}
+		if _, ok := seen[name]; ok {
+			return fmt.Errorf("projections[%d]: duplicate name %q", i, name)
+		}
+		seen[name] = struct{}{}
+		if !projection.Role.Valid() {
+			return fmt.Errorf("projections[%d]: role %q is not recognized", i, projection.Role)
+		}
+		if strings.TrimSpace(projection.Format) == "" {
+			return fmt.Errorf("projections[%d]: format is required", i)
+		}
+		if projection.EstimatedBytes <= 0 {
+			return fmt.Errorf("projections[%d]: estimated_bytes must be positive", i)
+		}
+	}
+	return nil
+}
+
+// ContextSelection is the exact advertisement projection chosen for
+// materialization. Passing the complete advertisement back lets a provider
+// verify identity and retain any source-specific routing metadata.
+type ContextSelection struct {
+	Advertisement ContextAdvertisement `json:"advertisement"`
+	Projection    ContextProjection    `json:"projection"`
+}

--- a/internal/runtime/agentctx/context_advertisement_test.go
+++ b/internal/runtime/agentctx/context_advertisement_test.go
@@ -1,0 +1,63 @@
+package agentctx
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+func TestContextAdvertisementValidate(t *testing.T) {
+	t.Parallel()
+
+	valid := ContextAdvertisement{
+		ID:      "alice",
+		Source:  "archivist",
+		Kind:    "dossier",
+		Ref:     "dossiers:alice.md",
+		Bucket:  ContextBucketRelated,
+		Summary: "A maintained subject dossier.",
+		Matches: []ContextMatchSignal{{Kind: ContextMatchExactSubject, Strength: 1}},
+		Projections: []ContextProjection{
+			{Name: "signal", Role: ContextRoleSignal, Format: "text/markdown", EstimatedBytes: 320},
+			{Name: "digest", Role: ContextRoleContext, Format: "text/markdown", EstimatedBytes: 2048},
+			{Name: "full", Role: ContextRoleDetail, Format: "text/markdown", EstimatedBytes: 8192},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(*ContextAdvertisement)
+		wantErr string
+	}{
+		{name: "valid"},
+		{name: "missing id", mutate: func(ad *ContextAdvertisement) { ad.ID = " " }, wantErr: "id is required"},
+		{name: "padded id", mutate: func(ad *ContextAdvertisement) { ad.ID = " alice " }, wantErr: "stable value"},
+		{name: "unknown bucket", mutate: func(ad *ContextAdvertisement) { ad.Bucket = "elsewhere" }, wantErr: "bucket"},
+		{name: "unknown match", mutate: func(ad *ContextAdvertisement) { ad.Matches[0].Kind = "vibes" }, wantErr: "matches[0]"},
+		{name: "nan strength", mutate: func(ad *ContextAdvertisement) { ad.Matches[0].Strength = math.NaN() }, wantErr: "finite"},
+		{name: "zero strength", mutate: func(ad *ContextAdvertisement) { ad.Matches[0].Strength = 0 }, wantErr: "greater than 0"},
+		{name: "duplicate projection", mutate: func(ad *ContextAdvertisement) { ad.Projections[1].Name = "signal" }, wantErr: "duplicate name"},
+		{name: "unbounded estimate", mutate: func(ad *ContextAdvertisement) { ad.Projections[0].EstimatedBytes = 0 }, wantErr: "estimated_bytes"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ad := valid
+			ad.Matches = append([]ContextMatchSignal(nil), valid.Matches...)
+			ad.Projections = append([]ContextProjection(nil), valid.Projections...)
+			if tt.mutate != nil {
+				tt.mutate(&ad)
+			}
+			err := ad.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("Validate() error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/runtime/loop/output.go
+++ b/internal/runtime/loop/output.go
@@ -107,13 +107,14 @@ type OutputSpec struct {
 	Mode OutputMode `yaml:"mode,omitempty" json:"mode,omitempty"`
 	// Purpose is optional model-facing guidance for this output.
 	Purpose string `yaml:"purpose,omitempty" json:"purpose,omitempty"`
-	// Facets declares which condensed views this output publishes for a maintained
-	// document: which of status_line, teaser, and digest the loop
-	// publishes alongside the full body. Empty means no facets. The
-	// declaration is a set — element order carries no meaning, because
-	// the ladder's order is fixed by the contract itself
-	// (status_line → teaser → digest); renderers and consumers use that
-	// canonical order and must not read anything into declaration order.
+	// Facets declares which condensed views this output publishes for a
+	// maintained document: any needed subset of status_line, teaser, and
+	// digest alongside the full body. status_line and teaser are different
+	// shapes of one outward-facing signal role; digest is a context payload.
+	// Empty means no facets. The declaration is a set — element order
+	// carries no meaning, because presentation order is fixed by the
+	// contract itself; renderers and consumers must not read anything into
+	// declaration order.
 	Facets []FacetSpec `yaml:"facets,omitempty" json:"facets,omitempty"`
 	// Audience overrides which surfaces may project this output. Empty
 	// defaults from Type: working_notes is internal, every other type
@@ -232,8 +233,8 @@ func (o OutputSpec) Validate() error {
 
 // validateOutputFacets checks a declared facet set. Facets are a
 // published-projection contract, so they attach only to published
-// maintained documents, and status_line anchors the ladder whenever any
-// facet is declared.
+// maintained documents. Each document declares only the projections its
+// consumers need; full remains implicit and always present.
 func validateOutputFacets(o OutputSpec) error {
 	if len(o.Facets) == 0 {
 		return nil
@@ -245,7 +246,6 @@ func validateOutputFacets(o OutputSpec) error {
 		return fmt.Errorf("facets declare published projections, but audience is %q; an internal output has no consumers to cut a facet for", OutputAudienceInternal)
 	}
 	seen := make(map[OutputFacet]struct{}, len(o.Facets))
-	hasStatusLine := false
 	for i, facet := range o.Facets {
 		switch facet.Name {
 		case OutputFacetStatusLine, OutputFacetTeaser, OutputFacetDigest:
@@ -259,12 +259,6 @@ func validateOutputFacets(o OutputSpec) error {
 			return fmt.Errorf("facets[%d]: duplicate facet %q", i, facet.Name)
 		}
 		seen[facet.Name] = struct{}{}
-		if facet.Name == OutputFacetStatusLine {
-			hasStatusLine = true
-		}
-	}
-	if !hasStatusLine {
-		return fmt.Errorf("facets must include %q; the ambient one-line projection is the one every surface can take (teaser and digest are optional)", OutputFacetStatusLine)
 	}
 	return nil
 }

--- a/internal/runtime/loop/output.go
+++ b/internal/runtime/loop/output.go
@@ -246,6 +246,7 @@ func validateOutputFacets(o OutputSpec) error {
 		return fmt.Errorf("facets declare published projections, but audience is %q; an internal output has no consumers to cut a facet for", OutputAudienceInternal)
 	}
 	seen := make(map[OutputFacet]struct{}, len(o.Facets))
+	hasStatusLine := false
 	for i, facet := range o.Facets {
 		switch facet.Name {
 		case OutputFacetStatusLine, OutputFacetTeaser, OutputFacetDigest:
@@ -259,6 +260,12 @@ func validateOutputFacets(o OutputSpec) error {
 			return fmt.Errorf("facets[%d]: duplicate facet %q", i, facet.Name)
 		}
 		seen[facet.Name] = struct{}{}
+		if facet.Name == OutputFacetStatusLine {
+			hasStatusLine = true
+		}
+	}
+	if !hasStatusLine {
+		return fmt.Errorf("facets must include %q; the ambient one-line projection is the one every surface can take (teaser and digest are optional)", OutputFacetStatusLine)
 	}
 	return nil
 }

--- a/internal/runtime/loop/output_facets.go
+++ b/internal/runtime/loop/output_facets.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 	"unicode/utf8"
+
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 )
 
 // Rune budgets for the published projection facets. They are display
@@ -59,17 +61,21 @@ type FacetPayload struct {
 // generated publish tool advertises it to the model.
 type FacetField struct {
 	// Key is the tool argument name.
-	Key string
+	Key string `json:"key"`
 	// MaxRunes is the display budget in runes; zero is unbounded.
-	MaxRunes int
+	MaxRunes int `json:"max_runes"`
 	// SingleLine marks a field that must not contain line breaks.
-	SingleLine bool
+	SingleLine bool `json:"single_line"`
 	// Guidance is the model-facing description of what this field is
 	// for and where it surfaces.
-	Guidance string
+	Guidance string `json:"guidance"`
 	// Format is how this facet's value is encoded. Empty on the full
 	// body, which is always markdown.
-	Format FacetFormat
+	Format FacetFormat `json:"format,omitempty"`
+	// ContextRole describes how a consumer should treat this projection
+	// when it is offered as model context. It does not grant injection or
+	// choose a rank; the context discriminator owns those decisions.
+	ContextRole agentctx.ContextProjectionRole `json:"context_role"`
 }
 
 // facetSection binds one projection to its canonical document section and
@@ -98,10 +104,11 @@ var facetSections = []facetSection{
 		Facet:   OutputFacetStatusLine,
 		Heading: "Status Line",
 		Field: FacetField{
-			Key:        "status_line",
-			MaxRunes:   statusLineMaxRunes,
-			SingleLine: true,
-			Guidance:   "One standalone line of current state, no line breaks. Reads as an ambient status: what is true right now. This is the only thing some surfaces show, so it must stand alone without the document around it.",
+			Key:         "status_line",
+			MaxRunes:    statusLineMaxRunes,
+			SingleLine:  true,
+			Guidance:    "The tight signal shape: one standalone line of current state, no line breaks. Reads as an ambient status: what is true right now. This is the only thing some surfaces show, so it must stand alone without the document around it.",
+			ContextRole: agentctx.ContextRoleSignal,
 		},
 		scaffoldHint: "one standalone line of what is true right now",
 		value:        func(p *FacetPayload) *string { return &p.StatusLine },
@@ -110,9 +117,10 @@ var facetSections = []facetSection{
 		Facet:   OutputFacetTeaser,
 		Heading: "Teaser",
 		Field: FacetField{
-			Key:      "teaser",
-			MaxRunes: teaserMaxRunes,
-			Guidance: "One short paragraph on why a reader would open this document right now. Surfaces as the snippet in search results and cross-references, so write the hook — the reason to look — rather than a compressed summary.",
+			Key:         "teaser",
+			MaxRunes:    teaserMaxRunes,
+			Guidance:    "The roomy signal shape: one short paragraph on why a reader would open this document right now. Surfaces as the snippet in search results and cross-references, so write the hook — the reason to look — rather than a compressed summary.",
+			ContextRole: agentctx.ContextRoleSignal,
 		},
 		scaffoldHint: "why a reader would open this document right now",
 		value:        func(p *FacetPayload) *string { return &p.Teaser },
@@ -121,9 +129,10 @@ var facetSections = []facetSection{
 		Facet:   OutputFacetDigest,
 		Heading: "Digest",
 		Field: FacetField{
-			Key:      "digest",
-			MaxRunes: digestMaxRunes,
-			Guidance: "A standalone summary carrying enough substance to act on without opening the full document. Surfaces in subscription rows and periodic digests.",
+			Key:         "digest",
+			MaxRunes:    digestMaxRunes,
+			Guidance:    "The context payload: a standalone summary carrying enough substance to act on without opening the full document. Surfaces in subscription rows and periodic digests.",
+			ContextRole: agentctx.ContextRoleContext,
 		},
 		scaffoldHint: "a summary with enough substance to act on",
 		value:        func(p *FacetPayload) *string { return &p.Digest },
@@ -131,8 +140,9 @@ var facetSections = []facetSection{
 	{
 		Heading: "Details",
 		Field: FacetField{
-			Key:      "full",
-			Guidance: "The complete current state in markdown. This is what a reader opens when the digest is not enough. Always required: it is the document's substance, and the other projections are views of it.",
+			Key:         "full",
+			Guidance:    "The detail payload: the complete current state in markdown. This is what a reader opens when the digest is not enough. Always required: it is the document's substance, and the other projections are views of it.",
+			ContextRole: agentctx.ContextRoleDetail,
 		},
 		scaffoldHint: "the complete current state",
 		value:        func(p *FacetPayload) *string { return &p.Full },
@@ -167,6 +177,17 @@ func (o OutputSpec) FacetFields() []FacetField {
 		}
 	}
 	return fields
+}
+
+// FacetFieldByKey returns the canonical metadata for one projection key.
+// Consumers that advertise faceted documents use this to share the same
+// role and size vocabulary as the generated publish tool.
+func FacetFieldByKey(key string) (FacetField, bool) {
+	section, ok := facetSectionByKey(key)
+	if !ok {
+		return FacetField{}, false
+	}
+	return section.Field, true
 }
 
 // HasFacets reports whether this output publishes through the faceted

--- a/internal/runtime/loop/output_facets_test.go
+++ b/internal/runtime/loop/output_facets_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 )
 
 func facetedOutput(names ...OutputFacet) OutputSpec {
@@ -36,6 +38,11 @@ func TestOutputSpecFacetFieldsFollowCanonicalOrder(t *testing.T) {
 			want:   []string{"status_line", "full"},
 		},
 		{
+			name:   "request-facing facets need no ambient status",
+			output: facetedOutput(OutputFacetTeaser, OutputFacetDigest),
+			want:   []string{"teaser", "digest", "full"},
+		},
+		{
 			name:   "declaration order is ignored",
 			output: facetedOutput(OutputFacetDigest, OutputFacetStatusLine),
 			want:   []string{"status_line", "digest", "full"},
@@ -58,6 +65,26 @@ func TestOutputSpecFacetFieldsFollowCanonicalOrder(t *testing.T) {
 				t.Fatalf("FacetFields() keys = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestFacetContextRolesUnifyOutwardSignals(t *testing.T) {
+	t.Parallel()
+
+	want := map[string]agentctx.ContextProjectionRole{
+		"status_line": agentctx.ContextRoleSignal,
+		"teaser":      agentctx.ContextRoleSignal,
+		"digest":      agentctx.ContextRoleContext,
+		"full":        agentctx.ContextRoleDetail,
+	}
+	for key, role := range want {
+		field, ok := FacetFieldByKey(key)
+		if !ok {
+			t.Fatalf("FacetFieldByKey(%q) missing", key)
+		}
+		if field.ContextRole != role {
+			t.Errorf("FacetFieldByKey(%q).ContextRole = %q, want %q", key, field.ContextRole, role)
+		}
 	}
 }
 

--- a/internal/runtime/loop/output_test.go
+++ b/internal/runtime/loop/output_test.go
@@ -109,7 +109,7 @@ func TestOutputSpecValidateAndToolName(t *testing.T) {
 			wantTool: "publish_output_ranch_status",
 		},
 		{
-			name: "status line alone anchors the ladder",
+			name: "status line can be the only declared projection",
 			output: OutputSpec{
 				Name:   "ranch status",
 				Type:   OutputTypeMaintainedDocument,
@@ -119,14 +119,14 @@ func TestOutputSpecValidateAndToolName(t *testing.T) {
 			wantTool: "publish_output_ranch_status",
 		},
 		{
-			name: "facets without status line rejected",
+			name: "request-facing facets do not require ambient status",
 			output: OutputSpec{
 				Name:   "ranch status",
 				Type:   OutputTypeMaintainedDocument,
 				Ref:    "core:ranch.md",
 				Facets: []FacetSpec{{Name: OutputFacetTeaser}, {Name: OutputFacetDigest}},
 			},
-			wantErr: true,
+			wantTool: "publish_output_ranch_status",
 		},
 		{
 			name: "unknown facet rejected",

--- a/internal/runtime/loop/output_test.go
+++ b/internal/runtime/loop/output_test.go
@@ -109,7 +109,7 @@ func TestOutputSpecValidateAndToolName(t *testing.T) {
 			wantTool: "publish_output_ranch_status",
 		},
 		{
-			name: "status line can be the only declared projection",
+			name: "status line alone anchors the ladder",
 			output: OutputSpec{
 				Name:   "ranch status",
 				Type:   OutputTypeMaintainedDocument,
@@ -119,14 +119,14 @@ func TestOutputSpecValidateAndToolName(t *testing.T) {
 			wantTool: "publish_output_ranch_status",
 		},
 		{
-			name: "request-facing facets do not require ambient status",
+			name: "facets without status line rejected",
 			output: OutputSpec{
 				Name:   "ranch status",
 				Type:   OutputTypeMaintainedDocument,
 				Ref:    "core:ranch.md",
 				Facets: []FacetSpec{{Name: OutputFacetTeaser}, {Name: OutputFacetDigest}},
 			},
-			wantTool: "publish_output_ranch_status",
+			wantErr: true,
 		},
 		{
 			name: "unknown facet rejected",

--- a/internal/state/awareness/system_self_assessment_provider.go
+++ b/internal/state/awareness/system_self_assessment_provider.go
@@ -2,10 +2,12 @@ package awareness
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
@@ -20,10 +22,10 @@ import (
 // buried in a document nobody read until a request_core_attention
 // fired (#1351).
 //
-// It is deliberately the seed crystal of the general pattern (every
-// faceted loop's status_line in a parent's context, the process-table
-// panel noted on #1341): one provider, one document, one line, so the
-// generalization has a proven shape when it comes due.
+// It is deliberately the seed crystal of the context-advertisement pattern:
+// one provider offers one faceted document's compact signal, and the shared
+// discriminator decides whether to materialize it. status_line and teaser
+// remain distinct document shapes but share that outward-facing signal role.
 //
 // Quiet by design in every degraded state: no document, no facet
 // sections (the document predates its faceted spec), or an empty
@@ -63,6 +65,50 @@ func NewSystemSelfAssessmentProvider(read func(ctx context.Context) (string, tim
 // reading of the system, not continuity material.
 func (p *SystemSelfAssessmentProvider) TagContextBucket() agentctx.ContextBucket {
 	return agentctx.ContextBucketLiveState
+}
+
+const systemSelfAssessmentAdvertisementID = "system_self_assessment"
+
+// ContextAdvertisements offers the metacognitive verdict as cheap ambient
+// context. Advertising does not read the document; only a selected projection
+// pays that cost.
+func (p *SystemSelfAssessmentProvider) ContextAdvertisements(context.Context, agentctx.ContextRequest) ([]agentctx.ContextAdvertisement, error) {
+	if p == nil || p.read == nil {
+		return nil, nil
+	}
+	field, ok := looppkg.FacetFieldByKey(string(looppkg.OutputFacetStatusLine))
+	if !ok {
+		return nil, fmt.Errorf("status_line facet metadata is unavailable")
+	}
+	return []agentctx.ContextAdvertisement{{
+		ID:      systemSelfAssessmentAdvertisementID,
+		Source:  "metacognition",
+		Kind:    "faceted_document",
+		Bucket:  agentctx.ContextBucketLiveState,
+		Summary: "The system's latest metacognitive verdict.",
+		Matches: []agentctx.ContextMatchSignal{{
+			Kind:     agentctx.ContextMatchAmbient,
+			Strength: 1,
+		}},
+		Projections: []agentctx.ContextProjection{{
+			Name:           field.Key,
+			Role:           field.ContextRole,
+			Format:         "text/markdown",
+			EstimatedBytes: field.MaxRunes*utf8.UTFMax + 256,
+		}},
+	}}, nil
+}
+
+// MaterializeContextAdvertisement renders the selected metacognitive signal
+// through the existing last-good and age-aware read path.
+func (p *SystemSelfAssessmentProvider) MaterializeContextAdvertisement(ctx context.Context, req agentctx.ContextRequest, selection agentctx.ContextSelection) (string, error) {
+	if selection.Advertisement.Source != "metacognition" || selection.Advertisement.ID != systemSelfAssessmentAdvertisementID {
+		return "", fmt.Errorf("unknown metacognitive context advertisement %q/%q", selection.Advertisement.Source, selection.Advertisement.ID)
+	}
+	if selection.Projection.Name != string(looppkg.OutputFacetStatusLine) {
+		return "", fmt.Errorf("unsupported metacognitive context projection %q", selection.Projection.Name)
+	}
+	return p.TagContext(ctx, req)
 }
 
 // TagContext implements the agent context-provider contract. It parses

--- a/internal/state/awareness/system_self_assessment_provider_test.go
+++ b/internal/state/awareness/system_self_assessment_provider_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 )
 
 // TestSystemSelfAssessmentProvider pins the provider's contract: the
@@ -74,5 +75,42 @@ func TestSystemSelfAssessmentProvider(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestSystemSelfAssessmentProviderAdvertisesSignalBeforeReading(t *testing.T) {
+	t.Parallel()
+
+	reads := 0
+	p := NewSystemSelfAssessmentProvider(func(context.Context) (string, time.Time, error) {
+		reads++
+		return "## Status Line\n\npanel clean\n\n## Details\n\nbody\n", time.Now(), nil
+	}, nil)
+	ads, err := p.ContextAdvertisements(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("ContextAdvertisements: %v", err)
+	}
+	if reads != 0 {
+		t.Fatalf("advertising performed %d document reads, want 0", reads)
+	}
+	if len(ads) != 1 {
+		t.Fatalf("advertisements = %#v, want one", ads)
+	}
+	if err := ads[0].Validate(); err != nil {
+		t.Fatalf("advertisement invalid: %v", err)
+	}
+	projection := ads[0].Projections[0]
+	if projection.Name != string(looppkg.OutputFacetStatusLine) || projection.Role != agentctx.ContextRoleSignal {
+		t.Fatalf("projection = %#v, want status_line signal", projection)
+	}
+	out, err := p.MaterializeContextAdvertisement(context.Background(), agentctx.ContextRequest{}, agentctx.ContextSelection{
+		Advertisement: ads[0],
+		Projection:    projection,
+	})
+	if err != nil {
+		t.Fatalf("MaterializeContextAdvertisement: %v", err)
+	}
+	if reads != 1 || !strings.Contains(out, "panel clean") {
+		t.Fatalf("materialized output = %q after %d reads", out, reads)
 	}
 }

--- a/internal/tools/document_tools.go
+++ b/internal/tools/document_tools.go
@@ -36,7 +36,7 @@ func RegisterDocumentTools(r *Registry, dt *documents.Tools) {
 				"level": map[string]any{
 					"type":        "string",
 					"enum":        looppkg.FacetKeys(),
-					"description": "How much of a faceted document to read. status_line is one line of current state; teaser is a paragraph on why you would open it; digest carries enough to act on without opening it; full is the whole body. Omit for the standard whole-document payload. Read at the level your decision actually needs — pulling full when a status line would answer the question spends context you will want later.",
+					"description": "How much of a faceted document to read. status_line is a tight ambient signal; teaser is a roomier search or cross-reference signal; digest carries enough context to act; full is the whole body. Omit for the standard whole-document payload. Read at the level your decision actually needs — pulling full when a signal or digest would answer the question spends context you will want later.",
 				},
 			},
 			"required": []string{"ref"},
@@ -183,7 +183,7 @@ func RegisterDocumentTools(r *Registry, dt *documents.Tools) {
 
 	r.Register(&Tool{
 		Name:        "doc_search",
-		Description: "Search indexed markdown documents by root, path prefix, query text, tags, frontmatter filters, and modified-time bounds. Returns compact document summaries with canonical refs like `kb:article.md` and modified-time delta fields like `-3600s`, not full bodies. A faceted document’s summary is its authored teaser (or status_line when no teaser is declared) rather than a derived excerpt, and the hit lists its available facets so the next step is one deliberate doc_read with level. Documents whose frontmatter declares `audience: internal` (private working surfaces such as loop working notes) are excluded by default; set include_internal true, or filter on the audience key explicitly, to see them.",
+		Description: "Search indexed markdown documents by root, path prefix, query text, tags, frontmatter filters, and modified-time bounds. Returns compact document summaries with canonical refs like `kb:article.md` and modified-time delta fields like `-3600s`, not full bodies. A faceted document’s summary is its authored outward-facing signal: teaser when present, otherwise status_line, rather than a derived excerpt. The hit lists its available facets so the next step is one deliberate doc_read with level. Documents whose frontmatter declares `audience: internal` (private working surfaces such as loop working notes) are excluded by default; set include_internal true, or filter on the audience key explicitly, to see them.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{

--- a/internal/tools/loop_create_tool.go
+++ b/internal/tools/loop_create_tool.go
@@ -870,7 +870,7 @@ func thaneLoopCreateSchema() map[string]any {
 					"facets": map[string]any{
 						"type":        "array",
 						"items":       map[string]any{"type": "string", "enum": []string{"status_line", "teaser", "digest"}},
-						"description": "Publish condensed projections alongside the full body, so each consumer takes the length it can afford — an ambient row takes status_line, a search snippet takes teaser, a digest row takes digest. Declaring these swaps the loop's generated tool from replace_output_* to publish_output_*, which takes one argument per projection. Declare them whenever anything other than this loop will read the document.",
+						"description": "Publish selected projections alongside the full body, so each consumer takes the shape it needs. status_line and teaser are both outward-facing signals: status_line is the tight ambient form and teaser is the roomier search or cross-reference form. digest carries enough context to act. Declare only the projections this output's readers need; a dossier can use teaser and digest without inventing ambient status. Declaring any swaps the loop's generated tool from replace_output_* to publish_output_*, which takes one argument per declared projection plus full.",
 					},
 					"initial": map[string]any{
 						"type":        "object",

--- a/internal/tools/loop_create_tool.go
+++ b/internal/tools/loop_create_tool.go
@@ -870,7 +870,7 @@ func thaneLoopCreateSchema() map[string]any {
 					"facets": map[string]any{
 						"type":        "array",
 						"items":       map[string]any{"type": "string", "enum": []string{"status_line", "teaser", "digest"}},
-						"description": "Publish selected projections alongside the full body, so each consumer takes the shape it needs. status_line and teaser are both outward-facing signals: status_line is the tight ambient form and teaser is the roomier search or cross-reference form. digest carries enough context to act. Declare only the projections this output's readers need; a dossier can use teaser and digest without inventing ambient status. Declaring any swaps the loop's generated tool from replace_output_* to publish_output_*, which takes one argument per declared projection plus full.",
+						"description": "Publish selected projections alongside the full body, so each consumer takes the shape it needs. status_line and teaser are both outward-facing signals: status_line is the tight ambient form and teaser is the roomier search or cross-reference form. digest carries enough context to act. status_line is required whenever facets are declared — the one-line projection every surface can take — and teaser and digest are optional. Declaring any swaps the loop's generated tool from replace_output_* to publish_output_*, which takes one argument per declared projection plus full.",
 					},
 					"initial": map[string]any{
 						"type":        "object",

--- a/internal/tools/loop_spec_schema.go
+++ b/internal/tools/loop_spec_schema.go
@@ -200,7 +200,7 @@ func loopOutputSpecSchema() map[string]any {
 						},
 					},
 				},
-				"description": "The facets this output publishes alongside its full body — views of the same understanding cut for different consumers: status_line is ambient current state, teaser advertises why to look, and digest is enough context to act. Declare only the projections this output's consumers need; full is always implicit. Declaring any swaps the generated tool from replace_output_* to publish_output_*, which takes one typed argument per declared facet plus full. Write a bare name for the default encoding, or an object to set a format. Order carries no meaning.",
+				"description": "The facets this output publishes alongside its full body — views of the same understanding cut for different consumers: status_line is ambient current state, teaser advertises why to look, and digest is enough context to act. status_line is required whenever facets are declared; teaser and digest are optional, and full is always implicit. Declaring any swaps the generated tool from replace_output_* to publish_output_*, which takes one typed argument per declared facet plus full. Write a bare name for the default encoding, or an object to set a format. Order carries no meaning.",
 			},
 			"audience": map[string]any{
 				"type":        "string",

--- a/internal/tools/loop_spec_schema.go
+++ b/internal/tools/loop_spec_schema.go
@@ -200,7 +200,7 @@ func loopOutputSpecSchema() map[string]any {
 						},
 					},
 				},
-				"description": "The facets this output publishes alongside its full body — condensed views of the same understanding, each cut for a surface rather than shortened from the one above. Declaring any swaps the generated tool from replace_output_* to publish_output_*, which takes one typed argument per facet. status_line is required whenever facets are declared; teaser and digest are optional. Write a bare name for the default encoding, or an object to set a format. Order carries no meaning.",
+				"description": "The facets this output publishes alongside its full body — views of the same understanding cut for different consumers: status_line is ambient current state, teaser advertises why to look, and digest is enough context to act. Declare only the projections this output's consumers need; full is always implicit. Declaring any swaps the generated tool from replace_output_* to publish_output_*, which takes one typed argument per declared facet plus full. Write a bare name for the default encoding, or an object to set a format. Order carries no meaning.",
 			},
 			"audience": map[string]any{
 				"type":        "string",

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=68
-interfaces=82
+interfaces=83
 large_files=57
 set_mutators=118
 database_opens=9

--- a/talents/documents.md
+++ b/talents/documents.md
@@ -123,7 +123,9 @@ and those publish the same understanding at several fidelities. Pass
 
 `status_line` is one line of what is true right now. `teaser` is a
 paragraph on why you would open the document. `digest` carries enough to
-act on without opening it. `full` is the whole body.
+act on without opening it. `full` is the whole body. The first two are
+different shapes of the same outward-facing signal role; `digest` is the
+context payload after that signal earns attention.
 
 This is not truncation — each level was written to stand alone at that
 size by the loop that owns the subject, so a status line is a sentence

--- a/talents/loops.md
+++ b/talents/loops.md
@@ -47,6 +47,14 @@ wants everything opens the document. Without facets, every consumer pays
 for the whole document or gets a blind truncation of it, so a curator
 whose value is being *consulted often* is the case for declaring them.
 
+`status_line` and `teaser` are two authored shapes of one consumer role:
+the document's outward-facing **signal**. A status line is the tight,
+single-line form for ambient surfaces; a teaser is the roomier form for a
+search result or cross-reference. Whether a signal is offered ambiently or
+because it matched a request is context policy, not something the prose gets
+to decide. `digest` is different: it is the payload selected when the match is
+strong enough to deserve enough context to act.
+
 Declaring facets changes the write interface: instead of
 `replace_output_*` taking a document body, the loop gets
 `publish_output_*` taking one argument per projection. Pass them all in
@@ -83,9 +91,11 @@ your mind — so the loop's private thinking opens with a belief to
 revise instead of a blank page. Author the seed from what you actually
 observed; when you have observed nothing, leave the placeholders.
 
-Declare `status_line` for any faceted output; add `teaser` when the
-output is something others search or link to, and `digest` when a
-reader should be able to act without opening the document.
+Declare only what the readers need. Use `status_line` for ambient current
+state, `teaser` for search and cross-reference signals, and `digest` when a
+reader should be able to act without opening the document. A dossier may
+reasonably declare `teaser` and `digest` without inventing an ambient status;
+a small live-state panel may need only `status_line`.
 
 What makes this concrete on the reading side: `doc_read` takes a `level`,
 so any consumer — another loop, a later turn of this one, you — can pull

--- a/talents/loops.md
+++ b/talents/loops.md
@@ -91,11 +91,11 @@ your mind — so the loop's private thinking opens with a belief to
 revise instead of a blank page. Author the seed from what you actually
 observed; when you have observed nothing, leave the placeholders.
 
-Declare only what the readers need. Use `status_line` for ambient current
-state, `teaser` for search and cross-reference signals, and `digest` when a
-reader should be able to act without opening the document. A dossier may
-reasonably declare `teaser` and `digest` without inventing an ambient status;
-a small live-state panel may need only `status_line`.
+Every faceted output declares `status_line` — the one-line projection any
+surface can take is the ladder's anchor. Add `teaser` for search and
+cross-reference signals, and `digest` when a reader should be able to act
+without opening the document; a small live-state panel may need only
+`status_line`.
 
 What makes this concrete on the reading side: `doc_read` takes a `level`,
 so any consumer — another loop, a later turn of this one, you — can pull


### PR DESCRIPTION
Phase 0 of #1431. This is `f1bc157a` from #1410 — Codex's context-advertisement foundation — cherry-picked onto today's main with original authorship preserved, plus the architecture-baseline bump its new interface requires. The second commit of #1410 (`dc93256c`, the `status_line`→`signal` facet rename) is deliberately left behind.

## What lands

- **The contract** (`internal/runtime/agentctx/context_advertisement.go`): advertisements with projection roles `signal`/`context`/`detail`, match kinds `exact_subject`/`alias`/`semantic`/`lexical`/`ambient` carrying strength, validated estimates — no global rank, no injection flag; those stay consumer policy.
- **The discriminator** (`internal/runtime/agent/context_discriminator.go`): deterministic ranking (evidence tier → strength → stable tiebreaks), dedup, offer/byte budgets, lazy materialization — only selected offers pay to render — and prepend-to-bucket so selected compact projections can't be starved by earlier eager providers.
- **The first advertiser**: metacog self-assessment, with the test proving advertise = 0 document reads, materialize = exactly 1.
- The `FacetField.ContextRole` mapping (facet → projection role) rides in this commit and is the piece that makes the rename unnecessary.

## Why the rename stays behind

The rename's "one vocabulary" premise doesn't hold: this very commit maps **both** `status_line` and `teaser` to role `signal` — both are signal-shaped projections — so renaming the facet would leave "signal" naming one facet *and* a role class that two facets fill, erasing the signal-vs-teaser distinction for the authoring model. Roles are consumer-side and Go-internal; keeping `status_line` costs the reading model nothing.

It also deletes the entire migration runbook the rename forced: no `## Status Line` heading migration across production's faceted documents (two schedule-root curators plus metacog publish that heading today), no opstate loop-definition surgery, no deliberately-quiet self-assessment provider until republish, no silent `/v1` consumer breaks, no signed talents backport for vocabulary. The facet ladder stays exactly as #1250 locked it and as production publishes it.

#1410 stays open until this merges; I've left a note there rather than closing someone else's PR.

## Test plan

- [x] `just ci` green under the CI-canonical toolchain (`GOTOOLCHAIN=go1.25.7`) — local Homebrew go 1.27's gofmt disagrees with CI's 1.25 comment alignment on a pre-existing file, which is an environment quirk, not a change in this PR
- [x] Cherry-pick applied clean; commit stands alone (contract, discriminator, wiring, advertiser, and role mapping are all in `f1bc157a`)
- [x] Contract validation, discriminator ordering/dedup/budget, assembly-survival, and advertise-vs-materialize read-count tests all green
- [x] Architecture baseline: interfaces 82→83 (`ContextAdvertiser`)
- [x] Review round 1 (9f36a8be): the pick had **silently relaxed the #1250 anchor** — `f1bc157a` removed mandatory `status_line` as groundwork for the rename commit, so carrying it alone left the ladder anchorless, with the relaxation spread into the schema, teaching prose, talent, and rewritten tests; all restored (whether teaser+digest-only dossiers should be legal is now an explicit #1431 question, not a smuggled change). Plus two discriminator contract bugs: dedup marked identities seen before selection succeeded (an empty claimant suppressed usable ones), and estimate overruns were admitted, spending later winners' reservations order-dependently — both fixed with regression tests verified failing against the prior commit.
- [ ] Verified against production once deployed

Refs #1431, #991. Supersedes #1410 when merged.
