### PR TITLE
feat(memory): stamp message provenance at ingest

### DIFF
--- a/internal/app/adapters.go
+++ b/internal/app/adapters.go
@@ -623,7 +623,7 @@ func (n *conversationSystemInjector) InjectSystemMessage(conversationID, message
 	if conversationID == "" || strings.TrimSpace(message) == "" {
 		return nil
 	}
-	return n.mem.AddMessage(conversationID, "system", message)
+	return n.mem.AddMessage(conversationID, "system", message, memory.OriginInternal)
 }
 
 // InjectAssistantMessage adds an assistant-authored message to the
@@ -636,7 +636,7 @@ func (n *conversationSystemInjector) InjectAssistantMessage(conversationID, mess
 	if conversationID == "" || strings.TrimSpace(message) == "" {
 		return nil
 	}
-	return n.mem.AddMessage(conversationID, "assistant", message)
+	return n.mem.AddMessage(conversationID, "assistant", message, memory.OriginInternal)
 }
 
 // IsSessionAlive reports whether the conversation has an active
@@ -708,7 +708,10 @@ func (r *signalMemoryRecorder) RecordOutbound(phone, message string) error {
 		}
 	}
 	convID := "signal-" + sb.String()
-	return r.mem.AddMessage(convID, "assistant", message)
+	// OriginChannel: this row records an outbound send that crossed the
+	// Signal transport to the counterparty — outbound contact, with
+	// direction carried by the assistant role.
+	return r.mem.AddMessage(convID, "assistant", message, memory.OriginChannel)
 }
 
 // channelActivityAdapter bridges [notifications.ChannelActivitySource]
@@ -1074,6 +1077,7 @@ func compileLoopAgentRequest(req looppkg.Request) *agent.Request {
 		RoutingFactors:        cloneStringMap(req.RoutingFactors),
 		Bindings:              cloneStringMap(req.Bindings),
 		DelegationGating:      req.DelegationGating,
+		MessageOrigin:         req.MessageOrigin,
 		InitialTags:           append([]string(nil), req.InitialTags...),
 		RuntimeTags:           append([]string(nil), req.RuntimeTags...),
 		RuntimeTools:          compileLoopRuntimeTools(req.RuntimeTools),

--- a/internal/channels/messaging/signal/bridge.go
+++ b/internal/channels/messaging/signal/bridge.go
@@ -1077,6 +1077,7 @@ func (b *Bridge) agentTurnMessages(convID string, binding *memory.ChannelBinding
 			ExcludeTools:     opts.ExcludeTools,
 			InitialTags:      []string{"signal"},
 			RuntimeTags:      []string{"message_channel"},
+			MessageOrigin:    memory.OriginChannel,
 			FallbackContent:  fallbackContent,
 		},
 		Summary: summary,

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -55,23 +55,30 @@ type Request struct {
 	// resources (see loop.Spec.Bindings). They reach tool handlers and
 	// context providers through the execution context, where each
 	// subsystem reads its own key.
-	Bindings         map[string]string                   `json:"bindings,omitempty"`
-	DelegationGating string                              `json:"delegation_gating,omitempty"` // Typed feature switch: "disabled" gives the model direct access to all tools instead of the orchestrator-and-delegate gating pattern
-	SkipContext      bool                                `json:"-"`                           // Skip memory, tools, and context injection (for lightweight completions)
-	AllowedTools     []string                            `json:"-"`                           // Optional allowlist of tools visible for this run
-	ExcludeTools     []string                            `json:"-"`                           // Tool names to exclude from this run (e.g., lifecycle tools for recurring wakes)
-	SkipTagFilter    bool                                `json:"-"`                           // Bypass capability tag filtering (for self-scoping contexts like metacognitive)
-	InitialTags      []string                            `json:"-"`                           // Tags to activate at Run start (carried forward from previous loop iterations)
-	RuntimeTags      []string                            `json:"-"`                           // Trusted runtime-asserted tags pinned for this run only
-	RuntimeTools     []*tools.Tool                       `json:"-"`                           // Request-scoped tools visible only to this run
-	PullInput        func(context.Context) []llm.Message `json:"-"`                           // Polled at each iteration boundary and at closure to merge newly-arrived input into the live turn (#1221); nil disables
-	MaxIterations    int                                 `json:"-"`                           // Optional per-request iteration cap (0 = default)
-	MaxOutputTokens  int                                 `json:"-"`                           // Optional output-token budget across all iterations (0 = unlimited)
-	ToolTimeout      time.Duration                       `json:"-"`                           // Optional per-tool timeout (0 = no extra timeout)
-	UsageRole        string                              `json:"-"`                           // Optional usage role override (e.g., "delegate")
-	UsageTaskName    string                              `json:"-"`                           // Optional usage task name override
-	FallbackContent  string                              `json:"-"`                           // Optional static fallback text when the run yields no content
-	PromptMode       agentctx.PromptMode                 `json:"-"`                           // Optional system-prompt shape override.
+	Bindings         map[string]string `json:"bindings,omitempty"`
+	DelegationGating string            `json:"delegation_gating,omitempty"` // Typed feature switch: "disabled" gives the model direct access to all tools instead of the orchestrator-and-delegate gating pattern
+	// MessageOrigin is the provenance stamped onto this request's
+	// Messages when they are recorded in conversation memory (see the
+	// memory.Origin* constants). Channel bridges declare
+	// memory.OriginChannel, API surfaces memory.OriginAPI; turn-builder
+	// wake requests that declare nothing default to memory.OriginWake in
+	// the loop runtime's request preparation. Empty means unstamped.
+	MessageOrigin   string                              `json:"-"`
+	SkipContext     bool                                `json:"-"` // Skip memory, tools, and context injection (for lightweight completions)
+	AllowedTools    []string                            `json:"-"` // Optional allowlist of tools visible for this run
+	ExcludeTools    []string                            `json:"-"` // Tool names to exclude from this run (e.g., lifecycle tools for recurring wakes)
+	SkipTagFilter   bool                                `json:"-"` // Bypass capability tag filtering (for self-scoping contexts like metacognitive)
+	InitialTags     []string                            `json:"-"` // Tags to activate at Run start (carried forward from previous loop iterations)
+	RuntimeTags     []string                            `json:"-"` // Trusted runtime-asserted tags pinned for this run only
+	RuntimeTools    []*tools.Tool                       `json:"-"` // Request-scoped tools visible only to this run
+	PullInput       func(context.Context) []llm.Message `json:"-"` // Polled at each iteration boundary and at closure to merge newly-arrived input into the live turn (#1221); nil disables
+	MaxIterations   int                                 `json:"-"` // Optional per-request iteration cap (0 = default)
+	MaxOutputTokens int                                 `json:"-"` // Optional output-token budget across all iterations (0 = unlimited)
+	ToolTimeout     time.Duration                       `json:"-"` // Optional per-tool timeout (0 = no extra timeout)
+	UsageRole       string                              `json:"-"` // Optional usage role override (e.g., "delegate")
+	UsageTaskName   string                              `json:"-"` // Optional usage task name override
+	FallbackContent string                              `json:"-"` // Optional static fallback text when the run yields no content
+	PromptMode      agentctx.PromptMode                 `json:"-"` // Optional system-prompt shape override.
 
 	// SystemPrompt, when non-empty, replaces the output of
 	// buildSystemPrompt(). Used by callers that assemble their own
@@ -170,12 +177,15 @@ type Response struct {
 // loop can build prompts and enforce context-window limits.
 type MemoryStore interface {
 	GetMessages(conversationID string) []memory.Message
-	AddMessage(conversationID, role, content string) error
+	// AddMessage records a message. origin is the provenance stamp for
+	// the row (memory.Origin* constants); callers pass "" when the
+	// enqueue site cannot know how the message entered the conversation.
+	AddMessage(conversationID, role, content, origin string) error
 	// AddMidTurnMessage records a user message that arrived mid-turn and was
 	// merged into the in-flight turn (#1230), tagging the record so consumers
 	// identify the injection structurally rather than by substring-matching
-	// the rendered arrival marker.
-	AddMidTurnMessage(conversationID, role, content string) error
+	// the rendered arrival marker. origin follows the AddMessage contract.
+	AddMidTurnMessage(conversationID, role, content, origin string) error
 	GetTokenCount(conversationID string) int
 	Clear(conversationID string) error
 	Stats() map[string]any
@@ -1647,7 +1657,7 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 			// External client (Open WebUI): only add the last user message
 			for i := len(req.Messages) - 1; i >= 0; i-- {
 				if req.Messages[i].Role == "user" {
-					if err := l.memory.AddMessage(convID, "user", req.Messages[i].Content); err != nil {
+					if err := l.memory.AddMessage(convID, "user", req.Messages[i].Content, req.MessageOrigin); err != nil {
 						log.Warn("failed to store message", "error", err)
 					}
 					break
@@ -1656,7 +1666,7 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 		} else {
 			// Internal/API clients: store all messages
 			for _, m := range req.Messages {
-				if err := l.memory.AddMessage(convID, m.Role, m.Content); err != nil {
+				if err := l.memory.AddMessage(convID, m.Role, m.Content, req.MessageOrigin); err != nil {
 					log.Warn("failed to store message", "error", err)
 				}
 			}
@@ -1676,7 +1686,7 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 	if isSimpleGreeting(userMessage) {
 		log.Debug("simple greeting detected, responding directly")
 		response := getGreetingResponse()
-		if err := l.memory.AddMessage(convID, "assistant", response); err != nil {
+		if err := l.memory.AddMessage(convID, "assistant", response, memory.OriginInternal); err != nil {
 			log.Warn("failed to store greeting response", "error", err)
 		}
 		return &Response{
@@ -2251,7 +2261,11 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 				if m.Role != "user" || m.Content == "" {
 					continue
 				}
-				if err := l.memory.AddMidTurnMessage(convID, "user", m.Content); err != nil {
+				// Origin "": mailbox items of mixed provenance (channel
+				// arrivals, internal notifies) are rendered to plain
+				// llm.Messages before this wrapper sees them, so the
+				// per-item origin is not recoverable here.
+				if err := l.memory.AddMidTurnMessage(convID, "user", m.Content, ""); err != nil {
 					logging.Logger(pctx).Warn("failed to record mid-turn input in conversation store",
 						"conversation_id", convID, "error", err)
 				}
@@ -2484,7 +2498,7 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 
 		// Post-response: memory storage, fact extraction, compaction.
 		OnTextResponse: func(iterCtx context.Context, content string, msgs []llm.Message) {
-			if err := l.memory.AddMessage(convID, "assistant", content); err != nil {
+			if err := l.memory.AddMessage(convID, "assistant", content, memory.OriginInternal); err != nil {
 				logging.Logger(iterCtx).Warn("failed to store response", "error", err)
 			}
 			// Async fact extraction.
@@ -2547,7 +2561,7 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 
 	// For exhausted runs, store the forced text in memory.
 	if iterResult.Exhausted && iterResult.Content != "" {
-		if err := l.memory.AddMessage(convID, "assistant", iterResult.Content); err != nil {
+		if err := l.memory.AddMessage(convID, "assistant", iterResult.Content, memory.OriginInternal); err != nil {
 			log.Warn("failed to store response", "error", err)
 		}
 	}
@@ -3218,7 +3232,7 @@ func (l *Loop) SplitSession(conversationID string, atIndex int, atMessage string
 		return fmt.Errorf("clear memory for split: %w", err)
 	}
 	for _, m := range postSplit {
-		if err := l.memory.AddMessage(conversationID, m.Role, m.Content); err != nil {
+		if err := l.memory.AddMessage(conversationID, m.Role, m.Content, m.Origin); err != nil {
 			l.logger.Error("failed to re-add post-split message", "error", err, "role", m.Role)
 		}
 	}

--- a/internal/runtime/agent/orchestrator_tools_test.go
+++ b/internal/runtime/agent/orchestrator_tools_test.go
@@ -56,12 +56,12 @@ type mockMem struct {
 func newMockMem() *mockMem { return &mockMem{msgs: make(map[string][]memory.Message)} }
 
 func (m *mockMem) GetMessages(id string) []memory.Message { return m.msgs[id] }
-func (m *mockMem) AddMessage(id, role, content string) error {
-	m.msgs[id] = append(m.msgs[id], memory.Message{Role: role, Content: content})
+func (m *mockMem) AddMessage(id, role, content, origin string) error {
+	m.msgs[id] = append(m.msgs[id], memory.Message{Role: role, Content: content, Origin: origin})
 	return nil
 }
-func (m *mockMem) AddMidTurnMessage(id, role, content string) error {
-	m.msgs[id] = append(m.msgs[id], memory.Message{Role: role, Content: content, MidTurn: true})
+func (m *mockMem) AddMidTurnMessage(id, role, content, origin string) error {
+	m.msgs[id] = append(m.msgs[id], memory.Message{Role: role, Content: content, MidTurn: true, Origin: origin})
 	return nil
 }
 func (m *mockMem) GetTokenCount(string) int { return 0 }

--- a/internal/runtime/agent/session_management_test.go
+++ b/internal/runtime/agent/session_management_test.go
@@ -89,7 +89,7 @@ func newMockMemWithCompaction() *mockMemWithCompaction {
 func (m *mockMemWithCompaction) AddCompactionSummary(convID, summary string) error {
 	m.summaries = append(m.summaries, compactionSummary{convID, summary})
 	// Also add as a message so GetMessages sees it.
-	return m.AddMessage(convID, "system", summary)
+	return m.AddMessage(convID, "system", summary, "")
 }
 
 func (m *mockMemWithCompaction) GetAllMessages(convID string) []memory.Message {
@@ -159,7 +159,7 @@ func TestCloseSession(t *testing.T) {
 
 			// Seed messages.
 			for _, m := range tt.messages {
-				_ = mem.AddMessage("conv1", m.Role, m.Content)
+				_ = mem.AddMessage("conv1", m.Role, m.Content, "")
 			}
 
 			err := loop.CloseSession("conv1", tt.reason, tt.carryForward)
@@ -225,7 +225,7 @@ func TestCloseSession_ClearsPersistedCapabilityTags(t *testing.T) {
 	if err := store.SaveTags("conv1", []string{"forge", "web"}); err != nil {
 		t.Fatalf("SaveTags() error: %v", err)
 	}
-	if err := mem.AddMessage("conv1", "user", "hello"); err != nil {
+	if err := mem.AddMessage("conv1", "user", "hello", ""); err != nil {
 		t.Fatalf("AddMessage() error: %v", err)
 	}
 
@@ -282,7 +282,7 @@ func TestCheckpointSession(t *testing.T) {
 			loop := newTestLoop(mem, archiver)
 
 			for _, m := range tt.messages {
-				_ = mem.AddMessage("conv1", m.Role, m.Content)
+				_ = mem.AddMessage("conv1", m.Role, m.Content, "")
 			}
 
 			err := loop.CheckpointSession("conv1", tt.label)
@@ -410,7 +410,7 @@ func TestSplitSession(t *testing.T) {
 			loop := newTestLoop(mem, archiver)
 
 			for _, m := range tt.messages {
-				_ = mem.AddMessage("conv1", m.Role, m.Content)
+				_ = mem.AddMessage("conv1", m.Role, m.Content, "")
 			}
 
 			err := loop.SplitSession("conv1", tt.atIndex, tt.atMessage)
@@ -474,7 +474,7 @@ func TestSplitSession_ClearsPersistedCapabilityTags(t *testing.T) {
 		{Role: "assistant", Content: "msg2"},
 		{Role: "user", Content: "msg3"},
 	} {
-		if err := mem.AddMessage("conv1", m.Role, m.Content); err != nil {
+		if err := mem.AddMessage("conv1", m.Role, m.Content, ""); err != nil {
 			t.Fatalf("AddMessage() error: %v", err)
 		}
 	}
@@ -502,7 +502,7 @@ func TestResetConversation_ClearsPersistedCapabilityTags(t *testing.T) {
 	if err := store.SaveTags("conv1", []string{"forge"}); err != nil {
 		t.Fatalf("SaveTags() error: %v", err)
 	}
-	if err := mem.AddMessage("conv1", "user", "hello"); err != nil {
+	if err := mem.AddMessage("conv1", "user", "hello", ""); err != nil {
 		t.Fatalf("AddMessage() error: %v", err)
 	}
 

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -46,6 +46,14 @@ type Request struct {
 	SkipTagFilter    bool              `yaml:"skip_tag_filter,omitempty" json:"skip_tag_filter,omitempty"`
 	RoutingFactors   map[string]string `yaml:"routing_factors,omitempty" json:"routing_factors,omitempty"`
 	DelegationGating string            `yaml:"delegation_gating,omitempty" json:"delegation_gating,omitempty"` // Typed feature switch; "disabled" gives the model direct tool access (no orchestrator-and-delegate gating).
+	// MessageOrigin is the provenance stamped onto this request's
+	// Messages when the agent loop records them in conversation memory
+	// (memory.Origin* constants). Channel-shaped turn builders MUST set
+	// memory.OriginChannel; a turn-builder request that leaves this
+	// empty is defaulted to memory.OriginWake in
+	// [Loop.prepareAgentTurnRequest], because an undeclared turn-builder
+	// turn is by definition an internally-originated wake.
+	MessageOrigin string `yaml:"-" json:"-"`
 	// InitialTags are capability tags to activate at the start of the Run,
 	// in addition to core and channel-pinned tags. Used by loops
 	// to carry forward tags activated in previous iterations.
@@ -2362,6 +2370,10 @@ func (l *Loop) prepareAgentTurnRequest(req Request, convID string, isSupervisor 
 	// "disabled" default reaches descendants when nothing closer
 	// declares a value.
 	req.DelegationGating = firstNonEmpty(l.requestOverride.DelegationGating, req.DelegationGating, l.config.DelegationGating, l.requestBase.DelegationGating, cascade.DelegationGating)
+	// Every loop-prepared turn is internally originated unless its
+	// builder declared otherwise (channel bridges declare
+	// memory.OriginChannel on their requests) — see Request.MessageOrigin.
+	req.MessageOrigin = firstNonEmpty(req.MessageOrigin, memory.OriginWake)
 	req.OnProgress = composeProgressFuncs(l.makeProgressFunc(), req.OnProgress, l.requestOverride.OnProgress)
 	req.InitialTags = mergeUniqueStrings(configuredInitialTags, l.activatedTags)
 	req.RuntimeTools = mergeRuntimeTools(l.config.RuntimeTools, req.RuntimeTools)

--- a/internal/runtime/loop/message_origin_test.go
+++ b/internal/runtime/loop/message_origin_test.go
@@ -1,0 +1,44 @@
+package loop
+
+import (
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/state/memory"
+)
+
+// TestPrepareAgentTurnRequestMessageOrigin covers the provenance default
+// at the loop's request-preparation boundary: an undeclared turn-builder
+// turn is by definition an internally-originated wake, while a builder
+// that declares its origin (a channel bridge declaring OriginChannel)
+// must not have that declaration overwritten. A wrong default here would
+// stamp counterparty contact as internal — or wake prompts as contact —
+// and poison every downstream contact-gap computation.
+func TestPrepareAgentTurnRequestMessageOrigin(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		declared string
+		want     string
+	}{
+		{"undeclared defaults to wake", "", memory.OriginWake},
+		{"channel declaration preserved", memory.OriginChannel, memory.OriginChannel},
+		{"api declaration preserved", memory.OriginAPI, memory.OriginAPI},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l, err := New(Config{Name: "origin-test", Task: "t"}, Deps{Runner: &noopRunner{}})
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			req, err := l.prepareAgentTurnRequest(Request{MessageOrigin: tt.declared}, "conv-1", false)
+			if err != nil {
+				t.Fatalf("prepareAgentTurnRequest: %v", err)
+			}
+			if req.MessageOrigin != tt.want {
+				t.Errorf("MessageOrigin = %q, want %q", req.MessageOrigin, tt.want)
+			}
+		})
+	}
+}

--- a/internal/server/api/agent_loop_bridge.go
+++ b/internal/server/api/agent_loop_bridge.go
@@ -45,6 +45,7 @@ func loopRequestFromAgent(req *agent.Request) loop.Request {
 		SkipTagFilter:         req.SkipTagFilter,
 		RoutingFactors:        cloneStringMap(req.RoutingFactors),
 		DelegationGating:      req.DelegationGating,
+		MessageOrigin:         req.MessageOrigin,
 		InitialTags:           append([]string(nil), req.InitialTags...),
 		RuntimeTags:           append([]string(nil), req.RuntimeTags...),
 		RuntimeTools:          runtimeTools,

--- a/internal/server/api/conversations_test.go
+++ b/internal/server/api/conversations_test.go
@@ -31,7 +31,7 @@ func addConv(t *testing.T, store *memory.SQLiteStore, id string, messages int, b
 		t.Fatalf("GetOrCreateConversation %s: %v", id, err)
 	}
 	for i := 0; i < messages; i++ {
-		if err := store.AddMessage(id, "user", "hello"); err != nil {
+		if err := store.AddMessage(id, "user", "hello", ""); err != nil {
 			t.Fatalf("AddMessage %s: %v", id, err)
 		}
 	}

--- a/internal/server/api/ollama.go
+++ b/internal/server/api/ollama.go
@@ -267,6 +267,7 @@ func handleOllamaChatShared(w http.ResponseWriter, r *http.Request, loop *agent.
 		ChannelBinding:   channelBinding,
 		SkipContext:      auxiliary,
 		SystemPrompt:     ocSystemPrompt,
+		MessageOrigin:    memory.OriginAPI,
 	}
 
 	// Derive a short display name for the conversation's dashboard node.

--- a/internal/server/api/server.go
+++ b/internal/server/api/server.go
@@ -766,6 +766,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		RoutingFactors:   hints,
 		DelegationGating: delegationGating,
 		SystemPrompt:     systemPrompt,
+		MessageOrigin:    memory.OriginAPI,
 	}
 
 	if req.Stream {
@@ -856,6 +857,7 @@ func (s *Server) handleSimpleChat(w http.ResponseWriter, r *http.Request) {
 		RoutingFactors: map[string]string{
 			"channel": "api",
 		},
+		MessageOrigin: memory.OriginAPI,
 	}
 
 	resp, err := s.runChatLoop(ctx, agentReq, nil, "api/simple-chat")

--- a/internal/state/memory/archive.go
+++ b/internal/state/memory/archive.go
@@ -512,10 +512,12 @@ func (s *ArchiveStore) msgSelectCols() string {
 		return `id, conversation_id, COALESCE(session_id, '') as session_id,
 			role, content, timestamp, token_count, tool_calls, tool_call_id,
 			COALESCE(archived_at, '') as archived_at,
-			COALESCE(archive_reason, '') as archive_reason`
+			COALESCE(archive_reason, '') as archive_reason,
+			COALESCE(origin, '') as origin`
 	}
 	return `id, conversation_id, session_id, role, content, timestamp,
-		token_count, tool_calls, tool_call_id, archived_at, archive_reason`
+		token_count, tool_calls, tool_call_id, archived_at, archive_reason,
+		COALESCE(origin, '') as origin`
 }
 
 // countSessionMessages returns the message count for a session from the
@@ -595,10 +597,11 @@ func (s *ArchiveStore) migrate() error {
 			tool_calls TEXT,
 			tool_call_id TEXT,
 			archived_at TIMESTAMP NOT NULL,
-			archive_reason TEXT NOT NULL
+			archive_reason TEXT NOT NULL,
+			origin TEXT DEFAULT ''
 		);
 
-		CREATE INDEX IF NOT EXISTS idx_archive_conversation 
+		CREATE INDEX IF NOT EXISTS idx_archive_conversation
 			ON archive_messages(conversation_id, timestamp);
 		CREATE INDEX IF NOT EXISTS idx_archive_session 
 			ON archive_messages(session_id, timestamp);
@@ -759,6 +762,13 @@ func (s *ArchiveStore) migrateSchema() {
 	if _, err := s.db.Exec("SELECT tools_offered FROM archive_iterations LIMIT 0"); err != nil {
 		_, _ = s.db.Exec("ALTER TABLE archive_iterations ADD COLUMN tools_offered TEXT")
 	}
+
+	// Add origin provenance column for existing archive_messages tables,
+	// keeping the legacy split-DB projection aligned with the unified
+	// messages table (both feed the same scanners).
+	if _, err := s.db.Exec("SELECT origin FROM archive_messages LIMIT 0"); err != nil {
+		_, _ = s.db.Exec("ALTER TABLE archive_messages ADD COLUMN origin TEXT DEFAULT ''")
+	}
 }
 
 // tryEnableFTS attempts to create the FTS5 virtual table. Returns true if
@@ -893,10 +903,10 @@ func (s *ArchiveStore) ArchiveMessages(messages []Message) error {
 	defer func() { _ = tx.Rollback() }()
 
 	insertMsg, err := tx.Prepare(`
-		INSERT OR IGNORE INTO archive_messages 
-			(id, conversation_id, session_id, role, content, timestamp, 
-			 token_count, tool_calls, tool_call_id, archived_at, archive_reason)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		INSERT OR IGNORE INTO archive_messages
+			(id, conversation_id, session_id, role, content, timestamp,
+			 token_count, tool_calls, tool_call_id, archived_at, archive_reason, origin)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`)
 	if err != nil {
 		return fmt.Errorf("prepare: %w", err)
@@ -933,7 +943,7 @@ func (s *ArchiveStore) ArchiveMessages(messages []Message) error {
 			m.ID, m.ConversationID, m.SessionID, m.Role, m.Content,
 			m.Timestamp.Format(time.RFC3339Nano),
 			m.TokenCount, nullString(m.ToolCalls), nullString(m.ToolCallID),
-			m.ArchivedAt.Format(time.RFC3339Nano), m.ArchiveReason,
+			m.ArchivedAt.Format(time.RFC3339Nano), m.ArchiveReason, m.Origin,
 		)
 		if err != nil {
 			return fmt.Errorf("insert message %s: %w", m.ID, err)
@@ -1028,8 +1038,8 @@ func (s *ArchiveStore) ImportMessages(messages []Message) error {
 		INSERT OR IGNORE INTO %s
 			(id, conversation_id, session_id, role, content, timestamp,
 			 token_count, tool_calls, tool_call_id,
-			 status, archived_at, archive_reason)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'archived', ?, ?)
+			 status, archived_at, archive_reason, origin)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'archived', ?, ?, ?)
 	`, s.msgTableName))
 	if err != nil {
 		return fmt.Errorf("prepare: %w", err)
@@ -1052,7 +1062,7 @@ func (s *ArchiveStore) ImportMessages(messages []Message) error {
 			m.ID, m.ConversationID, m.SessionID, m.Role, m.Content,
 			m.Timestamp.Format(time.RFC3339Nano),
 			m.TokenCount, nullString(m.ToolCalls), nullString(m.ToolCallID),
-			m.ArchivedAt.Format(time.RFC3339Nano), m.ArchiveReason,
+			m.ArchivedAt.Format(time.RFC3339Nano), m.ArchiveReason, m.Origin,
 		); err != nil {
 			return fmt.Errorf("insert message %s: %w", m.ID, err)
 		}
@@ -1525,7 +1535,7 @@ func (s *ArchiveStore) runFTSQuery(ftsExpr string, opts SearchOptions, limit int
 // ftsMatchColumns is the message-column projection shared by the FTS
 // SELECT here and the COUNT/scan paths, kept in one place so the column
 // order can't drift from [scanFTSMatches].
-const ftsMatchColumns = "am.id, am.conversation_id, COALESCE(am.session_id, '') as session_id, am.role, am.content, am.timestamp, am.token_count, am.tool_calls, am.tool_call_id, COALESCE(am.archived_at, '') as archived_at, COALESCE(am.archive_reason, '') as archive_reason"
+const ftsMatchColumns = "am.id, am.conversation_id, COALESCE(am.session_id, '') as session_id, am.role, am.content, am.timestamp, am.token_count, am.tool_calls, am.tool_call_id, COALESCE(am.archived_at, '') as archived_at, COALESCE(am.archive_reason, '') as archive_reason, COALESCE(am.origin, '') as origin"
 
 // ftsConditions builds the shared WHERE clause and bound args for an
 // FTS query: the MATCH expression plus optional conversation scope,
@@ -1668,7 +1678,7 @@ func scanFTSMatches(rows *sql.Rows) ([]matchWithHighlight, error) {
 		err := rows.Scan(
 			&m.ID, &m.ConversationID, &m.SessionID, &m.Role, &m.Content,
 			&tsStr, &m.TokenCount, &toolCalls, &toolCallID,
-			&archivedStr, &m.ArchiveReason, &highlight, &bm25,
+			&archivedStr, &m.ArchiveReason, &m.Origin, &highlight, &bm25,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("scan: %w", err)
@@ -1779,7 +1789,7 @@ func (s *ArchiveStore) expandContext(
 		err := rows.Scan(
 			&m.ID, &m.ConversationID, &m.SessionID, &m.Role, &m.Content,
 			&tsStr, &m.TokenCount, &toolCalls, &toolCallID,
-			&archivedStr, &m.ArchiveReason,
+			&archivedStr, &m.ArchiveReason, &m.Origin,
 		)
 		if err != nil {
 			continue
@@ -2851,7 +2861,7 @@ func (s *ArchiveStore) scanMessages(rows *sql.Rows) ([]Message, error) {
 		err := rows.Scan(
 			&m.ID, &m.ConversationID, &m.SessionID, &m.Role, &m.Content,
 			&tsStr, &m.TokenCount, &toolCalls, &toolCallID,
-			&archivedStr, &m.ArchiveReason,
+			&archivedStr, &m.ArchiveReason, &m.Origin,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("scan message: %w", err)

--- a/internal/state/memory/archive_adapter_test.go
+++ b/internal/state/memory/archive_adapter_test.go
@@ -42,7 +42,7 @@ func TestAdapter_ArchiveConversation(t *testing.T) {
 	// Add active messages to the unified table.
 	workingStore.GetOrCreateConversation("conv-1")
 	for _, content := range []string{"hello", "hi there!"} {
-		if err := workingStore.AddMessage("conv-1", "user", content); err != nil {
+		if err := workingStore.AddMessage("conv-1", "user", content, ""); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -91,7 +91,7 @@ func TestAdapter_ArchiveConversation_WithToolCalls(t *testing.T) {
 
 	// Add messages and tool calls to the unified tables.
 	workingStore.GetOrCreateConversation("conv-1")
-	workingStore.AddMessage("conv-1", "user", "search for test")
+	workingStore.AddMessage("conv-1", "user", "search for test", "")
 	workingStore.RecordToolCall("conv-1", "", "tc-1", "web_search", `{"query":"test"}`)
 	workingStore.CompleteToolCall("tc-1", "search results", "")
 

--- a/internal/state/memory/archive_integration_test.go
+++ b/internal/state/memory/archive_integration_test.go
@@ -29,7 +29,7 @@ func TestCompaction_PreservesMessages(t *testing.T) {
 	// Add enough messages to trigger compaction.
 	for i := 0; i < 20; i++ {
 		msg := "This is a test message with some content for token counting purposes."
-		if err := memStore.AddMessage("test-conv", "user", msg); err != nil {
+		if err := memStore.AddMessage("test-conv", "user", msg, ""); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/state/memory/archive_test.go
+++ b/internal/state/memory/archive_test.go
@@ -1094,7 +1094,7 @@ func TestNewArchiveStoreFromDB_CloseIsNoop(t *testing.T) {
 	}
 
 	// The working store should still be usable.
-	if err := workingStore.AddMessage("conv-1", "user", "after close"); err != nil {
+	if err := workingStore.AddMessage("conv-1", "user", "after close", ""); err != nil {
 		t.Fatalf("working store should still work after archive close: %v", err)
 	}
 }
@@ -1876,7 +1876,7 @@ func TestGetMessagesInRange_UnifiedTableSpaceFormat(t *testing.T) {
 
 	// Insert three messages via the production path (bound time.Time).
 	for i, content := range []string{"first", "second", "third"} {
-		if err := workingStore.AddMessage("conv-1", "user", content); err != nil {
+		if err := workingStore.AddMessage("conv-1", "user", content, ""); err != nil {
 			t.Fatalf("AddMessage[%d]: %v", i, err)
 		}
 		time.Sleep(2 * time.Millisecond) // distinguish timestamps

--- a/internal/state/memory/midturn_provenance_test.go
+++ b/internal/state/memory/midturn_provenance_test.go
@@ -14,10 +14,10 @@ import (
 func TestMidTurnMessageRoundTrip(t *testing.T) {
 	store := newWindowStore(t, 100)
 
-	if err := store.AddMessage("conv-1", "user", "ordinary"); err != nil {
+	if err := store.AddMessage("conv-1", "user", "ordinary", ""); err != nil {
 		t.Fatalf("AddMessage: %v", err)
 	}
-	if err := store.AddMidTurnMessage("conv-1", "user", "mid-turn arrival"); err != nil {
+	if err := store.AddMidTurnMessage("conv-1", "user", "mid-turn arrival", ""); err != nil {
 		t.Fatalf("AddMidTurnMessage: %v", err)
 	}
 
@@ -74,10 +74,10 @@ func TestMidTurnMessageNullLegacyRow(t *testing.T) {
 // AddMidTurnMessage contract as the SQLite store.
 func TestMidTurnMessageInMemoryParity(t *testing.T) {
 	s := NewStore(100)
-	if err := s.AddMessage("c", "user", "ordinary"); err != nil {
+	if err := s.AddMessage("c", "user", "ordinary", ""); err != nil {
 		t.Fatalf("AddMessage: %v", err)
 	}
-	if err := s.AddMidTurnMessage("c", "user", "mid"); err != nil {
+	if err := s.AddMidTurnMessage("c", "user", "mid", ""); err != nil {
 		t.Fatalf("AddMidTurnMessage: %v", err)
 	}
 	byContent := make(map[string]Message)

--- a/internal/state/memory/origin_provenance_test.go
+++ b/internal/state/memory/origin_provenance_test.go
@@ -113,6 +113,139 @@ func TestMessageOriginInMemoryParity(t *testing.T) {
 	}
 }
 
+// TestMessageOriginCompactionRows verifies the compaction insert paths
+// stamp their rows OriginInternal: ApplyCompaction and
+// AddCompactionSummary write system rows directly rather than through
+// addMessage, and a known system-authored row persisted as unstamped
+// would violate the contract that empty means the enqueue site could
+// not know.
+func TestMessageOriginCompactionRows(t *testing.T) {
+	store := newWindowStore(t, 100)
+
+	if err := store.AddMessage("conv-1", "user", "to be compacted", OriginChannel); err != nil {
+		t.Fatalf("AddMessage: %v", err)
+	}
+	compacted := store.GetMessages("conv-1")
+	if len(compacted) != 1 {
+		t.Fatalf("seed message missing")
+	}
+	summaryTS := time.Now().Add(-time.Minute)
+	if err := store.ApplyCompaction("conv-1", []string{compacted[0].ID}, CompactionSummaryPrefix+" the earlier exchange", summaryTS); err != nil {
+		t.Fatalf("ApplyCompaction: %v", err)
+	}
+	if err := store.AddCompactionSummary("conv-1", CompactionSummaryPrefix+" session handoff"); err != nil {
+		t.Fatalf("AddCompactionSummary: %v", err)
+	}
+
+	for _, m := range store.GetMessages("conv-1") {
+		if m.Role == "system" && m.Origin != OriginInternal {
+			t.Errorf("compaction row %q origin = %q, want %q", m.Content, m.Origin, OriginInternal)
+		}
+	}
+}
+
+// TestMessageOriginArchiveRoundTrip verifies origin survives the archive
+// write and read paths in both storage modes: ImportMessages into the
+// unified table read back through the session-transcript and search
+// scanners, and legacy split-DB ArchiveMessages into archive_messages —
+// including a NULL-origin legacy row surviving the legacy scanner.
+func TestMessageOriginArchiveRoundTrip(t *testing.T) {
+	base := time.Now().Add(-2 * time.Hour).Truncate(time.Second)
+	imported := []Message{
+		{
+			ID: "arch-1", ConversationID: "conv-arch", SessionID: "sess-arch",
+			Role: "user", Content: "archived inbound greeting",
+			Timestamp: base, Origin: OriginChannel,
+		},
+		{
+			ID: "arch-2", ConversationID: "conv-arch", SessionID: "sess-arch",
+			Role: "user", Content: "archived wake prompt",
+			Timestamp: base.Add(time.Minute), Origin: OriginWake,
+		},
+	}
+
+	t.Run("unified", func(t *testing.T) {
+		store := newWindowStore(t, 100)
+		archive, err := NewArchiveStoreFromDB(store.db, nil, nil)
+		if err != nil {
+			t.Fatalf("NewArchiveStoreFromDB: %v", err)
+		}
+		if err := archive.ImportMessages(imported); err != nil {
+			t.Fatalf("ImportMessages: %v", err)
+		}
+
+		transcript, err := archive.GetSessionTranscript("sess-arch")
+		if err != nil {
+			t.Fatalf("GetSessionTranscript: %v", err)
+		}
+		assertOrigins(t, "transcript", transcript, map[string]string{
+			"archived inbound greeting": OriginChannel,
+			"archived wake prompt":      OriginWake,
+		})
+
+		results, err := archive.Search(SearchOptions{Query: "archived inbound", Limit: 5})
+		if err != nil {
+			t.Fatalf("Search: %v", err)
+		}
+		if len(results) == 0 {
+			t.Fatalf("search found nothing for the archived row")
+		}
+		if got := results[0].Match.Origin; got != OriginChannel {
+			t.Errorf("search match origin = %q, want %q", got, OriginChannel)
+		}
+	})
+
+	t.Run("legacy split-DB", func(t *testing.T) {
+		archive, err := NewArchiveStore(t.TempDir()+"/archive.db", nil, nil, nil)
+		if err != nil {
+			t.Fatalf("NewArchiveStore: %v", err)
+		}
+		t.Cleanup(func() { _ = archive.Close() })
+
+		if err := archive.ArchiveMessages(imported); err != nil {
+			t.Fatalf("ArchiveMessages: %v", err)
+		}
+		// A pre-stamp legacy row: NULL origin must scan as "" rather
+		// than dropping the message.
+		if _, err := archive.DB().Exec(`
+			INSERT INTO archive_messages (id, conversation_id, session_id, role, content, timestamp, archived_at, archive_reason, origin)
+			VALUES ('arch-legacy', 'conv-arch', 'sess-arch', 'user', 'pre-stamp row', ?, ?, 'import', NULL)
+		`, base.Add(2*time.Minute).Format(time.RFC3339Nano), base.Add(2*time.Minute).Format(time.RFC3339Nano)); err != nil {
+			t.Fatalf("insert NULL-origin legacy row: %v", err)
+		}
+
+		transcript, err := archive.GetSessionTranscript("sess-arch")
+		if err != nil {
+			t.Fatalf("GetSessionTranscript: %v", err)
+		}
+		assertOrigins(t, "legacy transcript", transcript, map[string]string{
+			"archived inbound greeting": OriginChannel,
+			"archived wake prompt":      OriginWake,
+			"pre-stamp row":             "",
+		})
+	})
+}
+
+// assertOrigins checks each expected content string is present with the
+// expected origin.
+func assertOrigins(t *testing.T, path string, msgs []Message, want map[string]string) {
+	t.Helper()
+	byContent := make(map[string]Message, len(msgs))
+	for _, m := range msgs {
+		byContent[m.Content] = m
+	}
+	for content, origin := range want {
+		m, ok := byContent[content]
+		if !ok {
+			t.Errorf("%s: message %q missing", path, content)
+			continue
+		}
+		if m.Origin != origin {
+			t.Errorf("%s: %q origin = %q, want %q", path, content, m.Origin, origin)
+		}
+	}
+}
+
 // TestMessageOriginJSONContract locks the wire shape: origin appears only
 // when stamped, so unstamped rows stay unchanged for existing consumers.
 func TestMessageOriginJSONContract(t *testing.T) {

--- a/internal/state/memory/origin_provenance_test.go
+++ b/internal/state/memory/origin_provenance_test.go
@@ -1,0 +1,133 @@
+package memory
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestMessageOriginRoundTrip verifies the origin provenance stamp survives
+// a write/read cycle through the SQLite store on both read paths, for every
+// declared origin and the unstamped empty value. Origin is the structured
+// contract that replaces sniffing transport envelopes out of message
+// content to tell counterparty contact from internal wake prompts.
+func TestMessageOriginRoundTrip(t *testing.T) {
+	tests := []struct {
+		name   string
+		origin string
+	}{
+		{"channel", OriginChannel},
+		{"wake", OriginWake},
+		{"api", OriginAPI},
+		{"internal", OriginInternal},
+		{"unstamped", ""},
+	}
+
+	store := newWindowStore(t, 100)
+	for _, tt := range tests {
+		if err := store.AddMessage("conv-1", "user", "msg-"+tt.name, tt.origin); err != nil {
+			t.Fatalf("AddMessage(%s): %v", tt.name, err)
+		}
+	}
+	if err := store.AddMidTurnMessage("conv-1", "user", "msg-midturn", OriginChannel); err != nil {
+		t.Fatalf("AddMidTurnMessage: %v", err)
+	}
+
+	check := func(path string, msgs []Message) {
+		byContent := make(map[string]Message, len(msgs))
+		for _, m := range msgs {
+			byContent[m.Content] = m
+		}
+		for _, tt := range tests {
+			m, ok := byContent["msg-"+tt.name]
+			if !ok {
+				t.Fatalf("%s: message %q missing", path, tt.name)
+			}
+			if m.Origin != tt.origin {
+				t.Errorf("%s: origin = %q, want %q", path, m.Origin, tt.origin)
+			}
+		}
+		mid, ok := byContent["msg-midturn"]
+		if !ok {
+			t.Fatalf("%s: mid-turn message missing", path)
+		}
+		if !mid.MidTurn || mid.Origin != OriginChannel {
+			t.Errorf("%s: mid-turn row = (mid_turn=%v, origin=%q), want (true, %q) — the two stamps must compose",
+				path, mid.MidTurn, mid.Origin, OriginChannel)
+		}
+	}
+	check("GetMessages", store.GetMessages("conv-1"))
+	check("GetAllMessages", store.GetAllMessages("conv-1"))
+}
+
+// TestMessageOriginNullLegacyRow pins the read paths against a row whose
+// origin is NULL — the shape a pre-stamp row takes if the additive
+// migration ever lost its empty-string DEFAULT. Without the COALESCE in
+// every origin-bearing SELECT, scanning NULL into a string errors and
+// the read loops silently drop the message.
+func TestMessageOriginNullLegacyRow(t *testing.T) {
+	store := newWindowStore(t, 100)
+	base := time.Now().Add(-time.Hour).Truncate(time.Second)
+	if _, err := store.db.Exec(`
+		INSERT INTO messages (id, conversation_id, role, content, timestamp, token_count, origin)
+		VALUES ('legacy', 'conv-1', 'user', 'legacy null row', ?, 5, NULL)
+	`, base); err != nil {
+		t.Fatalf("insert NULL row: %v", err)
+	}
+
+	find := func(path string, msgs []Message) {
+		for _, m := range msgs {
+			if m.Content == "legacy null row" {
+				if m.Origin != "" {
+					t.Errorf("%s: NULL origin read as %q, want empty", path, m.Origin)
+				}
+				return
+			}
+		}
+		t.Fatalf("%s: NULL-origin row dropped from the read (silent message loss)", path)
+	}
+	find("GetMessages", store.GetMessages("conv-1"))
+	find("GetAllMessages", store.GetAllMessages("conv-1"))
+}
+
+// TestMessageOriginInMemoryParity confirms the in-memory Store honors the
+// same origin contract as the SQLite store.
+func TestMessageOriginInMemoryParity(t *testing.T) {
+	s := NewStore(100)
+	if err := s.AddMessage("c", "user", "from-channel", OriginChannel); err != nil {
+		t.Fatalf("AddMessage: %v", err)
+	}
+	if err := s.AddMidTurnMessage("c", "user", "mid", OriginWake); err != nil {
+		t.Fatalf("AddMidTurnMessage: %v", err)
+	}
+	byContent := make(map[string]Message)
+	for _, m := range s.GetMessages("c") {
+		byContent[m.Content] = m
+	}
+	if got := byContent["from-channel"].Origin; got != OriginChannel {
+		t.Errorf("origin = %q, want %q", got, OriginChannel)
+	}
+	if m := byContent["mid"]; !m.MidTurn || m.Origin != OriginWake {
+		t.Errorf("mid-turn row = (mid_turn=%v, origin=%q), want (true, %q)", m.MidTurn, m.Origin, OriginWake)
+	}
+}
+
+// TestMessageOriginJSONContract locks the wire shape: origin appears only
+// when stamped, so unstamped rows stay unchanged for existing consumers.
+func TestMessageOriginJSONContract(t *testing.T) {
+	on, err := json.Marshal(Message{Role: "user", Content: "x", Origin: OriginChannel})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(on), `"origin":"channel"`) {
+		t.Errorf("stamped origin not surfaced in JSON: %s", on)
+	}
+	off, err := json.Marshal(Message{Role: "user", Content: "x"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(off), "origin") {
+		t.Errorf("origin should be omitted when unstamped (omitempty): %s", off)
+	}
+}

--- a/internal/state/memory/schema.go
+++ b/internal/state/memory/schema.go
@@ -39,6 +39,7 @@ var schema = database.Schema{
 				archive_reason TEXT,
 				iteration_index INTEGER,
 				mid_turn INTEGER DEFAULT 0,
+				origin TEXT DEFAULT '',
 				FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
 			)`,
 		},
@@ -115,6 +116,7 @@ var schema = database.Schema{
 		database.ColumnAdd{Table: "messages", Column: "archive_reason", Typedef: "TEXT"},
 		database.ColumnAdd{Table: "messages", Column: "iteration_index", Typedef: "INTEGER"},
 		database.ColumnAdd{Table: "messages", Column: "mid_turn", Typedef: "INTEGER DEFAULT 0"},
+		database.ColumnAdd{Table: "messages", Column: "origin", Typedef: "TEXT DEFAULT ''"},
 		database.ColumnAdd{Table: "tool_calls", Column: "session_id", Typedef: "TEXT"},
 		database.ColumnAdd{Table: "tool_calls", Column: "status", Typedef: "TEXT DEFAULT 'active' CHECK (status IN ('active', 'archived'))"},
 		database.ColumnAdd{Table: "tool_calls", Column: "archived_at", Typedef: "TIMESTAMP"},

--- a/internal/state/memory/sqlite.go
+++ b/internal/state/memory/sqlite.go
@@ -125,20 +125,23 @@ func (s *SQLiteStore) GetOrCreateConversation(id string) (*Conversation, error) 
 	return &conv, nil
 }
 
-// AddMessage adds a message to a conversation.
-func (s *SQLiteStore) AddMessage(conversationID, role, content string) error {
-	return s.addMessage(conversationID, role, content, false)
+// AddMessage adds a message to a conversation. origin records how the
+// message entered the conversation (see the Origin* constants); pass ""
+// when the enqueue site cannot know.
+func (s *SQLiteStore) AddMessage(conversationID, role, content, origin string) error {
+	return s.addMessage(conversationID, role, content, origin, false)
 }
 
 // AddMidTurnMessage adds a message that arrived mid-turn and was merged into
 // an in-flight turn (#1230), tagging the row so consumers can identify the
 // injection from the structured record rather than substring-matching the
-// channel-rendered arrival marker in the content.
-func (s *SQLiteStore) AddMidTurnMessage(conversationID, role, content string) error {
-	return s.addMessage(conversationID, role, content, true)
+// channel-rendered arrival marker in the content. origin follows the same
+// contract as [SQLiteStore.AddMessage].
+func (s *SQLiteStore) AddMidTurnMessage(conversationID, role, content, origin string) error {
+	return s.addMessage(conversationID, role, content, origin, true)
 }
 
-func (s *SQLiteStore) addMessage(conversationID, role, content string, midTurn bool) error {
+func (s *SQLiteStore) addMessage(conversationID, role, content, origin string, midTurn bool) error {
 	now := time.Now()
 	msgID, err := uuid.NewV7()
 	if err != nil {
@@ -158,9 +161,9 @@ func (s *SQLiteStore) addMessage(conversationID, role, content string, midTurn b
 
 	// Insert message
 	_, err = s.db.Exec(`
-		INSERT INTO messages (id, conversation_id, role, content, timestamp, token_count, mid_turn)
-		VALUES (?, ?, ?, ?, ?, ?, ?)
-	`, msgID.String(), conversationID, role, content, now, llm.EstimateTokens(content), midTurnVal)
+		INSERT INTO messages (id, conversation_id, role, content, timestamp, token_count, mid_turn, origin)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`, msgID.String(), conversationID, role, content, now, llm.EstimateTokens(content), midTurnVal, origin)
 	if err != nil {
 		return fmt.Errorf("insert message: %w", err)
 	}
@@ -197,15 +200,15 @@ func (s *SQLiteStore) addMessage(conversationID, role, content string, midTurn b
 func (s *SQLiteStore) GetMessages(conversationID string) []Message {
 	rows, err := s.db.Query(`
 		WITH recent AS (
-			SELECT id, role, content, timestamp, COALESCE(mid_turn, 0) AS mid_turn
+			SELECT id, role, content, timestamp, COALESCE(mid_turn, 0) AS mid_turn, COALESCE(origin, '') AS origin
 			FROM messages
 			WHERE conversation_id = ? AND status = 'active'
 			ORDER BY timestamp DESC, id DESC
 			LIMIT ?
 		)
-		SELECT id, role, content, timestamp, mid_turn FROM recent
+		SELECT id, role, content, timestamp, mid_turn, origin FROM recent
 		UNION
-		SELECT id, role, content, timestamp, COALESCE(mid_turn, 0)
+		SELECT id, role, content, timestamp, COALESCE(mid_turn, 0), COALESCE(origin, '')
 		FROM messages
 		WHERE conversation_id = ? AND status = 'active' AND role = 'system'
 		  AND content LIKE ? || '%'
@@ -220,7 +223,7 @@ func (s *SQLiteStore) GetMessages(conversationID string) []Message {
 	for rows.Next() {
 		var m Message
 		var midTurn int
-		if err := rows.Scan(&m.ID, &m.Role, &m.Content, &m.Timestamp, &midTurn); err != nil {
+		if err := rows.Scan(&m.ID, &m.Role, &m.Content, &m.Timestamp, &midTurn, &m.Origin); err != nil {
 			continue
 		}
 		m.MidTurn = midTurn != 0
@@ -455,7 +458,7 @@ func (s *SQLiteStore) BindConversationChannel(conversationID string, binding *Ch
 // Includes tool call data for full-fidelity archiving — never lose primary sources.
 func (s *SQLiteStore) GetAllMessages(conversationID string) []Message {
 	rows, err := s.db.Query(`
-		SELECT id, role, content, timestamp, tool_calls, tool_call_id, COALESCE(mid_turn, 0)
+		SELECT id, role, content, timestamp, tool_calls, tool_call_id, COALESCE(mid_turn, 0), COALESCE(origin, '')
 		FROM messages
 		WHERE conversation_id = ?
 		ORDER BY timestamp ASC
@@ -470,7 +473,7 @@ func (s *SQLiteStore) GetAllMessages(conversationID string) []Message {
 		var m Message
 		var toolCalls, toolCallID sql.NullString
 		var midTurn int
-		if err := rows.Scan(&m.ID, &m.Role, &m.Content, &m.Timestamp, &toolCalls, &toolCallID, &midTurn); err != nil {
+		if err := rows.Scan(&m.ID, &m.Role, &m.Content, &m.Timestamp, &toolCalls, &toolCallID, &midTurn, &m.Origin); err != nil {
 			continue
 		}
 		if toolCalls.Valid {

--- a/internal/state/memory/sqlite.go
+++ b/internal/state/memory/sqlite.go
@@ -611,9 +611,9 @@ func (s *SQLiteStore) ApplyCompaction(conversationID string, compactedIDs []stri
 	}
 
 	if _, err := tx.Exec(`
-		INSERT INTO messages (id, conversation_id, role, content, timestamp, token_count, status)
-		VALUES (?, ?, 'system', ?, ?, ?, 'active')
-	`, msgID.String(), conversationID, summary, summaryTS, llm.EstimateTokens(summary)); err != nil {
+		INSERT INTO messages (id, conversation_id, role, content, timestamp, token_count, status, origin)
+		VALUES (?, ?, 'system', ?, ?, ?, 'active', ?)
+	`, msgID.String(), conversationID, summary, summaryTS, llm.EstimateTokens(summary), OriginInternal); err != nil {
 		return fmt.Errorf("insert summary: %w", err)
 	}
 
@@ -631,9 +631,9 @@ func (s *SQLiteStore) AddCompactionSummary(conversationID, summary string) error
 	}
 
 	_, err = s.db.Exec(`
-		INSERT INTO messages (id, conversation_id, role, content, timestamp, token_count, status)
-		VALUES (?, ?, 'system', ?, ?, ?, 'active')
-	`, msgID.String(), conversationID, summary, time.Now(), llm.EstimateTokens(summary))
+		INSERT INTO messages (id, conversation_id, role, content, timestamp, token_count, status, origin)
+		VALUES (?, ?, 'system', ?, ?, ?, 'active', ?)
+	`, msgID.String(), conversationID, summary, time.Now(), llm.EstimateTokens(summary), OriginInternal)
 
 	return err
 }

--- a/internal/state/memory/store.go
+++ b/internal/state/memory/store.go
@@ -26,11 +26,40 @@ import (
 // and SQLite). Both [Store] and [SQLiteStore] satisfy it.
 type MemoryStore interface {
 	GetMessages(conversationID string) []Message
-	AddMessage(conversationID, role, content string) error
+	AddMessage(conversationID, role, content, origin string) error
 	GetConversation(id string) *Conversation
 	Clear(conversationID string) error
 	Stats() map[string]any
 }
+
+// Origin values for [Message.Origin]. Each enqueue site stamps the value
+// it knows to be true; a site that cannot know passes "" rather than
+// guessing, so an empty origin always means "unstamped", never "wrong".
+const (
+	// OriginChannel marks a message that crossed a channel transport
+	// to or from the conversation's human counterparty — an inbound
+	// message recorded by a channel bridge, or an outbound send
+	// recorded by a delivery path. Channel-shaped turn builders MUST
+	// declare this on their requests; undeclared turn-builder turns
+	// default to OriginWake.
+	OriginChannel = "channel"
+
+	// OriginWake marks an internally-originated wake prompt: a turn
+	// opened by loop_wake, a subscription fire, a scheduled trigger,
+	// or another internal source rather than by counterparty contact.
+	OriginWake = "wake"
+
+	// OriginAPI marks a message that entered through an operator-facing
+	// API surface (REST endpoints, foreign-protocol compat shims).
+	OriginAPI = "api"
+
+	// OriginInternal marks rows the system authored into the
+	// conversation itself: the loop's own generated output, detached
+	// completion injections, and system notices. Whether such a row was
+	// also delivered to a channel counterparty is a delivery-path fact,
+	// recorded separately (see OriginChannel).
+	OriginInternal = "internal"
+)
 
 // Message represents a conversation message. This is the unified type for
 // both active working-memory messages and archived session transcripts.
@@ -53,6 +82,15 @@ type Message struct {
 	// opening its own turn. The structured contract that replaces
 	// substring-matching the channel-rendered arrival marker.
 	MidTurn bool `json:"mid_turn,omitempty"`
+	// Origin records how the row entered the conversation — see the
+	// Origin* constants. Stamped at ingest by the enqueue site; empty on
+	// rows written before provenance stamping existed and on paths that
+	// cannot know their provenance (notably mid-turn mailbox merges,
+	// whose per-item origin is flattened before recording). Same
+	// structured-contract lineage as MidTurn: a stamped value is the
+	// source of truth, and content sniffing is permissible only as a
+	// documented fallback for rows whose Origin is empty.
+	Origin string `json:"origin,omitempty"`
 }
 
 // Conversation holds the state of a single conversation.
@@ -117,19 +155,22 @@ func (s *Store) GetOrCreateConversation(id string) *Conversation {
 	return conv.copy()
 }
 
-// AddMessage adds a message to a conversation.
-func (s *Store) AddMessage(conversationID string, role, content string) error {
-	return s.addMessage(conversationID, role, content, false)
+// AddMessage adds a message to a conversation. origin records how the
+// message entered the conversation (see the Origin* constants); pass ""
+// when the enqueue site cannot know.
+func (s *Store) AddMessage(conversationID string, role, content, origin string) error {
+	return s.addMessage(conversationID, role, content, origin, false)
 }
 
 // AddMidTurnMessage adds a message that arrived mid-turn and was merged into
 // an in-flight turn (#1230), tagging it so consumers can identify the
-// injection without substring-matching the rendered arrival marker.
-func (s *Store) AddMidTurnMessage(conversationID string, role, content string) error {
-	return s.addMessage(conversationID, role, content, true)
+// injection without substring-matching the rendered arrival marker. origin
+// follows the same contract as [Store.AddMessage].
+func (s *Store) AddMidTurnMessage(conversationID string, role, content, origin string) error {
+	return s.addMessage(conversationID, role, content, origin, true)
 }
 
-func (s *Store) addMessage(conversationID string, role, content string, midTurn bool) error {
+func (s *Store) addMessage(conversationID string, role, content, origin string, midTurn bool) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -153,6 +194,7 @@ func (s *Store) addMessage(conversationID string, role, content string, midTurn 
 		Content:   content,
 		Timestamp: time.Now(),
 		MidTurn:   midTurn,
+		Origin:    origin,
 	})
 	conv.UpdatedAt = time.Now()
 

--- a/internal/state/memory/toolcall_test.go
+++ b/internal/state/memory/toolcall_test.go
@@ -37,7 +37,7 @@ func TestToolCallRecording(t *testing.T) {
 	}
 
 	// Record a tool call with message_id
-	err = store.AddMessage("test-conv", "user", "test message")
+	err = store.AddMessage("test-conv", "user", "test message", "")
 	if err != nil {
 		t.Fatalf("AddMessage failed: %v", err)
 	}


### PR DESCRIPTION
## Summary

First PR of #1440: stored messages learn how they entered the conversation. A counterparty Signal message and an internal wake prompt are both `role: user` rows today, distinguishable only by sniffing content for transport envelope headers — the pattern `Message.MidTurn` exists specifically to replace. This PR adds the structured counterpart for provenance: an `Origin` field stamped at ingest, no behavior change, no consumer yet. The conversation-timing narrative block (#1440's second PR) is the first consumer; contact-aware summarizer idle decisions are enabled later by the same datum.

## The contract

`Message.Origin` takes one of four constants, or stays empty. The rule that keeps it honest: **each enqueue site stamps what it knows to be true, and a site that cannot know passes "" rather than guessing** — an empty origin always means "unstamped", never "wrong".

- `channel` — crossed a channel transport to or from the human counterparty, either direction: inbound rows stamped by the Signal bridge's turn requests, outbound rows stamped by `signalMemoryRecorder.RecordOutbound` (direction rides the role).
- `wake` — an internally-originated wake prompt. Stamped as the default at `prepareAgentTurnRequest`, the loop runtime's shared request-preparation boundary: an undeclared turn-builder turn is by definition a wake. Channel-shaped turn builders MUST declare `channel` on their requests (the Signal bridge now does); the field's Godoc carries that contract.
- `api` — operator-facing API surfaces: native completions, simple chat, and the OWU compat shim.
- `internal` — rows the system authored into the conversation itself: the loop's own assistant output (including greeting fast-path and exhaustion fallback), detached completion injections, and system notices via `conversationSystemInjector`.

Provenance rides requests as `MessageOrigin` (on both `agent.Request` and `loop.Request`, copied through both bridge clones), so the stamp travels from the enqueue site that knows the truth to the storage calls in the agent loop. `AddMessage` and `AddMidTurnMessage` take the origin as an explicit parameter — every future caller must declare, which is the point.

## Deliberate gaps

Mid-turn mailbox merges stamp `""`. The pull path renders mailbox items of mixed provenance (channel arrivals, internal notifies) into plain `llm.Message`s before the recording wrapper sees them, so per-item origin is not recoverable there without widening the mailbox render contract. #1440's previous-contact query covers these rows with its legacy envelope-header fallback — mid-turn channel renders carry the channel voice — and per-item mailbox origins remain available as a follow-up if that fallback ever proves insufficient.

The session-split re-add path now carries `m.Origin` through rather than laundering it to unstamped — the restore path is where provenance would otherwise silently die.

Legacy rows are handled additively: the unified `messages` table and the legacy `archive_messages` table both gain `origin TEXT DEFAULT ''` via idempotent migrations, every read path COALESCEs, and a NULL-origin row (the shape a pre-stamp row takes if a migration loses its default) is pinned by test to read as `""` rather than being dropped on scan error.

## Test plan

- [x] Origin round-trips through the SQLite store on both read paths for all four constants plus unstamped, and composes with `mid_turn` on the same row
- [x] NULL-origin legacy row reads as `""` instead of being silently dropped
- [x] In-memory Store parity with the SQLite contract
- [x] JSON contract: `origin` surfaced only when stamped (omitempty)
- [x] `prepareAgentTurnRequest` defaults undeclared turns to `wake` and preserves declared `channel`/`api`
- [x] `just ci` green

Refs #1440
