### PR TITLE
feat(context): render conversational rhythm as interpreted narrative

### DIFF
--- a/docs/model-facing-context.md
+++ b/docs/model-facing-context.md
@@ -196,6 +196,29 @@ Use the shared helpers in `internal/model/promptfmt/timefmt.go`:
 When a tool naturally wants relative scheduling, accept delta syntax as
 input instead of forcing the model to invent RFC3339 timestamps.
 
+### Interpret conversational rhythm once, render it as prose
+
+The conversation-timing block ("You're in an active conversation that's
+been going on for about 25 minutes…", "This is the first contact today.
+The previous conversation was last night, about…") is the worked example
+of the "prose is genuinely the clearer contract" escape hatch: once Go
+has bucketed the gap and chosen the day word, there is no structure left
+to convey, and a `gap_class` enum would hand the interpretation work
+back to the model. The precise deltas stay in the Older Sessions catalog
+rendered beside it — narrative and catalog are two altitudes over the
+same timestamps, not two copies of the data. Rendering lives in
+`promptfmt.ConversationRecency`; grow its vocabularies rather than
+inventing parallel fuzzy-time prose elsewhere.
+
+Its vocabulary is part of the contract. The *current turn* is what the
+loop is processing now — a *contact* (counterparty communication, either
+direction) or a *wake* (internally originated); the *previous contact*
+is the most recent contact before the current turn, which wakes never
+move. Wherever a current-turn anchor exists, the term is *previous*,
+never *last* — "last message" is ambiguous the moment a just-arrived
+message is in frame. "Last" stays legal only in contexts with no
+current-turn referent (the summarizer's idle scan, for example).
+
 Curated prose gets the same treatment through temporal templates:
 `{{delta:2026-09-18}}` (bare date or RFC3339 value) expands at read
 time via `promptfmt.ExpandTemporalTemplates` — day words for a date

--- a/internal/app/new_awareness.go
+++ b/internal/app/new_awareness.go
@@ -85,7 +85,11 @@ func (a *App) initAwareness(s *newState) error {
 	messageChannelProvider := memory.NewMessageChannelProvider(
 		a.archiveStore,
 		tools.ConversationIDFromContext,
-		memory.MessageChannelProviderConfig{},
+		memory.MessageChannelProviderConfig{
+			Timezone:          cfg.Timezone,
+			OriginFromContext: tools.MessageOriginFromContext,
+			HintsFromContext:  tools.HintsFromContext,
+		},
 		logger,
 	)
 	a.loop.RegisterTagContextProvider("message_channel", messageChannelProvider)

--- a/internal/model/promptfmt/conversation_recency.go
+++ b/internal/model/promptfmt/conversation_recency.go
@@ -1,0 +1,311 @@
+package promptfmt
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// This file renders conversational rhythm as interpreted narrative for
+// interactive channels: where the current turn stands relative to the
+// previous contact with the channel counterparty, with all bucketing done
+// here so the model never does timestamp arithmetic or day-boundary
+// inference. Prose is deliberate — once the interpretation is complete
+// there is no structure left to convey, and a gap-class enum would hand
+// the interpretation work back to the model (the "prose is genuinely the
+// clearer contract" case in docs/model-facing-context.md). The precise
+// deltas stay in the Older Sessions catalog rendered alongside; the
+// sentence is a different altitude over the same timestamps.
+//
+// Vocabulary contract (used here and by every consumer of these facts):
+// the CURRENT TURN is what the loop is processing now — either a contact
+// message or a wake; CONTACT is communication with the channel
+// counterparty in either direction; a WAKE is an internally-originated
+// turn; the PREVIOUS CONTACT is the most recent contact before the
+// current turn, which wakes never move. With a current-turn anchor in
+// frame the term is always "previous", never "last" — "last message" is
+// ambiguous the moment a just-arrived message exists.
+
+// TurnKind classifies how the current turn originated.
+type TurnKind int
+
+const (
+	// TurnContact is a turn opened by a message from the channel
+	// counterparty.
+	TurnContact TurnKind = iota
+	// TurnWake is a turn opened internally — loop_wake, a subscription
+	// fire, a scheduled trigger — with no new message from the
+	// counterparty.
+	TurnWake
+)
+
+// ConversationRecencyFacts are the mechanical inputs to
+// [ConversationRecency]. Zero values mean "not known": callers pass what
+// their stores can state truthfully and the renderer degrades clause by
+// clause rather than guessing.
+type ConversationRecencyFacts struct {
+	// Kind is how the current turn originated.
+	Kind TurnKind
+
+	// WakeLoopName optionally names the loop behind a TurnWake turn,
+	// for "an internal wake from the X loop". Empty renders "an
+	// internal wake".
+	WakeLoopName string
+
+	// PreviousContactAt is when the previous contact occurred — the
+	// most recent contact-classified message before the current turn.
+	// Zero means no previous contact is known.
+	PreviousContactAt time.Time
+
+	// ActiveSessionStart is when the currently-open archive session
+	// began. Zero means no active session. Only rendered inside the
+	// active-conversation branch, where it is necessarily
+	// recent-anchored: session boundaries are activity-based and wake
+	// rows keep sessions open, so rhythm always gates on contact
+	// timestamps, never on session boundaries.
+	ActiveSessionStart time.Time
+
+	// PreviousSessionEnd is when the most recent closed session with
+	// content ended. Zero means none known.
+	PreviousSessionEnd time.Time
+
+	// PreviousSessionTopic is the archivist's summary of that session
+	// (one-liner or title). Empty degrades the clause to the time word
+	// alone — the archivist may simply not have run yet.
+	PreviousSessionTopic string
+
+	// HasHistory reports whether this conversation has any recorded
+	// past at all (prior sessions or contact). Distinguishes "first
+	// conversation ever" from "history exists but contact timing is
+	// not recorded".
+	HasHistory bool
+
+	// RecentWindow is the active/resumed boundary: a contact gap at or
+	// under it reads as an ongoing conversation. Zero defaults to 30
+	// minutes, matching the message-channel provider's catalog window.
+	RecentWindow time.Duration
+}
+
+// defaultRecentWindow mirrors MessageChannelProviderConfig's default so
+// the "active conversation" boundary and the catalog's recent-window
+// exclusion describe the same span when neither is configured.
+const defaultRecentWindow = 30 * time.Minute
+
+// lullCeiling bounds the "resuming after a quiet stretch" bucket: a gap
+// past the recent window but under this still reads as one conversation
+// pausing, not a new contact.
+const lullCeiling = 2 * time.Hour
+
+// ConversationRecency renders the conversational rhythm of the current
+// turn as one or two plain sentences, or "" when there is nothing
+// truthful to say. now anchors all deltas; loc is the household timezone
+// that anchors day words ("last night", "yesterday") — pass the
+// configured zone, never the server's.
+func ConversationRecency(f ConversationRecencyFacts, now time.Time, loc *time.Location) string {
+	if loc == nil {
+		loc = time.UTC
+	}
+	window := f.RecentWindow
+	if window <= 0 {
+		window = defaultRecentWindow
+	}
+
+	var gap time.Duration
+	if !f.PreviousContactAt.IsZero() {
+		gap = now.Sub(f.PreviousContactAt)
+		if gap < 0 {
+			gap = 0
+		}
+	}
+
+	rhythm, active := rhythmClause(f, now, loc, window, gap)
+
+	// The previous-conversation clause orients a fresh contact inside
+	// past experience. Inside an ongoing conversation it is noise (the
+	// working message list already carries the context), and a session
+	// that ended within the recent window is likewise still in the
+	// working list.
+	var prevConv string
+	if !active && !f.PreviousSessionEnd.IsZero() && now.Sub(f.PreviousSessionEnd) > window {
+		prevConv = previousConversationClause(f.PreviousSessionEnd, f.PreviousSessionTopic, now, loc)
+	}
+
+	switch {
+	case rhythm == "":
+		return prevConv
+	case prevConv == "":
+		return rhythm
+	default:
+		return rhythm + " " + prevConv
+	}
+}
+
+// rhythmClause renders the always-present clause describing where the
+// current turn stands, and reports whether the conversation is in the
+// active/continuing state (which suppresses the previous-conversation
+// clause).
+func rhythmClause(f ConversationRecencyFacts, now time.Time, loc *time.Location, window time.Duration, gap time.Duration) (string, bool) {
+	wake := f.Kind == TurnWake
+	wakePhrase := "an internal wake"
+	if f.WakeLoopName != "" {
+		wakePhrase = "an internal wake from the " + f.WakeLoopName + " loop"
+	}
+
+	if f.PreviousContactAt.IsZero() {
+		switch {
+		case wake && !f.HasHistory:
+			return "This turn is " + wakePhrase + "; there has been no contact on this channel yet.", false
+		case wake:
+			return "This turn is " + wakePhrase + ", not a message from them.", false
+		case !f.HasHistory:
+			return "This is the first conversation on this channel.", false
+		default:
+			// History exists but no contact time is recorded —
+			// say nothing rather than guess; the
+			// previous-conversation clause may still render.
+			return "", false
+		}
+	}
+
+	if wake {
+		if gap <= window {
+			return fmt.Sprintf(
+				"You're in an active conversation (previous contact %s ago), but this turn is %s, not a new message — they haven't said anything new.",
+				fuzzySpan(gap), wakePhrase), true
+		}
+		return fmt.Sprintf("This turn is %s, not a message from them. The previous contact was %s.",
+			wakePhrase, agoPhrase(f.PreviousContactAt, now, loc)), false
+	}
+
+	switch {
+	case gap <= window:
+		if !f.ActiveSessionStart.IsZero() {
+			return fmt.Sprintf(
+				"You're in an active conversation that's been going on for %s; the previous message was %s before this one.",
+				fuzzySpan(now.Sub(f.ActiveSessionStart)), fuzzySpan(gap)), true
+		}
+		return fmt.Sprintf("The conversation is continuing; the previous message was %s ago.", fuzzySpan(gap)), true
+	case gap <= lullCeiling:
+		return fmt.Sprintf("The conversation is resuming after a quiet stretch — the previous message was %s ago.", fuzzySpan(gap)), false
+	case sameDay(f.PreviousContactAt, now, loc):
+		return fmt.Sprintf("This is the first message in %s.", fuzzySpan(gap)), false
+	default:
+		return "This is the first contact today.", false
+	}
+}
+
+// previousConversationClause renders "The previous conversation was last
+// night, about the garage lighting circuits." — time word from day
+// bucketing, topic from the archivist when available.
+func previousConversationClause(end time.Time, topic string, now time.Time, loc *time.Location) string {
+	var sb strings.Builder
+	sb.WriteString("The previous conversation was ")
+	sb.WriteString(dayPhrase(end, now, loc))
+	if topic != "" {
+		sb.WriteString(", about ")
+		sb.WriteString(strings.TrimRight(topic, "."))
+	}
+	sb.WriteString(".")
+	return sb.String()
+}
+
+// agoPhrase renders a past instant relative to now: same-day gaps as a
+// fuzzy span ("about 3 hours ago"), older ones as a day word ("last
+// night", "yesterday", "on Tuesday").
+func agoPhrase(t, now time.Time, loc *time.Location) string {
+	if sameDay(t, now, loc) {
+		return fuzzySpan(now.Sub(t)) + " ago"
+	}
+	return dayPhrase(t, now, loc)
+}
+
+// fuzzySpan renders a duration in conversational units: "moments",
+// "about 5 minutes", "about an hour", "about 6 hours", "about 3 days".
+// Callers supply the surrounding grammar ("ago", "before this one",
+// "going on for").
+func fuzzySpan(d time.Duration) string {
+	switch {
+	case d < 90*time.Second:
+		return "moments"
+	case d < 60*time.Minute:
+		m := int((d + 30*time.Second) / time.Minute)
+		if m < 2 {
+			m = 2
+		}
+		return fmt.Sprintf("about %d minutes", m)
+	case d < 100*time.Minute:
+		return "about an hour"
+	case d < 24*time.Hour:
+		h := int((d + 30*time.Minute) / time.Hour)
+		return fmt.Sprintf("about %d hours", h)
+	default:
+		days := int((d + 12*time.Hour) / (24 * time.Hour))
+		if days == 1 {
+			return "about a day"
+		}
+		return fmt.Sprintf("about %d days", days)
+	}
+}
+
+// dayPhrase buckets a past instant into household-calendar words:
+// "earlier today", "last night", "yesterday", a weekday name inside the
+// week, "N weeks ago" inside the month, and an absolute date beyond.
+func dayPhrase(t, now time.Time, loc *time.Location) string {
+	t = t.In(loc)
+	now = now.In(loc)
+
+	if sameDay(t, now, loc) {
+		return "earlier today"
+	}
+
+	// "Last night": the instant fell in yesterday-evening-through-
+	// early-today (17:00 to 04:00) and it is still morning — after
+	// noon, "yesterday" reads more naturally than "last night".
+	if now.Hour() < 12 && inLastNightBand(t, now) {
+		return "last night"
+	}
+
+	days := calendarDaysBetween(t, now)
+	switch {
+	case days <= 1:
+		return "yesterday"
+	case days <= 6:
+		return "on " + t.Weekday().String()
+	case days <= 27:
+		weeks := days / 7
+		if weeks == 1 {
+			return "a week ago"
+		}
+		return fmt.Sprintf("%d weeks ago", weeks)
+	default:
+		if t.Year() == now.Year() {
+			return "on " + t.Format("January 2")
+		}
+		return "on " + t.Format("January 2, 2006")
+	}
+}
+
+// inLastNightBand reports whether t falls between 17:00 yesterday and
+// 04:00 today, in the timezone both t and now are already expressed in.
+func inLastNightBand(t, now time.Time) bool {
+	todayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	bandStart := todayStart.Add(-7 * time.Hour) // 17:00 yesterday
+	bandEnd := todayStart.Add(4 * time.Hour)    // 04:00 today
+	return !t.Before(bandStart) && t.Before(bandEnd)
+}
+
+// sameDay reports whether two instants fall on the same calendar day in
+// loc.
+func sameDay(a, b time.Time, loc *time.Location) bool {
+	a, b = a.In(loc), b.In(loc)
+	return a.Year() == b.Year() && a.YearDay() == b.YearDay()
+}
+
+// calendarDaysBetween counts whole calendar-day boundaries crossed
+// between t and now (both already in the same location). Rounded rather
+// than truncated so a 23-hour DST-transition day still counts as one day.
+func calendarDaysBetween(t, now time.Time) int {
+	tDay := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+	nowDay := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	return int(nowDay.Sub(tDay).Hours()/24 + 0.5)
+}

--- a/internal/model/promptfmt/conversation_recency.go
+++ b/internal/model/promptfmt/conversation_recency.go
@@ -254,15 +254,18 @@ func dayPhrase(t, now time.Time, loc *time.Location) string {
 	t = t.In(loc)
 	now = now.In(loc)
 
-	if sameDay(t, now, loc) {
-		return "earlier today"
-	}
-
 	// "Last night": the instant fell in yesterday-evening-through-
 	// early-today (17:00 to 04:00) and it is still morning — after
-	// noon, "yesterday" reads more naturally than "last night".
+	// noon, "yesterday" (or "earlier today" for the small-hours half)
+	// reads more naturally than "last night". Checked before the
+	// same-day bucket so a 02:00 session viewed at 09:00 renders "last
+	// night", which is what that conversation was.
 	if now.Hour() < 12 && inLastNightBand(t, now) {
 		return "last night"
+	}
+
+	if sameDay(t, now, loc) {
+		return "earlier today"
 	}
 
 	days := calendarDaysBetween(t, now)

--- a/internal/model/promptfmt/conversation_recency_test.go
+++ b/internal/model/promptfmt/conversation_recency_test.go
@@ -1,0 +1,230 @@
+package promptfmt
+
+import (
+	"testing"
+	"time"
+)
+
+func chicagoTime(t *testing.T) *time.Location {
+	t.Helper()
+	loc, err := time.LoadLocation("America/Chicago")
+	if err != nil {
+		t.Fatalf("LoadLocation: %v", err)
+	}
+	return loc
+}
+
+// TestConversationRecency locks the full sentence for every rhythm
+// branch and clause combination. The rendered prose IS the contract —
+// the model reads these sentences verbatim — so the expectations are
+// exact strings, not substring probes.
+func TestConversationRecency(t *testing.T) {
+	loc := chicagoTime(t)
+	// Wednesday 2026-08-26 09:00 in the household zone.
+	morning := time.Date(2026, 8, 26, 9, 0, 0, 0, loc)
+	afternoon := time.Date(2026, 8, 26, 15, 0, 0, 0, loc)
+
+	tests := []struct {
+		name  string
+		facts ConversationRecencyFacts
+		now   time.Time
+		want  string
+	}{
+		{
+			name:  "first conversation ever",
+			facts: ConversationRecencyFacts{Kind: TurnContact},
+			now:   morning,
+			want:  "This is the first conversation on this channel.",
+		},
+		{
+			name: "history exists but contact timing unknown",
+			facts: ConversationRecencyFacts{
+				Kind:                 TurnContact,
+				HasHistory:           true,
+				PreviousSessionEnd:   morning.Add(-15 * time.Hour),
+				PreviousSessionTopic: "the garage lighting circuits",
+			},
+			now:  morning,
+			want: "The previous conversation was last night, about the garage lighting circuits.",
+		},
+		{
+			name: "active conversation with session suppresses previous-conversation clause",
+			facts: ConversationRecencyFacts{
+				Kind:                 TurnContact,
+				PreviousContactAt:    morning.Add(-2 * time.Minute),
+				ActiveSessionStart:   morning.Add(-25 * time.Minute),
+				PreviousSessionEnd:   morning.Add(-15 * time.Hour),
+				PreviousSessionTopic: "the garage lighting circuits",
+				HasHistory:           true,
+			},
+			now:  morning,
+			want: "You're in an active conversation that's been going on for about 25 minutes; the previous message was about 2 minutes before this one.",
+		},
+		{
+			name: "active conversation without session",
+			facts: ConversationRecencyFacts{
+				Kind:              TurnContact,
+				PreviousContactAt: morning.Add(-time.Minute),
+				HasHistory:        true,
+			},
+			now:  morning,
+			want: "The conversation is continuing; the previous message was moments ago.",
+		},
+		{
+			name: "lull",
+			facts: ConversationRecencyFacts{
+				Kind:              TurnContact,
+				PreviousContactAt: morning.Add(-45 * time.Minute),
+				HasHistory:        true,
+			},
+			now:  morning,
+			want: "The conversation is resuming after a quiet stretch — the previous message was about 45 minutes ago.",
+		},
+		{
+			name: "first message in hours, same day",
+			facts: ConversationRecencyFacts{
+				Kind:              TurnContact,
+				PreviousContactAt: morning.Add(-6 * time.Hour),
+				HasHistory:        true,
+			},
+			now:  morning,
+			want: "This is the first message in about 6 hours.",
+		},
+		{
+			name: "first contact today with previous conversation last night",
+			facts: ConversationRecencyFacts{
+				Kind:                 TurnContact,
+				PreviousContactAt:    time.Date(2026, 8, 25, 22, 0, 0, 0, loc),
+				PreviousSessionEnd:   time.Date(2026, 8, 25, 22, 15, 0, 0, loc),
+				PreviousSessionTopic: "the garage lighting circuits",
+				HasHistory:           true,
+			},
+			now:  morning,
+			want: "This is the first contact today. The previous conversation was last night, about the garage lighting circuits.",
+		},
+		{
+			name: "previous conversation yesterday when it is already afternoon",
+			facts: ConversationRecencyFacts{
+				Kind:               TurnContact,
+				PreviousContactAt:  time.Date(2026, 8, 25, 20, 0, 0, 0, loc),
+				PreviousSessionEnd: time.Date(2026, 8, 25, 20, 0, 0, 0, loc),
+				HasHistory:         true,
+			},
+			now:  afternoon,
+			want: "This is the first contact today. The previous conversation was yesterday.",
+		},
+		{
+			name: "previous conversation on a weekday",
+			facts: ConversationRecencyFacts{
+				Kind:                 TurnContact,
+				PreviousContactAt:    morning.AddDate(0, 0, -4),
+				PreviousSessionEnd:   morning.AddDate(0, 0, -4),
+				PreviousSessionTopic: "NAS snapshot pruning",
+				HasHistory:           true,
+			},
+			now:  morning,
+			want: "This is the first contact today. The previous conversation was on Saturday, about NAS snapshot pruning.",
+		},
+		{
+			name: "previous conversation a week ago",
+			facts: ConversationRecencyFacts{
+				Kind:               TurnContact,
+				PreviousContactAt:  morning.AddDate(0, 0, -10),
+				PreviousSessionEnd: morning.AddDate(0, 0, -10),
+				HasHistory:         true,
+			},
+			now:  morning,
+			want: "This is the first contact today. The previous conversation was a week ago.",
+		},
+		{
+			name: "previous conversation on an absolute date",
+			facts: ConversationRecencyFacts{
+				Kind:               TurnContact,
+				PreviousContactAt:  morning.AddDate(0, 0, -40),
+				PreviousSessionEnd: morning.AddDate(0, 0, -40),
+				HasHistory:         true,
+			},
+			now:  morning,
+			want: "This is the first contact today. The previous conversation was on July 17.",
+		},
+		{
+			name: "wake into a quiet channel with loop name",
+			facts: ConversationRecencyFacts{
+				Kind:              TurnWake,
+				WakeLoopName:      "annunciator",
+				PreviousContactAt: morning.Add(-3 * time.Hour),
+				HasHistory:        true,
+			},
+			now:  morning,
+			want: "This turn is an internal wake from the annunciator loop, not a message from them. The previous contact was about 3 hours ago.",
+		},
+		{
+			name: "wake mid-conversation",
+			facts: ConversationRecencyFacts{
+				Kind:              TurnWake,
+				PreviousContactAt: morning.Add(-2 * time.Minute),
+				HasHistory:        true,
+			},
+			now:  morning,
+			want: "You're in an active conversation (previous contact about 2 minutes ago), but this turn is an internal wake, not a new message — they haven't said anything new.",
+		},
+		{
+			name:  "wake with no contact ever",
+			facts: ConversationRecencyFacts{Kind: TurnWake},
+			now:   morning,
+			want:  "This turn is an internal wake; there has been no contact on this channel yet.",
+		},
+		{
+			name: "wake with history but unknown contact timing",
+			facts: ConversationRecencyFacts{
+				Kind:               TurnWake,
+				HasHistory:         true,
+				PreviousSessionEnd: morning.AddDate(0, 0, -1),
+			},
+			now:  afternoon,
+			want: "This turn is an internal wake, not a message from them. The previous conversation was yesterday.",
+		},
+		{
+			name: "wake previous contact last night uses day word",
+			facts: ConversationRecencyFacts{
+				Kind:              TurnWake,
+				PreviousContactAt: time.Date(2026, 8, 25, 22, 0, 0, 0, loc),
+				HasHistory:        true,
+			},
+			now:  morning,
+			want: "This turn is an internal wake, not a message from them. The previous contact was last night.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ConversationRecency(tt.facts, tt.now, loc)
+			if got != tt.want {
+				t.Errorf("ConversationRecency:\n got: %q\nwant: %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFuzzySpan pins the vocabulary boundaries the sentences compose
+// from.
+func TestFuzzySpan(t *testing.T) {
+	tests := []struct {
+		d    time.Duration
+		want string
+	}{
+		{30 * time.Second, "moments"},
+		{89 * time.Second, "moments"},
+		{95 * time.Second, "about 2 minutes"},
+		{45 * time.Minute, "about 45 minutes"},
+		{70 * time.Minute, "about an hour"},
+		{5 * time.Hour, "about 5 hours"},
+		{26 * time.Hour, "about a day"},
+		{3 * 24 * time.Hour, "about 3 days"},
+	}
+	for _, tt := range tests {
+		if got := fuzzySpan(tt.d); got != tt.want {
+			t.Errorf("fuzzySpan(%v) = %q, want %q", tt.d, got, tt.want)
+		}
+	}
+}

--- a/internal/model/promptfmt/conversation_recency_test.go
+++ b/internal/model/promptfmt/conversation_recency_test.go
@@ -103,6 +103,17 @@ func TestConversationRecency(t *testing.T) {
 			want: "This is the first contact today. The previous conversation was last night, about the garage lighting circuits.",
 		},
 		{
+			name: "small-hours session this morning is last night, not earlier today",
+			facts: ConversationRecencyFacts{
+				Kind:               TurnContact,
+				PreviousContactAt:  time.Date(2026, 8, 26, 2, 0, 0, 0, loc),
+				PreviousSessionEnd: time.Date(2026, 8, 26, 2, 0, 0, 0, loc),
+				HasHistory:         true,
+			},
+			now:  morning,
+			want: "This is the first message in about 7 hours. The previous conversation was last night.",
+		},
+		{
 			name: "previous conversation yesterday when it is already afternoon",
 			facts: ConversationRecencyFacts{
 				Kind:               TurnContact,

--- a/internal/runtime/agent/conversation_scope_seam_test.go
+++ b/internal/runtime/agent/conversation_scope_seam_test.go
@@ -1,0 +1,98 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/model/llm"
+	"github.com/nugget/thane-ai-agent/internal/platform/config"
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+	"github.com/nugget/thane-ai-agent/internal/state/memory"
+	"github.com/nugget/thane-ai-agent/internal/tools"
+)
+
+// turnScopeObservation is one prompt build's view of the turn-scoped
+// context values a conversation-scoped provider depends on.
+type turnScopeObservation struct {
+	convID   string
+	origin   string
+	loopName string
+}
+
+// recordingScopeProvider records the conversation ID, message origin,
+// and loop_name hint it observed on every invocation.
+type recordingScopeProvider struct {
+	seen []turnScopeObservation
+}
+
+func (p *recordingScopeProvider) TagContextBucket() agentctx.ContextBucket {
+	return agentctx.ContextBucketContinuity
+}
+
+func (p *recordingScopeProvider) TagContext(ctx context.Context, _ agentctx.ContextRequest) (string, error) {
+	p.seen = append(p.seen, turnScopeObservation{
+		convID:   tools.ConversationIDFromContext(ctx),
+		origin:   tools.MessageOriginFromContext(ctx),
+		loopName: tools.HintsFromContext(ctx)["loop_name"],
+	})
+	return "scoped", nil
+}
+
+// TestConversationScopeReachesContextProvidersEveryIteration is the
+// conversation-scope sibling of the bindings seam test: OnIterationStart
+// rebuilds the system prompt from the iteration context, so any value
+// stamped only on the local promptCtx evaporates from iteration 1
+// onward. For conversation ID that failure mode silently emptied every
+// conversation-scoped provider (working memory, the message-channel
+// timing and catalog blocks) on multi-iteration turns —
+// ConversationIDFromContext falls back to "default" and the providers
+// decline to render. This test drives a real two-iteration run and
+// requires every prompt build to see the conversation ID, the turn's
+// message origin, and the routing hints.
+func TestConversationScopeReachesContextProvidersEveryIteration(t *testing.T) {
+	// Two responses: the first with a tool call so the run continues to
+	// a second iteration, which is where the rebuild happens.
+	mock := &mockLLM{
+		responses: []*llm.ChatResponse{
+			{
+				Model:       "test-model",
+				Message:     llm.Message{Role: "assistant", ToolCalls: []llm.ToolCall{newToolCall("c1", "base_tool")}},
+				InputTokens: 100, OutputTokens: 10,
+			},
+			{
+				Model:       "test-model",
+				Message:     llm.Message{Role: "assistant", Content: "Done."},
+				InputTokens: 100, OutputTokens: 10,
+			},
+		},
+	}
+
+	loop := buildTestLoop(mock, []string{"base_tool"})
+	loop.SetCapabilityTags(map[string]config.CapabilityTagConfig{
+		"scoped": {Description: "Scoped", Tools: []string{"base_tool"}, Core: true},
+	}, nil)
+
+	provider := &recordingScopeProvider{}
+	loop.RegisterTagContextProvider("scoped", provider)
+
+	if _, err := loop.Run(context.Background(), &Request{
+		Messages:       []Message{{Role: "user", Content: "go"}},
+		ConversationID: "conv-scope-seam",
+		InitialTags:    []string{"scoped"},
+		RoutingFactors: map[string]string{"loop_name": "annunciator"},
+		MessageOrigin:  memory.OriginWake,
+	}, nil); err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	if len(provider.seen) < 2 {
+		t.Fatalf("provider invoked %d times; need at least the initial build and one rebuild to observe the seam", len(provider.seen))
+	}
+	want := turnScopeObservation{convID: "conv-scope-seam", origin: memory.OriginWake, loopName: "annunciator"}
+	for i, got := range provider.seen {
+		if got != want {
+			t.Errorf("prompt build %d saw %+v, want %+v — a turn-scoped value did not reach this rebuild", i, got, want)
+		}
+	}
+	t.Logf("provider invoked %d times, all fully scoped", len(provider.seen))
+}

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -1890,14 +1890,19 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 	// painted door this narrowing exists to remove. Everything derived
 	// from ctx now inherits it.
 	ctx = loop.WithBindings(ctx, req.Bindings)
-	// On the run context for the same reason as bindings: the prompt is
-	// rebuilt from the iteration context on every iteration after the
-	// first, and turn provenance must survive those rebuilds.
+	// Every value a context provider reads goes on the run context for
+	// the same reason as bindings: conversation ID, hints, channel
+	// binding, the suppress flag, and turn provenance must all survive
+	// the per-iteration rebuilds. Stamping only promptCtx silently
+	// emptied conversation-scoped providers (working memory, the
+	// message-channel blocks) from iteration 1 onward — the same
+	// painted-door shape the bindings stamp above fixed.
 	ctx = tools.WithMessageOrigin(ctx, req.MessageOrigin)
-	promptCtx := tools.WithConversationID(ctx, convID)
-	promptCtx = tools.WithHints(promptCtx, req.RoutingFactors)
-	promptCtx = tools.WithChannelBinding(promptCtx, channelBinding)
-	promptCtx = tools.WithSuppressAlwaysContext(promptCtx, req.SuppressAlwaysContext)
+	ctx = tools.WithConversationID(ctx, convID)
+	ctx = tools.WithHints(ctx, req.RoutingFactors)
+	ctx = tools.WithChannelBinding(ctx, channelBinding)
+	ctx = tools.WithSuppressAlwaysContext(ctx, req.SuppressAlwaysContext)
+	promptCtx := ctx
 
 	var systemPrompt string
 	var systemSections []llm.PromptSection

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -1890,6 +1890,10 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 	// painted door this narrowing exists to remove. Everything derived
 	// from ctx now inherits it.
 	ctx = loop.WithBindings(ctx, req.Bindings)
+	// On the run context for the same reason as bindings: the prompt is
+	// rebuilt from the iteration context on every iteration after the
+	// first, and turn provenance must survive those rebuilds.
+	ctx = tools.WithMessageOrigin(ctx, req.MessageOrigin)
 	promptCtx := tools.WithConversationID(ctx, convID)
 	promptCtx = tools.WithHints(promptCtx, req.RoutingFactors)
 	promptCtx = tools.WithChannelBinding(promptCtx, channelBinding)

--- a/internal/state/memory/archive.go
+++ b/internal/state/memory/archive.go
@@ -2549,6 +2549,57 @@ func (s *ArchiveStore) GetMessagesInRange(opts RangeOptions) ([]Message, bool, e
 	return msgs, truncated, nil
 }
 
+// RecentContactTimes returns the timestamps of the most recent
+// contact-classified messages on a conversation, newest first, capped at
+// limit. Contact means communication with the channel counterparty:
+// rows stamped [OriginChannel] in either direction, plus — the one
+// documented fallback for rows written before provenance stamping
+// existed — unstamped user-role rows that are not wake-bridge synthetic
+// content (the "Anticipation matched:" prefix, the same exclusion the
+// search paths apply). Wake prompts (OriginWake) and system-authored
+// rows never move the result: the previous contact is the anchor the
+// conversation-timing narrative measures gaps against, and a wake that
+// shifted it would erase the very silence it is reporting.
+//
+// The current turn's just-stored inbound message is included when it is
+// already in the table — callers on a contact turn take the second entry
+// as the previous contact, and wake-turn callers take the first.
+func (s *ArchiveStore) RecentContactTimes(conversationID string, limit int) ([]time.Time, error) {
+	if limit <= 0 {
+		limit = 2
+	}
+	query := fmt.Sprintf(`
+		SELECT timestamp FROM %s
+		WHERE conversation_id = ?
+		  AND (
+			origin = ?
+			OR (COALESCE(origin, '') = '' AND role = 'user' AND content NOT LIKE 'Anticipation matched:%%')
+		  )
+		ORDER BY timestamp DESC, id DESC
+		LIMIT ?
+	`, s.msgTableName)
+
+	rows, err := s.msgDB().Query(query, conversationID, OriginChannel, limit)
+	if err != nil {
+		return nil, fmt.Errorf("recent contact times: %w", err)
+	}
+	defer rows.Close()
+
+	var out []time.Time
+	for rows.Next() {
+		var tsStr string
+		if err := rows.Scan(&tsStr); err != nil {
+			return nil, fmt.Errorf("scan contact time: %w", err)
+		}
+		ts, err := database.ParseTimestamp(tsStr)
+		if err != nil {
+			return nil, fmt.Errorf("parse contact time: %w", err)
+		}
+		out = append(out, ts)
+	}
+	return out, rows.Err()
+}
+
 func (s *ArchiveStore) queryMessagesDesc(conversationID, excludeSessionID string, from, to time.Time, limit int) ([]Message, error) {
 	cols := s.msgSelectCols()
 	table := s.msgTableName

--- a/internal/state/memory/conversation_timing_provider_test.go
+++ b/internal/state/memory/conversation_timing_provider_test.go
@@ -1,0 +1,159 @@
+package memory
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+)
+
+const providerOriginKey providerTestCtxKey = "message_origin"
+
+func providerCtxOrigin(ctx context.Context) string {
+	if v, ok := ctx.Value(providerOriginKey).(string); ok {
+		return v
+	}
+	return ""
+}
+
+// newTimingTestSetup wires a provider with the conversation-timing
+// inputs configured (origin extractor, household timezone, pinned
+// clock), against the same production-shape store as the catalog tests.
+func newTimingTestSetup(t *testing.T, now time.Time, hints map[string]string) (*MessageChannelProvider, *ArchiveStore, func(id, role, content string, origin any, ts time.Time)) {
+	t.Helper()
+	working, err := NewSQLiteStore(t.TempDir()+"/working.db", 100)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	t.Cleanup(func() { _ = working.Close() })
+
+	archive, err := NewArchiveStoreFromDB(working.DB(), nil, nil)
+	if err != nil {
+		t.Fatalf("NewArchiveStoreFromDB: %v", err)
+	}
+
+	provider := NewMessageChannelProvider(archive, providerCtxConvID, MessageChannelProviderConfig{
+		Timezone:          "America/Chicago",
+		OriginFromContext: providerCtxOrigin,
+		HintsFromContext:  func(context.Context) map[string]string { return hints },
+	}, nil)
+	provider.nowFunc = func() time.Time { return now }
+
+	insert := func(id, role, content string, origin any, ts time.Time) {
+		t.Helper()
+		if _, err := working.DB().Exec(`
+			INSERT INTO messages (id, conversation_id, role, content, timestamp, status, origin)
+			VALUES (?, 'signal-15551234567', ?, ?, ?, 'active', ?)
+		`, id, role, content, ts, origin); err != nil {
+			t.Fatalf("insert %s: %v", id, err)
+		}
+	}
+	return provider, archive, insert
+}
+
+func timingCtx(origin string) context.Context {
+	ctx := providerCtxWithConvID(context.Background(), "signal-15551234567")
+	return context.WithValue(ctx, providerOriginKey, origin)
+}
+
+// TestConversationTiming_ActiveContactTurn covers the main interactive
+// path: a contact turn inside an ongoing session renders the active
+// sentence, skips the second contact row (the current message itself,
+// already stored before prompt assembly), and stays clear of the
+// previous-conversation clause.
+func TestConversationTiming_ActiveContactTurn(t *testing.T) {
+	loc, _ := time.LoadLocation("America/Chicago")
+	now := time.Date(2026, 8, 26, 9, 0, 0, 0, loc)
+	provider, archive, insert := newTimingTestSetup(t, now, nil)
+
+	if _, err := archive.StartSessionAt("signal-15551234567", now.Add(-25*time.Minute)); err != nil {
+		t.Fatalf("StartSessionAt: %v", err)
+	}
+	insert("prev", "user", "earlier message", OriginChannel, now.Add(-2*time.Minute))
+	insert("current", "user", "the message being answered", OriginChannel, now)
+
+	out, err := provider.TagContext(timingCtx(OriginChannel), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	want := "You're in an active conversation that's been going on for about 25 minutes; the previous message was about 2 minutes before this one."
+	if !strings.Contains(out, "## Conversation Timing\n\n"+want) {
+		t.Errorf("timing block missing or wrong.\n got: %q\nwant to contain: %q", out, want)
+	}
+}
+
+// TestConversationTiming_WakeTurn covers the wake path: the wake prompt
+// never counts as contact, the newest contact row is the previous
+// contact (no self-skip), the waking loop is named from hints, and the
+// archivist's one-liner supplies the previous-conversation topic.
+func TestConversationTiming_WakeTurn(t *testing.T) {
+	loc, _ := time.LoadLocation("America/Chicago")
+	now := time.Date(2026, 8, 26, 9, 0, 0, 0, loc)
+	provider, archive, insert := newTimingTestSetup(t, now, map[string]string{"loop_name": "annunciator"})
+
+	sess, err := archive.StartSessionAt("signal-15551234567", now.Add(-4*time.Hour))
+	if err != nil {
+		t.Fatalf("StartSessionAt: %v", err)
+	}
+	insert("contact", "user", "last thing they said", OriginChannel, now.Add(-3*time.Hour))
+	if err := archive.EndSessionAt(sess.ID, "idle", now.Add(-3*time.Hour)); err != nil {
+		t.Fatalf("EndSessionAt: %v", err)
+	}
+	if err := archive.SetSessionMetadata(sess.ID, &SessionMetadata{OneLiner: "garage lighting circuit planning"}, "", nil); err != nil {
+		t.Fatalf("SetSessionMetadata: %v", err)
+	}
+	insert("wakeprompt", "user", "annunciator wake payload", OriginWake, now)
+
+	out, err := provider.TagContext(timingCtx(OriginWake), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	want := "This turn is an internal wake from the annunciator loop, not a message from them. The previous contact was about 3 hours ago. The previous conversation was earlier today, about garage lighting circuit planning."
+	if !strings.Contains(out, "## Conversation Timing\n\n"+want) {
+		t.Errorf("timing block missing or wrong.\n got: %q\nwant to contain: %q", out, want)
+	}
+}
+
+// TestConversationTiming_FirstContactEver covers the self-skip working
+// on an empty conversation: the only contact row is the current message,
+// so the narrative reports a first conversation instead of measuring a
+// gap against the message being answered.
+func TestConversationTiming_FirstContactEver(t *testing.T) {
+	loc, _ := time.LoadLocation("America/Chicago")
+	now := time.Date(2026, 8, 26, 9, 0, 0, 0, loc)
+	provider, _, insert := newTimingTestSetup(t, now, nil)
+
+	insert("current", "user", "hello there", OriginChannel, now)
+
+	out, err := provider.TagContext(timingCtx(OriginChannel), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	want := "This is the first conversation on this channel."
+	if !strings.Contains(out, "## Conversation Timing\n\n"+want) {
+		t.Errorf("timing block missing or wrong.\n got: %q\nwant to contain: %q", out, want)
+	}
+}
+
+// TestConversationTiming_OmittedWithoutOriginExtractor pins the
+// degradation contract: without an origin extractor the contact/wake
+// distinction would be a guess, so the timing block is omitted entirely
+// while the catalog still renders.
+func TestConversationTiming_OmittedWithoutOriginExtractor(t *testing.T) {
+	provider, archive, insert := newMessageChannelTestSetup(t)
+	now := time.Now()
+	closedSession(t, archive, insert, "conv-1", now.Add(-3*time.Hour), now.Add(-2*time.Hour), 3)
+
+	out, err := provider.TagContext(providerCtxWithConvID(context.Background(), "conv-1"), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	if strings.Contains(out, "Conversation Timing") {
+		t.Errorf("timing block rendered without an origin extractor:\n%q", out)
+	}
+	if !strings.Contains(out, "## Older Sessions") {
+		t.Errorf("catalog missing when timing is off:\n%q", out)
+	}
+}

--- a/internal/state/memory/conversation_timing_provider_test.go
+++ b/internal/state/memory/conversation_timing_provider_test.go
@@ -137,6 +137,34 @@ func TestConversationTiming_FirstContactEver(t *testing.T) {
 	}
 }
 
+// TestConversationTiming_AnchorsToArrivalNotAssemblyTime pins the
+// arrival-anchoring contract: the contact gap is measured to the current
+// message's stored arrival time, not to prompt-assembly time. Here
+// assembly runs 40 minutes after the message arrived; wall-clock
+// anchoring would push a 2-minute gap across the recent window into the
+// lull bucket, misnarrating an active exchange as a resumed one.
+func TestConversationTiming_AnchorsToArrivalNotAssemblyTime(t *testing.T) {
+	loc, _ := time.LoadLocation("America/Chicago")
+	assembly := time.Date(2026, 8, 26, 9, 40, 0, 0, loc)
+	arrival := assembly.Add(-40 * time.Minute)
+	provider, archive, insert := newTimingTestSetup(t, assembly, nil)
+
+	if _, err := archive.StartSessionAt("signal-15551234567", arrival.Add(-25*time.Minute)); err != nil {
+		t.Fatalf("StartSessionAt: %v", err)
+	}
+	insert("prev", "user", "earlier message", OriginChannel, arrival.Add(-2*time.Minute))
+	insert("current", "user", "the message being answered", OriginChannel, arrival)
+
+	out, err := provider.TagContext(timingCtx(OriginChannel), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	want := "You're in an active conversation that's been going on for about 25 minutes; the previous message was about 2 minutes before this one."
+	if !strings.Contains(out, "## Conversation Timing\n\n"+want) {
+		t.Errorf("timing not anchored to arrival.\n got: %q\nwant to contain: %q", out, want)
+	}
+}
+
 // TestConversationTiming_OmittedWithoutOriginExtractor pins the
 // degradation contract: without an origin extractor the contact/wake
 // distinction would be a guess, so the timing block is omitted entirely

--- a/internal/state/memory/message_channel_provider.go
+++ b/internal/state/memory/message_channel_provider.go
@@ -207,18 +207,33 @@ func (p *MessageChannelProvider) conversationTiming(ctx context.Context, convID 
 	}
 	// On a contact turn the newest contact row is the current message
 	// itself (stored before prompt assembly), so the previous contact
-	// is the second entry; a wake stores no contact row, so it is the
-	// first.
+	// is the second entry — and the current message's stored arrival
+	// time becomes the anchor the gap is measured to, per the contract
+	// that the gap ends at arrival, not at prompt assembly. Assembly
+	// can lag arrival, and an anchor drifting across the recent-window
+	// or a day boundary would select the wrong rhythm bucket. A wake
+	// stores no contact row, so its previous contact is the first entry
+	// and wall-clock now is the honest anchor.
+	anchor := now
 	idx := 0
 	if facts.Kind == promptfmt.TurnContact {
 		idx = 1
+		if len(contacts) > 0 {
+			anchor = contacts[0]
+		}
 	}
 	if len(contacts) > idx {
 		facts.PreviousContactAt = contacts[idx]
 		facts.HasHistory = true
 	}
 
-	if sess, err := p.archive.ActiveSession(convID); err == nil && sess != nil {
+	if sess, err := p.archive.ActiveSession(convID); err != nil {
+		// Degrading to the session-less wording is fine; doing it
+		// silently on a real query failure is not — no rows is (nil,
+		// nil), so this only fires on genuine breakage.
+		p.logger.Warn("active session lookup failed",
+			"conversation_id", convID, "error", err)
+	} else if sess != nil {
 		facts.ActiveSessionStart = sess.StartedAt
 	}
 
@@ -237,7 +252,7 @@ func (p *MessageChannelProvider) conversationTiming(ctx context.Context, convID 
 		}
 	}
 
-	return promptfmt.ConversationRecency(facts, now, p.loadLocation())
+	return promptfmt.ConversationRecency(facts, anchor, p.loadLocation())
 }
 
 // previousSessionScan bounds how many recent sessions the timing

--- a/internal/state/memory/message_channel_provider.go
+++ b/internal/state/memory/message_channel_provider.go
@@ -6,17 +6,20 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 )
 
-// MessageChannelProviderConfig configures the older-sessions catalog
-// provider for message-channel conversations (Signal, Matrix, iMessage).
-// Zero values fall back to defaults.
+// MessageChannelProviderConfig configures the conversation-timing and
+// older-sessions context provider for message-channel conversations
+// (Signal, Matrix, iMessage). Zero values fall back to defaults.
 type MessageChannelProviderConfig struct {
 	// RecentWindow excludes sessions that ended within this duration
 	// of now. Their messages are still present in the model's
 	// role-native working message list, so cataloging them would
-	// restate context the model already sees. Default: 30m.
+	// restate context the model already sees. The same window is the
+	// conversation-timing narrative's active/resumed boundary, so the
+	// two views describe one span. Default: 30m.
 	RecentWindow time.Duration
 
 	// SessionsLimit caps the number of session entries listed in the
@@ -26,12 +29,47 @@ type MessageChannelProviderConfig struct {
 	// SessionsByteCap is the JSON output ceiling for the catalog.
 	// Default: 8000.
 	SessionsByteCap int
+
+	// Timezone is the household IANA timezone anchoring the timing
+	// narrative's day words ("last night", "yesterday"). Empty falls
+	// back to the system's local zone.
+	Timezone string
+
+	// OriginFromContext extracts the current turn's message provenance
+	// (the Origin* constants) from a request context — pass
+	// tools.MessageOriginFromContext. Telling a counterparty-contact
+	// turn from an internal wake is load-bearing for the timing
+	// narrative, so when this is nil the narrative is omitted entirely
+	// rather than rendered on a guess.
+	OriginFromContext func(context.Context) string
+
+	// HintsFromContext extracts the request routing hints — pass
+	// tools.HintsFromContext. Optional: on wake turns the loop_name
+	// hint names the waking loop in the narrative.
+	HintsFromContext func(context.Context) map[string]string
 }
 
-// MessageChannelProvider injects an "Older Sessions" context block for
-// message-channel conversations: a compact JSON catalog of recent
-// closed sessions with substance, acting as enticement to call
-// archive_session_transcript or archive_search for fuller content.
+// MessageChannelProvider injects two context blocks for message-channel
+// conversations.
+//
+// "Conversation Timing" is one or two sentences of Go-side interpreted
+// narrative — where the current turn stands in the rhythm of contact
+// with the channel counterparty ("You're in an active conversation…",
+// "This is the first contact today. The previous conversation was last
+// night, about…"). Rendering is [promptfmt.ConversationRecency]; the
+// facts come from contact-classified message timestamps
+// ([ArchiveStore.RecentContactTimes]), the active session, and the most
+// recent archivist-summarized closed session. Rhythm anchors on contact
+// timestamps, never session boundaries — wake rows keep sessions open,
+// so session duration is only rendered inside the contact-gated active
+// branch.
+//
+// "Older Sessions" is a compact JSON catalog of recent closed sessions
+// with substance, acting as enticement to call
+// archive_session_transcript or archive_search for fuller content. The
+// catalog keeps the precise deltas and session ids; the narrative is an
+// interpretation layer over the same timestamps, not a second copy of
+// the data.
 //
 // Verbatim conversation history is deliberately NOT emitted here. The
 // model's working message list already carries stored history in
@@ -80,15 +118,18 @@ func NewMessageChannelProvider(archive *ArchiveStore, conversationIDFromCtx func
 	}
 }
 
-// TagContextBucket places the older-sessions catalog in continuity
-// context.
+// TagContextBucket places the timing narrative and older-sessions
+// catalog in continuity context: both orient the current turn inside
+// past experience, and the bucket is already uncached so the ticking
+// deltas cost nothing.
 func (p *MessageChannelProvider) TagContextBucket() agentctx.ContextBucket {
 	return agentctx.ContextBucketContinuity
 }
 
-// TagContext returns the older-sessions catalog for the active
-// conversation. Returns the empty string when there is nothing to emit
-// (no conversation context, no cataloged sessions).
+// TagContext returns the conversation-timing narrative and the
+// older-sessions catalog for the active conversation. Returns the empty
+// string when there is nothing to emit (no conversation context, and
+// neither block has content).
 func (p *MessageChannelProvider) TagContext(ctx context.Context, _ agentctx.ContextRequest) (string, error) {
 	if p.conversationIDFromCtx == nil {
 		return "", nil
@@ -101,28 +142,128 @@ func (p *MessageChannelProvider) TagContext(ctx context.Context, _ agentctx.Cont
 	now := p.nowFunc()
 	cutoff := now.Add(-p.cfg.RecentWindow)
 
+	timing := p.conversationTiming(ctx, convID, now)
+
 	older, more, err := p.olderSessions(convID, cutoff)
 	if err != nil {
 		p.logger.Warn("older sessions query failed",
 			"conversation_id", convID, "error", err)
 	}
-	if len(older) == 0 {
+	if timing == "" && len(older) == 0 {
 		return "", nil
 	}
 
-	// The truncated flag covers both fitting passes — the entry limit
-	// and the byte cap — so dropped sessions are never silent.
-	sessionsJSON := FitPrefix(len(older), p.cfg.SessionsByteCap, func(k int) []byte {
-		return FormatSessionsList(older[:k], now, more || k < len(older))
-	})
-
 	var sb strings.Builder
-	sb.WriteString("## Older Sessions\n\n")
-	sb.WriteString("Past sessions on this conversation, newest first. Use archive_session_transcript for full transcripts, or archive_search to search semantically.\n\n")
-	sb.WriteString("```json\n")
-	sb.Write(sessionsJSON)
-	sb.WriteString("\n```\n")
+	if timing != "" {
+		sb.WriteString("## Conversation Timing\n\n")
+		sb.WriteString(timing)
+		sb.WriteString("\n")
+	}
+	if len(older) > 0 {
+		if sb.Len() > 0 {
+			sb.WriteString("\n")
+		}
+		// The truncated flag covers both fitting passes — the entry
+		// limit and the byte cap — so dropped sessions are never
+		// silent.
+		sessionsJSON := FitPrefix(len(older), p.cfg.SessionsByteCap, func(k int) []byte {
+			return FormatSessionsList(older[:k], now, more || k < len(older))
+		})
+		sb.WriteString("## Older Sessions\n\n")
+		sb.WriteString("Past sessions on this conversation, newest first. Use archive_session_transcript for full transcripts, or archive_search to search semantically.\n\n")
+		sb.WriteString("```json\n")
+		sb.Write(sessionsJSON)
+		sb.WriteString("\n```\n")
+	}
 	return sb.String(), nil
+}
+
+// conversationTiming assembles the facts for the timing narrative and
+// renders it, or returns "" when the narrative cannot be stated
+// truthfully: no origin extractor is wired (contact vs wake would be a
+// guess), or the queries that anchor it fail. Failures degrade to the
+// catalog-only output rather than erroring the whole context bucket.
+func (p *MessageChannelProvider) conversationTiming(ctx context.Context, convID string, now time.Time) string {
+	if p.cfg.OriginFromContext == nil {
+		return ""
+	}
+
+	facts := promptfmt.ConversationRecencyFacts{
+		Kind:         promptfmt.TurnContact,
+		RecentWindow: p.cfg.RecentWindow,
+	}
+	if p.cfg.OriginFromContext(ctx) == OriginWake {
+		facts.Kind = promptfmt.TurnWake
+		if p.cfg.HintsFromContext != nil {
+			facts.WakeLoopName = p.cfg.HintsFromContext(ctx)["loop_name"]
+		}
+	}
+
+	contacts, err := p.archive.RecentContactTimes(convID, 2)
+	if err != nil {
+		p.logger.Warn("recent contact times query failed",
+			"conversation_id", convID, "error", err)
+		return ""
+	}
+	// On a contact turn the newest contact row is the current message
+	// itself (stored before prompt assembly), so the previous contact
+	// is the second entry; a wake stores no contact row, so it is the
+	// first.
+	idx := 0
+	if facts.Kind == promptfmt.TurnContact {
+		idx = 1
+	}
+	if len(contacts) > idx {
+		facts.PreviousContactAt = contacts[idx]
+		facts.HasHistory = true
+	}
+
+	if sess, err := p.archive.ActiveSession(convID); err == nil && sess != nil {
+		facts.ActiveSessionStart = sess.StartedAt
+	}
+
+	if sessions, err := p.archive.ListSessions(convID, previousSessionScan); err != nil {
+		p.logger.Warn("previous session lookup failed",
+			"conversation_id", convID, "error", err)
+	} else {
+		for _, s := range sessions {
+			if s.EndedAt == nil || !sessionHasContent(s) {
+				continue
+			}
+			facts.PreviousSessionEnd = *s.EndedAt
+			facts.PreviousSessionTopic = previousSessionTopic(s)
+			facts.HasHistory = true
+			break
+		}
+	}
+
+	return promptfmt.ConversationRecency(facts, now, p.loadLocation())
+}
+
+// previousSessionScan bounds how many recent sessions the timing
+// narrative examines to find the most recent closed one with content.
+const previousSessionScan = 10
+
+// previousSessionTopic picks the clause-sized summary of a session:
+// the archivist's one-liner first, then the title. Empty when the
+// archivist has not summarized yet — the clause degrades to the time
+// word alone.
+func previousSessionTopic(s *Session) string {
+	if s.Metadata != nil && s.Metadata.OneLiner != "" {
+		return s.Metadata.OneLiner
+	}
+	return s.Title
+}
+
+// loadLocation returns the configured household timezone, falling back
+// to the system's local zone.
+func (p *MessageChannelProvider) loadLocation() *time.Location {
+	if p.cfg.Timezone != "" {
+		if loc, err := time.LoadLocation(p.cfg.Timezone); err == nil {
+			return loc
+		}
+	}
+	return time.Now().Location()
 }
 
 // olderSessionsMaxScan bounds how many candidate rows one turn will

--- a/internal/state/memory/recent_contact_times_test.go
+++ b/internal/state/memory/recent_contact_times_test.go
@@ -1,0 +1,79 @@
+package memory
+
+import (
+	"testing"
+	"time"
+)
+
+// TestRecentContactTimes verifies contact classification over the unified
+// messages table: stamped channel rows count in either direction, wake
+// and internal rows never count, and the documented legacy fallback
+// counts unstamped user rows except wake-bridge synthetic content.
+func TestRecentContactTimes(t *testing.T) {
+	store := newWindowStore(t, 100)
+	archive, err := NewArchiveStoreFromDB(store.db, nil, nil)
+	if err != nil {
+		t.Fatalf("NewArchiveStoreFromDB: %v", err)
+	}
+
+	base := time.Now().Add(-time.Hour).Truncate(time.Second)
+	insert := func(id, role, content string, origin any, ts time.Time) {
+		t.Helper()
+		if _, err := store.db.Exec(`
+			INSERT INTO messages (id, conversation_id, role, content, timestamp, origin)
+			VALUES (?, 'c1', ?, ?, ?, ?)
+		`, id, role, content, ts, origin); err != nil {
+			t.Fatalf("insert %s: %v", id, err)
+		}
+	}
+
+	t1 := base.Add(1 * time.Minute)
+	t4 := base.Add(4 * time.Minute)
+	t6 := base.Add(6 * time.Minute)
+
+	insert("m1", "user", "inbound", OriginChannel, t1)
+	insert("m2", "assistant", "loop reply", OriginInternal, base.Add(2*time.Minute))
+	insert("m3", "user", "wake prompt", OriginWake, base.Add(3*time.Minute))
+	insert("m4", "user", "legacy inbound", nil, t4) // NULL origin: pre-stamp row
+	insert("m5", "user", "Anticipation matched: garage door", "", base.Add(5*time.Minute))
+	insert("m6", "assistant", "outbound notification", OriginChannel, t6)
+	insert("m7", "assistant", "legacy reply", "", base.Add(7*time.Minute))
+
+	// Another conversation must not leak in.
+	if _, err := store.db.Exec(`
+		INSERT INTO messages (id, conversation_id, role, content, timestamp, origin)
+		VALUES ('other', 'c2', 'user', 'elsewhere', ?, ?)
+	`, base.Add(8*time.Minute), OriginChannel); err != nil {
+		t.Fatalf("insert other-conversation row: %v", err)
+	}
+
+	got, err := archive.RecentContactTimes("c1", 5)
+	if err != nil {
+		t.Fatalf("RecentContactTimes: %v", err)
+	}
+	want := []time.Time{t6, t4, t1}
+	if len(got) != len(want) {
+		t.Fatalf("RecentContactTimes returned %d times, want %d: %v", len(got), len(want), got)
+	}
+	for i := range want {
+		if !got[i].Equal(want[i]) {
+			t.Errorf("contact[%d] = %v, want %v", i, got[i], want[i])
+		}
+	}
+
+	limited, err := archive.RecentContactTimes("c1", 2)
+	if err != nil {
+		t.Fatalf("RecentContactTimes limited: %v", err)
+	}
+	if len(limited) != 2 || !limited[0].Equal(t6) || !limited[1].Equal(t4) {
+		t.Errorf("limit 2 = %v, want [%v %v]", limited, t6, t4)
+	}
+
+	empty, err := archive.RecentContactTimes("c-nothing", 3)
+	if err != nil {
+		t.Fatalf("RecentContactTimes empty conversation: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Errorf("empty conversation returned %v, want none", empty)
+	}
+}

--- a/internal/tools/context.go
+++ b/internal/tools/context.go
@@ -20,6 +20,7 @@ const channelBindingKey contextKey = "channel_binding"
 const inheritableCapabilityTagsKey contextKey = "inheritable_capability_tags"
 const requestIDKey contextKey = "request_id"
 const modelKey contextKey = "model"
+const messageOriginKey contextKey = "message_origin"
 
 // WithConversationID adds the conversation ID to the context.
 func WithConversationID(ctx context.Context, id string) context.Context {
@@ -33,6 +34,26 @@ func ConversationIDFromContext(ctx context.Context) string {
 		return id
 	}
 	return "default"
+}
+
+// WithMessageOrigin adds the current turn's message provenance (the
+// memory.Origin* constants) to the context, so context providers can
+// tell a counterparty-contact turn from an internal wake while building
+// the prompt.
+func WithMessageOrigin(ctx context.Context, origin string) context.Context {
+	if origin == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, messageOriginKey, origin)
+}
+
+// MessageOriginFromContext extracts the current turn's message
+// provenance, or "" when the turn did not declare one.
+func MessageOriginFromContext(ctx context.Context) string {
+	if origin, ok := ctx.Value(messageOriginKey).(string); ok {
+		return origin
+	}
+	return ""
 }
 
 // WithRequestID adds the model request ID (r_…) of the current turn to the


### PR DESCRIPTION
## Summary

Second PR of #1440, stacked on #1441: interactive channels get the **Conversation Timing** block — one or two sentences of Go-side interpreted narrative telling the model where the current turn stands in the rhythm of contact with the channel counterparty, before it reads a single message.

> You're in an active conversation that's been going on for about 25 minutes; the previous message was about 2 minutes before this one.

> This is the first contact today. The previous conversation was last night, about the garage lighting circuits.

> This turn is an internal wake from the annunciator loop, not a message from them. The previous contact was about 3 hours ago.

All bucketing — gap words, day words, the active/lull/first-contact ladder — happens in Go, in the household timezone. The model never does timestamp arithmetic, never infers a day boundary, and never has to guess whether it is mid-conversation or being woken into a quiet room.

## Where it renders

Inside `MessageChannelProvider` (the `message_channel` tag gate), as its own `## Conversation Timing` section directly above the Older Sessions catalog it interprets — continuity bucket, already uncached, so the ticking sentence costs no cache. The narrative and the catalog are two altitudes over the same timestamps: the catalog keeps the precise deltas and session ids for `archive_session_transcript` follow-ups, the sentence carries the interpretation. Absent by construction on delegate, task-mode, and non-channel runs.

## How it knows

The renderer is a pure function, `promptfmt.ConversationRecency(facts, now, loc)` — times in, sentence out, zero I/O, sixteen branch cases locked by exact-string table tests. The design landed it in `promptfmt` rather than `awareness` for two reasons that turned out to agree: `awareness` imports the loop runtime (an import cycle from `memory`), and `promptfmt` is model-facing-context.md's designated home for time policy — the fuzzy vocabularies (`fuzzySpan`, `dayPhrase`) sit beside `FormatDelta` where the anticipated future consumers already look.

The facts come from three sources, and rhythm anchors on **contact timestamps, never session boundaries** — wake rows keep sessions open, so session duration is only rendered inside the contact-gated active branch:

- `ArchiveStore.RecentContactTimes` classifies contact over the #1441 provenance stamps: `channel` rows in either direction count; `wake` and `internal` rows never move the previous contact (a wake that shifted it would erase the very silence it reports). The one documented legacy fallback lives inside this query: unstamped user-role rows count, minus the wake-bridge's `Anticipation matched:` synthetic content — the same exclusion the search paths already apply.
- The current turn's own just-stored message is excluded by turn kind: a contact turn takes the second-newest contact row (the newest is the message being answered), a wake takes the newest. The first-contact-ever test pins this self-skip.
- The previous-conversation clause reads the most recent closed session with substance; the topic is the archivist's one-liner (title as fallback) and degrades to the time word alone when the archivist hasn't run yet.

Turn kind reaches the provider through the same channel conversation IDs already travel: the agent loop stamps `req.MessageOrigin` onto the run context (`tools.WithMessageOrigin`, surviving per-iteration prompt rebuilds like bindings do), and the provider receives an extractor via config. When no extractor is wired, the block is omitted entirely rather than rendered on a guess — telling contact from wake is load-bearing, and a wake narrated as "you're in an active conversation" would prompt the model to reply to a message that doesn't exist. On wake turns the `loop_name` routing hint names the waking loop.

## Why prose, when generated runtime data defaults to JSON

This is the "unless prose is genuinely the clearer contract" case, now written into model-facing-context.md as the worked example: once the interpretation is done there is no structure left to convey, and a `gap_class` enum would hand the work back to the model. The doc section also carries the vocabulary contract from #1440 — *current turn*, *contact*, *wake*, *previous contact*, and the scoped rule that "last" is banned wherever a current-turn anchor exists.

## A pre-existing defect this PR surfaced and fixes

Review of the context plumbing exposed that conversation ID, routing hints, channel binding, and the suppress flag were stamped only on the local `promptCtx`, while `OnIterationStart` rebuilds the system prompt from the iteration context — so every conversation-scoped provider (working memory, the message-channel catalog, and now this block) silently emptied from iteration 1 onward on multi-iteration turns. That is the same painted-door shape the bindings stamp had already fixed for itself. All turn-scoped values now ride the run context, and `TestConversationScopeReachesContextProvidersEveryIteration` drives a real two-iteration run — verified to fail against the old stamping.

Two narrative-correctness fixes from the same review: the contact gap is now measured to the current message's stored **arrival** time rather than prompt-assembly time (assembly lag across the recent window or a day boundary was selecting the wrong rhythm bucket; wakes keep the wall clock, having no arrival), and the last-night band is checked before the same-day bucket so a 02:00 session viewed at 09:00 renders "last night" instead of "earlier today".

## Seams left ready

The counterparty-timezone clause ("it's about 9:40 in the evening where they are") slots into `ConversationRecencyFacts` as an optional field plus one clause when the direct-measure data lands; absent data, absent clause. The awaiting-reply state ("you messaged them 10 minutes ago and haven't heard back") needs only delivery-side outbound stamping, which #1441's `RecordOutbound` already began.

## Test plan

- [x] `ConversationRecency`: 16 exact-string branch cases (active/lull/hours/first-today/first-ever, wake × quiet/mid-conversation/no-history/unknown-timing, day words: last night, yesterday-after-noon, weekday, week-ago, absolute date; topic degradation; active branch suppresses the previous-conversation clause)
- [x] `fuzzySpan` vocabulary boundaries
- [x] `RecentContactTimes`: stamped-channel both directions, wake/internal excluded, legacy user fallback with anticipation exclusion, NULL origin, cross-conversation isolation, ordering and limit
- [x] Provider integration: active contact turn end-to-end, wake turn with loop name and archivist topic, first-contact-ever self-skip, timing omitted without an origin extractor while the catalog still renders
- [x] Arrival anchoring: assembly delayed 40 minutes past arrival still narrates the active branch
- [x] Multi-iteration seam: conversation ID, origin, and hints reach context providers on every prompt rebuild (mutation-verified against the old stamping)
- [x] `just ci` green

Refs #1440

