### PR TITLE
Document index groundwork for the advertisement rail

### DIFF
--- a/internal/state/documents/advertise.go
+++ b/internal/state/documents/advertise.go
@@ -1,0 +1,133 @@
+package documents
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+)
+
+// Frontmatter keys the loop-creation tooling stamps on curator task
+// documents (internal/tools/loop_create_tool.go). The advertiser reads
+// them back as provenance: which loop definition owns the document and
+// what that loop is for, in the owner's own prose.
+const (
+	loopDefinitionNameFrontmatterKey = "loop_definition_name"
+	loopIntentFrontmatterKey         = "loop_intent"
+)
+
+// AdvertisableDocument is one indexed document projected for the
+// context-advertising rail (#1431): everything an advertiser needs to
+// build an offer — identity, authored summary, available projection
+// levels with honest byte costs, and provenance — with zero file I/O.
+type AdvertisableDocument struct {
+	// Root and Path identify the document within its root; Ref is the
+	// preassembled root:path form every document tool accepts.
+	Root string `json:"root"`
+	Path string `json:"path"`
+	Ref  string `json:"ref"`
+	// Title and Summary are the authored identity: for a faceted
+	// document the summary is its teaser (or status_line fallback),
+	// which is exactly the advertisement-shaped prose.
+	Title   string `json:"title"`
+	Summary string `json:"summary,omitempty"`
+	// Facets lists the condensed projections present in the body;
+	// FacetBytes carries the UTF-8 byte length of each present level,
+	// "full" included. Bytes, not runes: these are context-budget
+	// estimates, and they are exact because they were measured at index
+	// time — an advertiser can offer only levels that exist and cost
+	// them without reading the file.
+	Facets     []string       `json:"facets,omitempty"`
+	FacetBytes map[string]int `json:"facet_bytes,omitempty"`
+	Tags       []string       `json:"tags,omitempty"`
+	ModifiedAt time.Time      `json:"modified_at"`
+	// Provenance from the document's frontmatter: the loop definition
+	// that owns it, the generated tool that manages it, and the owning
+	// loop's intent in prose ("" when unstamped). LoopIntent is match
+	// evidence; the other two are the freshness-bound lookup keys into
+	// the definition registry.
+	LoopDefinitionName string `json:"loop_definition_name,omitempty"`
+	ManagedBy          string `json:"managed_by,omitempty"`
+	LoopIntent         string `json:"loop_intent,omitempty"`
+}
+
+// AdvertisableDocuments enumerates every indexed document eligible to
+// advertise context, in deterministic (root, rel_path) order, from a
+// single SELECT over the index.
+//
+// Unlike every other public query on [Store], this deliberately does
+// NOT call Refresh and does not touch refreshMu. Refresh takes
+// refreshMu before its throttle check, and that lock is periodically
+// held across a full git re-verification pass of every root — an
+// assembly-time caller on the serial context walk must never wait on
+// that. The background [Store.RunRefresher] keeps rows warm within its
+// refresh interval (~5s), which is fresh enough for advertising: a
+// stale offer is corrected one tick later, while a blocked context
+// assembly is a whole slow turn. The price is that a caller on a store
+// without a running refresher sees the index as of its last refresh.
+//
+// Documents whose audience column reads internal are excluded in the
+// SQL itself — the #1250 privacy gate: curator working notes must never
+// be offered to ambient context, and must not even be fetched and
+// decoded on a per-turn path.
+func (s *Store) AdvertisableDocuments(ctx context.Context) ([]AdvertisableDocument, error) {
+	if s == nil {
+		return nil, fmt.Errorf("document index not configured")
+	}
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT root, rel_path, title, summary, facets_json, COALESCE(facet_bytes_json, '{}'), tags_json, frontmatter_json, modified_at
+		 FROM indexed_documents
+		 WHERE LOWER(TRIM(COALESCE(audience, ''))) <> ?
+		 ORDER BY root, rel_path`,
+		audienceInternalValue,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("enumerate advertisable documents: %w", err)
+	}
+	defer rows.Close()
+
+	var docs []AdvertisableDocument
+	for rows.Next() {
+		var doc AdvertisableDocument
+		var facetsJSON, facetBytesJSON, tagsJSON, metaJSON, modified string
+		if err := rows.Scan(&doc.Root, &doc.Path, &doc.Title, &doc.Summary, &facetsJSON, &facetBytesJSON, &tagsJSON, &metaJSON, &modified); err != nil {
+			return nil, fmt.Errorf("scan advertisable document: %w", err)
+		}
+		doc.Ref = makeRef(doc.Root, doc.Path)
+		if err := json.Unmarshal([]byte(facetsJSON), &doc.Facets); err != nil || len(doc.Facets) == 0 {
+			doc.Facets = nil
+		}
+		if err := json.Unmarshal([]byte(facetBytesJSON), &doc.FacetBytes); err != nil || len(doc.FacetBytes) == 0 {
+			doc.FacetBytes = nil
+		}
+		if err := json.Unmarshal([]byte(tagsJSON), &doc.Tags); err != nil {
+			doc.Tags = nil
+		}
+		var frontmatter map[string][]string
+		if err := json.Unmarshal([]byte(metaJSON), &frontmatter); err != nil {
+			frontmatter = nil
+		}
+		// Defense in depth behind the SQL gate: the audience column
+		// holds the single promoted value, while frontmatter may carry
+		// several. A document any of whose audience values reads
+		// internal stays out, even if the promoted one does not.
+		if isInternalAudienceDocument(frontmatter) {
+			continue
+		}
+		doc.ModifiedAt, err = database.ParseTimestamp(modified)
+		if err != nil {
+			return nil, fmt.Errorf("parse modified_at for %s: %w", doc.Ref, err)
+		}
+		doc.LoopDefinitionName = firstValue(frontmatter, loopDefinitionNameFrontmatterKey)
+		doc.ManagedBy = firstValue(frontmatter, looppkg.OutputManagedByFrontmatterKey)
+		doc.LoopIntent = firstValue(frontmatter, loopIntentFrontmatterKey)
+		docs = append(docs, doc)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("enumerate advertisable documents: %w", err)
+	}
+	return docs, nil
+}

--- a/internal/state/documents/advertise_test.go
+++ b/internal/state/documents/advertise_test.go
@@ -1,0 +1,218 @@
+package documents
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
+)
+
+// newAdvertiseStore indexes two roots holding a faceted curator-style
+// document with provenance frontmatter, two plain documents, and one
+// internal-audience document that must never be offered.
+func newAdvertiseStore(t *testing.T) (*Store, map[string]string) {
+	t.Helper()
+
+	rootDir := t.TempDir()
+	alphaDir := filepath.Join(rootDir, "alpha")
+	betaDir := filepath.Join(rootDir, "beta")
+
+	writeFile(t, filepath.Join(alphaDir, "b-doc.md"), "---\ntags: [ops]\n---\n\n# Bravo\n\nSecond alphabetical document.\n")
+	writeFile(t, filepath.Join(alphaDir, "a-doc.md"), "# Alpha\n\nFirst alphabetical document.\n")
+	writeFile(t, filepath.Join(betaDir, "dossier.md"), `---
+title: Utah Trip Dossier
+tags: [travel, utah]
+audience: published
+managed_by: loop_output_trip
+loop_definition_name: trip-curator
+loop_intent: "Keep the Utah trip dossier current."
+---
+
+## Status Line
+
+trip is 20 days out
+
+## Teaser
+
+Why the dossier matters right now.
+
+## Details
+
+The full dossier body.
+`)
+	writeFile(t, filepath.Join(betaDir, "notes.md"), "---\naudience: internal\n---\n\n# Working Notes\n\nCurator process narration.\n")
+
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	roots := map[string]string{"alpha": alphaDir, "beta": betaDir}
+	store, err := NewStore(db, roots, nil)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if err := store.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	return store, roots
+}
+
+func advertisedRefs(docs []AdvertisableDocument) []string {
+	refs := make([]string, 0, len(docs))
+	for _, doc := range docs {
+		refs = append(refs, doc.Ref)
+	}
+	return refs
+}
+
+// TestAdvertisableDocumentsProjectsIndexFields pins the enumeration
+// contract the #1431 advertiser consumes: internal-audience documents
+// are excluded, order is deterministic (root, rel_path), and every
+// per-row field an offer needs — identity, summary, facet levels with
+// byte costs, tags, freshness, provenance — arrives from the index.
+func TestAdvertisableDocumentsProjectsIndexFields(t *testing.T) {
+	t.Parallel()
+
+	store, roots := newAdvertiseStore(t)
+	ctx := context.Background()
+
+	docs, err := store.AdvertisableDocuments(ctx)
+	if err != nil {
+		t.Fatalf("AdvertisableDocuments: %v", err)
+	}
+	wantRefs := []string{"alpha:a-doc.md", "alpha:b-doc.md", "beta:dossier.md"}
+	if got := advertisedRefs(docs); len(got) != len(wantRefs) || got[0] != wantRefs[0] || got[1] != wantRefs[1] || got[2] != wantRefs[2] {
+		t.Fatalf("refs = %v, want %v (internal excluded, (root, rel_path) order)", got, wantRefs)
+	}
+
+	dossier := docs[2]
+	if dossier.Root != "beta" || dossier.Path != "dossier.md" {
+		t.Errorf("dossier identity = %q %q, want beta dossier.md", dossier.Root, dossier.Path)
+	}
+	if dossier.Title != "Utah Trip Dossier" {
+		t.Errorf("Title = %q, want the authored title", dossier.Title)
+	}
+	if dossier.Summary != "Why the dossier matters right now." {
+		t.Errorf("Summary = %q, want the authored teaser", dossier.Summary)
+	}
+	if len(dossier.Facets) != 2 || dossier.Facets[0] != "status_line" || dossier.Facets[1] != "teaser" {
+		t.Errorf("Facets = %v, want [status_line teaser]", dossier.Facets)
+	}
+	wantBytes := map[string]int{
+		"status_line": len("trip is 20 days out"),
+		"teaser":      len("Why the dossier matters right now."),
+		"full":        len("The full dossier body."),
+	}
+	if len(dossier.FacetBytes) != len(wantBytes) {
+		t.Fatalf("FacetBytes = %v, want %v", dossier.FacetBytes, wantBytes)
+	}
+	for key, want := range wantBytes {
+		if got := dossier.FacetBytes[key]; got != want {
+			t.Errorf("FacetBytes[%q] = %d, want %d", key, got, want)
+		}
+	}
+	if len(dossier.Tags) != 2 || dossier.Tags[0] != "travel" || dossier.Tags[1] != "utah" {
+		t.Errorf("Tags = %v, want [travel utah]", dossier.Tags)
+	}
+	info, err := os.Stat(filepath.Join(roots["beta"], "dossier.md"))
+	if err != nil {
+		t.Fatalf("Stat dossier: %v", err)
+	}
+	if !dossier.ModifiedAt.Equal(info.ModTime().UTC()) {
+		t.Errorf("ModifiedAt = %v, want file mtime %v", dossier.ModifiedAt, info.ModTime().UTC())
+	}
+	if dossier.LoopDefinitionName != "trip-curator" {
+		t.Errorf("LoopDefinitionName = %q, want trip-curator", dossier.LoopDefinitionName)
+	}
+	if dossier.ManagedBy != "loop_output_trip" {
+		t.Errorf("ManagedBy = %q, want loop_output_trip", dossier.ManagedBy)
+	}
+	if dossier.LoopIntent != "Keep the Utah trip dossier current." {
+		t.Errorf("LoopIntent = %q, want the authored intent", dossier.LoopIntent)
+	}
+	for _, doc := range docs[:2] {
+		if len(doc.FacetBytes) != 1 || doc.FacetBytes["full"] == 0 {
+			t.Errorf("%s FacetBytes = %v, want a lone non-zero full entry", doc.Ref, doc.FacetBytes)
+		}
+	}
+}
+
+// TestAdvertisableDocumentsExcludesInternalInSQL pins that the privacy
+// gate lives in the SELECT itself, not only in the post-scan frontmatter
+// check: a row whose audience COLUMN reads internal — with frontmatter
+// that would pass the in-Go check — must never come back. Case and
+// whitespace variants are the LOWER(TRIM(...)) part of the clause.
+func TestAdvertisableDocumentsExcludesInternalInSQL(t *testing.T) {
+	t.Parallel()
+
+	store, _ := newAdvertiseStore(t)
+	ctx := context.Background()
+
+	if _, err := store.db.ExecContext(ctx,
+		`UPDATE indexed_documents SET audience = '  Internal ' WHERE root = 'alpha' AND rel_path = 'a-doc.md'`,
+	); err != nil {
+		t.Fatalf("mark row internal in column only: %v", err)
+	}
+	docs, err := store.AdvertisableDocuments(ctx)
+	if err != nil {
+		t.Fatalf("AdvertisableDocuments: %v", err)
+	}
+	for _, doc := range docs {
+		if doc.Ref == "alpha:a-doc.md" {
+			t.Fatalf("row with internal audience column leaked through the SQL gate: %v", advertisedRefs(docs))
+		}
+	}
+}
+
+// TestAdvertisableDocumentsDoesNotRefresh proves the no-Refresh design
+// behaviorally rather than structurally: the root directory is deleted
+// and the refresh throttle disabled, so ANY code path that calls
+// Refresh fails loudly ("document root does not exist"). Enumeration
+// must still serve the warm index rows — an assembly-time caller reads
+// what the background refresher last wrote and never joins the
+// refreshMu queue — while a Refresh-first query on the same store
+// state errors, which is the positive control that this construction
+// really does detect a Refresh call.
+func TestAdvertisableDocumentsDoesNotRefresh(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	kbDir := filepath.Join(rootDir, "kb")
+	writeFile(t, filepath.Join(kbDir, "doc.md"), "# Doc\n\nIndexed once.\n")
+
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	store, err := NewStore(db, map[string]string{"kb": kbDir}, nil)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	ctx := context.Background()
+	if err := store.Refresh(ctx); err != nil {
+		t.Fatalf("initial Refresh: %v", err)
+	}
+
+	store.refreshInterval = 0
+	if err := os.RemoveAll(kbDir); err != nil {
+		t.Fatalf("RemoveAll: %v", err)
+	}
+
+	docs, err := store.AdvertisableDocuments(ctx)
+	if err != nil {
+		t.Fatalf("AdvertisableDocuments refreshed (or failed) instead of reading the index: %v", err)
+	}
+	if len(docs) != 1 || docs[0].Ref != "kb:doc.md" {
+		t.Fatalf("docs = %v, want the one warm index row", advertisedRefs(docs))
+	}
+
+	if _, err := store.Search(ctx, SearchQuery{Root: "kb"}); err == nil || !strings.Contains(err.Error(), "does not exist") {
+		t.Fatalf("Search err = %v; the positive control expects the Refresh-first path to fail on the deleted root", err)
+	}
+}

--- a/internal/state/documents/parser.go
+++ b/internal/state/documents/parser.go
@@ -19,9 +19,24 @@ var (
 )
 
 type parsedDocument struct {
-	Title       string
-	Summary     string
-	Facets      []string
+	Title   string
+	Summary string
+	// Audience is the document's single audience frontmatter value
+	// ("" when undeclared), promoted out of the frontmatter map so the
+	// index can store it as a first-class column and exclude
+	// audience: internal rows in SQL rather than after decoding every
+	// row's frontmatter JSON (#1250, #1431).
+	Audience string
+	Facets   []string
+	// FacetBytes is the UTF-8 byte length of each present projection's
+	// content, keyed by facet key, with "full" always present. Byte
+	// length, not rune count, deliberately: facet budgets elsewhere in
+	// the contract are runes (display budgets), but these entries exist
+	// so a context advertiser can estimate what materializing a level
+	// costs against a byte-denominated context budget without any file
+	// I/O — and a rune count under-estimates multi-byte UTF-8 content,
+	// which the discriminator punishes with silent post-read drops.
+	FacetBytes  map[string]int
 	WordCount   int
 	Tags        []string
 	Frontmatter map[string][]string
@@ -69,7 +84,9 @@ func parseMarkdownDocumentParts(name string, meta map[string][]string, body stri
 	// pull (#1250).
 	summary := ""
 	var facets []string
-	if payload, faceted := looppkg.ParseFacetSections(body); faceted {
+	facetBytes := make(map[string]int, len(looppkg.FacetKeys()))
+	payload, faceted := looppkg.ParseFacetSections(body)
+	if faceted {
 		for _, key := range looppkg.FacetKeys() {
 			// full is every document's baseline and advertises nothing;
 			// the facet list exists to say which condensed projections
@@ -79,6 +96,7 @@ func parseMarkdownDocumentParts(name string, meta map[string][]string, body stri
 			}
 			if value, ok := payload.FacetByKey(key); ok && strings.TrimSpace(value) != "" {
 				facets = append(facets, key)
+				facetBytes[key] = len(value)
 			}
 		}
 		if teaser, ok := payload.FacetByKey(string(looppkg.OutputFacetTeaser)); ok && strings.TrimSpace(teaser) != "" {
@@ -91,11 +109,18 @@ func parseMarkdownDocumentParts(name string, meta map[string][]string, body stri
 	} else {
 		summary = firstParagraph(body)
 	}
+	// full is measured for every document, faceted or not: the full body
+	// is always a readable projection level, and an unfaceted body parses
+	// entirely into payload.Full, so both branches share one source of
+	// truth for what a full-level read yields.
+	facetBytes["full"] = len(payload.Full)
 
 	return parsedDocument{
 		Title:       title,
 		Summary:     summary,
+		Audience:    firstValue(meta, audienceFrontmatterKey),
 		Facets:      facets,
+		FacetBytes:  facetBytes,
 		WordCount:   len(strings.Fields(body)),
 		Tags:        append([]string(nil), meta["tags"]...),
 		Frontmatter: meta,

--- a/internal/state/documents/parser_test.go
+++ b/internal/state/documents/parser_test.go
@@ -1,6 +1,10 @@
 package documents
 
-import "testing"
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
 
 func TestSplitFrontmatterSupportsCRLF(t *testing.T) {
 	t.Parallel()
@@ -37,5 +41,131 @@ func TestSplitFrontmatterSupportsBlockListValues(t *testing.T) {
 	}
 	if got := meta["tags"]; len(got) != 2 || got[0] != "alpha" || got[1] != "beta" {
 		t.Fatalf("tags = %#v, want [alpha beta]", got)
+	}
+}
+
+// TestParseMarkdownDocumentCapturesFacetBytes pins the index-time byte
+// measurement the context advertiser costs offers with (#1431). The
+// expectations are BYTE lengths, not rune counts, on purpose: facet
+// budgets elsewhere in the contract are runes (display budgets), but
+// these entries price a projection against a byte-denominated context
+// budget, and a rune count under-estimates multi-byte UTF-8 content.
+func TestParseMarkdownDocumentCapturesFacetBytes(t *testing.T) {
+	t.Parallel()
+
+	const (
+		asciiStatus  = "all systems nominal"
+		asciiTeaser  = "why a reader would open this now"
+		asciiDigest  = "a standalone summary with enough substance to act on"
+		asciiDetails = "the full working body\n\nwith a second paragraph"
+		utf8Status   = "café ☕ prêt — übersicht"
+		utf8Details  = "détails complets: 状況は安定しています"
+		plainBody    = "# Plain\n\nJust a first paragraph.\n"
+	)
+	if len(utf8Status) == utf8.RuneCountInString(utf8Status) {
+		t.Fatalf("utf8Status must contain multi-byte runes for this test to prove bytes-not-runes")
+	}
+
+	tests := []struct {
+		name string
+		body string
+		want map[string]int
+	}{
+		{
+			name: "faceted ascii carries every present level plus full",
+			body: "## Status Line\n\n" + asciiStatus + "\n\n## Teaser\n\n" + asciiTeaser + "\n\n## Digest\n\n" + asciiDigest + "\n\n## Details\n\n" + asciiDetails + "\n",
+			want: map[string]int{
+				"status_line": len(asciiStatus),
+				"teaser":      len(asciiTeaser),
+				"digest":      len(asciiDigest),
+				"full":        len(asciiDetails),
+			},
+		},
+		{
+			name: "multi-byte content is measured in bytes",
+			body: "## Status Line\n\n" + utf8Status + "\n\n## Details\n\n" + utf8Details + "\n",
+			want: map[string]int{
+				"status_line": len(utf8Status),
+				"full":        len(utf8Details),
+			},
+		},
+		{
+			name: "absent facets get no entries",
+			body: "## Status Line\n\n" + asciiStatus + "\n\n## Details\n\n" + asciiDetails + "\n",
+			want: map[string]int{
+				"status_line": len(asciiStatus),
+				"full":        len(asciiDetails),
+			},
+		},
+		{
+			name: "unfaceted document still measures full",
+			body: plainBody,
+			want: map[string]int{
+				"full": len(strings.TrimSpace(plainBody)),
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			doc := parseMarkdownDocumentParts("doc.md", map[string][]string{}, tc.body)
+			if len(doc.FacetBytes) != len(tc.want) {
+				t.Fatalf("FacetBytes = %v, want %v", doc.FacetBytes, tc.want)
+			}
+			for key, want := range tc.want {
+				if got := doc.FacetBytes[key]; got != want {
+					t.Errorf("FacetBytes[%q] = %d, want %d", key, got, want)
+				}
+			}
+		})
+	}
+}
+
+// TestParseMarkdownDocumentPromotesAudience pins the promotion of the
+// single audience frontmatter value to a first-class parsed field, which
+// is what lets the index store it as a column and gate internal-audience
+// documents in SQL (#1250, #1431).
+func TestParseMarkdownDocumentPromotesAudience(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "absent audience promotes empty",
+			raw:  "---\ntitle: Plain\n---\n\n# Plain\n\nBody.\n",
+			want: "",
+		},
+		{
+			name: "internal audience",
+			raw:  "---\naudience: internal\n---\n\n# Notes\n\nBody.\n",
+			want: "internal",
+		},
+		{
+			name: "published audience",
+			raw:  "---\naudience: published\n---\n\n# Doc\n\nBody.\n",
+			want: "published",
+		},
+		{
+			name: "rendered quoting is unquoted",
+			raw:  "---\naudience: \"internal\"\n---\n\n# Notes\n\nBody.\n",
+			want: "internal",
+		},
+		{
+			name: "no frontmatter at all",
+			raw:  "# Doc\n\nBody.\n",
+			want: "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			doc := parseMarkdownDocument("doc.md", tc.raw)
+			if doc.Audience != tc.want {
+				t.Errorf("Audience = %q, want %q", doc.Audience, tc.want)
+			}
+		})
 	}
 }

--- a/internal/state/documents/schema.go
+++ b/internal/state/documents/schema.go
@@ -1,0 +1,79 @@
+package documents
+
+import "github.com/nugget/thane-ai-agent/internal/platform/database"
+
+// schema declares the document-index tables. The whole index is derived
+// state: every row is reproducible from the markdown on disk, which is
+// what lets schema evolution here purge-and-rebuild instead of
+// migrating data in place.
+var schema = database.Schema{
+	Name: "documents",
+	Steps: []database.MigrationStep{
+		database.TableCreate{
+			Table: "indexed_documents",
+			SQL: `CREATE TABLE IF NOT EXISTS indexed_documents (
+				root TEXT NOT NULL,
+				rel_path TEXT NOT NULL,
+				abs_path TEXT NOT NULL,
+				title TEXT NOT NULL DEFAULT '',
+				summary TEXT NOT NULL DEFAULT '',
+				facets_json TEXT NOT NULL DEFAULT '[]',
+				facet_bytes_json TEXT,
+				audience TEXT,
+				tags_json TEXT NOT NULL DEFAULT '[]',
+				frontmatter_json TEXT NOT NULL DEFAULT '{}',
+				links_json TEXT NOT NULL DEFAULT '[]',
+				modified_at TEXT NOT NULL,
+				size_bytes INTEGER NOT NULL DEFAULT 0,
+				word_count INTEGER NOT NULL DEFAULT 0,
+				PRIMARY KEY(root, rel_path)
+			)`,
+		},
+		database.IndexCreate{Name: "idx_indexed_documents_root_path", SQL: `CREATE INDEX IF NOT EXISTS idx_indexed_documents_root_path ON indexed_documents(root, rel_path)`},
+		database.IndexCreate{Name: "idx_indexed_documents_modified", SQL: `CREATE INDEX IF NOT EXISTS idx_indexed_documents_modified ON indexed_documents(root, modified_at DESC)`},
+		database.TableCreate{
+			Table: "indexed_document_sections",
+			SQL: `CREATE TABLE IF NOT EXISTS indexed_document_sections (
+				root TEXT NOT NULL,
+				rel_path TEXT NOT NULL,
+				ordinal INTEGER NOT NULL,
+				level INTEGER NOT NULL,
+				heading TEXT NOT NULL,
+				slug TEXT NOT NULL,
+				start_line INTEGER NOT NULL DEFAULT 0,
+				end_line INTEGER NOT NULL DEFAULT 0,
+				PRIMARY KEY(root, rel_path, ordinal)
+			)`,
+		},
+		database.IndexCreate{Name: "idx_indexed_document_sections_doc", SQL: `CREATE INDEX IF NOT EXISTS idx_indexed_document_sections_doc ON indexed_document_sections(root, rel_path, ordinal)`},
+		// Additive upgrades for databases whose indexed_documents table
+		// predates a column above. facets_json arrived with the #1250
+		// facet ladder; facet_bytes_json and audience arrive with the
+		// context-advertising groundwork (#1431).
+		database.ColumnAdd{Table: "indexed_documents", Column: "facets_json", Typedef: "TEXT NOT NULL DEFAULT '[]'"},
+		database.ColumnAdd{Table: "indexed_documents", Column: "facet_bytes_json", Typedef: "TEXT"},
+		database.ColumnAdd{Table: "indexed_documents", Column: "audience", Typedef: "TEXT"},
+		// Rebuild trigger for rows written before facet_bytes_json and
+		// audience existed. The index re-parses a document only when its
+		// mtime or size changes, so a pre-upgrade row would otherwise
+		// carry NULLs indefinitely — and NULL facet_bytes_json means the
+		// advertiser cannot cost a single facet, while NULL audience
+		// falls on the excluded side of the SQL privacy gate, silently
+		// hiding published documents. The index is derived data, so the
+		// cure is deletion: purge the stale rows and let the background
+		// refresher rebuild them from disk on its next pass.
+		//
+		// NULL facet_bytes_json is the marker for "row predates this
+		// upgrade": every post-upgrade upsert writes the column, so the
+		// step self-gates — it bites exactly once per pre-upgrade row and
+		// no-ops on every later boot, without a schema probe that a
+		// partially applied upgrade could fool. Sections are purged
+		// first, while the marker rows that select them still exist.
+		database.Raw{
+			Description: "purge pre-facet_bytes_json index rows so the refresher rebuilds them",
+			SQL: `DELETE FROM indexed_document_sections WHERE (root, rel_path) IN
+					(SELECT root, rel_path FROM indexed_documents WHERE facet_bytes_json IS NULL);
+				DELETE FROM indexed_documents WHERE facet_bytes_json IS NULL`,
+		},
+	},
+}

--- a/internal/state/documents/schema.go
+++ b/internal/state/documents/schema.go
@@ -58,10 +58,12 @@ var schema = database.Schema{
 		// mtime or size changes, so a pre-upgrade row would otherwise
 		// carry NULLs indefinitely — and NULL facet_bytes_json means the
 		// advertiser cannot cost a single facet, while NULL audience
-		// falls on the excluded side of the SQL privacy gate, silently
-		// hiding published documents. The index is derived data, so the
-		// cure is deletion: purge the stale rows and let the background
-		// refresher rebuild them from disk on its next pass.
+		// passes the SQL privacy gate (COALESCE reads it as ""), so a
+		// pre-upgrade row for an internal document would lean solely on
+		// the in-Go frontmatter backstop until re-parsed. The index is
+		// derived data, so the cure is deletion: purge the stale rows
+		// and let the background refresher rebuild them from disk on its
+		// next pass.
 		//
 		// NULL facet_bytes_json is the marker for "row predates this
 		// upgrade": every post-upgrade upsert writes the column, so the

--- a/internal/state/documents/schema_test.go
+++ b/internal/state/documents/schema_test.go
@@ -1,0 +1,138 @@
+package documents
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
+)
+
+// TestMigratePurgesRowsPredatingFacetBytesForRebuild pins the upgrade
+// path for indexes built before facet_bytes_json and audience existed.
+// The trap being simulated is specific: the refresher re-parses a
+// document only when its mtime or size changes, so the seeded row
+// matches the on-disk file exactly — the row an incremental refresh
+// would consider fresh and never touch, leaving its new columns NULL
+// forever. The migration must clear it (sections too) so the refresher
+// rebuilds it from disk with both columns populated, and a second
+// migrate must leave the rebuilt row alone.
+func TestMigratePurgesRowsPredatingFacetBytesForRebuild(t *testing.T) {
+	t.Parallel()
+
+	kbDir := t.TempDir()
+	docPath := filepath.Join(kbDir, "doc.md")
+	writeFile(t, docPath, "---\naudience: published\n---\n\n# Doc\n\nBody text.\n\n## Section\n\nMore.\n")
+	info, err := os.Stat(docPath)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	// The table shape as it existed before this schema revision, seeded
+	// with a row whose modified_at and size_bytes match the real file.
+	preUpgrade := `
+	CREATE TABLE indexed_documents (
+		root TEXT NOT NULL,
+		rel_path TEXT NOT NULL,
+		abs_path TEXT NOT NULL,
+		title TEXT NOT NULL DEFAULT '',
+		summary TEXT NOT NULL DEFAULT '',
+		facets_json TEXT NOT NULL DEFAULT '[]',
+		tags_json TEXT NOT NULL DEFAULT '[]',
+		frontmatter_json TEXT NOT NULL DEFAULT '{}',
+		links_json TEXT NOT NULL DEFAULT '[]',
+		modified_at TEXT NOT NULL,
+		size_bytes INTEGER NOT NULL DEFAULT 0,
+		word_count INTEGER NOT NULL DEFAULT 0,
+		PRIMARY KEY(root, rel_path)
+	);
+	CREATE TABLE indexed_document_sections (
+		root TEXT NOT NULL,
+		rel_path TEXT NOT NULL,
+		ordinal INTEGER NOT NULL,
+		level INTEGER NOT NULL,
+		heading TEXT NOT NULL,
+		slug TEXT NOT NULL,
+		start_line INTEGER NOT NULL DEFAULT 0,
+		end_line INTEGER NOT NULL DEFAULT 0,
+		PRIMARY KEY(root, rel_path, ordinal)
+	);`
+	if _, err := db.Exec(preUpgrade); err != nil {
+		t.Fatalf("create pre-upgrade shape: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO indexed_documents (root, rel_path, abs_path, title, modified_at, size_bytes) VALUES ('kb', 'doc.md', ?, 'Doc', ?, ?)`,
+		docPath, info.ModTime().UTC().Format(time.RFC3339Nano), info.Size(),
+	); err != nil {
+		t.Fatalf("seed pre-upgrade row: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO indexed_document_sections (root, rel_path, ordinal, level, heading, slug) VALUES ('kb', 'doc.md', 0, 1, 'Doc', 'doc')`,
+	); err != nil {
+		t.Fatalf("seed pre-upgrade section: %v", err)
+	}
+
+	store, err := NewStore(db, map[string]string{"kb": kbDir}, nil)
+	if err != nil {
+		t.Fatalf("NewStore (migrate): %v", err)
+	}
+	ctx := context.Background()
+
+	countRows := func(table string) int {
+		t.Helper()
+		var n int
+		if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM `+table).Scan(&n); err != nil {
+			t.Fatalf("count %s: %v", table, err)
+		}
+		return n
+	}
+	if got := countRows("indexed_documents"); got != 0 {
+		t.Fatalf("indexed_documents rows after migrate = %d, want 0 (pre-upgrade rows purged for rebuild)", got)
+	}
+	if got := countRows("indexed_document_sections"); got != 0 {
+		t.Fatalf("indexed_document_sections rows after migrate = %d, want 0", got)
+	}
+
+	// The refresher rebuilds the cleared row from disk with the new
+	// columns populated.
+	if err := store.Refresh(ctx); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	var facetBytesNull, audienceNull bool
+	var facetBytesJSON, audience string
+	if err := db.QueryRowContext(ctx,
+		`SELECT facet_bytes_json IS NULL, audience IS NULL, COALESCE(facet_bytes_json, ''), COALESCE(audience, '')
+		 FROM indexed_documents WHERE root = 'kb' AND rel_path = 'doc.md'`,
+	).Scan(&facetBytesNull, &audienceNull, &facetBytesJSON, &audience); err != nil {
+		t.Fatalf("rebuilt row missing: %v", err)
+	}
+	if facetBytesNull || audienceNull {
+		t.Fatalf("rebuilt row still carries NULLs: facet_bytes_json NULL=%v audience NULL=%v", facetBytesNull, audienceNull)
+	}
+	if facetBytesJSON == "" || facetBytesJSON == "{}" {
+		t.Errorf("facet_bytes_json = %q, want a measured full entry", facetBytesJSON)
+	}
+	if audience != "published" {
+		t.Errorf("audience = %q, want published", audience)
+	}
+	if got := countRows("indexed_document_sections"); got == 0 {
+		t.Errorf("sections not rebuilt after refresh")
+	}
+
+	// Idempotency: a later boot's migrate must not purge rebuilt rows —
+	// the NULL marker is gone, so the purge step no-ops.
+	if err := store.migrate(); err != nil {
+		t.Fatalf("second migrate: %v", err)
+	}
+	if got := countRows("indexed_documents"); got != 1 {
+		t.Fatalf("indexed_documents rows after second migrate = %d, want 1 (purge must self-gate on the NULL marker)", got)
+	}
+}

--- a/internal/state/documents/store.go
+++ b/internal/state/documents/store.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
 )
 
 // RootSummary describes one indexed document root.
@@ -164,7 +166,7 @@ func NewStoreWithOptions(db *sql.DB, roots map[string]string, logger *slog.Logge
 		refreshInterval: defaultRefreshInterval,
 	}
 	if err := s.migrate(); err != nil {
-		return nil, fmt.Errorf("migrate documents schema: %w", err)
+		return nil, err
 	}
 	return s, nil
 }
@@ -184,74 +186,13 @@ func normalizeRoots(roots map[string]string) map[string]string {
 	return out
 }
 
+// migrate applies the declared schema. The historical facets_json
+// probe-and-purge upgrade is subsumed by the schema's ColumnAdd steps
+// plus its NULL-marker purge: a pre-facets database gains the column
+// via ColumnAdd and its rows are purged for rebuild by the same step
+// that handles pre-facet_bytes_json rows.
 func (s *Store) migrate() error {
-	schema := `
-	CREATE TABLE IF NOT EXISTS indexed_documents (
-		root TEXT NOT NULL,
-		rel_path TEXT NOT NULL,
-		abs_path TEXT NOT NULL,
-		title TEXT NOT NULL DEFAULT '',
-		summary TEXT NOT NULL DEFAULT '',
-		facets_json TEXT NOT NULL DEFAULT '[]',
-		tags_json TEXT NOT NULL DEFAULT '[]',
-		frontmatter_json TEXT NOT NULL DEFAULT '{}',
-		links_json TEXT NOT NULL DEFAULT '[]',
-		modified_at TEXT NOT NULL,
-		size_bytes INTEGER NOT NULL DEFAULT 0,
-		word_count INTEGER NOT NULL DEFAULT 0,
-		PRIMARY KEY(root, rel_path)
-	);
-	CREATE INDEX IF NOT EXISTS idx_indexed_documents_root_path ON indexed_documents(root, rel_path);
-	CREATE INDEX IF NOT EXISTS idx_indexed_documents_modified ON indexed_documents(root, modified_at DESC);
-
-	CREATE TABLE IF NOT EXISTS indexed_document_sections (
-		root TEXT NOT NULL,
-		rel_path TEXT NOT NULL,
-		ordinal INTEGER NOT NULL,
-		level INTEGER NOT NULL,
-		heading TEXT NOT NULL,
-		slug TEXT NOT NULL,
-		start_line INTEGER NOT NULL DEFAULT 0,
-		end_line INTEGER NOT NULL DEFAULT 0,
-		PRIMARY KEY(root, rel_path, ordinal)
-	);
-	CREATE INDEX IF NOT EXISTS idx_indexed_document_sections_doc ON indexed_document_sections(root, rel_path, ordinal);
-	`
-	if _, err := s.db.Exec(schema); err != nil {
-		return err
-	}
-	// Upgrade path for indexes created before facets_json existed. The
-	// index is derived state, so the one-time purge after adding the
-	// column is the reindex trigger: Refresh repopulates every row with
-	// its facets on the next pass, rather than leaving pre-upgrade rows
-	// advertising nothing until their documents happen to change.
-	if _, err := s.db.Exec(`SELECT facets_json FROM indexed_documents LIMIT 1`); err != nil {
-		// One transaction, deliberately: the probe above only fails
-		// while the column is absent, so a partial upgrade — column
-		// added, purge half done — would pass the probe on the next
-		// boot and never heal. Atomic means the upgrade either fully
-		// happened or fully retries.
-		tx, err := s.db.Begin()
-		if err != nil {
-			return fmt.Errorf("begin facets upgrade: %w", err)
-		}
-		defer func() {
-			_ = tx.Rollback()
-		}()
-		if _, err := tx.Exec(`ALTER TABLE indexed_documents ADD COLUMN facets_json TEXT NOT NULL DEFAULT '[]'`); err != nil {
-			return fmt.Errorf("add facets_json column: %w", err)
-		}
-		if _, err := tx.Exec(`DELETE FROM indexed_documents`); err != nil {
-			return fmt.Errorf("purge index for facets reindex: %w", err)
-		}
-		if _, err := tx.Exec(`DELETE FROM indexed_document_sections`); err != nil {
-			return fmt.Errorf("purge section index for facets reindex: %w", err)
-		}
-		if err := tx.Commit(); err != nil {
-			return fmt.Errorf("commit facets upgrade: %w", err)
-		}
-	}
-	return nil
+	return database.Migrate(s.db, schema, s.logger)
 }
 
 // Refresh incrementally refreshes all indexed roots.
@@ -448,6 +389,17 @@ func (s *Store) upsertFile(ctx context.Context, root, relPath string) error {
 	if err != nil {
 		return fmt.Errorf("marshal facets: %w", err)
 	}
+	// A nil map would marshal to JSON null; the parser always builds the
+	// map, but the guard keeps every stored value an object — and keeps
+	// facet_bytes_json non-NULL, which is the marker the schema's purge
+	// step uses to tell post-upgrade rows from pre-upgrade ones.
+	if doc.FacetBytes == nil {
+		doc.FacetBytes = map[string]int{}
+	}
+	facetBytesJSON, err := json.Marshal(doc.FacetBytes)
+	if err != nil {
+		return fmt.Errorf("marshal facet bytes: %w", err)
+	}
 	metaJSON, err := json.Marshal(doc.Frontmatter)
 	if err != nil {
 		return fmt.Errorf("marshal frontmatter: %w", err)
@@ -467,20 +419,22 @@ func (s *Store) upsertFile(ctx context.Context, root, relPath string) error {
 
 	if _, err := tx.ExecContext(ctx,
 		`INSERT INTO indexed_documents
-			(root, rel_path, abs_path, title, summary, facets_json, tags_json, frontmatter_json, links_json, modified_at, size_bytes, word_count)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			(root, rel_path, abs_path, title, summary, facets_json, facet_bytes_json, audience, tags_json, frontmatter_json, links_json, modified_at, size_bytes, word_count)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(root, rel_path) DO UPDATE SET
 		 	abs_path = excluded.abs_path,
 		 	title = excluded.title,
 		 	summary = excluded.summary,
 		 	facets_json = excluded.facets_json,
+		 	facet_bytes_json = excluded.facet_bytes_json,
+		 	audience = excluded.audience,
 		 	tags_json = excluded.tags_json,
 		 	frontmatter_json = excluded.frontmatter_json,
 		 	links_json = excluded.links_json,
 		 	modified_at = excluded.modified_at,
 		 	size_bytes = excluded.size_bytes,
 		 	word_count = excluded.word_count`,
-		root, relPath, absPath, doc.Title, doc.Summary, string(facetsJSON), string(tagsJSON), string(metaJSON), string(linksJSON), modified, size, doc.WordCount,
+		root, relPath, absPath, doc.Title, doc.Summary, string(facetsJSON), string(facetBytesJSON), doc.Audience, string(tagsJSON), string(metaJSON), string(linksJSON), modified, size, doc.WordCount,
 	); err != nil {
 		return fmt.Errorf("upsert indexed document: %w", err)
 	}


### PR DESCRIPTION
Phase 1 groundwork for #1431, first of three: the documents index learns what a context advertiser needs to enumerate a corpus with **zero file I/O and honest byte estimates**.

## What changes

- **Per-facet byte lengths indexed** (`facet_bytes_json`): the parser captures UTF-8 byte length for every present facet including `full`. Bytes, not runes, deliberately — facet *budgets* are runes, but the discriminator's estimates are bytes, and the 4× gap between them is exactly the silent-drop trap the #1431 critique documented.
- **`audience` promoted to a column**, so the #1250 privacy gate (`audience: internal` — curator working notes) is enforceable *in SQL*, before a per-turn path ever fetches or decodes a row. An in-Go frontmatter scan backstops multi-valued audience.
- **`Store.AdvertisableDocuments(ctx)`**: one SELECT, deterministic `(root, rel_path)` order, returning ref, title, summary, facets + byte map, tags, `modified_at`, and provenance (`loop_definition_name`, `managed_by`, `loop_intent`). Unlike every other public query it does **not** call `Refresh` and never touches `refreshMu` — that lock is periodically held across a full git re-verification pass, and an assembly-time caller on the serial 2s context walk must never wait on it (the metacog 1.95s incident is the cautionary tale). The background refresher keeps rows warm within ~5s, which is fresh enough for advertising.
- **Schema consolidation + rebuild trigger**: the store's inline migration moves to the standard `database.Schema` declaration, and a self-gating `Raw` purge deletes rows predating the new columns so the refresher rebuilds them from disk — the index re-parses only on mtime+size change, so pre-upgrade rows would otherwise carry NULLs indefinitely. NULL `facet_bytes_json` doubles as the "predates upgrade" marker; every post-upgrade upsert writes it, so the purge bites exactly once per stale row.

Search/browse hit shapes are untouched.

## Verification

Mutation-verified guards (each observed failing under the named mutation, then restored):
- migration purge removed → rebuild test fails on the exact trap row (mtime+size matching disk, so incremental refresh alone would never heal it); second `migrate()` leaves rebuilt rows alone
- `Refresh()` inserted into the enumeration → no-Refresh test fails *behaviorally* (root dir deleted + throttle disabled so any Refresh errors; in-test positive control proves `Search` fails on identical state)
- SQL `WHERE` removed → the SQL-gate test fails on `'  Internal '` (pinning `LOWER`/`TRIM` specifically) while the general test stays green under the same mutation — proof the dedicated test was necessary, the in-Go backstop masks it
- byte-length swapped to rune-length → multi-byte fixture fails (23 ≠ 30), with an in-test precondition proving the fixture is genuinely multi-byte

`just ci` green under the CI-pinned toolchain (`GOTOOLCHAIN=go1.25.7`), plus `-race` on the package. Implemented by a workflow agent; reviewed, and one purge-comment polarity error corrected in the follow-up commit.

## Deliberately left out

The `DocumentAdvertiser`, root `advertise` policy, match evidence, envelope, and freshness bands — the sibling PR built on this contract. Root-level eligibility filtering also stays with the advertiser (this method returns rows from search-excluded roots by design; the per-root `advertise` policy is the advertiser's to enforce).

## Test plan
- [x] `just ci` green (pinned toolchain), `-race` package pass
- [x] Four mutation-verified behavioral guards (above)
- [x] Existing search/facet/audience tests unchanged and green
- [ ] Verified against production once deployed (first boot purges + rebuilds the index; watch one refresher pass)

Refs #1431