### PR TITLE
Temporal templates: curated prose that stops rotting by the day

### DIFF
--- a/docs/model-facing-context.md
+++ b/docs/model-facing-context.md
@@ -196,6 +196,18 @@ Use the shared helpers in `internal/model/promptfmt/timefmt.go`:
 When a tool naturally wants relative scheduling, accept delta syntax as
 input instead of forcing the model to invent RFC3339 timestamps.
 
+Curated prose gets the same treatment through temporal templates:
+`{{delta:2026-09-18}}` (bare date or RFC3339 value) expands at read
+time via `promptfmt.ExpandTemporalTemplates` — day words for a date
+("today", "+20d"), a signed compact delta for an instant ("+3d16h") —
+so an authored document stays true between rewrites. Only reader
+surfaces expand (tagged-article injection today); author surfaces
+(`doc_read`, the publish tools, git) keep the raw template so the
+round-trip is byte-exact, and a malformed template renders verbatim
+rather than disappearing. Templates render values, never claims —
+prose whose truth changes with data is a wake concern, not a
+substitution concern (#1431).
+
 ### Keep schemas stable and deterministic
 
 For model-facing data:

--- a/internal/app/finalize_capability_tags.go
+++ b/internal/app/finalize_capability_tags.go
@@ -147,6 +147,7 @@ func (a *App) finalizeCapabilityTags(s *newState) error {
 		Verifier:    contextVerifier,
 		HAInject:    a.loop.HAInject(),
 		Logger:      logger.With("component", "tag_context"),
+		Timezone:    cfg.Timezone,
 	})
 
 	// Wire the assembler before tag context providers register so the

--- a/internal/model/promptfmt/temporal.go
+++ b/internal/model/promptfmt/temporal.go
@@ -1,0 +1,105 @@
+package promptfmt
+
+import (
+	"strings"
+	"time"
+)
+
+// Temporal template delimiters and the one tag the v1 vocabulary
+// defines. The vocabulary is deliberately closed — see
+// [ExpandTemporalTemplates].
+const (
+	temporalOpen  = "{{"
+	temporalClose = "}}"
+	temporalDelta = "delta:"
+)
+
+// ExpandTemporalTemplates renders the temporal-substitution vocabulary
+// in curated prose: each {{delta:VALUE}} template becomes the
+// now-relative form of VALUE, computed with this package's own delta
+// formatters. VALUE is either a bare date (2026-09-18) or an RFC3339
+// timestamp — that is the entire v1 vocabulary. Sugar forms like
+// {{until:...}}/{{ago:...}} and references to entities or events are
+// deliberately parked: a date literal cannot dangle, while the general
+// data-reference form waits on a stable-identity substrate (issue
+// #1431 records both decisions).
+//
+// A bare date names a day, not a moment, so it renders through
+// [FormatDayDelta] ("today", "tomorrow", "+20d"); an RFC3339 instant
+// renders through [FormatDeltaOnly] ("+3d16h"). Day distance is a
+// calendar comparison, so callers must pass now already in the zone
+// the reader thinks in — the household timezone — or a late evening
+// there will render tomorrow's date as "today" the moment UTC rolls
+// over.
+//
+// Templates render values, never claims. Prose whose truth changes
+// with data is a wake concern, not a substitution concern:
+// substitution keeps true prose fresh, while waking the authoring
+// loop is how prose that stopped being true gets fixed (#1431). That
+// boundary is why the vocabulary stays closed.
+//
+// Anything brace-delimited that is not a well-formed delta template —
+// an unknown tag, a malformed or empty value, an unterminated open —
+// passes through byte-for-byte, unexpanded. A visible bug beats a
+// silent drop: a verbatim template in the prompt is something the
+// authoring loop or its operator can see and fix, where a silently
+// dropped phrase reads as nothing at all. A string containing no "{{"
+// is returned unchanged without allocating.
+func ExpandTemporalTemplates(s string, now time.Time) string {
+	i := strings.Index(s, temporalOpen)
+	if i < 0 {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i >= 0 {
+		b.WriteString(s[:i])
+		s = s[i:]
+		if expanded, consumed, ok := expandLeadingTemporal(s, now); ok {
+			b.WriteString(expanded)
+			s = s[consumed:]
+		} else {
+			// Not a well-formed template. Emit the opening braces
+			// literally and rescan just past them, so a stray "{{"
+			// earlier in the prose cannot swallow a valid template
+			// that follows it. A fully malformed {{...}} still lands
+			// verbatim: its close braces carry through as plain text.
+			b.WriteString(temporalOpen)
+			s = s[len(temporalOpen):]
+		}
+		i = strings.Index(s, temporalOpen)
+	}
+	b.WriteString(s)
+	return b.String()
+}
+
+// expandLeadingTemporal attempts to expand the template opening at the
+// start of s (the caller guarantees s begins with "{{"). It returns
+// the rendered replacement, the byte length of the template consumed,
+// and whether the leading token was a well-formed {{delta:...}}
+// template. The grammar is strict — no interior whitespace, no case
+// folding — because the templates are machine-taught, not hand-typed,
+// and leniency here would just widen the set of near-misses that
+// silently half-work.
+func expandLeadingTemporal(s string, now time.Time) (string, int, bool) {
+	end := strings.Index(s, temporalClose)
+	if end < 0 {
+		return "", 0, false
+	}
+	value, ok := strings.CutPrefix(s[len(temporalOpen):end], temporalDelta)
+	if !ok {
+		return "", 0, false
+	}
+	// A bare date first: RFC3339 rejects it anyway, and the two forms
+	// deliberately render differently — a date occupies a day, so day
+	// words; an instant is a moment, so a signed compact delta. The
+	// zone a bare date parses in is irrelevant: FormatDayDelta reads
+	// each argument's calendar fields in its own location.
+	if day, err := time.Parse(time.DateOnly, value); err == nil {
+		return FormatDayDelta(day, now), end + len(temporalClose), true
+	}
+	if t, err := time.Parse(time.RFC3339, value); err == nil {
+		return FormatDeltaOnly(t, now), end + len(temporalClose), true
+	}
+	return "", 0, false
+}

--- a/internal/model/promptfmt/temporal.go
+++ b/internal/model/promptfmt/temporal.go
@@ -82,14 +82,27 @@ func ExpandTemporalTemplates(s string, now time.Time) string {
 // and leniency here would just widen the set of near-misses that
 // silently half-work.
 func expandLeadingTemporal(s string, now time.Time) (string, int, bool) {
-	end := strings.Index(s, temporalClose)
-	if end < 0 {
-		return "", 0, false
-	}
-	value, ok := strings.CutPrefix(s[len(temporalOpen):end], temporalDelta)
+	// The tag check comes before any search, and the search for the
+	// close is bounded at the next opening. Order matters for cost, not
+	// correctness: a malformed document with many openings and one
+	// distant close would otherwise rescan nearly the whole suffix per
+	// opening — quadratic on a per-turn path. A well-formed value never
+	// contains "{{", so the bound rejects exactly the strings the date
+	// parsers were going to reject anyway.
+	rest, ok := strings.CutPrefix(s[len(temporalOpen):], temporalDelta)
 	if !ok {
 		return "", 0, false
 	}
+	searchIn := rest
+	if next := strings.Index(rest, temporalOpen); next >= 0 {
+		searchIn = rest[:next]
+	}
+	closeAt := strings.Index(searchIn, temporalClose)
+	if closeAt < 0 {
+		return "", 0, false
+	}
+	value := rest[:closeAt]
+	end := len(temporalOpen) + len(temporalDelta) + closeAt
 	// A bare date first: RFC3339 rejects it anyway, and the two forms
 	// deliberately render differently — a date occupies a day, so day
 	// words; an instant is a moment, so a signed compact delta. The

--- a/internal/model/promptfmt/temporal_test.go
+++ b/internal/model/promptfmt/temporal_test.go
@@ -1,6 +1,7 @@
 package promptfmt
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -172,5 +173,18 @@ func TestExpandTemporalTemplates_FastPathDoesNotAllocate(t *testing.T) {
 	})
 	if allocs != 0 {
 		t.Errorf("template-free expansion allocated %.1f times per run, want 0", allocs)
+	}
+}
+
+func TestExpandTemporalTemplatesManyOpeningsOneClose(t *testing.T) {
+	// The pathological shape the bounded close-search exists for: many
+	// openings, a single distant close. Output contract is unchanged —
+	// everything renders verbatim except the one well-formed template.
+	now := time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
+	input := strings.Repeat("{{delta:x ", 500) + "{{delta:2026-08-30}}"
+	got := ExpandTemporalTemplates(input, now)
+	want := strings.Repeat("{{delta:x ", 500) + "tomorrow"
+	if got != want {
+		t.Fatalf("pathological input mishandled:\n got tail: %q\nwant tail: %q", got[len(got)-40:], want[len(want)-40:])
 	}
 }

--- a/internal/model/promptfmt/temporal_test.go
+++ b/internal/model/promptfmt/temporal_test.go
@@ -1,0 +1,176 @@
+package promptfmt
+
+import (
+	"testing"
+	"time"
+)
+
+// temporalTestNow is a fixed household-zone instant late enough in the
+// local evening that the UTC date has already rolled to the next day
+// (2026-08-29T22:00-05:00 is 2026-08-30T03:00Z). Cases that pivot on
+// "today" vs "tomorrow" only prove the zone contract because of that
+// straddle.
+var temporalTestNow = time.Date(2026, 8, 29, 22, 0, 0, 0, time.FixedZone("CDT", -5*3600))
+
+func TestExpandTemporalTemplates(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "bare date today",
+			in:   "{{delta:2026-08-29}}",
+			want: "today",
+		},
+		{
+			// The UTC date is already Aug 30 at temporalTestNow; only a
+			// household-zone now keeps this rendering "tomorrow".
+			name: "bare date tomorrow across the UTC midnight straddle",
+			in:   "{{delta:2026-08-30}}",
+			want: "tomorrow",
+		},
+		{
+			name: "bare date yesterday",
+			in:   "{{delta:2026-08-28}}",
+			want: "yesterday",
+		},
+		{
+			name: "bare date future day count",
+			in:   "{{delta:2026-09-18}}",
+			want: "+20d",
+		},
+		{
+			name: "bare date past day count",
+			in:   "{{delta:2026-08-26}}",
+			want: "-3d",
+		},
+		{
+			name: "rfc3339 future instant",
+			in:   "{{delta:2026-09-02T14:00:00-05:00}}",
+			want: "+3d16h",
+		},
+		{
+			name: "rfc3339 past instant stays exact seconds",
+			in:   "{{delta:2026-08-29T21:30:00-05:00}}",
+			want: "-1800s",
+		},
+		{
+			name: "rfc3339 zulu instant equal to now",
+			in:   "{{delta:2026-08-30T03:00:00Z}}",
+			want: "-0s",
+		},
+		{
+			name: "multiple templates with adjacent text byte-exact",
+			in:   "Trip window Sep 18–30 ({{delta:2026-09-18}}, ends {{delta:2026-09-30}}).",
+			want: "Trip window Sep 18–30 (+20d, ends +32d).",
+		},
+		{
+			name: "template at start of string",
+			in:   "{{delta:2026-08-30}} the window opens",
+			want: "tomorrow the window opens",
+		},
+		{
+			name: "template at end of string",
+			in:   "the window closed {{delta:2026-08-28}}",
+			want: "the window closed yesterday",
+		},
+		{
+			name: "template is the whole string plus trailing braces",
+			in:   "{{delta:2026-08-29}}}}",
+			want: "today}}",
+		},
+		{
+			name: "malformed value renders verbatim",
+			in:   "departs {{delta:not-a-date}} sharp",
+			want: "departs {{delta:not-a-date}} sharp",
+		},
+		{
+			name: "out of range date renders verbatim",
+			in:   "{{delta:2026-02-31}}",
+			want: "{{delta:2026-02-31}}",
+		},
+		{
+			name: "unknown tag renders verbatim",
+			in:   "{{until:2026-09-18}}",
+			want: "{{until:2026-09-18}}",
+		},
+		{
+			name: "empty value renders verbatim",
+			in:   "{{delta:}}",
+			want: "{{delta:}}",
+		},
+		{
+			name: "empty braces render verbatim",
+			in:   "a {{}} b",
+			want: "a {{}} b",
+		},
+		{
+			name: "unterminated open renders verbatim",
+			in:   "text {{delta:2026-09-18",
+			want: "text {{delta:2026-09-18",
+		},
+		{
+			name: "bare open braces render verbatim",
+			in:   "a {{ b",
+			want: "a {{ b",
+		},
+		{
+			// The stray "{{" is emitted literally and scanning resumes
+			// just past it, so it cannot swallow the valid template
+			// that follows — malformed noise stays visible without
+			// disabling substitution downstream of it.
+			name: "stray open braces do not swallow a following template",
+			in:   "{{ x {{delta:2026-09-18}}",
+			want: "{{ x +20d",
+		},
+		{
+			// The outer token's value is not a date, so its bytes pass
+			// through untouched; the inner well-formed template still
+			// renders, per the same resume-past-the-braces rule.
+			name: "nested template expands inner only",
+			in:   "{{delta:{{delta:2026-09-18}}}}",
+			want: "{{delta:+20d}}",
+		},
+		{
+			name: "whitespace inside template renders verbatim",
+			in:   "{{delta: 2026-09-18}}",
+			want: "{{delta: 2026-09-18}}",
+		},
+		{
+			name: "no templates returns input unchanged",
+			in:   "plain prose, no braces at all",
+			want: "plain prose, no braces at all",
+		},
+		{
+			name: "empty string",
+			in:   "",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExpandTemporalTemplates(tt.in, temporalTestNow)
+			if got != tt.want {
+				t.Errorf("ExpandTemporalTemplates(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestExpandTemporalTemplates_FastPathDoesNotAllocate pins the
+// contract that template-free prose — the overwhelmingly common case
+// on the per-turn injection path — costs nothing: the input string is
+// returned as-is.
+func TestExpandTemporalTemplates_FastPathDoesNotAllocate(t *testing.T) {
+	in := "a perfectly ordinary article body with no templates in it"
+	allocs := testing.AllocsPerRun(100, func() {
+		if got := ExpandTemporalTemplates(in, temporalTestNow); got != in {
+			t.Fatalf("fast path changed the string: %q", got)
+		}
+	})
+	if allocs != 0 {
+		t.Errorf("template-free expansion allocated %.1f times per run, want 0", allocs)
+	}
+}

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -701,6 +701,7 @@ func (l *Loop) contextAssemblerForPrompt() *TagContextAssembler {
 	assembler = NewTagContextAssembler(TagContextAssemblerConfig{
 		HAInject: l.haInject,
 		Logger:   l.logger,
+		Timezone: l.timezone,
 	})
 	for tag, p := range pendingTagged {
 		assembler.RegisterTaggedProvider(tag, p)

--- a/internal/runtime/agent/tag_context.go
+++ b/internal/runtime/agent/tag_context.go
@@ -13,6 +13,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
 	"github.com/nugget/thane-ai-agent/internal/model/talents"
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/platform/paths"
@@ -73,6 +74,12 @@ type TagContextAssembler struct {
 	}
 	haInject homeassistant.StateFetcher // nil-safe — delegates pass nil
 	logger   *slog.Logger
+	// loc is the zone temporal templates expand against; see
+	// [TagContextAssemblerConfig.Timezone] for why it matters.
+	loc *time.Location
+	// nowFunc returns the current time. Tests override it to pin
+	// template expansion to a fixed instant.
+	nowFunc func() time.Time
 
 	mu           sync.Mutex
 	tagProviders map[string]TagContextProvider
@@ -144,6 +151,13 @@ type TagContextAssemblerConfig struct {
 	}
 	HAInject homeassistant.StateFetcher // nil-safe
 	Logger   *slog.Logger
+	// Timezone is the household IANA timezone (e.g. "America/Chicago")
+	// that temporal templates in injected documents expand against.
+	// [promptfmt.FormatDayDelta] compares calendar days, so the zone
+	// decides which day "today" is — a household evening must not read
+	// as "tomorrow" because the process clock runs in UTC. Empty or
+	// unloadable falls back to the process-local zone.
+	Timezone string
 }
 
 // NewTagContextAssembler creates an assembler. The KB directory is
@@ -157,6 +171,20 @@ func NewTagContextAssembler(cfg TagContextAssemblerConfig) *TagContextAssembler 
 	if cfg.Logger == nil {
 		cfg.Logger = slog.Default()
 	}
+	// Config validation already rejects a bad household timezone, but
+	// this constructor is also reached directly (tests, the loop's
+	// pending-provider fallback), so degrade to the process-local zone
+	// with a warning rather than failing construction over a
+	// presentation concern.
+	loc := time.Local
+	if cfg.Timezone != "" {
+		if parsed, err := time.LoadLocation(cfg.Timezone); err == nil {
+			loc = parsed
+		} else {
+			cfg.Logger.Warn("invalid timezone for temporal template expansion; using process-local zone",
+				"timezone", cfg.Timezone, "error", err)
+		}
+	}
 	return &TagContextAssembler{
 		capTags:     cfg.CapTags,
 		kbDir:       cfg.KBDir,
@@ -165,7 +193,24 @@ func NewTagContextAssembler(cfg TagContextAssemblerConfig) *TagContextAssembler 
 		verifier:    cfg.Verifier,
 		haInject:    cfg.HAInject,
 		logger:      cfg.Logger,
+		loc:         loc,
+		nowFunc:     time.Now,
 	}
+}
+
+// templateNow is the instant temporal templates in injected documents
+// expand against: the current time in the household zone when one was
+// configured, the process-local zone otherwise. Day-word rendering
+// compares calendar days, so the zone decides which day "today" is.
+func (a *TagContextAssembler) templateNow() time.Time {
+	now := time.Now()
+	if a.nowFunc != nil {
+		now = a.nowFunc()
+	}
+	if a.loc != nil {
+		now = now.In(a.loc)
+	}
+	return now
 }
 
 // InjectRoot is one injection-eligible document root: the directory to
@@ -419,6 +464,13 @@ func (a *TagContextAssembler) BuildSections(ctx context.Context, req agentctx.Co
 		// Strip frontmatter before injection — the model doesn't need
 		// the YAML metadata, just the knowledge content.
 		_, content := talents.ParseFrontmatterMetadata(string(data))
+		// Temporal templates expand before ha-inject resolution so
+		// only the curated prose is expanded, never entity state
+		// fetched a moment ago. This is a reader surface: the model
+		// sees "+20d" here while doc_read, the publish tools, and git
+		// keep the raw {{delta:...}} so the author round-trip stays
+		// byte-exact.
+		content = promptfmt.ExpandTemporalTemplates(content, a.templateNow())
 		data = homeassistant.ResolveInject(ctx, []byte(content), a.haInject, a.logger)
 		bucket := agentctx.ContextBucketTaggedGuidance
 		if acc.append(bucket, data) {

--- a/internal/runtime/agent/tag_context.go
+++ b/internal/runtime/agent/tag_context.go
@@ -442,6 +442,12 @@ func (a *TagContextAssembler) BuildSections(ctx context.Context, req agentctx.Co
 	// all-of activation. Both compose; see [articleMatchesTags].
 	kbStart := time.Now()
 	articles := a.loadKBArticles()
+	// One instant for every article in this assembly. Sampling the clock
+	// per article lets a prompt that crosses a second — or local
+	// midnight — render identical templates differently a few lines
+	// apart ("today" above, "tomorrow" below), which reads as two
+	// documents disagreeing rather than one clock ticking.
+	templateNow := a.templateNow()
 	for _, article := range articles {
 		if !articleMatchesTags(article, req.ActiveTags) {
 			continue
@@ -470,7 +476,7 @@ func (a *TagContextAssembler) BuildSections(ctx context.Context, req agentctx.Co
 		// sees "+20d" here while doc_read, the publish tools, and git
 		// keep the raw {{delta:...}} so the author round-trip stays
 		// byte-exact.
-		content = promptfmt.ExpandTemporalTemplates(content, a.templateNow())
+		content = promptfmt.ExpandTemporalTemplates(content, templateNow)
 		data = homeassistant.ResolveInject(ctx, []byte(content), a.haInject, a.logger)
 		bucket := agentctx.ContextBucketTaggedGuidance
 		if acc.append(bucket, data) {

--- a/internal/runtime/agent/tag_context_test.go
+++ b/internal/runtime/agent/tag_context_test.go
@@ -1334,3 +1334,45 @@ func TestUnclassifiedDocumentsRefusedAtStartup(t *testing.T) {
 		t.Fatalf("refusal must name the root, got: %v", err)
 	}
 }
+
+func TestTagContextAssemblerSamplesOneClockPerAssembly(t *testing.T) {
+	// Two articles carrying the identical template must render the same
+	// words even when the clock ticks between article renders. A
+	// per-article clock sample would let one prompt say "today" above
+	// and "tomorrow" below for the same date — two documents appearing
+	// to disagree when only the clock moved.
+	kbDir := t.TempDir()
+	body := "---\ntags: [trip]\n---\nDay: {{delta:2026-08-30}}."
+	for _, name := range []string{"one.md", "two.md"} {
+		if err := os.WriteFile(filepath.Join(kbDir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	a := NewTagContextAssembler(TagContextAssemblerConfig{
+		CapTags:  map[string]config.CapabilityTagConfig{"trip": {}},
+		KBDir:    kbDir,
+		Timezone: "UTC",
+	})
+	// Each clock read jumps a whole day, straddling the template's date:
+	// the first sample renders it "tomorrow", a second sample would
+	// render "today". Only a single per-assembly sample keeps the two
+	// articles agreeing.
+	tick := 0
+	a.nowFunc = func() time.Time {
+		tick++
+		return time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC).AddDate(0, 0, tick-1)
+	}
+
+	sections := a.BuildSections(context.Background(), agentctx.ContextRequest{ActiveTags: map[string]bool{"trip": true}})
+	var rendered string
+	for _, s := range sections {
+		rendered += s.Content
+	}
+	if !strings.Contains(rendered, "Day: tomorrow.") {
+		t.Fatalf("expected the single-sample rendering, got: %q", rendered)
+	}
+	if strings.Contains(rendered, "Day: today.") {
+		t.Fatalf("identical templates rendered differently within one assembly: %q", rendered)
+	}
+}

--- a/internal/runtime/agent/tag_context_test.go
+++ b/internal/runtime/agent/tag_context_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/model/talents"
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
@@ -564,6 +565,41 @@ func TestTagContextAssembler_TaggedKBArticles(t *testing.T) {
 	// Frontmatter should be stripped.
 	if strings.Contains(result, "tags:") {
 		t.Error("frontmatter should be stripped from KB articles")
+	}
+}
+
+// TestTagContextAssembler_TemporalTemplatesExpandedInArticles proves the
+// tagged-article surface is a reader surface for temporal templates: a
+// {{delta:...}} in a curated body reaches the prompt as a now-relative
+// value, a malformed template stays verbatim, and the surrounding prose
+// is untouched. Author surfaces (doc_read, the publish tools, git) keep
+// the raw templates; only injection renders them.
+func TestTagContextAssembler_TemporalTemplatesExpandedInArticles(t *testing.T) {
+	kbDir := t.TempDir()
+	body := "---\ntags: [trip]\n---\nDeparture is Sep 18 ({{delta:2026-09-18}}); broken {{delta:not-a-date}} stays."
+	if err := os.WriteFile(filepath.Join(kbDir, "trip.md"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	a := NewTagContextAssembler(TagContextAssemblerConfig{
+		CapTags:  map[string]config.CapabilityTagConfig{"trip": {}},
+		KBDir:    kbDir,
+		Timezone: "America/Chicago",
+	})
+	// 2026-08-29T22:00 in the household zone; the UTC date is already
+	// Aug 30, so a render that ignored the configured zone would say
+	// "+19d" here instead of "+20d".
+	a.nowFunc = func() time.Time {
+		return time.Date(2026, 8, 30, 3, 0, 0, 0, time.UTC)
+	}
+
+	result := a.Build(context.Background(), agentctx.ContextRequest{ActiveTags: map[string]bool{"trip": true}})
+
+	if !strings.Contains(result, "Departure is Sep 18 (+20d);") {
+		t.Errorf("temporal template not expanded on the article injection surface:\n%s", result)
+	}
+	if !strings.Contains(result, "broken {{delta:not-a-date}} stays.") {
+		t.Errorf("malformed template should render verbatim with prose intact:\n%s", result)
 	}
 }
 

--- a/talents/loops.md
+++ b/talents/loops.md
@@ -73,6 +73,19 @@ at the ceiling is not a retry prompt: the document has outgrown
 single-document maintenance, so move detail into linked documents
 rather than shaving bytes.
 
+Relative time is the fastest-rotting thing curated prose can carry:
+"~20 days out" is wrong by morning and stays wrong until a wake
+rewrites it. Write the absolute date wrapped in the delta template
+instead — "Sep 18–30 ({{delta:2026-09-18}})" reads as "Sep 18–30
+(+20d)" on every injection surface and stays true between publishes. A
+bare date renders in day words ("today", "tomorrow", "+20d"); an
+RFC3339 timestamp renders as a compact offset ("+3d16h"). That one
+form is the whole vocabulary, and a malformed template renders
+verbatim instead of vanishing, so a typo shows itself in the injected
+prose. The template substitutes a value, never a claim: when data
+changes enough to make a sentence false, that is your wake to rewrite
+the sentence, not something substitution will paper over.
+
 A faceted document created through `thane_loop_create` arrives
 scaffolded: its section skeleton is pre-rendered with a placeholder
 under each heading, so the body a loop sees on its first wake is

--- a/talents/loops.md
+++ b/talents/loops.md
@@ -77,7 +77,8 @@ Relative time is the fastest-rotting thing curated prose can carry:
 "~20 days out" is wrong by morning and stays wrong until a wake
 rewrites it. Write the absolute date wrapped in the delta template
 instead — "Sep 18–30 ({{delta:2026-09-18}})" reads as "Sep 18–30
-(+20d)" on every injection surface and stays true between publishes. A
+(+20d)" where tagged documents are injected, and stays true between
+publishes. A
 bare date renders in day words ("today", "tomorrow", "+20d"); an
 RFC3339 timestamp renders as a compact offset ("+3d16h"). That one
 form is the whole vocabulary, and a malformed template renders


### PR DESCRIPTION
Phase 1 groundwork for #1431, second of three: the temporal-substitution vocabulary, expanded on reader surfaces only.

## The problem it kills

The fastest-rotting content in a curator document is relative time. The production Utah dossier says "~20 days out" in three places; every one is wrong tomorrow morning unless a model wake rewrites it — and relative time is precisely what curators write *because* models can't do timestamp arithmetic themselves.

## The contract

- **Grammar**: `{{delta:VALUE}}`, the whole v1 vocabulary. A bare `YYYY-MM-DD` renders day-granular via `FormatDayDelta` ("today", "tomorrow", "+20d") — a date names a day, not a moment. An RFC3339 instant renders via `FormatDeltaOnly` ("+3d16h"). `until:`/`ago:` sugar and entity references are deliberately parked (#644 stable IDs first); the godoc says so.
- **Malformed renders verbatim** — the whole `{{...}}` untouched. A visible bug beats a silent drop; a stray `{{` cannot swallow a valid template after it.
- **Values, never claims**: prose whose truth changes with data is a wake concern, not a substitution concern. In the godoc as doctrine, citing #1431.
- **Reader surfaces only**: expansion runs at tagged-KB-article injection (beside the `ha-inject` precedent, and deliberately *before* it so freshly-fetched entity state never passes through the expander). Author surfaces — `doc_read`, publish tools, git — stay raw, so the curator's round-trip is byte-exact. The advertisement materializer (sibling PR) calls the same function.
- **Zone-aware "today"**: the assembler learns the household timezone; `FormatDayDelta` compares calendar days, so the zone decides which day "today" is — a household evening must not read as "tomorrow" because the process clock runs in UTC. The guard test straddles local midnight with a UTC instant, so a zone-ignoring implementation renders "+19d" instead of "+20d" and fails.

Teaching rides along: `talents/loops.md` tells curators to write absolute dates wrapped in `{{delta:...}}` (verified the talent's own literal example is *not* expanded — talents render outside the article path), and the `docs/model-facing-context.md` delta-time section gains the vocabulary.

## Verification

- `just ci` green under the CI-pinned toolchain; scanner has no regexp, zero allocations on the template-free fast path (pinned by an `AllocsPerRun` test)
- 23 table cases: both value forms, multi-template adjacency byte-exact, nested braces (documented behavior), unterminated/empty/whitespace-strict/stray-brace edges, start/end/whole-string positions
- Injection-surface guard verified failing with the expansion call mutated out (edit inverted in place, per house rule — never `git checkout` to undo)

Implemented by a workflow agent; reviewed.

## Test plan
- [x] `just ci` green (pinned toolchain)
- [x] Expander table + allocation fast-path tests
- [x] Zone-boundary guard test, mutation-verified
- [ ] Verified against production once deployed — the check is the schedule curator's next dossier publish using `{{delta:...}}` and reading correctly days later without a wake

Refs #1431