### PR TITLE
The mechanical calendar block: wall-clock truth, unconditionally

### DIFF
--- a/docs/model-facing-context.md
+++ b/docs/model-facing-context.md
@@ -427,6 +427,7 @@ right track.
 Good places to look for existing patterns:
 
 - `internal/model/promptfmt/timefmt.go`
+- `internal/integrations/companion/calendar_snapshot.go`
 - `internal/state/awareness/entity_format.go`
 - `loops/ego.md` — an instruction document shaped by the job each form
   does (prose stance, numbered protocol, constraints at their point of

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -249,7 +249,27 @@ func (a *App) initServers(s *newState) error {
 		// mid-session. A Mac-authored tool shadows the legacy floor by name.
 		registrar := tools.NewCompanionRegistrar(a.companionRegistry, companionHome, logger)
 		a.loop.SetDynamicToolSource(registrar)
-		a.companionRegistry.SetOnChange(registrar.Rebuild)
+
+		// The mechanical calendar block (#1432): an in-memory snapshot of
+		// every connected account's near-term calendar, refreshed on the
+		// runner's own clock and rendered into Live State every turn.
+		// Wall-clock truth deliberately does not ride the advertisement
+		// rail — ambient evidence loses to request-matched offers by
+		// design, and today's calendar must not lose a lottery on busy
+		// turns. The registry's single change callback fans out to both
+		// consumers: tool synthesis rebuilds, and the snapshot refreshes
+		// so a Mac reconnecting after a night away repopulates without
+		// waiting out the interval.
+		calendarSnapshot := companion.NewCalendarSnapshot(a.companionRegistry, companionHome, logger)
+		a.companionRegistry.SetOnChange(func() {
+			registrar.Rebuild()
+			calendarSnapshot.NudgeRefresh()
+		})
+		a.loop.RegisterAlwaysContextProvider(calendarSnapshot)
+		a.deferWorker("companion-calendar-snapshot", func(ctx context.Context) error {
+			go calendarSnapshot.Run(ctx)
+			return nil
+		})
 
 		// On companion-tagged turns, tell the model which companions are
 		// connected and what they currently offer (uncached live state).

--- a/internal/integrations/companion/calendar_snapshot.go
+++ b/internal/integrations/companion/calendar_snapshot.go
@@ -80,16 +80,16 @@ type accountCalendarSnapshot struct {
 	Truncated bool
 }
 
-// CalendarSnapshot keeps an in-memory, background-refreshed view of every
-// connected companion account's near-term calendar, and renders it as an
-// always-on Live State block — the wall-clock-truth half of the #1432
-// design. Assembly only ever reads memory; the companion is called on the
-// runner's own clock, under its own bound, never inside a turn.
 // calendarProviderLister enumerates the connected providers; a func
 // rather than an interface, matching the registrar's injection style, so
 // tests supply a fake list without a fake registry.
 type calendarProviderLister func() []ProviderInfo
 
+// CalendarSnapshot keeps an in-memory, background-refreshed view of every
+// connected companion account's near-term calendar, and renders it as an
+// always-on Live State block — the wall-clock-truth half of the #1432
+// design. Assembly only ever reads memory; the companion is called on the
+// runner's own clock, under its own bound, never inside a turn.
 type CalendarSnapshot struct {
 	list     calendarProviderLister
 	call     func(ctx context.Context, req CallRequest) (json.RawMessage, error)
@@ -428,7 +428,7 @@ func (s *CalendarSnapshot) TagContext(context.Context, agentctx.ContextRequest) 
 type renderedCalendarAccount struct {
 	Account     string                  `json:"account"`
 	Client      string                  `json:"client,omitempty"`
-	SnapshotAge string                  `json:"snapshot_age"`
+	SnapshotAge string                  `json:"snapshot_age,omitempty"`
 	Stale       bool                    `json:"stale,omitempty"`
 	Offline     bool                    `json:"offline,omitempty"`
 	ActiveNow   []renderedCalendarEvent `json:"active_now,omitempty"`
@@ -593,13 +593,20 @@ func allDayRange(event snapshotCalendarEvent) (first, last time.Time, ok bool) {
 	}
 	last = first
 	if event.End != "" {
-		if parsed, dateOnly, ok := parseSnapshotDate(event.End); ok {
-			if !dateOnly {
-				parsed = parsed.AddDate(0, 0, -1)
-			}
-			if !parsed.Before(first) {
-				last = parsed
-			}
+		parsed, dateOnly, ok := parseSnapshotDate(event.End)
+		if !ok {
+			// A non-empty end that does not parse is companion drift,
+			// not an omission — rendering a confident one-day event from
+			// it would state a range nobody published. The tool renderer
+			// marks the same payload unparsed; the ambient block's
+			// equivalent of loud is absence.
+			return time.Time{}, time.Time{}, false
+		}
+		if !dateOnly {
+			parsed = parsed.AddDate(0, 0, -1)
+		}
+		if !parsed.Before(first) {
+			last = parsed
 		}
 	}
 	return first, last, true
@@ -701,8 +708,21 @@ func parseSnapshotSpan(event snapshotCalendarEvent) (start, end time.Time, endOK
 	if err != nil {
 		return time.Time{}, time.Time{}, false, false
 	}
-	end, err = time.Parse(time.RFC3339, strings.TrimSpace(event.End))
-	endOK = err == nil && end.After(start)
+	trimmedEnd := strings.TrimSpace(event.End)
+	if trimmedEnd == "" {
+		// A genuinely absent end gets the synthetic minute so active-now
+		// has an interval to classify; the invention is never rendered.
+		return start, start.Add(time.Minute), false, true
+	}
+	end, err = time.Parse(time.RFC3339, trimmedEnd)
+	if err != nil {
+		// A non-empty end that does not parse is drift, not omission —
+		// classifying corrupted data as active would present it with
+		// more confidence than the tool renderer, which marks the same
+		// payload unparsed. Skip; the tool remains the loud surface.
+		return time.Time{}, time.Time{}, false, false
+	}
+	endOK = end.After(start)
 	if !endOK {
 		end = start.Add(time.Minute)
 	}

--- a/internal/integrations/companion/calendar_snapshot.go
+++ b/internal/integrations/companion/calendar_snapshot.go
@@ -1,0 +1,655 @@
+package companion
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+)
+
+// Calendar snapshot defaults. The window and limit describe what ambient
+// context needs — today and tomorrow, a few dozen events — not what the
+// calendar tools can reach; anything beyond this is a pull through
+// macos_calendar_events.
+const (
+	calendarSnapshotWindow   = 48 * time.Hour
+	calendarSnapshotLimit    = 30
+	calendarSnapshotInterval = 15 * time.Minute
+
+	// calendarSnapshotCallTimeout bounds one refresh call, mirroring the
+	// dispatch bound the calendar tools use: a Mac blocked on a
+	// permission prompt must cost a refresh tick, never wedge the runner.
+	calendarSnapshotCallTimeout = 30 * time.Second
+
+	// calendarSnapshotMaxBackoff caps how long a failing account waits
+	// between attempts. Failure is the normal overnight state of a
+	// lid-closed laptop, so backoff exists to quiet the attempts, not to
+	// give up: even at the cap the account retries every two hours, and
+	// a reconnect clears the wait entirely. Denominated in time, not
+	// refresh passes — nudges from unrelated companions' churn must not
+	// erode a wedged Mac's backoff into a retry storm.
+	calendarSnapshotMaxBackoff = 2 * time.Hour
+
+	// calendarSnapshotStaleAfter is the age past which a rendered
+	// snapshot must carry the stale flag. Twice the refresh interval:
+	// one missed tick is jitter, two is a story the reader needs.
+	calendarSnapshotStaleAfter = 2 * calendarSnapshotInterval
+
+	// calendarSnapshotRenderCutoff is how long a departed account's
+	// snapshot keeps rendering. The morning-after scenario needs hours;
+	// a Mac gone for good needs to stop haunting every prompt.
+	calendarSnapshotRenderCutoff = 24 * time.Hour
+)
+
+// snapshotCalendarEvent mirrors the companion calendar wire shape. The
+// field vocabulary deliberately tracks the tool renderer's
+// (internal/tools/companion_calendar_format.go): the same event must not
+// reach the model under two names depending on whether it arrived
+// ambiently or through a tool call.
+type snapshotCalendarEvent struct {
+	Title    string `json:"title"`
+	Calendar string `json:"calendar,omitempty"`
+	Start    string `json:"start"`
+	End      string `json:"end,omitempty"`
+	AllDay   bool   `json:"all_day,omitempty"`
+	TimeZone string `json:"time_zone,omitempty"`
+	Location string `json:"location,omitempty"`
+}
+
+type snapshotCalendarResponse struct {
+	Events    []snapshotCalendarEvent `json:"events"`
+	Truncated bool                    `json:"truncated,omitempty"`
+}
+
+// accountCalendarSnapshot is one account's most recent successful fetch.
+// A snapshot outlives its companion's connection on purpose: the morning's
+// first turns after a lid-closed night legitimately render yesterday
+// evening's events with an honest age, which beats rendering nothing.
+type accountCalendarSnapshot struct {
+	Account   string
+	ClientID  string
+	FetchedAt time.Time
+	Events    []snapshotCalendarEvent
+	Truncated bool
+}
+
+// CalendarSnapshot keeps an in-memory, background-refreshed view of every
+// connected companion account's near-term calendar, and renders it as an
+// always-on Live State block — the wall-clock-truth half of the #1432
+// design. Assembly only ever reads memory; the companion is called on the
+// runner's own clock, under its own bound, never inside a turn.
+// calendarProviderLister enumerates the connected providers; a func
+// rather than an interface, matching the registrar's injection style, so
+// tests supply a fake list without a fake registry.
+type calendarProviderLister func() []ProviderInfo
+
+type CalendarSnapshot struct {
+	list     calendarProviderLister
+	call     func(ctx context.Context, req CallRequest) (json.RawMessage, error)
+	homeZone *time.Location
+	now      func() time.Time
+	logger   *slog.Logger
+
+	mu        sync.RWMutex
+	snapshots map[string]accountCalendarSnapshot
+	pinned    map[string]string // account → client_id, held while connected
+	failures  map[string]int    // account → consecutive refresh failures
+	retryAt   map[string]time.Time
+	capable   map[string]string // account → sorted capable client_ids fingerprint
+	attempts  map[string]time.Time
+
+	nudge chan struct{}
+}
+
+// NewCalendarSnapshot builds the snapshot service over a live registry.
+func NewCalendarSnapshot(registry *Registry, homeZone *time.Location, logger *slog.Logger) *CalendarSnapshot {
+	return newCalendarSnapshot(registry.List, registry.Call, homeZone, logger)
+}
+
+// newCalendarSnapshot is the func-injected constructor tests use.
+func newCalendarSnapshot(list calendarProviderLister, call func(context.Context, CallRequest) (json.RawMessage, error), homeZone *time.Location, logger *slog.Logger) *CalendarSnapshot {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if homeZone == nil {
+		homeZone = time.Local
+	}
+	return &CalendarSnapshot{
+		list:      list,
+		call:      call,
+		homeZone:  homeZone,
+		now:       time.Now,
+		logger:    logger.With("component", "calendar_snapshot"),
+		snapshots: make(map[string]accountCalendarSnapshot),
+		pinned:    make(map[string]string),
+		failures:  make(map[string]int),
+		retryAt:   make(map[string]time.Time),
+		capable:   make(map[string]string),
+		attempts:  make(map[string]time.Time),
+		nudge:     make(chan struct{}, 1),
+	}
+}
+
+// NudgeRefresh asks the runner to refresh soon — wired to the registry's
+// change callback so a companion connecting after a night away repopulates
+// the snapshot without waiting out the interval. Non-blocking and
+// coalescing: a burst of reconnects is one refresh.
+func (s *CalendarSnapshot) NudgeRefresh() {
+	select {
+	case s.nudge <- struct{}{}:
+	default:
+	}
+}
+
+// Run refreshes on the interval and on nudges until ctx ends.
+func (s *CalendarSnapshot) Run(ctx context.Context) {
+	ticker := time.NewTicker(calendarSnapshotInterval)
+	defer ticker.Stop()
+
+	s.refreshAll(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.refreshAll(ctx)
+		case <-s.nudge:
+			s.refreshAll(ctx)
+		}
+	}
+}
+
+// refreshAll fetches every calendar-capable connected account, honoring
+// per-account backoff.
+func (s *CalendarSnapshot) refreshAll(ctx context.Context) {
+	now := s.now()
+	for account, clientID := range s.calendarAccounts() {
+		s.mu.Lock()
+		waiting := now.Before(s.retryAt[account])
+		if !waiting {
+			s.attempts[account] = now
+		}
+		s.mu.Unlock()
+		if waiting {
+			continue
+		}
+		s.refreshAccount(ctx, account, clientID)
+	}
+}
+
+// calendarAccounts maps each connected account that offers
+// macos.calendar/list_events to its pinned client. Pinning matters when
+// one account has two Macs online: their EventKit stores differ, and a
+// snapshot that alternated between them would flap between two truths.
+// The pin holds while that client stays connected; when it drops, the
+// lexicographically first capable client takes over — a deterministic
+// hand-off the snapshot's provenance makes visible.
+func (s *CalendarSnapshot) calendarAccounts() map[string]string {
+	capable := make(map[string][]string)
+	for _, info := range s.list() {
+		for _, capability := range info.Capabilities {
+			if capability.Name != "macos.calendar" {
+				continue
+			}
+			for _, method := range capability.Methods {
+				if method == "list_events" {
+					capable[info.Account] = append(capable[info.Account], info.ClientID)
+					break
+				}
+			}
+		}
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Forget the fingerprint of any account that departed entirely, so
+	// its eventual reconnect — even with the identical client — reads as
+	// the set change it is. Without this, a Mac that fully disconnects
+	// and returns with the same client_id matches its old fingerprint
+	// and inherits a backoff sentence earned while unreachable.
+	for account := range s.capable {
+		if _, still := capable[account]; !still {
+			delete(s.capable, account)
+		}
+	}
+
+	out := make(map[string]string, len(capable))
+	for account, clients := range capable {
+		sort.Strings(clients)
+
+		// A change in the capable-client set is new evidence that
+		// invalidates the backoff: the Mac that was timing out all
+		// night is not the Mac that just connected, even when it is —
+		// a fresh connection means a fresh chance to answer. Without
+		// this, the reconnect nudge arrives, finds the account still
+		// serving out a two-hour sentence earned while asleep, and the
+		// snapshot stays stale with the Mac sitting right there.
+		fingerprint := strings.Join(clients, "\x00")
+		if s.capable[account] != fingerprint {
+			s.capable[account] = fingerprint
+			s.failures[account] = 0
+			delete(s.retryAt, account)
+		}
+
+		pinnedClient := s.pinned[account]
+		stillConnected := false
+		for _, c := range clients {
+			if c == pinnedClient {
+				stillConnected = true
+				break
+			}
+		}
+		if !stillConnected {
+			pinnedClient = clients[0]
+			s.pinned[account] = pinnedClient
+		}
+		out[account] = pinnedClient
+	}
+	return out
+}
+
+// refreshAccount fetches one account's window. EventKit's range predicate
+// matches events that overlap the window, so a meeting already in
+// progress at refresh time — the one thing active-now exists to show —
+// comes back even though its start precedes the window's.
+func (s *CalendarSnapshot) refreshAccount(ctx context.Context, account, clientID string) {
+	now := s.now().In(s.homeZone)
+	params, err := json.Marshal(map[string]any{
+		"start": now.Format(time.RFC3339),
+		"end":   now.Add(calendarSnapshotWindow).Format(time.RFC3339),
+		"limit": calendarSnapshotLimit,
+	})
+	if err != nil {
+		return
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, calendarSnapshotCallTimeout)
+	raw, err := s.call(callCtx, CallRequest{
+		Account:    account,
+		ClientID:   clientID,
+		Capability: "macos.calendar",
+		Method:     "list_events",
+		Params:     params,
+	})
+	cancel()
+	if err != nil {
+		// The app dying is not the companion failing: a shutdown that
+		// coincides with a tick must not warn about the account or
+		// charge it backoff (the retry paths are where mistakes like
+		// that live longest).
+		if ctx.Err() != nil {
+			return
+		}
+		s.recordFailure(account, err)
+		return
+	}
+
+	var resp snapshotCalendarResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		s.recordFailure(account, fmt.Errorf("decode calendar snapshot: %w", err))
+		return
+	}
+
+	s.mu.Lock()
+	recovered := s.failures[account] > 0
+	s.failures[account] = 0
+	delete(s.retryAt, account)
+	s.snapshots[account] = accountCalendarSnapshot{
+		Account:   account,
+		ClientID:  clientID,
+		FetchedAt: now,
+		Events:    resp.Events,
+		Truncated: resp.Truncated,
+	}
+	s.mu.Unlock()
+	if recovered {
+		s.logger.Info("calendar snapshot recovered", "account", account, "events", len(resp.Events))
+	}
+}
+
+// recordFailure backs the account off without log spam: the first failure
+// warns, later ones only extend the skip count. An overnight lid-closed
+// Mac makes failure the normal state, and a log line per tick would bury
+// the signal a real fault carries.
+func (s *CalendarSnapshot) recordFailure(account string, err error) {
+	s.mu.Lock()
+	s.failures[account]++
+	failures := s.failures[account]
+	// One interval after the first failure — a single miss is jitter and
+	// costs nothing visible — then doubling to the cap.
+	wait := calendarSnapshotInterval << min(failures-1, 4)
+	if wait > calendarSnapshotMaxBackoff {
+		wait = calendarSnapshotMaxBackoff
+	}
+	s.retryAt[account] = s.now().Add(wait)
+	s.mu.Unlock()
+	if failures == 1 {
+		s.logger.Warn("calendar snapshot refresh failed; backing off",
+			"account", account, "error", err)
+	}
+}
+
+// TagContextBucket places the calendar block in live state beside the
+// watchlist: current operational world-state, uncached by design.
+func (s *CalendarSnapshot) TagContextBucket() agentctx.ContextBucket {
+	return agentctx.ContextBucketLiveState
+}
+
+// TagContext renders the block from memory and the registry's in-memory
+// provider list; nothing here can block on a companion or the disk.
+func (s *CalendarSnapshot) TagContext(context.Context, agentctx.ContextRequest) (string, error) {
+	now := s.now().In(s.homeZone)
+	capableClients := s.calendarAccounts()
+
+	s.mu.RLock()
+	snaps := make([]accountCalendarSnapshot, 0, len(s.snapshots))
+	for _, snap := range s.snapshots {
+		snaps = append(snaps, snap)
+	}
+	attempts := make(map[string]time.Time, len(s.attempts))
+	for account, at := range s.attempts {
+		attempts[account] = at
+	}
+	s.mu.RUnlock()
+
+	connected := s.connectedAccounts()
+	haveSnapshot := make(map[string]bool, len(snaps))
+
+	var accounts []renderedCalendarAccount
+	for _, snap := range snaps {
+		haveSnapshot[snap.Account] = true
+		// A departed account's snapshot serves the morning-after
+		// scenario for a day; past that it is an eternal tombstone,
+		// which the block stops carrying.
+		if !connected[snap.Account] && now.Sub(snap.FetchedAt) > calendarSnapshotRenderCutoff {
+			continue
+		}
+		accounts = append(accounts, s.renderAccount(snap, now, connected[snap.Account]))
+	}
+	// The honest-absence row: a capable companion is connected but no
+	// fetch has ever succeeded. Without it, a permission-blocked Mac and
+	// a household with no calendar capability read identically as
+	// silence — the third behavior the design forbids.
+	for account, clientID := range capableClients {
+		if haveSnapshot[account] {
+			continue
+		}
+		row := renderedCalendarAccount{Account: account, Client: clientID, Unavailable: true}
+		if at, ok := attempts[account]; ok {
+			row.LastAttemptAge = promptfmt.FormatDeltaOnly(at, now)
+		}
+		accounts = append(accounts, row)
+	}
+	if len(accounts) == 0 {
+		// Nothing fetched and nothing capable: a household with no
+		// calendar-capable companion carries no calendar block, rather
+		// than a standing apology for a capability it does not have.
+		return "", nil
+	}
+	sort.Slice(accounts, func(i, j int) bool { return accounts[i].Account < accounts[j].Account })
+
+	payload := struct {
+		Zone     string                    `json:"zone"`
+		Accounts []renderedCalendarAccount `json:"accounts"`
+	}{
+		Zone:     s.homeZone.String(),
+		Accounts: accounts,
+	}
+	return "### Calendar\n\n" + promptfmt.MarshalCompact(payload), nil
+}
+
+func (s *CalendarSnapshot) connectedAccounts() map[string]bool {
+	out := make(map[string]bool)
+	for _, info := range s.list() {
+		out[info.Account] = true
+	}
+	return out
+}
+
+// renderedCalendarAccount is one account's block as the model reads it.
+type renderedCalendarAccount struct {
+	Account     string                  `json:"account"`
+	Client      string                  `json:"client,omitempty"`
+	SnapshotAge string                  `json:"snapshot_age"`
+	Stale       bool                    `json:"stale,omitempty"`
+	Offline     bool                    `json:"offline,omitempty"`
+	ActiveNow   []renderedCalendarEvent `json:"active_now,omitempty"`
+	Next        *renderedCalendarEvent  `json:"next,omitempty"`
+	TodayLeft   []renderedCalendarEvent `json:"today_remaining,omitempty"`
+	TodayAllDay []renderedCalendarEvent `json:"today_all_day,omitempty"`
+	Truncated   bool                    `json:"truncated,omitempty"`
+
+	// Unavailable marks a capable, connected companion that has never
+	// produced a snapshot — a Mac blocked on a permission prompt, most
+	// likely. Silence here would be indistinguishable from having no
+	// calendar capability at all, which is the third behavior the
+	// design forbids.
+	Unavailable    bool   `json:"unavailable,omitempty"`
+	LastAttemptAge string `json:"last_attempt_age,omitempty"`
+}
+
+// renderedCalendarEvent reuses the tool renderer's field vocabulary. The
+// derivations differ by role: an active event's useful delta is when it
+// ends, an upcoming one's is when it starts.
+type renderedCalendarEvent struct {
+	Title      string `json:"title"`
+	Calendar   string `json:"calendar,omitempty"`
+	Start      string `json:"start,omitempty"`
+	End        string `json:"end,omitempty"`
+	FirstDay   string `json:"first_day,omitempty"`
+	LastDay    string `json:"last_day,omitempty"`
+	StartDelta string `json:"start_delta,omitempty"`
+	// EndsIn is this block's one addition to the tool vocabulary: an
+	// active event's actionable delta is when it ends, a shape the tool
+	// renderer never needs because it renders windows, not "now".
+	EndsIn          string `json:"ends_in,omitempty"`
+	EventZone       string `json:"event_zone,omitempty"`
+	EventLocalStart string `json:"event_local_start,omitempty"`
+	EventLocalEnd   string `json:"event_local_end,omitempty"`
+	Location        string `json:"location,omitempty"`
+}
+
+// renderAccount derives the account's view at one instant. Event rows
+// sort by start so the block is deterministic whatever order the wire
+// delivered; a rendered event carries the event's own clock beside home's
+// whenever the two disagree, the same rule and field names as the tool
+// renderer — one event, one vocabulary, however it reaches the model.
+func (s *CalendarSnapshot) renderAccount(snap accountCalendarSnapshot, now time.Time, connected bool) renderedCalendarAccount {
+	out := renderedCalendarAccount{
+		Account:     snap.Account,
+		Client:      snap.ClientID,
+		SnapshotAge: promptfmt.FormatDeltaOnly(snap.FetchedAt, now),
+		Stale:       now.Sub(snap.FetchedAt) > calendarSnapshotStaleAfter,
+		Offline:     !connected,
+		Truncated:   snap.Truncated,
+	}
+
+	events := make([]snapshotCalendarEvent, len(snap.Events))
+	copy(events, snap.Events)
+	sort.SliceStable(events, func(i, j int) bool { return events[i].Start < events[j].Start })
+
+	var next *snapshotTimedEvent
+	for _, event := range events {
+		if event.AllDay {
+			if rendered, ok := s.renderAllDay(event, now); ok {
+				out.TodayAllDay = append(out.TodayAllDay, rendered)
+			}
+			continue
+		}
+		start, end, endOK, ok := parseSnapshotSpan(event)
+		if !ok {
+			// A boundary that does not parse is a companion bug; the
+			// ambient block is the wrong place to surface bytes, so the
+			// event is omitted here and remains visible through the
+			// calendar tool, which echoes malformed input loudly.
+			continue
+		}
+		switch {
+		case !start.After(now) && end.After(now):
+			rendered := s.renderTimed(event, start, end, endOK)
+			if endOK {
+				rendered.EndsIn = promptfmt.FormatDeltaOnly(end, now)
+			}
+			out.ActiveNow = append(out.ActiveNow, rendered)
+		case start.After(now):
+			if next == nil || start.Before(next.start) {
+				next = &snapshotTimedEvent{event: event, start: start, end: end, endOK: endOK}
+			}
+			if sameHomeDay(start.In(s.homeZone), now) {
+				rendered := s.renderTimed(event, start, end, endOK)
+				rendered.StartDelta = promptfmt.FormatDeltaOnly(start, now)
+				out.TodayLeft = append(out.TodayLeft, rendered)
+			}
+		}
+	}
+	if next != nil {
+		rendered := s.renderTimed(next.event, next.start, next.end, next.endOK)
+		rendered.StartDelta = promptfmt.FormatDeltaOnly(next.start, now)
+		out.Next = &rendered
+	}
+	return out
+}
+
+// renderTimed fills the fields every timed row shares. The end appears
+// only when the companion supplied one, and the event-local reading
+// appears only when the event's own clock disagrees with home's at either
+// end — mirroring the tool renderer's rule, bare-Z suppression included:
+// a zone-less UTC instant is an older companion discarding the zone, not
+// an event scheduled on UTC's clock.
+func (s *CalendarSnapshot) renderTimed(event snapshotCalendarEvent, start, end time.Time, endOK bool) renderedCalendarEvent {
+	rendered := renderedCalendarEvent{
+		Title: event.Title, Calendar: event.Calendar,
+		Start:    start.In(s.homeZone).Format(time.RFC3339),
+		Location: event.Location,
+	}
+	if endOK {
+		rendered.End = end.In(s.homeZone).Format(time.RFC3339)
+	}
+
+	awayStart, awayEnd, diverges := s.eventLocalReading(event, start, end, endOK)
+	if diverges {
+		if name := strings.TrimSpace(event.TimeZone); name != "" {
+			rendered.EventZone = name
+		}
+		rendered.EventLocalStart = awayStart.Format(time.RFC3339)
+		if endOK {
+			rendered.EventLocalEnd = awayEnd.Format(time.RFC3339)
+		}
+	}
+	return rendered
+}
+
+// eventLocalReading resolves the event on its own clock and reports
+// whether that reading differs from home at either end.
+func (s *CalendarSnapshot) eventLocalReading(event snapshotCalendarEvent, start, end time.Time, endOK bool) (time.Time, time.Time, bool) {
+	awayStart, awayEnd := start, end
+	if name := strings.TrimSpace(event.TimeZone); name != "" {
+		if loc, err := time.LoadLocation(name); err == nil {
+			awayStart, awayEnd = start.In(loc), end.In(loc)
+		}
+	} else if _, offset := start.Zone(); offset == 0 {
+		return time.Time{}, time.Time{}, false
+	}
+
+	if offsetsMatch(awayStart, awayStart.In(s.homeZone)) &&
+		(!endOK || offsetsMatch(awayEnd, awayEnd.In(s.homeZone))) {
+		return time.Time{}, time.Time{}, false
+	}
+	return awayStart, awayEnd, true
+}
+
+func offsetsMatch(a, b time.Time) bool {
+	_, ao := a.Zone()
+	_, bo := b.Zone()
+	return ao == bo
+}
+
+type snapshotTimedEvent struct {
+	event snapshotCalendarEvent
+	start time.Time
+	end   time.Time
+	endOK bool
+}
+
+// renderAllDay reports the event when today falls inside its inclusive
+// date range. All-day events have no clock to be active against; they
+// occupy the date, so "today's all-day events" is their whole ambient
+// story and the delta vocabulary is day words by construction.
+func (s *CalendarSnapshot) renderAllDay(event snapshotCalendarEvent, now time.Time) (renderedCalendarEvent, bool) {
+	first, _, ok := parseSnapshotDate(event.Start)
+	if !ok {
+		return renderedCalendarEvent{}, false
+	}
+	last := first
+	if event.End != "" {
+		if parsed, dateOnly, ok := parseSnapshotDate(event.End); ok {
+			if !dateOnly {
+				// The legacy instant form is EventKit-exclusive; the
+				// tool renderer subtracts the day, and the same event
+				// must not claim an extra day here.
+				parsed = parsed.AddDate(0, 0, -1)
+			}
+			if !parsed.Before(first) {
+				last = parsed
+			}
+		}
+	}
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	if today.Before(first) || today.After(last) {
+		return renderedCalendarEvent{}, false
+	}
+	return renderedCalendarEvent{
+		Title: event.Title, Calendar: event.Calendar,
+		FirstDay: first.Format("2006-01-02"), LastDay: last.Format("2006-01-02"),
+		Location: event.Location,
+	}, true
+}
+
+// parseSnapshotDate resolves an all-day boundary: the date form directly,
+// and the legacy instant form (a pre-#49 companion's zone-discarded
+// midnight) by rounding to the nearest UTC midnight — the same ±12h
+// recovery the tool renderer uses. dateOnly distinguishes the two,
+// because they carry different end conventions: a date-form end is
+// already inclusive (the Mac resolved it), while an instant-form end is
+// EventKit-exclusive and the day before it is the last one occupied.
+func parseSnapshotDate(value string) (t time.Time, dateOnly, ok bool) {
+	value = strings.TrimSpace(value)
+	if t, err := time.Parse("2006-01-02", value); err == nil {
+		return t, true, true
+	}
+	if t, err := time.Parse(time.RFC3339, value); err == nil {
+		rounded := t.UTC().Round(24 * time.Hour)
+		return time.Date(rounded.Year(), rounded.Month(), rounded.Day(), 0, 0, 0, 0, time.UTC), false, true
+	}
+	return time.Time{}, false, false
+}
+
+// parseSnapshotSpan parses a timed event's boundaries. endOK reports
+// whether the end is the companion's or a synthetic minute added so the
+// active-now classification has an interval to test — the synthetic end
+// is never rendered, because the ambient block must not state a time
+// nobody scheduled.
+func parseSnapshotSpan(event snapshotCalendarEvent) (start, end time.Time, endOK, ok bool) {
+	start, err := time.Parse(time.RFC3339, strings.TrimSpace(event.Start))
+	if err != nil {
+		return time.Time{}, time.Time{}, false, false
+	}
+	end, err = time.Parse(time.RFC3339, strings.TrimSpace(event.End))
+	endOK = err == nil && end.After(start)
+	if !endOK {
+		end = start.Add(time.Minute)
+	}
+	return start, end, endOK, true
+}
+
+func sameHomeDay(a, b time.Time) bool {
+	return a.Year() == b.Year() && a.YearDay() == b.YearDay()
+}

--- a/internal/integrations/companion/calendar_snapshot.go
+++ b/internal/integrations/companion/calendar_snapshot.go
@@ -193,6 +193,7 @@ func (s *CalendarSnapshot) refreshAll(ctx context.Context) {
 // hand-off the snapshot's provenance makes visible.
 func (s *CalendarSnapshot) calendarAccounts() map[string]string {
 	capable := make(map[string][]string)
+	incarnations := make(map[string][]string)
 	for _, info := range s.list() {
 		for _, capability := range info.Capabilities {
 			if capability.Name != "macos.calendar" {
@@ -201,6 +202,14 @@ func (s *CalendarSnapshot) calendarAccounts() map[string]string {
 			for _, method := range capability.Methods {
 				if method == "list_events" {
 					capable[info.Account] = append(capable[info.Account], info.ClientID)
+					// The provider ID is minted fresh per connection —
+					// useless for stable identity, which is exactly why
+					// it belongs in the change fingerprint: a fast
+					// disconnect/reconnect can coalesce into one nudge
+					// that never samples the empty set, and the same
+					// client_id would then read as no change at all.
+					// The incarnation cannot lie about that.
+					incarnations[info.Account] = append(incarnations[info.Account], info.ID)
 					break
 				}
 			}
@@ -232,7 +241,9 @@ func (s *CalendarSnapshot) calendarAccounts() map[string]string {
 		// this, the reconnect nudge arrives, finds the account still
 		// serving out a two-hour sentence earned while asleep, and the
 		// snapshot stays stale with the Mac sitting right there.
-		fingerprint := strings.Join(clients, "\x00")
+		ids := incarnations[account]
+		sort.Strings(ids)
+		fingerprint := strings.Join(clients, "\x00") + "\x00\x00" + strings.Join(ids, "\x00")
 		if s.capable[account] != fingerprint {
 			s.capable[account] = fingerprint
 			s.failures[account] = 0
@@ -360,7 +371,14 @@ func (s *CalendarSnapshot) TagContext(context.Context, agentctx.ContextRequest) 
 	}
 	s.mu.RUnlock()
 
-	connected := s.connectedAccounts()
+	// Connectivity means calendar-capable connectivity: an account whose
+	// only remaining companion has no calendar would otherwise read as
+	// online forever, its stale snapshot bypassing the departure cutoff
+	// on the strength of a Mac that cannot answer.
+	connected := make(map[string]bool, len(capableClients))
+	for account := range capableClients {
+		connected[account] = true
+	}
 	haveSnapshot := make(map[string]bool, len(snaps))
 
 	var accounts []renderedCalendarAccount
@@ -406,14 +424,6 @@ func (s *CalendarSnapshot) TagContext(context.Context, agentctx.ContextRequest) 
 	return "### Calendar\n\n" + promptfmt.MarshalCompact(payload), nil
 }
 
-func (s *CalendarSnapshot) connectedAccounts() map[string]bool {
-	out := make(map[string]bool)
-	for _, info := range s.list() {
-		out[info.Account] = true
-	}
-	return out
-}
-
 // renderedCalendarAccount is one account's block as the model reads it.
 type renderedCalendarAccount struct {
 	Account     string                  `json:"account"`
@@ -457,11 +467,13 @@ type renderedCalendarEvent struct {
 	Location        string `json:"location,omitempty"`
 }
 
-// renderAccount derives the account's view at one instant. Event rows
-// sort by start so the block is deterministic whatever order the wire
-// delivered; a rendered event carries the event's own clock beside home's
-// whenever the two disagree, the same rule and field names as the tool
-// renderer — one event, one vocabulary, however it reaches the model.
+// renderAccount derives the account's view at one instant. Events are
+// parsed first and ordered by instant — RFC3339 text with mixed offsets
+// does not sort as time sorts, and a Berlin-offset event must not trail a
+// Chicago one it precedes. A rendered event carries the event's own clock
+// beside home's whenever the two disagree, the same rule and field names
+// as the tool renderer — one event, one vocabulary, however it reaches
+// the model.
 func (s *CalendarSnapshot) renderAccount(snap accountCalendarSnapshot, now time.Time, connected bool) renderedCalendarAccount {
 	out := renderedCalendarAccount{
 		Account:     snap.Account,
@@ -472,15 +484,26 @@ func (s *CalendarSnapshot) renderAccount(snap accountCalendarSnapshot, now time.
 		Truncated:   snap.Truncated,
 	}
 
-	events := make([]snapshotCalendarEvent, len(snap.Events))
-	copy(events, snap.Events)
-	sort.SliceStable(events, func(i, j int) bool { return events[i].Start < events[j].Start })
-
-	var next *snapshotTimedEvent
-	for _, event := range events {
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	var timed []snapshotTimedEvent
+	var nextAllDay *snapshotAllDayEvent
+	for _, event := range snap.Events {
 		if event.AllDay {
-			if rendered, ok := s.renderAllDay(event, now); ok {
-				out.TodayAllDay = append(out.TodayAllDay, rendered)
+			first, last, ok := allDayRange(event)
+			if !ok {
+				continue
+			}
+			switch {
+			case !today.Before(first) && !today.After(last):
+				out.TodayAllDay = append(out.TodayAllDay, renderedCalendarEvent{
+					Title: event.Title, Calendar: event.Calendar,
+					FirstDay: first.Format("2006-01-02"), LastDay: last.Format("2006-01-02"),
+					Location: event.Location,
+				})
+			case first.After(today):
+				if nextAllDay == nil || first.Before(nextAllDay.first) {
+					nextAllDay = &snapshotAllDayEvent{event: event, first: first, last: last}
+				}
 			}
 			continue
 		}
@@ -492,38 +515,102 @@ func (s *CalendarSnapshot) renderAccount(snap accountCalendarSnapshot, now time.
 			// calendar tool, which echoes malformed input loudly.
 			continue
 		}
+		timed = append(timed, snapshotTimedEvent{event: event, start: start, end: end, endOK: endOK})
+	}
+	sort.SliceStable(timed, func(i, j int) bool {
+		if !timed[i].start.Equal(timed[j].start) {
+			return timed[i].start.Before(timed[j].start)
+		}
+		return timed[i].event.Title < timed[j].event.Title
+	})
+	sort.SliceStable(out.TodayAllDay, func(i, j int) bool {
+		if out.TodayAllDay[i].FirstDay != out.TodayAllDay[j].FirstDay {
+			return out.TodayAllDay[i].FirstDay < out.TodayAllDay[j].FirstDay
+		}
+		return out.TodayAllDay[i].Title < out.TodayAllDay[j].Title
+	})
+
+	var nextTimed *snapshotTimedEvent
+	for i := range timed {
+		item := &timed[i]
 		switch {
-		case !start.After(now) && end.After(now):
-			rendered := s.renderTimed(event, start, end, endOK)
-			if endOK {
-				rendered.EndsIn = promptfmt.FormatDeltaOnly(end, now)
+		case !item.start.After(now) && item.end.After(now):
+			rendered := s.renderTimed(item.event, item.start, item.end, item.endOK)
+			if item.endOK {
+				rendered.EndsIn = promptfmt.FormatDeltaOnly(item.end, now)
 			}
 			out.ActiveNow = append(out.ActiveNow, rendered)
-		case start.After(now):
-			if next == nil || start.Before(next.start) {
-				next = &snapshotTimedEvent{event: event, start: start, end: end, endOK: endOK}
+		case item.start.After(now):
+			if nextTimed == nil {
+				nextTimed = item
 			}
-			if sameHomeDay(start.In(s.homeZone), now) {
-				rendered := s.renderTimed(event, start, end, endOK)
-				rendered.StartDelta = promptfmt.FormatDeltaOnly(start, now)
+			if sameHomeDay(item.start.In(s.homeZone), now) {
+				rendered := s.renderTimed(item.event, item.start, item.end, item.endOK)
+				rendered.StartDelta = promptfmt.FormatDeltaOnly(item.start, now)
 				out.TodayLeft = append(out.TodayLeft, rendered)
 			}
 		}
 	}
-	if next != nil {
-		rendered := s.renderTimed(next.event, next.start, next.end, next.endOK)
-		rendered.StartDelta = promptfmt.FormatDeltaOnly(next.start, now)
+
+	// Next is the earliest upcoming event of either kind. An all-day
+	// event's instant, for the comparison only, is home midnight of its
+	// first day; its rendered delta stays day-granular, because a date
+	// is not a moment to be early for.
+	if nextAllDay != nil {
+		allDayInstant := time.Date(nextAllDay.first.Year(), nextAllDay.first.Month(), nextAllDay.first.Day(), 0, 0, 0, 0, s.homeZone)
+		if nextTimed == nil || allDayInstant.Before(nextTimed.start) {
+			out.Next = &renderedCalendarEvent{
+				Title: nextAllDay.event.Title, Calendar: nextAllDay.event.Calendar,
+				FirstDay:   nextAllDay.first.Format("2006-01-02"),
+				LastDay:    nextAllDay.last.Format("2006-01-02"),
+				StartDelta: promptfmt.FormatDayDelta(nextAllDay.first, now),
+				Location:   nextAllDay.event.Location,
+			}
+		}
+	}
+	if out.Next == nil && nextTimed != nil {
+		rendered := s.renderTimed(nextTimed.event, nextTimed.start, nextTimed.end, nextTimed.endOK)
+		rendered.StartDelta = promptfmt.FormatDeltaOnly(nextTimed.start, now)
 		out.Next = &rendered
 	}
 	return out
 }
 
+type snapshotAllDayEvent struct {
+	event snapshotCalendarEvent
+	first time.Time
+	last  time.Time
+}
+
+// allDayRange resolves an all-day event's inclusive date range: date-form
+// bounds directly (the Mac already resolved inclusivity), instant-form
+// legacy bounds via midnight rounding with the EventKit-exclusive end
+// converted — the same rules the tool renderer applies to the same wire.
+func allDayRange(event snapshotCalendarEvent) (first, last time.Time, ok bool) {
+	first, _, ok = parseSnapshotDate(event.Start)
+	if !ok {
+		return time.Time{}, time.Time{}, false
+	}
+	last = first
+	if event.End != "" {
+		if parsed, dateOnly, ok := parseSnapshotDate(event.End); ok {
+			if !dateOnly {
+				parsed = parsed.AddDate(0, 0, -1)
+			}
+			if !parsed.Before(first) {
+				last = parsed
+			}
+		}
+	}
+	return first, last, true
+}
+
 // renderTimed fills the fields every timed row shares. The end appears
 // only when the companion supplied one, and the event-local reading
-// appears only when the event's own clock disagrees with home's at either
-// end — mirroring the tool renderer's rule, bare-Z suppression included:
-// a zone-less UTC instant is an older companion discarding the zone, not
-// an event scheduled on UTC's clock.
+// appears only when the event's own validated clock disagrees with home's
+// at either end — mirroring the tool renderer's rule, bare-Z suppression
+// included: a zone-less UTC instant is an older companion discarding the
+// zone, not an event scheduled on UTC's clock.
 func (s *CalendarSnapshot) renderTimed(event snapshotCalendarEvent, start, end time.Time, endOK bool) renderedCalendarEvent {
 	rendered := renderedCalendarEvent{
 		Title: event.Title, Calendar: event.Calendar,
@@ -534,11 +621,9 @@ func (s *CalendarSnapshot) renderTimed(event snapshotCalendarEvent, start, end t
 		rendered.End = end.In(s.homeZone).Format(time.RFC3339)
 	}
 
-	awayStart, awayEnd, diverges := s.eventLocalReading(event, start, end, endOK)
+	awayStart, awayEnd, zoneName, diverges := s.eventLocalReading(event, start, end, endOK)
 	if diverges {
-		if name := strings.TrimSpace(event.TimeZone); name != "" {
-			rendered.EventZone = name
-		}
+		rendered.EventZone = zoneName
 		rendered.EventLocalStart = awayStart.Format(time.RFC3339)
 		if endOK {
 			rendered.EventLocalEnd = awayEnd.Format(time.RFC3339)
@@ -548,22 +633,30 @@ func (s *CalendarSnapshot) renderTimed(event snapshotCalendarEvent, start, end t
 }
 
 // eventLocalReading resolves the event on its own clock and reports
-// whether that reading differs from home at either end.
-func (s *CalendarSnapshot) eventLocalReading(event snapshotCalendarEvent, start, end time.Time, endOK bool) (time.Time, time.Time, bool) {
+// whether that reading differs from home at either end. The declared zone
+// is used only when it validates — an unloadable name must not be
+// published as event_zone, and must not defeat the bare-Z suppression the
+// way falling through to the embedded offset would.
+func (s *CalendarSnapshot) eventLocalReading(event snapshotCalendarEvent, start, end time.Time, endOK bool) (time.Time, time.Time, string, bool) {
 	awayStart, awayEnd := start, end
+	zoneName := ""
 	if name := strings.TrimSpace(event.TimeZone); name != "" {
 		if loc, err := time.LoadLocation(name); err == nil {
 			awayStart, awayEnd = start.In(loc), end.In(loc)
+			zoneName = name
 		}
-	} else if _, offset := start.Zone(); offset == 0 {
-		return time.Time{}, time.Time{}, false
+	}
+	if zoneName == "" {
+		if _, offset := start.Zone(); offset == 0 {
+			return time.Time{}, time.Time{}, "", false
+		}
 	}
 
 	if offsetsMatch(awayStart, awayStart.In(s.homeZone)) &&
 		(!endOK || offsetsMatch(awayEnd, awayEnd.In(s.homeZone))) {
-		return time.Time{}, time.Time{}, false
+		return time.Time{}, time.Time{}, "", false
 	}
-	return awayStart, awayEnd, true
+	return awayStart, awayEnd, zoneName, true
 }
 
 func offsetsMatch(a, b time.Time) bool {
@@ -577,40 +670,6 @@ type snapshotTimedEvent struct {
 	start time.Time
 	end   time.Time
 	endOK bool
-}
-
-// renderAllDay reports the event when today falls inside its inclusive
-// date range. All-day events have no clock to be active against; they
-// occupy the date, so "today's all-day events" is their whole ambient
-// story and the delta vocabulary is day words by construction.
-func (s *CalendarSnapshot) renderAllDay(event snapshotCalendarEvent, now time.Time) (renderedCalendarEvent, bool) {
-	first, _, ok := parseSnapshotDate(event.Start)
-	if !ok {
-		return renderedCalendarEvent{}, false
-	}
-	last := first
-	if event.End != "" {
-		if parsed, dateOnly, ok := parseSnapshotDate(event.End); ok {
-			if !dateOnly {
-				// The legacy instant form is EventKit-exclusive; the
-				// tool renderer subtracts the day, and the same event
-				// must not claim an extra day here.
-				parsed = parsed.AddDate(0, 0, -1)
-			}
-			if !parsed.Before(first) {
-				last = parsed
-			}
-		}
-	}
-	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
-	if today.Before(first) || today.After(last) {
-		return renderedCalendarEvent{}, false
-	}
-	return renderedCalendarEvent{
-		Title: event.Title, Calendar: event.Calendar,
-		FirstDay: first.Format("2006-01-02"), LastDay: last.Format("2006-01-02"),
-		Location: event.Location,
-	}, true
 }
 
 // parseSnapshotDate resolves an all-day boundary: the date form directly,

--- a/internal/integrations/companion/calendar_snapshot_test.go
+++ b/internal/integrations/companion/calendar_snapshot_test.go
@@ -677,3 +677,48 @@ func TestCalendarSnapshotOrdersByInstantNotText(t *testing.T) {
 		t.Fatalf("today_remaining must order by instant:\n%s", out)
 	}
 }
+
+func TestCalendarSnapshotMalformedEndsAreDriftNotOmission(t *testing.T) {
+	// A non-empty end that does not parse is companion drift. The tool
+	// renderer marks the same payload unparsed and loud; the ambient
+	// block's equivalent is absence — never a confident one-day range or
+	// a briefly-active classification fabricated from corrupt bytes.
+	now := time.Date(2026, 8, 29, 15, 0, 30, 0, time.UTC)
+	fake := &calendarFake{
+		infos: []ProviderInfo{calendarProvider("aimee", "pocket")},
+		response: snapshotCalendarResponse{Events: []snapshotCalendarEvent{
+			{Title: "Broken all-day", AllDay: true, Start: "2026-08-29", End: "not-a-date"},
+			{Title: "Broken timed", Start: "2026-08-29T15:00:00Z", End: "garbage"},
+			{Title: "Genuinely endless", Start: "2026-08-29T15:00:00Z"},
+		}},
+	}
+	s := snapshotUnderTest(t, fake, now)
+	s.refreshAll(context.Background())
+
+	out, err := s.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	if strings.Contains(out, "Broken all-day") || strings.Contains(out, "Broken timed") {
+		t.Fatalf("malformed non-empty ends must be omitted, not reshaped:\n%s", out)
+	}
+	// The truly absent end keeps its synthetic classification.
+	if !strings.Contains(out, `"active_now":[{"title":"Genuinely endless"`) {
+		t.Fatalf("an absent end still classifies through the synthetic interval:\n%s", out)
+	}
+}
+
+func TestCalendarSnapshotUnavailableRowCarriesNoSnapshotAge(t *testing.T) {
+	now := time.Date(2026, 8, 29, 10, 0, 0, 0, time.UTC)
+	fake := &calendarFake{
+		infos: []ProviderInfo{calendarProvider("aimee", "pocket")},
+		err:   fmt.Errorf("companion did not respond"),
+	}
+	s := snapshotUnderTest(t, fake, now)
+	s.refreshAll(context.Background())
+
+	out, _ := s.TagContext(context.Background(), agentctx.ContextRequest{})
+	if strings.Contains(out, `"snapshot_age"`) {
+		t.Fatalf("a row stating no snapshot exists must not carry an empty age:\n%s", out)
+	}
+}

--- a/internal/integrations/companion/calendar_snapshot_test.go
+++ b/internal/integrations/companion/calendar_snapshot_test.go
@@ -44,7 +44,12 @@ func (f *calendarFake) call(_ context.Context, req CallRequest) (json.RawMessage
 }
 
 func calendarProvider(account, clientID string) ProviderInfo {
+	return calendarProviderIncarnation(account, clientID, "conn-"+clientID)
+}
+
+func calendarProviderIncarnation(account, clientID, id string) ProviderInfo {
 	return ProviderInfo{
+		ID:       id,
 		Account:  account,
 		ClientID: clientID,
 		Capabilities: []Capability{{
@@ -508,5 +513,167 @@ func TestCalendarSnapshotDepartedAccountStopsRenderingAfterCutoff(t *testing.T) 
 	out, _ = s.TagContext(context.Background(), agentctx.ContextRequest{})
 	if out != "" {
 		t.Fatalf("a long-departed account must stop haunting the prompt, got:\n%s", out)
+	}
+}
+
+func TestCalendarSnapshotFastReconnectClearsBackoffByIncarnation(t *testing.T) {
+	// The nudge channel coalesces, so a disconnect/reconnect pair can
+	// arrive as one refresh that never samples the empty provider set.
+	// The client_id is stable across the bounce; only the per-connection
+	// incarnation betrays that this is a fresh Mac deserving a fresh try.
+	base := time.Date(2026, 8, 29, 3, 0, 0, 0, time.UTC)
+	now := base
+	fake := &calendarFake{
+		infos: []ProviderInfo{calendarProviderIncarnation("aimee", "pocket", "conn-1")},
+		err:   fmt.Errorf("companion did not respond"),
+	}
+	s := snapshotUnderTest(t, fake, base)
+	s.now = func() time.Time { return now }
+
+	for i := 0; i < 6; i++ {
+		s.refreshAll(context.Background())
+		if i < 5 {
+			now = now.Add(calendarSnapshotMaxBackoff + time.Minute)
+		}
+	}
+	now = now.Add(time.Minute)
+
+	// Reconnect: same account, same client_id, new incarnation — and the
+	// runner never sees the empty set in between.
+	fake.infos = []ProviderInfo{calendarProviderIncarnation("aimee", "pocket", "conn-2")}
+	fake.err = nil
+	before := len(fake.calls)
+
+	s.mu.RLock()
+	blocked := now.Before(s.retryAt["aimee"])
+	s.mu.RUnlock()
+	if !blocked {
+		t.Fatal("test setup broken: account must still be inside its backoff window")
+	}
+
+	s.refreshAll(context.Background())
+
+	if len(fake.calls) != before+1 {
+		t.Fatalf("fast reconnect inherited the old backoff (%d calls, want %d)", len(fake.calls), before+1)
+	}
+}
+
+func TestCalendarSnapshotOfflineMeansCalendarCapableOffline(t *testing.T) {
+	// The calendar Mac departs; a capability-less companion on the same
+	// account stays. The snapshot must read offline — and age out at the
+	// cutoff — on the strength of calendar availability, not account
+	// presence.
+	fetched := time.Date(2026, 8, 29, 3, 0, 0, 0, time.UTC)
+	fake := &calendarFake{
+		infos:    []ProviderInfo{calendarProvider("nugget", "macbook")},
+		response: snapshotCalendarResponse{},
+	}
+	s := snapshotUnderTest(t, fake, fetched)
+	s.refreshAll(context.Background())
+
+	// Calendar Mac gone; a no-capability companion remains on the account.
+	fake.infos = []ProviderInfo{{ID: "conn-x", Account: "nugget", ClientID: "deepslate"}}
+
+	s.now = func() time.Time { return fetched.Add(time.Hour) }
+	out, _ := s.TagContext(context.Background(), agentctx.ContextRequest{})
+	if !strings.Contains(out, `"offline":true`) {
+		t.Fatalf("calendarless account presence must not read as online:\n%s", out)
+	}
+
+	s.now = func() time.Time { return fetched.Add(calendarSnapshotRenderCutoff + time.Hour) }
+	out, _ = s.TagContext(context.Background(), agentctx.ContextRequest{})
+	if strings.Contains(out, `"account":"nugget"`) {
+		t.Fatalf("the cutoff must apply despite the capability-less companion:\n%s", out)
+	}
+}
+
+func TestCalendarSnapshotNextCanBeAnAllDayEvent(t *testing.T) {
+	// Tomorrow's holiday is the earliest upcoming event; an empty timed
+	// schedule must not render an empty next. The delta is day-granular —
+	// a date is not a moment to be early for.
+	now := time.Date(2026, 8, 29, 15, 0, 0, 0, time.UTC)
+	fake := &calendarFake{
+		infos: []ProviderInfo{calendarProvider("aimee", "pocket")},
+		response: snapshotCalendarResponse{Events: []snapshotCalendarEvent{
+			{Title: "Labor Day", AllDay: true, Start: "2026-08-30", End: "2026-08-30"},
+			{Title: "Monday standup", Start: "2026-08-31T09:00:00-05:00", End: "2026-08-31T09:30:00-05:00"},
+		}},
+	}
+	s := snapshotUnderTest(t, fake, now)
+	s.refreshAll(context.Background())
+
+	out, err := s.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	if !strings.Contains(out, `"next":{"title":"Labor Day"`) {
+		t.Fatalf("the all-day event is the earliest upcoming and must be next:\n%s", out)
+	}
+	if !strings.Contains(out, `"first_day":"2026-08-30"`) || !strings.Contains(out, `"start_delta":"tomorrow"`) {
+		t.Fatalf("an all-day next carries inclusive dates and a day-word delta:\n%s", out)
+	}
+}
+
+func TestCalendarSnapshotInvalidZoneNeitherPublishesNorDefeatsSuppression(t *testing.T) {
+	now := time.Date(2026, 8, 29, 15, 0, 0, 0, time.UTC)
+	fake := &calendarFake{
+		infos: []ProviderInfo{calendarProvider("aimee", "pocket")},
+		response: snapshotCalendarResponse{Events: []snapshotCalendarEvent{
+			// An unloadable zone on a legacy bare-Z timestamp: the invalid
+			// name must not be published, and it must not defeat the
+			// bare-Z suppression by falling through to the embedded
+			// offset.
+			{Title: "Broken zone Z", TimeZone: "Mars/Olympus_Mons", Start: "2026-08-29T21:00:00Z", End: "2026-08-29T22:00:00Z"},
+			// An unloadable zone on an offset-carrying timestamp: the
+			// embedded offset is real evidence, so the local reading
+			// renders — but with no event_zone name, matching the tool's
+			// validated-declaration rule.
+			{Title: "Broken zone offset", TimeZone: "Mars/Olympus_Mons", Start: "2026-08-29T21:00:00+02:00", End: "2026-08-29T22:00:00+02:00"},
+		}},
+	}
+	s := snapshotUnderTest(t, fake, now)
+	s.refreshAll(context.Background())
+
+	out, err := s.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	if strings.Contains(out, "Mars/Olympus_Mons") {
+		t.Fatalf("an unloadable zone name must never be published:\n%s", out)
+	}
+	if c := strings.Count(out, "event_local_start"); c != 2 {
+		// "Broken zone offset" appears as next and in today_remaining;
+		// both rows carry the offset-evidence reading. The bare-Z event
+		// contributes none.
+		t.Fatalf("only the offset-carrying event's rows may carry local readings, got %d:\n%s", c, out)
+	}
+	if strings.Contains(out, `"event_zone"`) {
+		t.Fatalf("no validated zone name exists, so event_zone must be absent:\n%s", out)
+	}
+}
+
+func TestCalendarSnapshotOrdersByInstantNotText(t *testing.T) {
+	// RFC3339 text does not sort as time sorts: "16:00-05:00" is after
+	// "21:00+02:00" (14:00 home) but sorts before it lexicographically.
+	now := time.Date(2026, 8, 29, 13, 0, 0, 0, time.UTC)
+	fake := &calendarFake{
+		infos: []ProviderInfo{calendarProvider("aimee", "pocket")},
+		response: snapshotCalendarResponse{Events: []snapshotCalendarEvent{
+			{Title: "Chicago late", Start: "2026-08-29T16:00:00-05:00", End: "2026-08-29T17:00:00-05:00"},
+			{Title: "Berlin early", Start: "2026-08-29T21:00:00+02:00", End: "2026-08-29T22:00:00+02:00"},
+		}},
+	}
+	s := snapshotUnderTest(t, fake, now)
+	s.refreshAll(context.Background())
+
+	out, err := s.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	if !strings.Contains(out, `"next":{"title":"Berlin early"`) {
+		t.Fatalf("next must be the earlier instant, not the lexicographically smaller text:\n%s", out)
+	}
+	if strings.Index(out, "Berlin early") > strings.Index(out, "Chicago late") {
+		t.Fatalf("today_remaining must order by instant:\n%s", out)
 	}
 }

--- a/internal/integrations/companion/calendar_snapshot_test.go
+++ b/internal/integrations/companion/calendar_snapshot_test.go
@@ -1,0 +1,512 @@
+package companion
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+)
+
+func chicagoZone(t *testing.T) *time.Location {
+	t.Helper()
+	loc, err := time.LoadLocation("America/Chicago")
+	if err != nil {
+		t.Fatalf("load zone: %v", err)
+	}
+	return loc
+}
+
+// calendarFake wires a snapshot to a scripted provider list and call
+// response without a registry.
+type calendarFake struct {
+	infos    []ProviderInfo
+	response snapshotCalendarResponse
+	err      error
+	calls    []CallRequest
+	callN    atomic.Int32
+}
+
+func (f *calendarFake) list() []ProviderInfo { return f.infos }
+
+func (f *calendarFake) call(_ context.Context, req CallRequest) (json.RawMessage, error) {
+	f.calls = append(f.calls, req)
+	f.callN.Add(1)
+	if f.err != nil {
+		return nil, f.err
+	}
+	raw, err := json.Marshal(f.response)
+	return raw, err
+}
+
+func calendarProvider(account, clientID string) ProviderInfo {
+	return ProviderInfo{
+		Account:  account,
+		ClientID: clientID,
+		Capabilities: []Capability{{
+			Name:    "macos.calendar",
+			Methods: []string{"list_events", "create_event"},
+		}},
+	}
+}
+
+func snapshotUnderTest(t *testing.T, fake *calendarFake, now time.Time) *CalendarSnapshot {
+	t.Helper()
+	s := newCalendarSnapshot(fake.list, fake.call, chicagoZone(t), nil)
+	s.now = func() time.Time { return now }
+	return s
+}
+
+func TestCalendarSnapshotRefreshTargetsPinnedClientWithOverlapWindow(t *testing.T) {
+	now := time.Date(2026, 8, 29, 10, 0, 0, 0, time.UTC)
+	fake := &calendarFake{infos: []ProviderInfo{
+		calendarProvider("aimee", "pocket-b"),
+		calendarProvider("aimee", "pocket-a"),
+		{Account: "nugget", ClientID: "deepslate"}, // no calendar capability
+	}}
+	s := snapshotUnderTest(t, fake, now)
+
+	s.refreshAll(context.Background())
+
+	if len(fake.calls) != 1 {
+		t.Fatalf("calls = %d, want exactly one (capability-less accounts are skipped)", len(fake.calls))
+	}
+	call := fake.calls[0]
+	if call.Account != "aimee" || call.ClientID != "pocket-a" {
+		t.Fatalf("routed to %s/%s, want aimee's lexicographically first capable client pocket-a", call.Account, call.ClientID)
+	}
+	var params struct {
+		Start string `json:"start"`
+		End   string `json:"end"`
+		Limit int    `json:"limit"`
+	}
+	if err := json.Unmarshal(call.Params, &params); err != nil {
+		t.Fatalf("params: %v", err)
+	}
+	start, _ := time.Parse(time.RFC3339, params.Start)
+	end, _ := time.Parse(time.RFC3339, params.End)
+	if !start.Equal(now) || end.Sub(start) != calendarSnapshotWindow {
+		t.Fatalf("window = [%s, %s], want [now, now+%s]", params.Start, params.End, calendarSnapshotWindow)
+	}
+	if params.Limit != calendarSnapshotLimit {
+		t.Fatalf("limit = %d, want %d", params.Limit, calendarSnapshotLimit)
+	}
+}
+
+func TestCalendarSnapshotPinSurvivesWhileClientConnected(t *testing.T) {
+	now := time.Date(2026, 8, 29, 10, 0, 0, 0, time.UTC)
+	fake := &calendarFake{infos: []ProviderInfo{calendarProvider("aimee", "pocket-b")}}
+	s := snapshotUnderTest(t, fake, now)
+
+	s.refreshAll(context.Background())
+	// A second, alphabetically earlier Mac connects. The pin must hold:
+	// two EventKit stores differ, and alternating between them would
+	// flap the snapshot between two truths.
+	fake.infos = append(fake.infos, calendarProvider("aimee", "pocket-a"))
+	s.refreshAll(context.Background())
+
+	if got := fake.calls[1].ClientID; got != "pocket-b" {
+		t.Fatalf("second refresh routed to %s, want the pinned pocket-b", got)
+	}
+
+	// The pinned Mac drops; the hand-off is deterministic.
+	fake.infos = []ProviderInfo{calendarProvider("aimee", "pocket-a")}
+	s.refreshAll(context.Background())
+	if got := fake.calls[2].ClientID; got != "pocket-a" {
+		t.Fatalf("post-drop refresh routed to %s, want pocket-a", got)
+	}
+}
+
+func TestCalendarSnapshotRendersWallClockTruth(t *testing.T) {
+	// 10:00 Saturday morning in Chicago.
+	now := time.Date(2026, 8, 29, 15, 0, 0, 0, time.UTC)
+	fake := &calendarFake{
+		infos: []ProviderInfo{calendarProvider("aimee", "pocket")},
+		response: snapshotCalendarResponse{Events: []snapshotCalendarEvent{
+			{Title: "Standup", Calendar: "Work", Start: "2026-08-29T09:30:00-05:00", End: "2026-08-29T10:30:00-05:00"},
+			{Title: "Dentist", Calendar: "Personal", Start: "2026-08-29T14:00:00-05:00", End: "2026-08-29T15:00:00-05:00"},
+			{Title: "Sunday brunch", Start: "2026-08-30T11:00:00-05:00", End: "2026-08-30T12:00:00-05:00"},
+			{Title: "Conference", AllDay: true, Start: "2026-08-28", End: "2026-08-30"},
+			{Title: "Next week", AllDay: true, Start: "2026-09-02", End: "2026-09-02"},
+		}},
+	}
+	s := snapshotUnderTest(t, fake, now)
+	s.refreshAll(context.Background())
+
+	out, err := s.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+
+	// The standup started before now and ends after: active, with an
+	// ends_in delta — when it ends is the actionable fact.
+	for _, want := range []string{
+		`"zone":"America/Chicago"`,
+		`"account":"aimee"`, `"client":"pocket"`,
+		`"active_now":[{"title":"Standup","calendar":"Work"`, `"ends_in":"+1800s"`,
+		`"next":{"title":"Dentist"`, `"start_delta":"+4h"`,
+		`"today_remaining":[{"title":"Dentist"`,
+		`"today_all_day":[{"title":"Conference"`, `"first_day":"2026-08-28","last_day":"2026-08-30"`,
+		`"snapshot_age":"-0s"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("rendered block missing %s:\n%s", want, out)
+		}
+	}
+	// Tomorrow's brunch is next-day: not in today_remaining. Next week's
+	// all-day event does not include today: absent entirely.
+	if strings.Contains(out, `"today_remaining":[{"title":"Sunday brunch"`) || strings.Contains(out, "Next week") {
+		t.Fatalf("events outside today leaked into today's view:\n%s", out)
+	}
+	if strings.Contains(out, `"stale":true`) {
+		t.Fatalf("fresh snapshot must not read stale:\n%s", out)
+	}
+}
+
+func TestCalendarSnapshotActiveNowCatchesAnEventStartedBeforeTheWindow(t *testing.T) {
+	// The overlap contract: a meeting already in progress at refresh time
+	// is exactly what active_now exists to show. The fake returns it the
+	// way EventKit's overlap predicate would; the renderer must classify
+	// it active even though its start precedes the request window.
+	now := time.Date(2026, 8, 29, 15, 0, 0, 0, time.UTC)
+	fake := &calendarFake{
+		infos: []ProviderInfo{calendarProvider("aimee", "pocket")},
+		response: snapshotCalendarResponse{Events: []snapshotCalendarEvent{
+			{Title: "All-hands offsite", Start: "2026-08-29T08:00:00-05:00", End: "2026-08-29T17:00:00-05:00"},
+		}},
+	}
+	s := snapshotUnderTest(t, fake, now)
+	s.refreshAll(context.Background())
+
+	out, err := s.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	if !strings.Contains(out, `"active_now":[{"title":"All-hands offsite"`) {
+		t.Fatalf("in-progress event missing from active_now:\n%s", out)
+	}
+	if !strings.Contains(out, `"ends_in":"+7h"`) {
+		t.Fatalf("active event should carry ends_in, got:\n%s", out)
+	}
+}
+
+func TestCalendarSnapshotStaleAndOfflineAreHonest(t *testing.T) {
+	fetchedAt := time.Date(2026, 8, 29, 3, 0, 0, 0, time.UTC)
+	fake := &calendarFake{
+		infos:    []ProviderInfo{calendarProvider("aimee", "pocket")},
+		response: snapshotCalendarResponse{Events: nil},
+	}
+	s := snapshotUnderTest(t, fake, fetchedAt)
+	s.refreshAll(context.Background())
+
+	// Seven hours pass; the Mac has gone offline (lid closed). The
+	// snapshot outlives the connection and says exactly what it is:
+	// seven hours old, stale, from an offline companion.
+	s.now = func() time.Time { return fetchedAt.Add(7 * time.Hour) }
+	fake.infos = nil
+
+	out, err := s.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	for _, want := range []string{`"snapshot_age":"-7h"`, `"stale":true`, `"offline":true`} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stale block missing %s:\n%s", want, out)
+		}
+	}
+}
+
+func TestCalendarSnapshotRendersNothingBeforeAnyFetch(t *testing.T) {
+	fake := &calendarFake{}
+	s := snapshotUnderTest(t, fake, time.Now())
+
+	out, err := s.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	if out != "" {
+		t.Fatalf("a household with no calendar snapshot should carry no block, got: %q", out)
+	}
+}
+
+func TestCalendarSnapshotBacksOffInTimeNotPasses(t *testing.T) {
+	base := time.Date(2026, 8, 29, 10, 0, 0, 0, time.UTC)
+	now := base
+	fake := &calendarFake{
+		infos: []ProviderInfo{calendarProvider("aimee", "pocket")},
+		err:   fmt.Errorf("companion did not respond"),
+	}
+	s := snapshotUnderTest(t, fake, base)
+	s.now = func() time.Time { return now }
+
+	s.refreshAll(context.Background()) // fails; retry not before one interval
+
+	// A storm of passes at the same instant — the registry-churn shape a
+	// flapping second companion produces — must not erode the backoff.
+	for i := 0; i < 10; i++ {
+		s.refreshAll(context.Background())
+	}
+	if len(fake.calls) != 1 {
+		t.Fatalf("backoff eroded by passes: %d calls, want 1", len(fake.calls))
+	}
+
+	// Time, not passes, releases the retry — and the companion answering
+	// clears the failure state entirely.
+	fake.err = nil
+	now = base.Add(calendarSnapshotInterval + time.Second)
+	s.refreshAll(context.Background())
+	if len(fake.calls) != 2 {
+		t.Fatalf("retry did not land after the wait: %d calls", len(fake.calls))
+	}
+	s.mu.RLock()
+	_, ok := s.snapshots["aimee"]
+	s.mu.RUnlock()
+	if !ok {
+		t.Fatal("snapshot should recover once the companion answers again")
+	}
+}
+
+func TestCalendarSnapshotReconnectClearsBackoff(t *testing.T) {
+	// The headline scenario: a lid-closed Mac times out all night and
+	// earns the maximum backoff; morning comes, it reconnects, the
+	// registry change nudges a refresh — and that refresh must fetch NOW,
+	// not serve out a sentence earned while asleep. The backoff state and
+	// the nudge were tested separately before this test existed, which is
+	// exactly how their broken interaction slipped through.
+	base := time.Date(2026, 8, 29, 3, 0, 0, 0, time.UTC)
+	now := base
+	fake := &calendarFake{
+		infos: []ProviderInfo{calendarProvider("aimee", "pocket")},
+		err:   fmt.Errorf("companion did not respond"),
+	}
+	s := snapshotUnderTest(t, fake, base)
+	s.now = func() time.Time { return now }
+
+	// Accrue failures into deep backoff, advancing just far enough each
+	// time for the next attempt to land — after the last failure the
+	// clock moves only a minute, so the account still owes nearly the
+	// whole two-hour wait when the reconnect arrives. That's the pin:
+	// if time alone released the retry, this test would prove nothing.
+	for i := 0; i < 6; i++ {
+		s.refreshAll(context.Background())
+		if i < 5 {
+			now = now.Add(calendarSnapshotMaxBackoff + time.Minute)
+		}
+	}
+	now = now.Add(time.Minute)
+
+	// The Mac drops off the registry, then reconnects healthy.
+	fake.infos = nil
+	s.refreshAll(context.Background())
+	fake.infos = []ProviderInfo{calendarProvider("aimee", "pocket")}
+	fake.err = nil
+	before := len(fake.calls)
+
+	s.mu.RLock()
+	blocked := now.Before(s.retryAt["aimee"])
+	s.mu.RUnlock()
+	if !blocked {
+		t.Fatal("test setup broken: the account must still be inside its backoff window for the reconnect to prove anything")
+	}
+
+	s.refreshAll(context.Background()) // the reconnect nudge's refresh
+
+	if len(fake.calls) != before+1 {
+		t.Fatalf("reconnect refresh was skipped by stale backoff (%d calls, want %d)", len(fake.calls), before+1)
+	}
+	s.mu.RLock()
+	_, ok := s.snapshots["aimee"]
+	s.mu.RUnlock()
+	if !ok {
+		t.Fatal("reconnect should repopulate the snapshot immediately")
+	}
+}
+
+func TestCalendarSnapshotShutdownIsNotAnAccountFailure(t *testing.T) {
+	now := time.Date(2026, 8, 29, 10, 0, 0, 0, time.UTC)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	fake := &calendarFake{
+		infos: []ProviderInfo{calendarProvider("aimee", "pocket")},
+		err:   context.Canceled,
+	}
+	s := snapshotUnderTest(t, fake, now)
+
+	s.refreshAll(ctx)
+
+	s.mu.RLock()
+	failures := s.failures["aimee"]
+	s.mu.RUnlock()
+	if failures != 0 {
+		t.Fatalf("the app dying charged the account %d failures; shutdown is not the companion's fault", failures)
+	}
+}
+func TestCalendarSnapshotNudgeCoalesces(t *testing.T) {
+	s := snapshotUnderTest(t, &calendarFake{}, time.Now())
+	s.NudgeRefresh()
+	s.NudgeRefresh()
+	s.NudgeRefresh()
+	if len(s.nudge) != 1 {
+		t.Fatalf("nudges should coalesce to one pending refresh, got %d", len(s.nudge))
+	}
+}
+
+func TestCalendarSnapshotLegacyAllDayEndStaysExclusive(t *testing.T) {
+	// A pre-#49 companion sends all-day bounds as zone-discarded UTC
+	// midnights with an EventKit-exclusive end. The block must render the
+	// same inclusive last day the tool renderer derives — one event, one
+	// shape — not claim the extra day a literal read of the end implies.
+	now := time.Date(2026, 8, 29, 15, 0, 0, 0, time.UTC)
+	fake := &calendarFake{
+		infos: []ProviderInfo{calendarProvider("aimee", "pocket")},
+		response: snapshotCalendarResponse{Events: []snapshotCalendarEvent{
+			{Title: "Legacy conference", AllDay: true, Start: "2026-08-28T05:00:00Z", End: "2026-08-31T05:00:00Z"},
+		}},
+	}
+	s := snapshotUnderTest(t, fake, now)
+	s.refreshAll(context.Background())
+
+	out, err := s.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	if !strings.Contains(out, `"first_day":"2026-08-28","last_day":"2026-08-30"`) {
+		t.Fatalf("legacy exclusive end should render inclusive last day 08-30:\n%s", out)
+	}
+}
+
+func TestCalendarSnapshotNeverPublishesAFabricatedEnd(t *testing.T) {
+	now := time.Date(2026, 8, 29, 15, 0, 30, 0, time.UTC)
+	fake := &calendarFake{
+		infos: []ProviderInfo{calendarProvider("aimee", "pocket")},
+		response: snapshotCalendarResponse{Events: []snapshotCalendarEvent{
+			// Started a moment ago, no end: classified active via the
+			// synthetic interval, but no invented end or ends_in may be
+			// stated as fact.
+			{Title: "Open-ended ping", Start: "2026-08-29T15:00:00Z"},
+		}},
+	}
+	s := snapshotUnderTest(t, fake, now)
+	s.refreshAll(context.Background())
+
+	out, err := s.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	if !strings.Contains(out, `"active_now":[{"title":"Open-ended ping"`) {
+		t.Fatalf("endless event should still classify active:\n%s", out)
+	}
+	if strings.Contains(out, `"end"`) || strings.Contains(out, `"ends_in"`) {
+		t.Fatalf("a time nobody scheduled must not be rendered:\n%s", out)
+	}
+}
+
+func TestCalendarSnapshotEventLocalReadingMatchesToolRule(t *testing.T) {
+	now := time.Date(2026, 8, 29, 15, 0, 0, 0, time.UTC)
+	fake := &calendarFake{
+		infos: []ProviderInfo{calendarProvider("aimee", "pocket")},
+		response: snapshotCalendarResponse{Events: []snapshotCalendarEvent{
+			{Title: "Berlin sync", TimeZone: "Europe/Berlin", Start: "2026-08-29T21:00:00+02:00", End: "2026-08-29T22:00:00+02:00"},
+			{Title: "Winnipeg call", TimeZone: "America/Winnipeg", Start: "2026-08-29T16:00:00-05:00", End: "2026-08-29T17:00:00-05:00"},
+			{Title: "Legacy Z", Start: "2026-08-29T21:30:00Z", End: "2026-08-29T22:30:00Z"},
+		}},
+	}
+	s := snapshotUnderTest(t, fake, now)
+	s.refreshAll(context.Background())
+
+	out, err := s.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	if !strings.Contains(out, `"event_zone":"Europe/Berlin"`) || !strings.Contains(out, `"event_local_start":"2026-08-29T21:00:00+02:00"`) {
+		t.Fatalf("a diverging declared zone should carry the event-local reading:\n%s", out)
+	}
+	// Winnipeg keeps Chicago's clock: no annotation. A bare Z is an older
+	// companion discarding the zone, not a UTC-scheduled event: suppressed.
+	if strings.Contains(out, "America/Winnipeg") || strings.Contains(out, `"event_zone":"UTC"`) {
+		t.Fatalf("same-clock and bare-Z events must not carry event-local noise:\n%s", out)
+	}
+	// Berlin sync renders twice — as next and in today_remaining — and
+	// both rows carry the reading; no other event contributes one.
+	if c := strings.Count(out, "event_local_start"); c != 2 {
+		t.Fatalf("only Berlin sync's two rows should carry local readings, got %d:\n%s", c, out)
+	}
+}
+
+func TestCalendarSnapshotEventsSortByStart(t *testing.T) {
+	now := time.Date(2026, 8, 29, 13, 0, 0, 0, time.UTC)
+	fake := &calendarFake{
+		infos: []ProviderInfo{calendarProvider("aimee", "pocket")},
+		response: snapshotCalendarResponse{Events: []snapshotCalendarEvent{
+			{Title: "Later", Start: "2026-08-29T16:00:00-05:00", End: "2026-08-29T17:00:00-05:00"},
+			{Title: "Sooner", Start: "2026-08-29T14:00:00-05:00", End: "2026-08-29T15:00:00-05:00"},
+		}},
+	}
+	s := snapshotUnderTest(t, fake, now)
+	s.refreshAll(context.Background())
+
+	out, err := s.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	if strings.Index(out, "Sooner") > strings.Index(out, "Later") {
+		t.Fatalf("today_remaining should sort by start regardless of wire order:\n%s", out)
+	}
+	if !strings.Contains(out, `"next":{"title":"Sooner"`) {
+		t.Fatalf("next should be the earliest upcoming event:\n%s", out)
+	}
+}
+
+func TestCalendarSnapshotUnavailableRowForNeverFetchedAccount(t *testing.T) {
+	// A capable companion is connected but every fetch has failed since
+	// boot — the permission-prompt-blocked Mac. Silence would read
+	// identically to having no calendar capability; the block says so
+	// instead.
+	now := time.Date(2026, 8, 29, 10, 0, 0, 0, time.UTC)
+	fake := &calendarFake{
+		infos: []ProviderInfo{calendarProvider("aimee", "pocket")},
+		err:   fmt.Errorf("companion did not respond"),
+	}
+	s := snapshotUnderTest(t, fake, now)
+	s.refreshAll(context.Background())
+
+	out, err := s.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	for _, want := range []string{`"account":"aimee"`, `"unavailable":true`, `"last_attempt_age":"-`} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("unavailable row missing %s:\n%s", want, out)
+		}
+	}
+}
+
+func TestCalendarSnapshotDepartedAccountStopsRenderingAfterCutoff(t *testing.T) {
+	fetched := time.Date(2026, 8, 29, 3, 0, 0, 0, time.UTC)
+	fake := &calendarFake{
+		infos:    []ProviderInfo{calendarProvider("aimee", "pocket")},
+		response: snapshotCalendarResponse{},
+	}
+	s := snapshotUnderTest(t, fake, fetched)
+	s.refreshAll(context.Background())
+
+	fake.infos = nil // the account departs for good
+
+	// Within the cutoff: the morning-after scenario renders, honestly aged.
+	s.now = func() time.Time { return fetched.Add(8 * time.Hour) }
+	out, _ := s.TagContext(context.Background(), agentctx.ContextRequest{})
+	if !strings.Contains(out, `"offline":true`) {
+		t.Fatalf("recent departed snapshot should render offline:\n%s", out)
+	}
+
+	// Past the cutoff: no eternal tombstone.
+	s.now = func() time.Time { return fetched.Add(calendarSnapshotRenderCutoff + time.Hour) }
+	out, _ = s.TagContext(context.Background(), agentctx.ContextRequest{})
+	if out != "" {
+		t.Fatalf("a long-departed account must stop haunting the prompt, got:\n%s", out)
+	}
+}

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=68
 interfaces=83
-large_files=57
+large_files=58
 set_mutators=118
 database_opens=9

--- a/talents/companion.md
+++ b/talents/companion.md
@@ -30,6 +30,13 @@ How to work here:
 - When more than one account has a Mac connected, a call may come back
   asking you to disambiguate. Retry with `account` (and `client_id` if one
   account has several hosts) set to one of the choices it names.
+- A "### Calendar" block in Live State is the mechanical snapshot of the
+  household's near-term calendar: events active right now (with an
+  ends-in delta), the next upcoming one, and today's remainder,
+  refreshed in the background from a connected Mac. Trust its
+  snapshot-age, stale, and offline fields over assumptions about
+  freshness; when it reads truncated, or you need more than two days
+  out, pull the window you need with `macos_calendar_events`.
 - These are read surfaces — inspect before you expect to change anything.
   Writing host data (e.g. creating calendar events) is gated separately and
   is not available just because a read tool is.


### PR DESCRIPTION
Phase 2 of the context-assembly cycle — implements #1432, and the first production slice of #644's source-neutral temporal injector.

## What the model gets

A `### Calendar` block in Live State, every turn, rendered from memory:

- **`active_now`** — events the wall clock is currently inside, each with an `ends_in` delta (when it ends is the actionable fact; the tool renderer never needs this shape because it renders windows, not *now*)
- **`next`** — the earliest upcoming event with its `start_delta`
- **`today_remaining`** / **`today_all_day`** — the rest of today
- per-account **`snapshot_age`**, `stale` past two refresh intervals, `offline` when the companion is gone, `truncated` when the window held more, and an explicit **`unavailable`** row for a capable companion that has never answered (a permission-blocked Mac must not read as "no calendar capability")

Field vocabulary is the tool renderer's — home-zone instants, start deltas, inclusive all-day dates (with the legacy exclusive-end conversion), event-local readings when a declared zone diverges at either end, bare-Z suppression — so one event never reaches the model under two names. The companion talent teaches the block and the escalation path.

## The machinery

In-memory snapshot per account, refreshed on 15-minute ticks plus a registry-change nudge (the single `SetOnChange` now fans out to registrar + snapshot). Fetches go through the bounded companion path with `Account` always explicit and a **pinned client per account** — two Macs on one account hold two EventKit stores, and alternating between them would flap between two truths. Overlap semantics verified against the shipped Swift: EventKit's predicate matches intersecting occurrences and nothing downstream start-filters, so in-progress meetings return.

**Staleness is the normal state.** Failures back off in time (one quiet interval, doubling to a 2h cap, one WARN); a reconnect — including the same Mac after a full disconnect — is new evidence that clears the backoff, so the morning nudge fetches *immediately*. Departed accounts stop rendering after a day. App shutdown is never recorded as an account failure.

Deliberately **not** on the advertisement rail: ambient evidence loses to request-matched offers by design, and today's calendar must not lose a lottery on busy trip-planning turns (this exact failure was proven in the #1431 design review).

## The adversarial round, credited

A three-critic panel ran before this PR; its findings shaped the final shape: the reconnect-nudge/backoff interaction (the headline scenario didn't survive their trace — twice: the sharpened regression test then caught my first fix missing same-client reconnects), time-based rather than pass-based backoff, the exclusive→inclusive all-day conversion, never publishing fabricated ends, the unavailable row, shutdown-is-not-failure, event sorting, the second-clock removal, and the heading demotion. Each fix is pinned by a test verified failing against the unfixed code.

## Deploy coupling (the checklist item that is not code)

Per #1432: **the same deploy must re-scope `calendar_curator`** (a prod loop definition) to stop restating wall-clock listings — otherwise a 3–6h-stale digest ships beside a 15-minute snapshot as the same fact in conflicting shapes. Nothing in the repo can enforce this; it rides the deploy checklist with the schedule root's `advertise: always` line.

## Test plan
- [x] `just ci` green (pinned toolchain); package suite green under `-race`
- [x] 16 tests: pinning + deterministic hand-off, overlap classification, wall-clock derivations, event-local readings (divergence, same-clock suppression, bare-Z suppression), legacy all-day inclusivity, fabricated-end omission, stale/offline/unavailable honesty, silent absence only when nothing is capable, time-based backoff immune to pass-storms, reconnect-clears-backoff (with an in-test guard proving the account was still inside its window), shutdown-not-failure, departed-account cutoff, nudge coalescing
- [x] Mutation-verified: reconnect-clears-backoff and exclusive-end conversion, both directions
- [ ] Verified against production once deployed: standup in progress shows in `active_now` with a correct `ends_in`; lid-closed morning renders yesterday's snapshot honestly aged, then repopulates on reconnect without waiting out the interval

Refs #1432, #644