### PR TITLE
The corpus advertiser: faceted documents compete for context

### DIFF
--- a/docs/model-facing-context.md
+++ b/docs/model-facing-context.md
@@ -201,7 +201,8 @@ Curated prose gets the same treatment through temporal templates:
 time via `promptfmt.ExpandTemporalTemplates` — day words for a date
 ("today", "+20d"), a signed compact delta for an instant ("+3d16h") —
 so an authored document stays true between rewrites. Only reader
-surfaces expand (tagged-article injection today); author surfaces
+surfaces expand — tagged-article injection and advertisement
+materialization; author surfaces
 (`doc_read`, the publish tools, git) keep the raw template so the
 round-trip is byte-exact, and a malformed template renders verbatim
 rather than disappearing. Templates render values, never claims —

--- a/docs/model-facing-context.md
+++ b/docs/model-facing-context.md
@@ -338,7 +338,10 @@ Projection roles describe what a consumer gets:
   escalation, never selected automatically.
 
 Go owns evidence ordering, deduplication, projection choice, stable ties, and
-count and byte limits. Providers own domain matching and materialization. A
+count and byte limits. When those limits refuse a genuinely selectable offer,
+the refusal is rendered — a closing line counts the withheld offers and names
+the pull door — because a capped rail must never read as a complete one.
+Providers own domain matching and materialization. A
 model-authored facet can describe why it is useful, but it cannot grant itself
 injection or assign its own rank.
 

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -310,6 +310,17 @@ roots:
       # Gating search the same way would need the document store to see
       # active capability tags, which it deliberately does not.
       requires_tag: ""
+      # Advertise controls whether this root's documents may offer
+      # themselves to context assembly through the advertisement rail
+      # (#1431): "never" (default), "tagged" (offers only while
+      # RequiresTag's capability tag is active), or "always" (ambient
+      # offers on every eligible turn). Advertising is a third door
+      # beside Inject and Search rather than a mode of either: injection
+      # pushes whole documents on a tag, search answers an explicit ask,
+      # and advertising lets a document compete for a bounded slice of
+      # unasked-for attention. A root must opt in — the safe reading of
+      # silence is that a corpus does not volunteer itself.
+      advertise: ""
       # Untagged decides what a document carrying no tags means in this
       # root: "ignore" (default) skips it, "refuse" makes it an error.
       # 
@@ -467,6 +478,17 @@ roots:
       # Gating search the same way would need the document store to see
       # active capability tags, which it deliberately does not.
       requires_tag: ""
+      # Advertise controls whether this root's documents may offer
+      # themselves to context assembly through the advertisement rail
+      # (#1431): "never" (default), "tagged" (offers only while
+      # RequiresTag's capability tag is active), or "always" (ambient
+      # offers on every eligible turn). Advertising is a third door
+      # beside Inject and Search rather than a mode of either: injection
+      # pushes whole documents on a tag, search answers an explicit ask,
+      # and advertising lets a document compete for a bounded slice of
+      # unasked-for attention. A root must opt in — the safe reading of
+      # silence is that a corpus does not volunteer itself.
+      advertise: ""
       # Untagged decides what a document carrying no tags means in this
       # root: "ignore" (default) skips it, "refuse" makes it an error.
       # 
@@ -589,6 +611,17 @@ roots:
       # Gating search the same way would need the document store to see
       # active capability tags, which it deliberately does not.
       requires_tag: ""
+      # Advertise controls whether this root's documents may offer
+      # themselves to context assembly through the advertisement rail
+      # (#1431): "never" (default), "tagged" (offers only while
+      # RequiresTag's capability tag is active), or "always" (ambient
+      # offers on every eligible turn). Advertising is a third door
+      # beside Inject and Search rather than a mode of either: injection
+      # pushes whole documents on a tag, search answers an explicit ask,
+      # and advertising lets a document compete for a bounded slice of
+      # unasked-for attention. A root must opt in — the safe reading of
+      # silence is that a corpus does not volunteer itself.
+      advertise: ""
       # Untagged decides what a document carrying no tags means in this
       # root: "ignore" (default) skips it, "refuse" makes it an error.
       # 

--- a/internal/app/new_awareness.go
+++ b/internal/app/new_awareness.go
@@ -14,6 +14,7 @@ import (
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/state/awareness"
 	"github.com/nugget/thane-ai-agent/internal/state/contacts"
+	"github.com/nugget/thane-ai-agent/internal/state/documents"
 	"github.com/nugget/thane-ai-agent/internal/state/introspection"
 	"github.com/nugget/thane-ai-agent/internal/state/knowledge"
 	"github.com/nugget/thane-ai-agent/internal/state/memory"
@@ -217,6 +218,47 @@ func (a *App) initAwareness(s *newState) error {
 	// discriminator selects it and prepends the materialized projection to
 	// Live State, so a busy eager state window cannot starve the verdict.
 	a.loop.RegisterAlwaysContextProvider(awareness.NewSystemSelfAssessmentProvider(a.readSystemSelfAssessmentDocument, logger))
+
+	// The corpus advertiser: any document root whose context policy opts
+	// in (advertise: always|tagged) offers its faceted documents to the
+	// discriminator. Index-only at offer time; a file is read only for a
+	// selected projection, under the rail's own detached budget. Sleep
+	// bounds come from the live definition registry — never frontmatter,
+	// which carries no updated stamp and rots after retunes (#1431).
+	if a.documentStore != nil {
+		advertisePolicies := make(map[string]documents.DocumentRootAdvertisePolicy, len(cfg.DocRoots))
+		for name, rootCfg := range cfg.DocRoots {
+			advertisePolicies[name] = documents.DocumentRootAdvertisePolicy{
+				Mode:        rootCfg.Context.EffectiveAdvertise(),
+				RequiresTag: rootCfg.Context.RequiresTag,
+			}
+		}
+		homeZone := time.Local
+		if cfg.Timezone != "" {
+			if loc, err := time.LoadLocation(cfg.Timezone); err == nil {
+				homeZone = loc
+			}
+		}
+		registry := a.loopDefinitionRegistry
+		a.loop.RegisterAlwaysContextProvider(documents.NewDocumentAdvertiser(documents.DocumentAdvertiserConfig{
+			Store: a.documentStore,
+			RootPolicy: func(root string) documents.DocumentRootAdvertisePolicy {
+				return advertisePolicies[root]
+			},
+			SleepMax: func(loopName string) (time.Duration, bool) {
+				if registry == nil {
+					return 0, false
+				}
+				spec, ok := registry.Get(loopName)
+				if !ok {
+					return 0, false
+				}
+				return spec.SleepMax, spec.SleepMax > 0
+			},
+			HomeZone: homeZone,
+			Logger:   logger,
+		}))
+	}
 
 	stateWindowProvider := homeassistant.NewStateWindowProvider(
 		cfg.StateWindow.MaxEntries,

--- a/internal/app/new_awareness.go
+++ b/internal/app/new_awareness.go
@@ -228,6 +228,16 @@ func (a *App) initAwareness(s *newState) error {
 	if a.documentStore != nil {
 		advertisePolicies := make(map[string]documents.DocumentRootAdvertisePolicy, len(cfg.DocRoots))
 		for name, rootCfg := range cfg.DocRoots {
+			// Canonicalize exactly as the store's own root wiring does
+			// (document_roots.go): legacy doc_roots keys tolerate
+			// whitespace and a trailing colon, and index rows carry the
+			// canonical name — a noncanonical key here would make the
+			// policy lookup miss and advertise: always silently behave
+			// as never.
+			name = strings.TrimSuffix(strings.TrimSpace(name), ":")
+			if name == "" {
+				continue
+			}
 			advertisePolicies[name] = documents.DocumentRootAdvertisePolicy{
 				Mode:        rootCfg.Context.EffectiveAdvertise(),
 				RequiresTag: rootCfg.Context.RequiresTag,

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -1070,6 +1070,20 @@ const (
 	// refuses says which file is unclassified instead of inferring an
 	// answer from its name.
 	RootUntaggedRefuse = "refuse"
+
+	// RootAdvertiseNever keeps this root's documents off the context
+	// advertisement rail entirely. The default: ambient attention is a
+	// per-turn spend, and a corpus earns it by opting in.
+	RootAdvertiseNever = "never"
+	// RootAdvertiseTagged lets documents offer themselves only while the
+	// root's requires_tag capability tag is active on the turn, so a
+	// specialist corpus surfaces exactly when its capability does.
+	RootAdvertiseTagged = "tagged"
+	// RootAdvertiseAlways lets documents make ambient offers on every
+	// eligible turn — the posture for a small curated corpus like a
+	// schedule root, whose freshest signal is worth a standing seat at
+	// the discriminator's table.
+	RootAdvertiseAlways = "always"
 )
 
 // RootContextPolicy declares how one document root may reach a model.
@@ -1097,6 +1111,18 @@ type RootContextPolicy struct {
 	// active capability tags, which it deliberately does not.
 	RequiresTag string `yaml:"requires_tag,omitempty"`
 
+	// Advertise controls whether this root's documents may offer
+	// themselves to context assembly through the advertisement rail
+	// (#1431): "never" (default), "tagged" (offers only while
+	// RequiresTag's capability tag is active), or "always" (ambient
+	// offers on every eligible turn). Advertising is a third door
+	// beside Inject and Search rather than a mode of either: injection
+	// pushes whole documents on a tag, search answers an explicit ask,
+	// and advertising lets a document compete for a bounded slice of
+	// unasked-for attention. A root must opt in — the safe reading of
+	// silence is that a corpus does not volunteer itself.
+	Advertise string `yaml:"advertise,omitempty"`
+
 	// Untagged decides what a document carrying no tags means in this
 	// root: "ignore" (default) skips it, "refuse" makes it an error.
 	//
@@ -1111,7 +1137,7 @@ type RootContextPolicy struct {
 // An undeclared policy keeps the root's historical behavior so an
 // existing config does not silently change how context is assembled.
 func (p RootContextPolicy) Declared() bool {
-	return p.Inject != "" || p.Search != "" || p.RequiresTag != ""
+	return p.Inject != "" || p.Search != "" || p.RequiresTag != "" || p.Advertise != ""
 }
 
 // EffectiveInject resolves the injection policy. A root that declares a
@@ -1135,6 +1161,17 @@ func (p RootContextPolicy) EffectiveSearch() string {
 	return p.Search
 }
 
+// EffectiveAdvertise resolves the advertisement policy. The default is
+// "never" for the same reason EffectiveInject defaults closed: ambient
+// attention is spent on every turn, and a corpus earns it by explicit
+// opt-in, not by existing.
+func (p RootContextPolicy) EffectiveAdvertise() string {
+	if p.Advertise == "" {
+		return RootAdvertiseNever
+	}
+	return p.Advertise
+}
+
 // EffectiveUntagged resolves what a tagless document means here,
 // defaulting to skipping it.
 func (p RootContextPolicy) EffectiveUntagged() string {
@@ -1156,6 +1193,14 @@ func (p RootContextPolicy) Validate(rootName string) error {
 	default:
 		return fmt.Errorf("roots.%s.context.search must be %q, %q, or %q, got %q", rootName, RootSearchDefault, RootSearchOnRequest, RootSearchNever, p.Search)
 	}
+	switch p.Advertise {
+	case "", RootAdvertiseNever, RootAdvertiseTagged, RootAdvertiseAlways:
+	default:
+		return fmt.Errorf("roots.%s.context.advertise must be %q, %q, or %q, got %q", rootName, RootAdvertiseNever, RootAdvertiseTagged, RootAdvertiseAlways, p.Advertise)
+	}
+	if p.Advertise == RootAdvertiseTagged && p.RequiresTag == "" {
+		return fmt.Errorf("roots.%s.context.advertise %q needs requires_tag to name the gating capability tag", rootName, RootAdvertiseTagged)
+	}
 	switch p.Untagged {
 	case "", RootUntaggedIgnore, RootUntaggedRefuse:
 	default:
@@ -1168,12 +1213,13 @@ func (p RootContextPolicy) Validate(rootName string) error {
 		// for, which reads as a broken config rather than a policy.
 		return fmt.Errorf("roots.%s.context.untagged is %q but the root does not inject; set inject: %q or drop the untagged policy", rootName, RootUntaggedRefuse, RootInjectTagged)
 	}
-	// requires_tag gates prompt injection only. Search runs below the
-	// capability layer — the document store has no view of which tags
-	// are active — so accepting the field on a root that does not inject
-	// would silently do nothing, which is worse than refusing it.
-	if p.RequiresTag != "" && p.EffectiveInject() != RootInjectTagged {
-		return fmt.Errorf("roots.%s.context.requires_tag gates prompt injection and requires inject: %q (got %q); it does not gate search, because search does not see active capability tags", rootName, RootInjectTagged, p.EffectiveInject())
+	// requires_tag gates the capability-aware doors: tagged injection
+	// and tagged advertising. Search runs below the capability layer —
+	// the document store has no view of which tags are active — so
+	// accepting the field on a root that neither injects nor advertises
+	// by tag would silently do nothing, which is worse than refusing it.
+	if p.RequiresTag != "" && p.EffectiveInject() != RootInjectTagged && p.EffectiveAdvertise() != RootAdvertiseTagged {
+		return fmt.Errorf("roots.%s.context.requires_tag gates tagged injection and tagged advertising; set inject: %q or advertise: %q (got inject %q, advertise %q). It does not gate search, because search does not see active capability tags", rootName, RootInjectTagged, RootAdvertiseTagged, p.EffectiveInject(), p.EffectiveAdvertise())
 	}
 	return nil
 }

--- a/internal/platform/config/config_root_context_test.go
+++ b/internal/platform/config/config_root_context_test.go
@@ -31,7 +31,28 @@ func TestRootContextPolicyValidate(t *testing.T) {
 		{
 			name:    "requires_tag without injection rejected",
 			policy:  RootContextPolicy{Search: RootSearchOnRequest, RequiresTag: "devops"},
-			wantErr: "requires_tag gates prompt injection",
+			wantErr: "requires_tag gates tagged injection and tagged advertising",
+		},
+		{name: "always advertising", policy: RootContextPolicy{Advertise: RootAdvertiseAlways}},
+		{
+			name:   "tagged advertising with its gate",
+			policy: RootContextPolicy{Advertise: RootAdvertiseTagged, RequiresTag: "schedule"},
+		},
+		{
+			// requires_tag no longer forces inject: tagged — advertising is
+			// the second capability-aware door it can be gating.
+			name:   "requires_tag satisfied by tagged advertising alone",
+			policy: RootContextPolicy{Advertise: RootAdvertiseTagged, RequiresTag: "schedule", Search: RootSearchOnRequest},
+		},
+		{
+			name:    "unknown advertise rejected",
+			policy:  RootContextPolicy{Advertise: "sometimes"},
+			wantErr: "context.advertise",
+		},
+		{
+			name:    "tagged advertising without a gate rejected",
+			policy:  RootContextPolicy{Advertise: RootAdvertiseTagged},
+			wantErr: "needs requires_tag",
 		},
 	}
 
@@ -55,6 +76,9 @@ func TestRootContextPolicyEffectiveDefaults(t *testing.T) {
 	var p RootContextPolicy
 	if got := p.EffectiveInject(); got != RootInjectNone {
 		t.Fatalf("EffectiveInject() = %q, want none", got)
+	}
+	if got := p.EffectiveAdvertise(); got != RootAdvertiseNever {
+		t.Fatalf("EffectiveAdvertise() = %q, want never", got)
 	}
 	if got := p.EffectiveSearch(); got != RootSearchDefault {
 		t.Fatalf("EffectiveSearch() = %q, want default", got)

--- a/internal/runtime/agent/context_discriminator.go
+++ b/internal/runtime/agent/context_discriminator.go
@@ -18,6 +18,15 @@ const (
 	maxSelectedContextAdvertisements = 8
 	maxAdvertisedContextBytes        = 16 * 1024
 	contextContentSeparatorBytes     = len("\n\n---\n\n")
+
+	// contextMaterializationBudget bounds the whole lazy-materialization
+	// phase, detached from the assembly walk's shared deadline.
+	// Materialization runs at the tail of the serial walk, when the
+	// shared 2s budget is most depleted — structurally, the
+	// highest-ranked content would otherwise be the first casualty of a
+	// slow turn. Same shape, same figure as the self-assessment
+	// provider's detach, and for the same reason.
+	contextMaterializationBudget = 1500 * time.Millisecond
 )
 
 type contextAdvertisementCandidate struct {
@@ -35,7 +44,14 @@ type contextAdvertisementSelection struct {
 // decide what they can offer and how the current request matches; this pass
 // owns cross-provider evidence ordering, deduplication, projection choice,
 // count, and byte limits. Complete detail is never selected automatically.
-func selectContextAdvertisements(candidates []contextAdvertisementCandidate) []contextAdvertisementSelection {
+// selectContextAdvertisements picks the winning offers. The second return
+// counts identities that made a genuinely selectable offer — a projection
+// automatic selection could have taken on an empty rail — but lost to the
+// offer cap or the byte budget. Losing must be observable: a turn that
+// silently renders eight offers out of twenty reads as "this is
+// everything", and the one thing an attention budget must never buy is a
+// false sense of completeness.
+func selectContextAdvertisements(candidates []contextAdvertisementCandidate) ([]contextAdvertisementSelection, int) {
 	valid := make([]contextAdvertisementCandidate, 0, len(candidates))
 	for _, candidate := range candidates {
 		if candidate.advertiser == nil || candidate.advertisement.Validate() != nil {
@@ -69,13 +85,23 @@ func selectContextAdvertisements(candidates []contextAdvertisementCandidate) []c
 
 	selected := make([]contextAdvertisementSelection, 0, min(len(valid), maxSelectedContextAdvertisements))
 	seen := make(map[string]struct{}, len(valid))
+	withheld := make(map[string]struct{})
 	remaining := maxAdvertisedContextBytes
 	for _, candidate := range valid {
 		key := candidate.advertisement.Source + "\x00" + candidate.advertisement.ID
 		if _, duplicate := seen[key]; duplicate {
+			delete(withheld, key)
 			continue
 		}
 		match, _ := bestContextMatch(candidate.advertisement.Matches)
+		if len(selected) == maxSelectedContextAdvertisements || remaining <= 0 {
+			// Past capacity. Anything that could have been chosen on an
+			// empty rail is a withheld offer, not a non-offer.
+			if _, ok := chooseContextProjection(candidate.advertisement.Projections, match.Kind, maxAdvertisedContextBytes); ok {
+				withheld[key] = struct{}{}
+			}
+			continue
+		}
 		separator := 0
 		if len(selected) > 0 {
 			separator = contextContentSeparatorBytes
@@ -83,13 +109,19 @@ func selectContextAdvertisements(candidates []contextAdvertisementCandidate) []c
 		projection, ok := chooseContextProjection(candidate.advertisement.Projections, match.Kind, remaining-separator)
 		if !ok {
 			// Not marked seen: this claimant offered nothing selectable
-			// (detail-only, or nothing fits the remaining budget), and a
-			// lower-ranked claimant of the same identity may still carry a
-			// projection that does. Marking the identity here would let
-			// the emptiest offer suppress every usable one behind it.
+			// here, and a lower-ranked claimant of the same identity may
+			// still carry a projection that fits. Marking the identity
+			// would let the emptiest offer suppress every usable one
+			// behind it. But if the offer would have fit an empty rail,
+			// the budget is what refused it — count it withheld unless a
+			// later claimant of the identity gets selected after all.
+			if _, fits := chooseContextProjection(candidate.advertisement.Projections, match.Kind, maxAdvertisedContextBytes); fits {
+				withheld[key] = struct{}{}
+			}
 			continue
 		}
 		seen[key] = struct{}{}
+		delete(withheld, key)
 		selected = append(selected, contextAdvertisementSelection{
 			advertiser: candidate.advertiser,
 			selection: agentctx.ContextSelection{
@@ -99,11 +131,8 @@ func selectContextAdvertisements(candidates []contextAdvertisementCandidate) []c
 			match: match,
 		})
 		remaining -= separator + projection.EstimatedBytes
-		if len(selected) == maxSelectedContextAdvertisements || remaining <= 0 {
-			break
-		}
 	}
-	return selected
+	return selected, len(withheld)
 }
 
 func bestContextMatch(matches []agentctx.ContextMatchSignal) (agentctx.ContextMatchSignal, int) {
@@ -186,15 +215,21 @@ func contextAdvertisementFingerprint(ad agentctx.ContextAdvertisement) string {
 // whole. An oversized projection is dropped rather than clipped into an
 // unmarked fragment.
 func (a *TagContextAssembler) materializeContextAdvertisements(ctx context.Context, req agentctx.ContextRequest, candidates []contextAdvertisementCandidate) map[agentctx.ContextBucket]string {
-	selected := selectContextAdvertisements(candidates)
-	if len(selected) == 0 {
+	selected, withheld := selectContextAdvertisements(candidates)
+	if len(selected) == 0 && withheld == 0 {
 		return nil
 	}
+
+	// Values (loop id, logging) survive WithoutCancel; only the walk's
+	// depleted deadline is replaced with this phase's own bound.
+	materializeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), contextMaterializationBudget)
+	defer cancel()
+
 	buffers := make(map[agentctx.ContextBucket]*strings.Builder)
 	used := 0
 	for _, item := range selected {
 		started := time.Now()
-		content, err := item.advertiser.MaterializeContextAdvertisement(ctx, req, item.selection)
+		content, err := item.advertiser.MaterializeContextAdvertisement(materializeCtx, req, item.selection)
 		warnSlowContextSource(a.logger, "context_advertisement_materialization", item.selection.Advertisement.Source+"/"+item.selection.Advertisement.ID, started)
 		if err != nil {
 			a.logger.Warn("context advertisement materialization failed",
@@ -256,6 +291,22 @@ func (a *TagContextAssembler) materializeContextAdvertisements(ctx context.Conte
 			"match_strength", item.match.Strength,
 			"bytes", len(content))
 	}
+	// Withheld offers get one explicit line so a capped rail never reads
+	// as a complete one. It rides the Related bucket — "lightweight and
+	// clearly optional" is that bucket's charter, and the door it names
+	// is a pull the model can choose.
+	if withheld > 0 {
+		buf := buffers[agentctx.ContextBucketRelated]
+		if buf == nil {
+			buf = &strings.Builder{}
+			buffers[agentctx.ContextBucketRelated] = buf
+		}
+		if buf.Len() > 0 {
+			buf.WriteString("\n\n")
+		}
+		fmt.Fprintf(buf, "[%d context offer(s) withheld by the advertisement budget; doc_search reaches the full corpus]", withheld)
+	}
+
 	out := make(map[agentctx.ContextBucket]string, len(buffers))
 	for bucket, buf := range buffers {
 		if buf.Len() > 0 {

--- a/internal/runtime/agent/context_discriminator_test.go
+++ b/internal/runtime/agent/context_discriminator_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -62,7 +63,7 @@ func TestSelectContextAdvertisementsRanksEvidenceDeterministically(t *testing.T)
 		for _, ad := range order {
 			candidates = append(candidates, contextAdvertisementCandidate{advertiser: provider, advertisement: ad})
 		}
-		selected := selectContextAdvertisements(candidates)
+		selected, _ := selectContextAdvertisements(candidates)
 		if len(selected) != 3 {
 			t.Fatalf("order %d selected %d advertisements, want 3", i, len(selected))
 		}
@@ -126,7 +127,7 @@ func TestSelectContextAdvertisementsChoosesProjectionForMatchAndBudget(t *testin
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			selected := selectContextAdvertisements([]contextAdvertisementCandidate{{advertiser: provider, advertisement: tt.ad}})
+			selected, _ := selectContextAdvertisements([]contextAdvertisementCandidate{{advertiser: provider, advertisement: tt.ad}})
 			if tt.empty {
 				if len(selected) != 0 {
 					t.Fatalf("selected = %#v, want none", selected)
@@ -154,7 +155,7 @@ func TestSelectContextAdvertisementsDeduplicatesAndLimits(t *testing.T) {
 		candidates = append(candidates, contextAdvertisementCandidate{advertiser: provider, advertisement: ad})
 	}
 
-	selected := selectContextAdvertisements(candidates)
+	selected, _ := selectContextAdvertisements(candidates)
 	if len(selected) != maxSelectedContextAdvertisements {
 		t.Fatalf("selected %d advertisements, want cap %d", len(selected), maxSelectedContextAdvertisements)
 	}
@@ -222,7 +223,7 @@ func TestSelectContextAdvertisementsDuplicateWithoutProjectionDoesNotSuppressLat
 	usable := testAdvertisement("memory", "same", agentctx.ContextMatchAmbient, 0.5,
 		testProjection("signal", agentctx.ContextRoleSignal, 100))
 
-	selected := selectContextAdvertisements([]contextAdvertisementCandidate{
+	selected, _ := selectContextAdvertisements([]contextAdvertisementCandidate{
 		{advertiser: provider, advertisement: empty},
 		{advertiser: provider, advertisement: usable},
 	})
@@ -264,5 +265,95 @@ func TestMaterializeDropsPayloadExceedingItsOwnEstimate(t *testing.T) {
 	}
 	if !strings.Contains(rendered, "fits fine") {
 		t.Fatalf("honest payload should survive, got: %q", rendered)
+	}
+}
+
+func TestSelectContextAdvertisementsCountsWithheldOffers(t *testing.T) {
+	t.Parallel()
+
+	provider := &testContextAdvertiser{}
+	// Twelve genuinely selectable offers against a cap of eight: four are
+	// withheld and the count must say so. A thirteenth offers only detail —
+	// never selectable, so it is a non-offer, not a withheld one.
+	var candidates []contextAdvertisementCandidate
+	for i := 0; i < 12; i++ {
+		ad := testAdvertisement("memory", fmt.Sprintf("doc-%02d", i), agentctx.ContextMatchSemantic, 1,
+			testProjection("digest", agentctx.ContextRoleContext, 64))
+		candidates = append(candidates, contextAdvertisementCandidate{advertiser: provider, advertisement: ad})
+	}
+	detailOnly := testAdvertisement("memory", "detail-only", agentctx.ContextMatchSemantic, 0.9,
+		testProjection("full", agentctx.ContextRoleDetail, 64))
+	candidates = append(candidates, contextAdvertisementCandidate{advertiser: provider, advertisement: detailOnly})
+
+	selected, withheld := selectContextAdvertisements(candidates)
+
+	if len(selected) != maxSelectedContextAdvertisements {
+		t.Fatalf("selected %d, want the cap %d", len(selected), maxSelectedContextAdvertisements)
+	}
+	if withheld != 4 {
+		t.Fatalf("withheld = %d, want 4 (selectable losers only, never the detail-only non-offer)", withheld)
+	}
+}
+
+func TestMaterializeRendersTheWithheldLine(t *testing.T) {
+	t.Parallel()
+
+	provider := &testContextAdvertiser{}
+	provider.content = map[string]string{}
+	var candidates []contextAdvertisementCandidate
+	for i := 0; i < 10; i++ {
+		id := fmt.Sprintf("doc-%02d", i)
+		ad := testAdvertisement("memory", id, agentctx.ContextMatchSemantic, 1,
+			testProjection("digest", agentctx.ContextRoleContext, 64))
+		provider.content["memory/"+id+"/digest"] = "content for " + id
+		candidates = append(candidates, contextAdvertisementCandidate{advertiser: provider, advertisement: ad})
+	}
+
+	assembler := NewTagContextAssembler(TagContextAssemblerConfig{})
+	buckets := assembler.materializeContextAdvertisements(context.Background(), agentctx.ContextRequest{}, candidates)
+
+	related := buckets[agentctx.ContextBucketRelated]
+	if !strings.Contains(related, "2 context offer(s) withheld") {
+		t.Fatalf("expected a withheld line naming 2 offers, got: %q", related)
+	}
+	if !strings.Contains(related, "doc_search") {
+		t.Fatalf("the withheld line must name the pull door, got: %q", related)
+	}
+}
+
+// ctxHonoringAdvertiser materializes like a real provider: a dead context
+// is an error, not something to ignore. The plain test advertiser never
+// looks at ctx, which would let a detach regression pass unnoticed.
+type ctxHonoringAdvertiser struct{ testContextAdvertiser }
+
+func (p *ctxHonoringAdvertiser) MaterializeContextAdvertisement(ctx context.Context, req agentctx.ContextRequest, selection agentctx.ContextSelection) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	return p.testContextAdvertiser.MaterializeContextAdvertisement(ctx, req, selection)
+}
+
+func TestMaterializeDetachesFromADepletedWalkBudget(t *testing.T) {
+	t.Parallel()
+
+	provider := &ctxHonoringAdvertiser{}
+	provider.advertisements = []agentctx.ContextAdvertisement{
+		testAdvertisement("memory", "survivor", agentctx.ContextMatchSemantic, 1,
+			testProjection("digest", agentctx.ContextRoleContext, 64)),
+	}
+	provider.content = map[string]string{"memory/survivor/digest": "made it"}
+
+	// The walk's context is already dead — the exact state at the tail of
+	// a slow turn. The winners must not inherit it.
+	dead, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	assembler := NewTagContextAssembler(TagContextAssemblerConfig{})
+	buckets := assembler.materializeContextAdvertisements(dead, agentctx.ContextRequest{}, []contextAdvertisementCandidate{
+		{advertiser: provider, advertisement: provider.advertisements[0]},
+	})
+
+	if !strings.Contains(buckets[agentctx.ContextBucketRelated], "made it") {
+		t.Fatalf("materialization must survive a dead walk context, got: %#v", buckets)
 	}
 }

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -1230,6 +1230,12 @@ func (l *Loop) buildSystemPromptWithProfileSections(ctx context.Context, userMes
 			IncludeAlways:     !taskPrompt && !suppressAlways,
 			IncludeLoopScoped: !suppressAlways,
 		}
+		// Refs the session-origin policy injects whole are pinned so
+		// advertisers do not spend rail budget offering a document the
+		// prompt already carries in full.
+		if result := sessionOriginPolicyResultFromContext(ctx); result != nil {
+			req.PinnedRefs = result.ContextRefs
+		}
 		for _, contextSection := range assembler.BuildSections(haCtx, req) {
 			title := contextSection.Bucket.Title()
 			appendTrackedMarkdown(strings.ToUpper(title), 2, title, contextSection.Content)

--- a/internal/runtime/agentctx/request.go
+++ b/internal/runtime/agentctx/request.go
@@ -44,6 +44,13 @@ type ContextRequest struct {
 	UserMessage string
 	ActiveTags  map[string]bool
 
+	// PinnedRefs names managed-document refs the turn already injects
+	// whole through session-origin context (contact origin policy's
+	// context_refs). Advertisers skip them: a document the prompt
+	// carries in full must not also spend advertisement budget offering
+	// its own summary.
+	PinnedRefs []string
+
 	// IncludeAlways admits the ambient experiential bucket: presence,
 	// episodic memory, working memory, notification history, and the
 	// other continuity context an interactive turn wears. Full-mode

--- a/internal/state/documents/advertise.go
+++ b/internal/state/documents/advertise.go
@@ -44,6 +44,9 @@ type AdvertisableDocument struct {
 	FacetBytes map[string]int `json:"facet_bytes,omitempty"`
 	Tags       []string       `json:"tags,omitempty"`
 	ModifiedAt time.Time      `json:"modified_at"`
+	// AbsPath lets a materializer read the file directly, off the
+	// store's locks — the same reason enumeration skips Refresh.
+	AbsPath string `json:"-"`
 	// Provenance from the document's frontmatter: the loop definition
 	// that owns it, the generated tool that manages it, and the owning
 	// loop's intent in prose ("" when unstamped). LoopIntent is match
@@ -78,7 +81,7 @@ func (s *Store) AdvertisableDocuments(ctx context.Context) ([]AdvertisableDocume
 		return nil, fmt.Errorf("document index not configured")
 	}
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT root, rel_path, title, summary, facets_json, COALESCE(facet_bytes_json, '{}'), tags_json, frontmatter_json, modified_at
+		`SELECT root, rel_path, abs_path, title, summary, facets_json, COALESCE(facet_bytes_json, '{}'), tags_json, frontmatter_json, modified_at
 		 FROM indexed_documents
 		 WHERE LOWER(TRIM(COALESCE(audience, ''))) <> ?
 		 ORDER BY root, rel_path`,
@@ -93,7 +96,7 @@ func (s *Store) AdvertisableDocuments(ctx context.Context) ([]AdvertisableDocume
 	for rows.Next() {
 		var doc AdvertisableDocument
 		var facetsJSON, facetBytesJSON, tagsJSON, metaJSON, modified string
-		if err := rows.Scan(&doc.Root, &doc.Path, &doc.Title, &doc.Summary, &facetsJSON, &facetBytesJSON, &tagsJSON, &metaJSON, &modified); err != nil {
+		if err := rows.Scan(&doc.Root, &doc.Path, &doc.AbsPath, &doc.Title, &doc.Summary, &facetsJSON, &facetBytesJSON, &tagsJSON, &metaJSON, &modified); err != nil {
 			return nil, fmt.Errorf("scan advertisable document: %w", err)
 		}
 		doc.Ref = makeRef(doc.Root, doc.Path)

--- a/internal/state/documents/advertise.go
+++ b/internal/state/documents/advertise.go
@@ -44,9 +44,12 @@ type AdvertisableDocument struct {
 	FacetBytes map[string]int `json:"facet_bytes,omitempty"`
 	Tags       []string       `json:"tags,omitempty"`
 	ModifiedAt time.Time      `json:"modified_at"`
-	// AbsPath lets a materializer read the file directly, off the
-	// store's locks — the same reason enumeration skips Refresh.
-	AbsPath string `json:"-"`
+	// AbsPath and SizeBytes let a materializer read the file directly,
+	// off the store's locks — the same reason enumeration skips Refresh
+	// — and prove before rendering that the bytes on disk are still the
+	// bytes this row described.
+	AbsPath   string `json:"-"`
+	SizeBytes int64  `json:"-"`
 	// Provenance from the document's frontmatter: the loop definition
 	// that owns it, the generated tool that manages it, and the owning
 	// loop's intent in prose ("" when unstamped). LoopIntent is match
@@ -81,7 +84,7 @@ func (s *Store) AdvertisableDocuments(ctx context.Context) ([]AdvertisableDocume
 		return nil, fmt.Errorf("document index not configured")
 	}
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT root, rel_path, abs_path, title, summary, facets_json, COALESCE(facet_bytes_json, '{}'), tags_json, frontmatter_json, modified_at
+		`SELECT root, rel_path, abs_path, title, summary, facets_json, COALESCE(facet_bytes_json, '{}'), tags_json, frontmatter_json, modified_at, size_bytes
 		 FROM indexed_documents
 		 WHERE LOWER(TRIM(COALESCE(audience, ''))) <> ?
 		 ORDER BY root, rel_path`,
@@ -96,7 +99,7 @@ func (s *Store) AdvertisableDocuments(ctx context.Context) ([]AdvertisableDocume
 	for rows.Next() {
 		var doc AdvertisableDocument
 		var facetsJSON, facetBytesJSON, tagsJSON, metaJSON, modified string
-		if err := rows.Scan(&doc.Root, &doc.Path, &doc.AbsPath, &doc.Title, &doc.Summary, &facetsJSON, &facetBytesJSON, &tagsJSON, &metaJSON, &modified); err != nil {
+		if err := rows.Scan(&doc.Root, &doc.Path, &doc.AbsPath, &doc.Title, &doc.Summary, &facetsJSON, &facetBytesJSON, &tagsJSON, &metaJSON, &modified, &doc.SizeBytes); err != nil {
 			return nil, fmt.Errorf("scan advertisable document: %w", err)
 		}
 		doc.Ref = makeRef(doc.Root, doc.Path)

--- a/internal/state/documents/advertiser.go
+++ b/internal/state/documents/advertiser.go
@@ -29,12 +29,16 @@ const (
 	// only orders lexical matches among themselves.
 	advertiseLexicalStrength = 0.60
 
-	// advertiseEnvelopeOverheadBytes covers the one-line JSON envelope a
-	// materialized fragment opens with, on top of the indexed facet
-	// bytes. Estimates are commitments — the discriminator drops a
-	// payload that overruns its own declaration — so the overhead is
-	// budgeted generously.
-	advertiseEnvelopeOverheadBytes = 320
+	// advertiseEnvelopeSlackBytes absorbs the only way a materialized
+	// envelope can differ from the one measured at estimate time: a
+	// concurrent turn re-advertising the same document with different
+	// evidence (a longer match kind), a freshness band appearing as the
+	// document ages across the boundary, or a delta string gaining a
+	// unit. Estimates are commitments — the discriminator drops a
+	// payload that overruns its own declaration — so the drift is
+	// bounded and budgeted rather than guessed at: the envelope itself
+	// is measured exactly, and this covers only cross-turn skew.
+	advertiseEnvelopeSlackBytes = 32
 
 	// Fallback staleness bounds for a document no loop maintains: a
 	// hand-authored dossier is fresh for a day and aging for a week.
@@ -93,7 +97,7 @@ type DocumentAdvertiser struct {
 	// happen on the same turn, but nothing forbids concurrent turns —
 	// hence the lock.
 	mu       sync.RWMutex
-	lastRows map[string]AdvertisableDocument
+	lastRows map[string]advertisedDocument
 	lastNow  time.Time
 }
 
@@ -111,7 +115,7 @@ func NewDocumentAdvertiser(cfg DocumentAdvertiserConfig) *DocumentAdvertiser {
 	if cfg.HomeZone == nil {
 		cfg.HomeZone = time.Local
 	}
-	return &DocumentAdvertiser{cfg: cfg, lastRows: make(map[string]AdvertisableDocument)}
+	return &DocumentAdvertiser{cfg: cfg, lastRows: make(map[string]advertisedDocument)}
 }
 
 // TagContext implements TagContextProvider with an empty eager render:
@@ -141,7 +145,7 @@ func (d *DocumentAdvertiser) ContextAdvertisements(ctx context.Context, req agen
 	subjects := knowledge.SubjectsFromContext(ctx)
 
 	now := d.cfg.Now().In(d.cfg.HomeZone)
-	remembered := make(map[string]AdvertisableDocument)
+	remembered := make(map[string]advertisedDocument)
 	var ads []agentctx.ContextAdvertisement
 	for _, row := range rows {
 		policy := d.cfg.RootPolicy(row.Root)
@@ -161,15 +165,6 @@ func (d *DocumentAdvertiser) ContextAdvertisements(ctx context.Context, req agen
 			continue
 		}
 
-		projections := d.projectionsFor(row)
-		if len(projections) == 0 {
-			// An unfaceted document has only detail to offer, and
-			// automatic selection never takes detail. It stays reachable
-			// through search; the rail is for documents that authored
-			// their own compact projections.
-			continue
-		}
-
 		matches := []agentctx.ContextMatchSignal{{
 			Kind:     agentctx.ContextMatchAmbient,
 			Strength: d.freshnessStrength(row, now),
@@ -181,7 +176,29 @@ func (d *DocumentAdvertiser) ContextAdvertisements(ctx context.Context, req agen
 			matches = append(matches, m)
 		}
 
-		remembered[row.Ref] = row
+		// The envelope is rendered now, with this offer's real values,
+		// and its measured length feeds the estimates. A fixed overhead
+		// constant would be a guess containing the unbounded ref twice;
+		// a measurement cannot be wrong about itself.
+		envelope := promptfmt.MarshalCompact(documentFragmentEnvelope{
+			Ref:          row.Ref,
+			SourceLoop:   row.LoopDefinitionName,
+			Match:        string(bestMatchKind(matches)),
+			UpdatedDelta: promptfmt.FormatDeltaOnly(row.ModifiedAt, now),
+			Stale:        d.freshnessBand(row, now),
+			More:         fmt.Sprintf("doc_read(%s, level=full)", row.Ref),
+		})
+
+		projections := d.projectionsFor(row, len(envelope)+1)
+		if len(projections) == 0 {
+			// An unfaceted document has only detail to offer, and
+			// automatic selection never takes detail. It stays reachable
+			// through search; the rail is for documents that authored
+			// their own compact projections.
+			continue
+		}
+
+		remembered[row.Ref] = advertisedDocument{row: row, envelope: envelope}
 		ads = append(ads, agentctx.ContextAdvertisement{
 			ID:          row.Ref,
 			Source:      "documents",
@@ -217,40 +234,71 @@ func (d *DocumentAdvertiser) ContextAdvertisements(ctx context.Context, req agen
 func (d *DocumentAdvertiser) MaterializeContextAdvertisement(ctx context.Context, _ agentctx.ContextRequest, selection agentctx.ContextSelection) (string, error) {
 	ref := selection.Advertisement.Ref
 	d.mu.RLock()
-	row, ok := d.lastRows[ref]
+	entry, ok := d.lastRows[ref]
 	now := d.lastNow
 	d.mu.RUnlock()
-	if now.IsZero() {
-		now = d.cfg.Now().In(d.cfg.HomeZone)
-	}
 	if !ok {
 		return "", fmt.Errorf("no remembered enumeration row for %s", ref)
+	}
+	if now.IsZero() {
+		now = d.cfg.Now().In(d.cfg.HomeZone)
 	}
 	if err := ctx.Err(); err != nil {
 		return "", err
 	}
+	row := entry.row
 
-	raw, err := os.ReadFile(row.AbsPath)
+	// The offer was made from a row the index measured; the render must
+	// prove the file is still that document. Enumeration deliberately
+	// serves a slightly stale index, so between offer and selection the
+	// file can be republished internal, replaced unsigned, or grown
+	// pathological — and a direct read would carry whatever is there now
+	// into the prompt under the old row's provenance. mtime+size
+	// equality is the same change detector the store's own refresher
+	// trusts to decide whether a file needs re-parsing, so matching it
+	// gives this path exactly the index's guarantees: any change the
+	// refresher would notice refuses the render here, and the next
+	// enumeration re-offers the document as whatever it has become.
+	info, err := os.Stat(row.AbsPath)
+	if err != nil {
+		return "", fmt.Errorf("stat %s: %w", ref, err)
+	}
+	if !info.ModTime().Equal(row.ModifiedAt) || info.Size() != row.SizeBytes {
+		return "", fmt.Errorf("document %s changed since it was offered; declining to render the stale offer", ref)
+	}
+
+	// Same bounded funnel as every other document-file read, then a
+	// fresh audience check from the bytes actually read — the SQL gate
+	// filtered the indexed row; this closes the window on the file.
+	raw, err := readDocumentBytes(row.AbsPath)
 	if err != nil {
 		return "", fmt.Errorf("read %s: %w", ref, err)
 	}
-	payload, _ := looppkg.ParseFacetSections(string(raw))
+	meta, body := splitFrontmatter(string(raw))
+	if isInternalAudienceDocument(meta) {
+		return "", fmt.Errorf("document %s is audience-internal; refusing to materialize", ref)
+	}
+
+	payload, _ := looppkg.ParseFacetSections(body)
 	content := facetContent(payload, selection.Projection.Name)
 	if strings.TrimSpace(content) == "" {
 		return "", fmt.Errorf("document %s no longer carries facet %s", ref, selection.Projection.Name)
 	}
-
 	content = promptfmt.ExpandTemporalTemplates(content, now)
 
-	envelope := documentFragmentEnvelope{
-		Ref:          ref,
-		SourceLoop:   row.LoopDefinitionName,
-		Match:        string(bestMatchKind(selection.Advertisement.Matches)),
-		UpdatedDelta: promptfmt.FormatDeltaOnly(row.ModifiedAt, now),
-		Stale:        d.freshnessBand(row, now),
-		More:         fmt.Sprintf("doc_read(%s, level=full)", ref),
-	}
-	return promptfmt.MarshalCompact(envelope) + "\n" + content, nil
+	// The stored envelope is the one whose length the estimate promised;
+	// prepending those exact bytes keeps the commitment by construction.
+	return entry.envelope + "\n" + content, nil
+}
+
+// advertisedDocument is one remembered enumeration entry: the row a
+// materialization needs to find and validate the file, plus the exact
+// envelope line measured into this offer's estimates. Storing the
+// rendered envelope makes the estimate honest by construction — the
+// materializer prepends these bytes, not a reconstruction of them.
+type advertisedDocument struct {
+	row      AdvertisableDocument
+	envelope string
 }
 
 // documentFragmentEnvelope is the one-line JSON header a materialized
@@ -268,7 +316,7 @@ type documentFragmentEnvelope struct {
 // cost plus envelope overhead, and the full body as detail. Roles come
 // from the facet contract's own table, so the advertiser cannot drift
 // from what the ladder means.
-func (d *DocumentAdvertiser) projectionsFor(row AdvertisableDocument) []agentctx.ContextProjection {
+func (d *DocumentAdvertiser) projectionsFor(row AdvertisableDocument, envelopeBytes int) []agentctx.ContextProjection {
 	var out []agentctx.ContextProjection
 	compact := false
 	for facet, size := range row.FacetBytes {
@@ -283,7 +331,7 @@ func (d *DocumentAdvertiser) projectionsFor(row AdvertisableDocument) []agentctx
 			Name:           facet,
 			Role:           field.ContextRole,
 			Format:         "text/markdown",
-			EstimatedBytes: size + advertiseEnvelopeOverheadBytes,
+			EstimatedBytes: size + envelopeBytes + advertiseEnvelopeSlackBytes,
 		})
 	}
 	if !compact {

--- a/internal/state/documents/advertiser.go
+++ b/internal/state/documents/advertiser.go
@@ -85,11 +85,16 @@ type DocumentAdvertiser struct {
 
 	// lastRows remembers the most recent enumeration by ref, so
 	// materialization can find the file and freshness facts for a
-	// selection without a second index query. Advertise and materialize
+	// selection without a second index query; lastNow is the instant that
+	// enumeration was judged against, reused by every materialization it
+	// feeds so all fragments of one turn share one clock — a prompt must
+	// not say "today" in one fragment and "tomorrow" in the next because
+	// the clock ticked between file reads. Advertise and materialize
 	// happen on the same turn, but nothing forbids concurrent turns —
 	// hence the lock.
 	mu       sync.RWMutex
 	lastRows map[string]AdvertisableDocument
+	lastNow  time.Time
 }
 
 // NewDocumentAdvertiser builds the advertiser. It implements the
@@ -193,6 +198,7 @@ func (d *DocumentAdvertiser) ContextAdvertisements(ctx context.Context, req agen
 	for ref, row := range remembered {
 		d.lastRows[ref] = row
 	}
+	d.lastNow = now
 	d.mu.Unlock()
 	return ads, nil
 }
@@ -212,7 +218,11 @@ func (d *DocumentAdvertiser) MaterializeContextAdvertisement(ctx context.Context
 	ref := selection.Advertisement.Ref
 	d.mu.RLock()
 	row, ok := d.lastRows[ref]
+	now := d.lastNow
 	d.mu.RUnlock()
+	if now.IsZero() {
+		now = d.cfg.Now().In(d.cfg.HomeZone)
+	}
 	if !ok {
 		return "", fmt.Errorf("no remembered enumeration row for %s", ref)
 	}
@@ -230,7 +240,6 @@ func (d *DocumentAdvertiser) MaterializeContextAdvertisement(ctx context.Context
 		return "", fmt.Errorf("document %s no longer carries facet %s", ref, selection.Projection.Name)
 	}
 
-	now := d.cfg.Now().In(d.cfg.HomeZone)
 	content = promptfmt.ExpandTemporalTemplates(content, now)
 
 	envelope := documentFragmentEnvelope{

--- a/internal/state/documents/advertiser.go
+++ b/internal/state/documents/advertiser.go
@@ -1,0 +1,409 @@
+package documents
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/state/knowledge"
+)
+
+// Freshness bands. A continuous freshness score would flip near-ties from
+// turn to turn with no request change, churning selection order for
+// nothing a reader can see; three coarse bands keep ordering stable while
+// still letting a rotting document lose its seat.
+const (
+	advertiseFreshStrength = 0.55
+	advertiseAgingStrength = 0.40
+	advertiseStaleStrength = 0.25
+
+	// advertiseLexicalStrength rides evidence tier "lexical", which
+	// outranks every ambient offer regardless of strength — the value
+	// only orders lexical matches among themselves.
+	advertiseLexicalStrength = 0.60
+
+	// advertiseEnvelopeOverheadBytes covers the one-line JSON envelope a
+	// materialized fragment opens with, on top of the indexed facet
+	// bytes. Estimates are commitments — the discriminator drops a
+	// payload that overruns its own declaration — so the overhead is
+	// budgeted generously.
+	advertiseEnvelopeOverheadBytes = 320
+
+	// Fallback staleness bounds for a document no loop maintains: a
+	// hand-authored dossier is fresh for a day and aging for a week.
+	advertiseDefaultFreshFor = 24 * time.Hour
+	advertiseDefaultAgingFor = 7 * 24 * time.Hour
+)
+
+// DocumentRootAdvertisePolicy is the per-root answer the advertiser needs
+// from configuration: whether this root's documents may offer themselves,
+// and which capability tag gates them when the mode is "tagged". Values
+// mirror config.RootAdvertise*; the string coupling is validated at wiring.
+type DocumentRootAdvertisePolicy struct {
+	Mode        string
+	RequiresTag string
+}
+
+// DocumentAdvertiserConfig wires the advertiser's dependencies.
+type DocumentAdvertiserConfig struct {
+	Store *Store
+	// RootPolicy resolves a root name to its advertise policy. Roots
+	// with no policy (or mode "never") never offer.
+	RootPolicy func(root string) DocumentRootAdvertisePolicy
+	// SleepMax resolves the live sleep ceiling of the loop maintaining a
+	// document, when one does. It must read the live definition
+	// registry, not document frontmatter: publishes stamp no updated
+	// field, and create-time sleep bounds rot when retunes promote
+	// scalars into the running spec.
+	SleepMax func(loopDefinitionName string) (time.Duration, bool)
+	// HomeZone anchors deltas and temporal-template expansion; nil falls
+	// back to the process-local zone.
+	HomeZone *time.Location
+	// Now is overridable for tests; nil means time.Now.
+	Now    func() time.Time
+	Logger *slog.Logger
+}
+
+// DocumentAdvertiser offers faceted documents to the context-advertisement
+// rail (#1431). It is the generic consumer of the corpus: any root that
+// opts in through its advertise policy competes here, with the schedule
+// root's curated calendar as the first production case.
+//
+// Advertising is index-only — one enumeration, no file reads, no store
+// locks — because it runs inside the serial context-assembly walk. Only a
+// selected offer pays for a file read, at materialization, under the
+// discriminator's own detached budget.
+type DocumentAdvertiser struct {
+	cfg DocumentAdvertiserConfig
+
+	// lastRows remembers the most recent enumeration by ref, so
+	// materialization can find the file and freshness facts for a
+	// selection without a second index query. Advertise and materialize
+	// happen on the same turn, but nothing forbids concurrent turns —
+	// hence the lock.
+	mu       sync.RWMutex
+	lastRows map[string]AdvertisableDocument
+}
+
+// NewDocumentAdvertiser builds the advertiser. It implements the
+// assembler's TagContextProvider and ContextAdvertiser contracts
+// structurally: TagContext renders nothing (this provider only offers),
+// and the advertisement path carries all content.
+func NewDocumentAdvertiser(cfg DocumentAdvertiserConfig) *DocumentAdvertiser {
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	if cfg.HomeZone == nil {
+		cfg.HomeZone = time.Local
+	}
+	return &DocumentAdvertiser{cfg: cfg, lastRows: make(map[string]AdvertisableDocument)}
+}
+
+// TagContext implements TagContextProvider with an empty eager render:
+// every byte this provider contributes goes through the advertisement
+// rail, where it competes instead of assuming a seat.
+func (d *DocumentAdvertiser) TagContext(context.Context, agentctx.ContextRequest) (string, error) {
+	return "", nil
+}
+
+// ContextAdvertisements enumerates the corpus and offers every eligible
+// faceted document. Zero file I/O: everything an offer needs — facet
+// presence, exact byte costs, tags, provenance, freshness — was captured
+// at index time.
+func (d *DocumentAdvertiser) ContextAdvertisements(ctx context.Context, req agentctx.ContextRequest) ([]agentctx.ContextAdvertisement, error) {
+	if d.cfg.Store == nil || d.cfg.RootPolicy == nil {
+		return nil, nil
+	}
+	rows, err := d.cfg.Store.AdvertisableDocuments(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("enumerate corpus for advertising: %w", err)
+	}
+
+	pinned := make(map[string]struct{}, len(req.PinnedRefs))
+	for _, ref := range req.PinnedRefs {
+		pinned[ref] = struct{}{}
+	}
+	subjects := knowledge.SubjectsFromContext(ctx)
+
+	now := d.cfg.Now().In(d.cfg.HomeZone)
+	remembered := make(map[string]AdvertisableDocument)
+	var ads []agentctx.ContextAdvertisement
+	for _, row := range rows {
+		policy := d.cfg.RootPolicy(row.Root)
+		switch policy.Mode {
+		case "always":
+		case "tagged":
+			if policy.RequiresTag == "" || !req.ActiveTags[policy.RequiresTag] {
+				continue
+			}
+		default:
+			continue
+		}
+		if _, isPinned := pinned[row.Ref]; isPinned {
+			// Session-origin context refs inject this document whole
+			// already; offering it again would spend rail budget saying
+			// something twice.
+			continue
+		}
+
+		projections := d.projectionsFor(row)
+		if len(projections) == 0 {
+			// An unfaceted document has only detail to offer, and
+			// automatic selection never takes detail. It stays reachable
+			// through search; the rail is for documents that authored
+			// their own compact projections.
+			continue
+		}
+
+		matches := []agentctx.ContextMatchSignal{{
+			Kind:     agentctx.ContextMatchAmbient,
+			Strength: d.freshnessStrength(row, now),
+		}}
+		if m, ok := lexicalMatch(req.UserMessage, row); ok {
+			matches = append(matches, m)
+		}
+		if m, ok := subjectMatch(subjects, row); ok {
+			matches = append(matches, m)
+		}
+
+		remembered[row.Ref] = row
+		ads = append(ads, agentctx.ContextAdvertisement{
+			ID:          row.Ref,
+			Source:      "documents",
+			Kind:        "faceted_document",
+			Ref:         row.Ref,
+			Bucket:      agentctx.ContextBucketRelated,
+			Summary:     advertisementSummary(row),
+			Matches:     matches,
+			Projections: projections,
+		})
+	}
+
+	d.mu.Lock()
+	for ref, row := range remembered {
+		d.lastRows[ref] = row
+	}
+	d.mu.Unlock()
+	return ads, nil
+}
+
+// MaterializeContextAdvertisement reads the selected document — directly
+// from disk, off the store's locks, under the discriminator's detached
+// budget — extracts the selected facet, expands temporal templates, and
+// opens the fragment with a one-line JSON envelope.
+//
+// The envelope is what makes a fragment self-explaining: why it appeared
+// (match kind), where it came from (ref, maintaining loop), how live it is
+// (delta plus staleness band), and the door to more. It also marks the
+// boundary doctrine demands — curator documents are loop-authored prose,
+// and a reader should see them as quoted material with provenance, never
+// as anonymous instructions.
+func (d *DocumentAdvertiser) MaterializeContextAdvertisement(ctx context.Context, _ agentctx.ContextRequest, selection agentctx.ContextSelection) (string, error) {
+	ref := selection.Advertisement.Ref
+	d.mu.RLock()
+	row, ok := d.lastRows[ref]
+	d.mu.RUnlock()
+	if !ok {
+		return "", fmt.Errorf("no remembered enumeration row for %s", ref)
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	raw, err := os.ReadFile(row.AbsPath)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", ref, err)
+	}
+	payload, _ := looppkg.ParseFacetSections(string(raw))
+	content := facetContent(payload, selection.Projection.Name)
+	if strings.TrimSpace(content) == "" {
+		return "", fmt.Errorf("document %s no longer carries facet %s", ref, selection.Projection.Name)
+	}
+
+	now := d.cfg.Now().In(d.cfg.HomeZone)
+	content = promptfmt.ExpandTemporalTemplates(content, now)
+
+	envelope := documentFragmentEnvelope{
+		Ref:          ref,
+		SourceLoop:   row.LoopDefinitionName,
+		Match:        string(bestMatchKind(selection.Advertisement.Matches)),
+		UpdatedDelta: promptfmt.FormatDeltaOnly(row.ModifiedAt, now),
+		Stale:        d.freshnessBand(row, now),
+		More:         fmt.Sprintf("doc_read(%s, level=full)", ref),
+	}
+	return promptfmt.MarshalCompact(envelope) + "\n" + content, nil
+}
+
+// documentFragmentEnvelope is the one-line JSON header a materialized
+// fragment opens with.
+type documentFragmentEnvelope struct {
+	Ref          string `json:"ref"`
+	SourceLoop   string `json:"source_loop,omitempty"`
+	Match        string `json:"match"`
+	UpdatedDelta string `json:"updated_delta"`
+	Stale        string `json:"stale,omitempty"`
+	More         string `json:"more"`
+}
+
+// projectionsFor offers each declared compact facet at its indexed byte
+// cost plus envelope overhead, and the full body as detail. Roles come
+// from the facet contract's own table, so the advertiser cannot drift
+// from what the ladder means.
+func (d *DocumentAdvertiser) projectionsFor(row AdvertisableDocument) []agentctx.ContextProjection {
+	var out []agentctx.ContextProjection
+	compact := false
+	for facet, size := range row.FacetBytes {
+		field, ok := looppkg.FacetFieldByKey(facet)
+		if !ok || size <= 0 {
+			continue
+		}
+		if field.ContextRole != agentctx.ContextRoleDetail {
+			compact = true
+		}
+		out = append(out, agentctx.ContextProjection{
+			Name:           facet,
+			Role:           field.ContextRole,
+			Format:         "text/markdown",
+			EstimatedBytes: size + advertiseEnvelopeOverheadBytes,
+		})
+	}
+	if !compact {
+		return nil
+	}
+	return out
+}
+
+// freshnessBand places a document in one of three coarse bands against
+// the sleep ceiling of the loop that maintains it — the live registry
+// value, because frontmatter carries no updated stamp and create-time
+// sleep bounds rot after retunes. A document no loop maintains uses the
+// hand-authored defaults.
+func (d *DocumentAdvertiser) freshnessBand(row AdvertisableDocument, now time.Time) string {
+	freshFor := advertiseDefaultFreshFor
+	agingFor := advertiseDefaultAgingFor
+	if row.LoopDefinitionName != "" && d.cfg.SleepMax != nil {
+		if sleepMax, ok := d.cfg.SleepMax(row.LoopDefinitionName); ok && sleepMax > 0 {
+			// Fresh means "within one wake of true": the loop had no
+			// chance to republish yet. Aging tolerates a few missed or
+			// quiet wakes before the document reads as stale.
+			freshFor = sleepMax + sleepMax/2
+			agingFor = 4 * sleepMax
+		}
+	}
+	age := now.Sub(row.ModifiedAt)
+	switch {
+	case age <= freshFor:
+		return ""
+	case age <= agingFor:
+		return "aging"
+	default:
+		return "stale"
+	}
+}
+
+func (d *DocumentAdvertiser) freshnessStrength(row AdvertisableDocument, now time.Time) float64 {
+	switch d.freshnessBand(row, now) {
+	case "":
+		return advertiseFreshStrength
+	case "aging":
+		return advertiseAgingStrength
+	default:
+		return advertiseStaleStrength
+	}
+}
+
+// lexicalMatch reports whether the user's message names this document —
+// by a tag, or by a distinctive word of its title. Distinctive means four
+// runes or longer: matching "the" to a title would promote every document
+// on every turn, which is ambient relevance wearing a costume.
+func lexicalMatch(userMessage string, row AdvertisableDocument) (agentctx.ContextMatchSignal, bool) {
+	message := strings.ToLower(userMessage)
+	if strings.TrimSpace(message) == "" {
+		return agentctx.ContextMatchSignal{}, false
+	}
+	for _, tag := range row.Tags {
+		if tag = strings.ToLower(strings.TrimSpace(tag)); len([]rune(tag)) >= 3 && strings.Contains(message, tag) {
+			return agentctx.ContextMatchSignal{Kind: agentctx.ContextMatchLexical, Strength: advertiseLexicalStrength}, true
+		}
+	}
+	for _, word := range strings.FieldsFunc(strings.ToLower(row.Title), func(r rune) bool {
+		return ('a' > r || r > 'z') && ('0' > r || r > '9') && r != '-'
+	}) {
+		if len([]rune(word)) >= 4 && strings.Contains(message, word) {
+			return agentctx.ContextMatchSignal{Kind: agentctx.ContextMatchLexical, Strength: advertiseLexicalStrength}, true
+		}
+	}
+	return agentctx.ContextMatchSignal{}, false
+}
+
+// subjectMatch reports whether one of the turn's subject handles (#986's
+// cross-silo vocabulary, placed on ctx by wake bridges) exactly matches a
+// document tag. This is the strongest evidence a document can carry: the
+// turn is already about the thing the document is about.
+func subjectMatch(subjects []string, row AdvertisableDocument) (agentctx.ContextMatchSignal, bool) {
+	if len(subjects) == 0 {
+		return agentctx.ContextMatchSignal{}, false
+	}
+	tags := make(map[string]struct{}, len(row.Tags))
+	for _, tag := range row.Tags {
+		tags[strings.ToLower(strings.TrimSpace(tag))] = struct{}{}
+	}
+	for _, subject := range subjects {
+		if _, ok := tags[strings.ToLower(strings.TrimSpace(subject))]; ok {
+			return agentctx.ContextMatchSignal{Kind: agentctx.ContextMatchExactSubject, Strength: 1}, true
+		}
+	}
+	return agentctx.ContextMatchSignal{}, false
+}
+
+func advertisementSummary(row AdvertisableDocument) string {
+	if s := strings.TrimSpace(row.Summary); s != "" {
+		return s
+	}
+	if s := strings.TrimSpace(row.Title); s != "" {
+		return s
+	}
+	return row.Ref
+}
+
+func bestMatchKind(matches []agentctx.ContextMatchSignal) agentctx.ContextMatchKind {
+	best := agentctx.ContextMatchAmbient
+	bestRank := 0
+	rank := map[agentctx.ContextMatchKind]int{
+		agentctx.ContextMatchAmbient: 1, agentctx.ContextMatchLexical: 2,
+		agentctx.ContextMatchSemantic: 3, agentctx.ContextMatchAlias: 4,
+		agentctx.ContextMatchExactSubject: 5,
+	}
+	for _, m := range matches {
+		if r := rank[m.Kind]; r > bestRank {
+			best, bestRank = m.Kind, r
+		}
+	}
+	return best
+}
+
+// facetContent selects one projection's text from a parsed facet payload.
+func facetContent(payload looppkg.FacetPayload, name string) string {
+	switch name {
+	case string(looppkg.OutputFacetStatusLine):
+		return payload.StatusLine
+	case string(looppkg.OutputFacetTeaser):
+		return payload.Teaser
+	case string(looppkg.OutputFacetDigest):
+		return payload.Digest
+	case "full":
+		return payload.Full
+	default:
+		return ""
+	}
+}

--- a/internal/state/documents/advertiser_test.go
+++ b/internal/state/documents/advertiser_test.go
@@ -2,6 +2,8 @@ package documents
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -118,7 +120,7 @@ func TestDocumentAdvertiserProjectionsCarryIndexedCosts(t *testing.T) {
 	roles := map[string]agentctx.ContextProjectionRole{}
 	for _, p := range ads[0].Projections {
 		roles[p.Name] = p.Role
-		if p.EstimatedBytes <= advertiseEnvelopeOverheadBytes {
+		if p.EstimatedBytes <= advertiseEnvelopeSlackBytes {
 			t.Fatalf("projection %s estimate %d does not cover content plus envelope", p.Name, p.EstimatedBytes)
 		}
 	}
@@ -274,6 +276,11 @@ Utah trip Sep 18 ({{delta:2026-09-18}})
 
 Body.
 `)
+	// The fixture's first Refresh ran moments ago; without disabling the
+	// throttle this second one would no-op, the index would still hold
+	// the pre-rewrite row, and the materializer's changed-since-offered
+	// check would (correctly) refuse to render.
+	store.refreshInterval = 0
 	if err := store.Refresh(context.Background()); err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
@@ -301,5 +308,111 @@ Body.
 	}
 	if strings.Contains(out, "{{delta:") {
 		t.Fatalf("raw template leaked to the reader surface: %q", out)
+	}
+}
+
+func TestDocumentAdvertiserRefusesAFileChangedSinceTheOffer(t *testing.T) {
+	store, dirs := newAdvertiseStore(t)
+	adv := NewDocumentAdvertiser(DocumentAdvertiserConfig{
+		Store:      store,
+		RootPolicy: func(string) DocumentRootAdvertisePolicy { return DocumentRootAdvertisePolicy{Mode: "always"} },
+		HomeZone:   time.UTC,
+	})
+	ads, err := adv.ContextAdvertisements(context.Background(), agentctx.ContextRequest{})
+	if err != nil || len(ads) != 1 {
+		t.Fatalf("ContextAdvertisements: %v (%d)", err, len(ads))
+	}
+
+	// The file changes after the offer and before selection — the shape
+	// enumeration's deliberate staleness makes possible. The stale index
+	// row must not lend its provenance to whatever is on disk now.
+	writeFile(t, filepath.Join(dirs["beta"], "dossier.md"), "---\ntitle: Swapped\n---\n\n## Status Line\n\nnot what was offered\n")
+
+	_, err = adv.MaterializeContextAdvertisement(context.Background(), agentctx.ContextRequest{}, agentctx.ContextSelection{
+		Advertisement: ads[0],
+		Projection:    agentctx.ContextProjection{Name: "status_line", Role: agentctx.ContextRoleSignal, Format: "text/markdown", EstimatedBytes: 512},
+	})
+	if err == nil || !strings.Contains(err.Error(), "changed since it was offered") {
+		t.Fatalf("want changed-since-offered refusal, got %v", err)
+	}
+}
+
+func TestDocumentAdvertiserRefusesAFreshlyInternalDocument(t *testing.T) {
+	store, dirs := newAdvertiseStore(t)
+	adv := NewDocumentAdvertiser(DocumentAdvertiserConfig{
+		Store:      store,
+		RootPolicy: func(string) DocumentRootAdvertisePolicy { return DocumentRootAdvertisePolicy{Mode: "always"} },
+		HomeZone:   time.UTC,
+	})
+	ads, err := adv.ContextAdvertisements(context.Background(), agentctx.ContextRequest{})
+	if err != nil || len(ads) != 1 {
+		t.Fatalf("ContextAdvertisements: %v (%d)", err, len(ads))
+	}
+
+	// Republished as internal after the offer. The mtime/size check
+	// would already refuse this rewrite; the fresh audience check is the
+	// second lock on the same door, pinned here by defeating the first:
+	// remember the row, rewrite the file, then restore the remembered
+	// stat identity is impossible — so instead assert through the
+	// internal seam that the audience gate alone refuses.
+	d := adv
+	d.mu.RLock()
+	entry := d.lastRows[ads[0].Ref]
+	d.mu.RUnlock()
+
+	internalBody := "---\naudience: internal\n---\n\n## Status Line\n\nsecret\n"
+	writeFile(t, filepath.Join(dirs["beta"], "dossier.md"), internalBody)
+	info, err := os.Stat(filepath.Join(dirs["beta"], "dossier.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry.row.ModifiedAt = info.ModTime()
+	entry.row.SizeBytes = info.Size()
+	d.mu.Lock()
+	d.lastRows[ads[0].Ref] = entry
+	d.mu.Unlock()
+
+	_, err = adv.MaterializeContextAdvertisement(context.Background(), agentctx.ContextRequest{}, agentctx.ContextSelection{
+		Advertisement: ads[0],
+		Projection:    agentctx.ContextProjection{Name: "status_line", Role: agentctx.ContextRoleSignal, Format: "text/markdown", EstimatedBytes: 512},
+	})
+	if err == nil || !strings.Contains(err.Error(), "audience-internal") {
+		t.Fatalf("want audience-internal refusal, got %v", err)
+	}
+}
+
+func TestDocumentAdvertiserEstimatesCoverTheMeasuredEnvelope(t *testing.T) {
+	store, _ := newAdvertiseStore(t)
+	fixed := time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
+	adv := NewDocumentAdvertiser(DocumentAdvertiserConfig{
+		Store:      store,
+		RootPolicy: func(string) DocumentRootAdvertisePolicy { return DocumentRootAdvertisePolicy{Mode: "always"} },
+		HomeZone:   time.UTC,
+		Now:        func() time.Time { return fixed },
+	})
+	ads, err := adv.ContextAdvertisements(context.Background(), agentctx.ContextRequest{})
+	if err != nil || len(ads) != 1 {
+		t.Fatalf("ContextAdvertisements: %v (%d)", err, len(ads))
+	}
+
+	// The commitment the discriminator enforces: rendered bytes never
+	// exceed the declared estimate. Estimates are built from the exact
+	// stored envelope plus the indexed facet bytes, so this must hold
+	// for every offered projection — including one with a long ref that
+	// a fixed overhead constant would have under-counted.
+	for _, p := range ads[0].Projections {
+		if p.Role == agentctx.ContextRoleDetail {
+			continue
+		}
+		out, err := adv.MaterializeContextAdvertisement(context.Background(), agentctx.ContextRequest{}, agentctx.ContextSelection{
+			Advertisement: ads[0],
+			Projection:    p,
+		})
+		if err != nil {
+			t.Fatalf("Materialize %s: %v", p.Name, err)
+		}
+		if len(out) > p.EstimatedBytes {
+			t.Fatalf("projection %s rendered %d bytes over its own estimate %d", p.Name, len(out), p.EstimatedBytes)
+		}
 	}
 }

--- a/internal/state/documents/advertiser_test.go
+++ b/internal/state/documents/advertiser_test.go
@@ -1,0 +1,305 @@
+package documents
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+	"github.com/nugget/thane-ai-agent/internal/state/knowledge"
+)
+
+// advertiserUnderTest builds a DocumentAdvertiser over the shared
+// advertise-store fixture: root "beta" holds the faceted curator dossier
+// (plus an internal notes doc), root "alpha" holds plain documents.
+func advertiserUnderTest(t *testing.T, policies map[string]DocumentRootAdvertisePolicy, sleepMax func(string) (time.Duration, bool)) *DocumentAdvertiser {
+	t.Helper()
+	store, _ := newAdvertiseStore(t)
+	return NewDocumentAdvertiser(DocumentAdvertiserConfig{
+		Store: store,
+		RootPolicy: func(root string) DocumentRootAdvertisePolicy {
+			return policies[root]
+		},
+		SleepMax: sleepMax,
+		HomeZone: time.UTC,
+		Now:      func() time.Time { return time.Now() },
+	})
+}
+
+func TestDocumentAdvertiserHonorsRootPolicy(t *testing.T) {
+	tests := []struct {
+		name     string
+		policies map[string]DocumentRootAdvertisePolicy
+		req      agentctx.ContextRequest
+		wantRefs []string
+	}{
+		{
+			name:     "no policy offers nothing",
+			policies: map[string]DocumentRootAdvertisePolicy{},
+			wantRefs: nil,
+		},
+		{
+			name: "always offers the faceted document",
+			policies: map[string]DocumentRootAdvertisePolicy{
+				"beta": {Mode: "always"},
+			},
+			wantRefs: []string{"beta:dossier.md"},
+		},
+		{
+			name: "tagged stays quiet without its tag",
+			policies: map[string]DocumentRootAdvertisePolicy{
+				"beta": {Mode: "tagged", RequiresTag: "travel"},
+			},
+			wantRefs: nil,
+		},
+		{
+			name: "tagged offers while its tag is active",
+			policies: map[string]DocumentRootAdvertisePolicy{
+				"beta": {Mode: "tagged", RequiresTag: "travel"},
+			},
+			req:      agentctx.ContextRequest{ActiveTags: map[string]bool{"travel": true}},
+			wantRefs: []string{"beta:dossier.md"},
+		},
+		{
+			// alpha's documents are unfaceted: detail is all they could
+			// offer, and automatic selection never takes detail — they
+			// stay reachable through search instead of burning offers.
+			name: "an always root with only unfaceted documents offers nothing",
+			policies: map[string]DocumentRootAdvertisePolicy{
+				"alpha": {Mode: "always"},
+			},
+			wantRefs: nil,
+		},
+		{
+			name: "a pinned ref is not offered twice",
+			policies: map[string]DocumentRootAdvertisePolicy{
+				"beta": {Mode: "always"},
+			},
+			req:      agentctx.ContextRequest{PinnedRefs: []string{"beta:dossier.md"}},
+			wantRefs: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			adv := advertiserUnderTest(t, tc.policies, nil)
+			ads, err := adv.ContextAdvertisements(context.Background(), tc.req)
+			if err != nil {
+				t.Fatalf("ContextAdvertisements: %v", err)
+			}
+			var refs []string
+			for _, ad := range ads {
+				refs = append(refs, ad.Ref)
+			}
+			if len(refs) != len(tc.wantRefs) {
+				t.Fatalf("offered %v, want %v", refs, tc.wantRefs)
+			}
+			for i := range refs {
+				if refs[i] != tc.wantRefs[i] {
+					t.Fatalf("offered %v, want %v", refs, tc.wantRefs)
+				}
+			}
+		})
+	}
+}
+
+func TestDocumentAdvertiserProjectionsCarryIndexedCosts(t *testing.T) {
+	adv := advertiserUnderTest(t, map[string]DocumentRootAdvertisePolicy{"beta": {Mode: "always"}}, nil)
+
+	ads, err := adv.ContextAdvertisements(context.Background(), agentctx.ContextRequest{})
+	if err != nil || len(ads) != 1 {
+		t.Fatalf("ContextAdvertisements: %v (%d ads)", err, len(ads))
+	}
+	if err := ads[0].Validate(); err != nil {
+		t.Fatalf("advertisement does not satisfy the contract: %v", err)
+	}
+
+	roles := map[string]agentctx.ContextProjectionRole{}
+	for _, p := range ads[0].Projections {
+		roles[p.Name] = p.Role
+		if p.EstimatedBytes <= advertiseEnvelopeOverheadBytes {
+			t.Fatalf("projection %s estimate %d does not cover content plus envelope", p.Name, p.EstimatedBytes)
+		}
+	}
+	// The dossier declares status_line + teaser (both role signal) and a
+	// full body (detail). Roles come from the facet contract's table.
+	if roles["status_line"] != agentctx.ContextRoleSignal || roles["teaser"] != agentctx.ContextRoleSignal {
+		t.Fatalf("compact facets should carry role signal, got %v", roles)
+	}
+	if roles["full"] != agentctx.ContextRoleDetail {
+		t.Fatalf("full should carry role detail, got %v", roles)
+	}
+}
+
+func TestDocumentAdvertiserFreshnessBandsAgainstTheLiveSleepCeiling(t *testing.T) {
+	base := time.Now()
+	tests := []struct {
+		name         string
+		age          time.Duration
+		sleepMax     time.Duration
+		wantStrength float64
+	}{
+		{"within one wake is fresh", 4 * time.Hour, 6 * time.Hour, advertiseFreshStrength},
+		{"a few quiet wakes is aging", 20 * time.Hour, 6 * time.Hour, advertiseAgingStrength},
+		{"beyond four wakes is stale", 30 * time.Hour, 6 * time.Hour, advertiseStaleStrength},
+		{"no maintaining loop uses the daily default", 20 * time.Hour, 0, advertiseFreshStrength},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sleepMax := func(string) (time.Duration, bool) { return tc.sleepMax, tc.sleepMax > 0 }
+			adv := advertiserUnderTest(t, map[string]DocumentRootAdvertisePolicy{"beta": {Mode: "always"}}, sleepMax)
+			adv.cfg.Now = func() time.Time { return base }
+
+			row := AdvertisableDocument{ModifiedAt: base.Add(-tc.age), LoopDefinitionName: "trip-curator"}
+			if got := adv.freshnessStrength(row, base); got != tc.wantStrength {
+				t.Fatalf("strength = %v, want %v", got, tc.wantStrength)
+			}
+		})
+	}
+}
+
+func TestDocumentAdvertiserMatchEvidence(t *testing.T) {
+	adv := advertiserUnderTest(t, map[string]DocumentRootAdvertisePolicy{"beta": {Mode: "always"}}, nil)
+
+	// A user message naming a doc tag earns lexical evidence.
+	ads, err := adv.ContextAdvertisements(context.Background(),
+		agentctx.ContextRequest{UserMessage: "what's the plan for the utah drive?"})
+	if err != nil || len(ads) != 1 {
+		t.Fatalf("ContextAdvertisements: %v (%d)", err, len(ads))
+	}
+	kinds := map[agentctx.ContextMatchKind]bool{}
+	for _, m := range ads[0].Matches {
+		kinds[m.Kind] = true
+	}
+	if !kinds[agentctx.ContextMatchAmbient] || !kinds[agentctx.ContextMatchLexical] {
+		t.Fatalf("want ambient + lexical evidence, got %v", ads[0].Matches)
+	}
+
+	// A subject handle on ctx matching a doc tag is the strongest evidence.
+	ctx := knowledge.WithSubjects(context.Background(), []string{"utah"})
+	ads, err = adv.ContextAdvertisements(ctx, agentctx.ContextRequest{})
+	if err != nil || len(ads) != 1 {
+		t.Fatalf("ContextAdvertisements with subjects: %v (%d)", err, len(ads))
+	}
+	found := false
+	for _, m := range ads[0].Matches {
+		if m.Kind == agentctx.ContextMatchExactSubject && m.Strength == 1 {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("want exact_subject evidence, got %v", ads[0].Matches)
+	}
+}
+
+func TestDocumentAdvertiserMaterializesWithEnvelopeAndTemplates(t *testing.T) {
+	store, dirs := newAdvertiseStore(t)
+	_ = dirs
+	fixedNow := time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
+	adv := NewDocumentAdvertiser(DocumentAdvertiserConfig{
+		Store:      store,
+		RootPolicy: func(string) DocumentRootAdvertisePolicy { return DocumentRootAdvertisePolicy{Mode: "always"} },
+		HomeZone:   time.UTC,
+		Now:        func() time.Time { return fixedNow },
+	})
+
+	// Rewrite the dossier teaser to carry a temporal template, then
+	// re-index so enumeration sees it.
+	ads, err := adv.ContextAdvertisements(context.Background(), agentctx.ContextRequest{})
+	if err != nil || len(ads) == 0 {
+		t.Fatalf("ContextAdvertisements: %v (%d)", err, len(ads))
+	}
+	var dossier agentctx.ContextAdvertisement
+	for _, ad := range ads {
+		if ad.Ref == "beta:dossier.md" {
+			dossier = ad
+		}
+	}
+	var teaser agentctx.ContextProjection
+	for _, p := range dossier.Projections {
+		if p.Name == "teaser" {
+			teaser = p
+		}
+	}
+	if teaser.Name == "" {
+		t.Fatalf("dossier offered no teaser projection: %v", dossier.Projections)
+	}
+
+	out, err := adv.MaterializeContextAdvertisement(context.Background(), agentctx.ContextRequest{}, agentctx.ContextSelection{
+		Advertisement: dossier,
+		Projection:    teaser,
+	})
+	if err != nil {
+		t.Fatalf("Materialize: %v", err)
+	}
+	lines := strings.SplitN(out, "\n", 2)
+	if len(lines) != 2 {
+		t.Fatalf("fragment should open with an envelope line, got: %q", out)
+	}
+	for _, want := range []string{`"ref":"beta:dossier.md"`, `"source_loop":"trip-curator"`, `"match":"ambient"`, `"updated_delta":"`, `"more":"doc_read(beta:dossier.md, level=full)"`} {
+		if !strings.Contains(lines[0], want) {
+			t.Fatalf("envelope missing %s: %s", want, lines[0])
+		}
+	}
+	if !strings.Contains(lines[1], "Why the dossier matters") {
+		t.Fatalf("fragment should carry the teaser content, got: %q", lines[1])
+	}
+
+	// A selection for a facet the document no longer carries errors
+	// loudly instead of rendering an empty fragment.
+	_, err = adv.MaterializeContextAdvertisement(context.Background(), agentctx.ContextRequest{}, agentctx.ContextSelection{
+		Advertisement: dossier,
+		Projection:    agentctx.ContextProjection{Name: "digest", Role: agentctx.ContextRoleContext, Format: "text/markdown", EstimatedBytes: 64},
+	})
+	if err == nil || !strings.Contains(err.Error(), "no longer carries facet") {
+		t.Fatalf("want missing-facet error, got %v", err)
+	}
+}
+
+func TestDocumentAdvertiserExpandsTemporalTemplatesAtMaterialization(t *testing.T) {
+	store, dirs := newAdvertiseStore(t)
+	writeFile(t, dirs["beta"]+"/dossier.md", `---
+title: Utah Trip Dossier
+tags: [travel, utah]
+managed_by: loop_output_trip
+loop_definition_name: trip-curator
+---
+
+## Status Line
+
+Utah trip Sep 18 ({{delta:2026-09-18}})
+
+## Details
+
+Body.
+`)
+	if err := store.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	fixedNow := time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
+	adv := NewDocumentAdvertiser(DocumentAdvertiserConfig{
+		Store:      store,
+		RootPolicy: func(string) DocumentRootAdvertisePolicy { return DocumentRootAdvertisePolicy{Mode: "always"} },
+		HomeZone:   time.UTC,
+		Now:        func() time.Time { return fixedNow },
+	})
+
+	ads, err := adv.ContextAdvertisements(context.Background(), agentctx.ContextRequest{})
+	if err != nil || len(ads) == 0 {
+		t.Fatalf("ContextAdvertisements: %v", err)
+	}
+	out, err := adv.MaterializeContextAdvertisement(context.Background(), agentctx.ContextRequest{}, agentctx.ContextSelection{
+		Advertisement: ads[0],
+		Projection:    agentctx.ContextProjection{Name: "status_line", Role: agentctx.ContextRoleSignal, Format: "text/markdown", EstimatedBytes: 512},
+	})
+	if err != nil {
+		t.Fatalf("Materialize: %v", err)
+	}
+	if !strings.Contains(out, "Utah trip Sep 18 (+20d)") {
+		t.Fatalf("temporal template should expand at materialization, got: %q", out)
+	}
+	if strings.Contains(out, "{{delta:") {
+		t.Fatalf("raw template leaked to the reader surface: %q", out)
+	}
+}


### PR DESCRIPTION
Phase 1's capstone for #1431 — **draft until #1434 and #1435 merge** (this branch contains both; the diff collapses to its own three commits once they land).

## What this adds on top of the groundwork

**The `DocumentAdvertiser`** (`internal/state/documents/advertiser.go`): enumerates the corpus through #1434's no-Refresh read path, offers every eligible faceted document with costs taken from indexed byte measurements (+ budgeted envelope overhead — estimates are commitments, the discriminator drops overruns), and materializes only selected projections — direct disk read, off the store's locks, under the rail's detached budget.

**Root policy** (`advertise: never|tagged|always` on `RootContextPolicy`, default never): a corpus earns ambient attention by explicit opt-in. `tagged` requires `requires_tag`, whose validation loosens to accept advertising as the second capability-aware door it can gate. The schedule root's prod config gains one line when this deploys.

**Evidence**: ambient strength in three coarse freshness bands against the maintaining loop's **live** sleep ceiling (registry lookup — frontmatter stamps no update time and its create-time sleep bounds rot after retunes); lexical when the user message names a doc tag or distinctive title word; `exact_subject` at full strength when a turn subject handle matches a doc tag. Bands, not continuous decay: a decaying float flips near-ties turn-to-turn with nothing a reader can see.

**The envelope**: every fragment opens with one JSON line — `ref`, `source_loop`, `match`, `updated_delta`, `stale`, `more: doc_read(...)`. Provenance, the data-not-instruction boundary for loop-authored prose, freshness, and the escalation door in ~120 bytes. Temporal templates (#1435) expand at this same seam, so curated countdowns read true however stale the wake.

**Rail properties** (assembler-side): selection counts genuinely-selectable offers it refused and renders `[N context offer(s) withheld …]` — a capped rail must never read as complete; materialization detaches from the walk's depleted deadline into its own 1.5s bound (the self-assessment precedent) so the turn's best content isn't the first casualty of a slow turn. Plus `PinnedRefs` on `ContextRequest`: docs the session-origin policy injects whole are never offered twice.

**Deliberate exclusions**: unfaceted documents (detail-only, never auto-selected — search reaches them); `audience: internal` (SQL gate from #1434); empty eager render (every byte competes).

## Test plan
- [x] `just ci` green (pinned toolchain)
- [x] Policy gating table (never/always/tagged±tag/pinned/unfaceted), contract validation on emitted ads
- [x] Freshness bands against live sleep ceiling + no-loop defaults
- [x] Lexical + subject evidence; envelope fields; missing-facet loud error; `{{delta:...}}` expands at materialization and never leaks raw
- [x] Withheld count/line and detach tests (mutation-verified in their own commit)
- [ ] Verified against production once deployed: add `advertise: always` to the schedule root, watch the calendar dossier's signal appear in Related context with an honest envelope

Refs #1431. Stacked on #1434 + #1435.