### PR TITLE
feat(companion): durable device inventory survives the connection

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -51,6 +51,7 @@ import (
 	cdav "github.com/nugget/thane-ai-agent/internal/server/carddav"
 	"github.com/nugget/thane-ai-agent/internal/state/attachments"
 	"github.com/nugget/thane-ai-agent/internal/state/awareness"
+	"github.com/nugget/thane-ai-agent/internal/state/companions"
 	"github.com/nugget/thane-ai-agent/internal/state/contacts"
 	"github.com/nugget/thane-ai-agent/internal/state/documents"
 	"github.com/nugget/thane-ai-agent/internal/state/introspection"
@@ -130,8 +131,10 @@ type App struct {
 	ha   *homeassistant.Client
 	haWS *homeassistant.WSClient
 
-	// Companion app registry
+	// Companion app registry (live connections) and durable device
+	// inventory (records that outlive them).
 	companionRegistry *companion.Registry
+	companionDevices  *companions.Store
 
 	// Connection health
 	connMgr *connwatch.Manager

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -276,6 +276,9 @@ func (a *App) initServers(s *newState) error {
 		a.loop.RegisterTagContextProvider("companion", companion.NewContextProvider(a.companionRegistry))
 
 		handler := companion.NewHandler(cfg.Companion.TokenIndex(), a.companionRegistry, logger)
+		// Durable inventory: authentication upserts the device record,
+		// disconnect stamps timestamps without deleting it (#1437).
+		handler.SetDeviceRecorder(a.companionDevices)
 		server.SetCompanionHandler(handler)
 
 		a.connMgr.Watch(s.ctx, connwatch.WatcherConfig{

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -278,7 +278,10 @@ func (a *App) initServers(s *newState) error {
 		handler := companion.NewHandler(cfg.Companion.TokenIndex(), a.companionRegistry, logger)
 		// Durable inventory: authentication upserts the device record,
 		// disconnect stamps timestamps without deleting it (#1437).
+		// The LIFO closer drains queued inventory writes before the
+		// memory store closes the database they land in.
 		handler.SetDeviceRecorder(a.companionDevices)
+		a.onClose("companion-device-recorder", handler.CloseDeviceRecorder)
 		server.SetCompanionHandler(handler)
 
 		a.connMgr.Watch(s.ctx, connwatch.WatcherConfig{

--- a/internal/app/new_stores.go
+++ b/internal/app/new_stores.go
@@ -19,6 +19,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/scheduler"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/state/awareness"
+	"github.com/nugget/thane-ai-agent/internal/state/companions"
 	"github.com/nugget/thane-ai-agent/internal/state/loopqueue"
 	"github.com/nugget/thane-ai-agent/internal/state/memory"
 )
@@ -140,6 +141,19 @@ func (a *App) initStores(s *newState) error {
 		return fmt.Errorf("loop queue store: %w", err)
 	}
 	a.loopQueue = loopQueue
+
+	// --- Companion device inventory ---
+	// Durable record of every known companion device (#1437), written by
+	// the WebSocket connection lifecycle in initServers. Constructed
+	// unconditionally: the inventory's lifetime deliberately exceeds the
+	// companion config that feeds it — unconfiguring companions must not
+	// orphan the records. Shares the main thane.db connection; no
+	// separate close hook (mem owns the DB).
+	companionDevices, err := companions.NewStore(a.mem.DB(), logger)
+	if err != nil {
+		return fmt.Errorf("companion device store: %w", err)
+	}
+	a.companionDevices = companionDevices
 
 	// Daily prune for the completions journal Ack writes — the audit
 	// trail is bounded by age, mirroring the log-index pruner's shape.

--- a/internal/integrations/companion/devices.go
+++ b/internal/integrations/companion/devices.go
@@ -51,14 +51,34 @@ type DeviceRecorder interface {
 // connection lifecycle and starts the recording goroutine. Optional: a
 // nil recorder (the default) disables persistence and the handler
 // behaves as a pure live-connection endpoint. Call before the handler
-// starts serving; the queue goroutine lives for the process lifetime.
+// starts serving, and pair with [Handler.CloseDeviceRecorder] at
+// shutdown so queued writes land before their database closes.
 func (h *Handler) SetDeviceRecorder(recorder DeviceRecorder) {
 	h.devices = recorder
 	if recorder == nil || h.deviceOps != nil {
 		return
 	}
 	h.deviceOps = make(chan func(context.Context), deviceOpQueueSize)
+	h.deviceOpsDone = make(chan struct{})
 	go h.runDeviceOps()
+}
+
+// CloseDeviceRecorder stops accepting new inventory writes, drains the
+// ones already queued, and returns once the recording goroutine has
+// exited. Registered on the app's LIFO closer stack ahead of the
+// database owner, so a restart cannot lose a just-recorded lifecycle
+// event or write into a closed database. Safe to call more than once;
+// lifecycle events after close are dropped (best-effort, as ever).
+func (h *Handler) CloseDeviceRecorder() {
+	h.deviceOpsMu.Lock()
+	if h.deviceOps == nil || h.deviceOpsClosed {
+		h.deviceOpsMu.Unlock()
+		return
+	}
+	h.deviceOpsClosed = true
+	close(h.deviceOps)
+	h.deviceOpsMu.Unlock()
+	<-h.deviceOpsDone
 }
 
 // runDeviceOps applies queued inventory writes in order. A single
@@ -66,6 +86,7 @@ func (h *Handler) SetDeviceRecorder(recorder DeviceRecorder) {
 // sequence ordered without ever putting a database write on the
 // WebSocket handshake or teardown path.
 func (h *Handler) runDeviceOps() {
+	defer close(h.deviceOpsDone)
 	for op := range h.deviceOps {
 		ctx, cancel := context.WithTimeout(context.Background(), deviceOpTimeout)
 		op(ctx)
@@ -74,9 +95,15 @@ func (h *Handler) runDeviceOps() {
 }
 
 // enqueueDeviceOp hands a write to the recording goroutine without
-// blocking the connection path. Dropping on overflow is deliberate:
-// inventory is best-effort relative to live traffic.
+// blocking the connection path. Dropping on overflow or after close is
+// deliberate: inventory is best-effort relative to live traffic.
 func (h *Handler) enqueueDeviceOp(op func(context.Context)) {
+	h.deviceOpsMu.Lock()
+	defer h.deviceOpsMu.Unlock()
+	if h.deviceOpsClosed {
+		h.logger.Debug("companion device inventory recorder closed; dropping record")
+		return
+	}
 	select {
 	case h.deviceOps <- op:
 	default:

--- a/internal/integrations/companion/devices.go
+++ b/internal/integrations/companion/devices.go
@@ -1,0 +1,115 @@
+package companion
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+)
+
+// DeviceMetadata is the client-reported device description carried from
+// the auth handshake into the durable inventory. Every field is
+// optional; the inventory treats absent fields as "not reported", not
+// as an erasure of what the device said before.
+type DeviceMetadata struct {
+	ClientName string
+	Platform   string
+	AppVersion string
+	OSVersion  string
+}
+
+// DeviceRecorder receives durable device-inventory events from the
+// connection lifecycle. Connections are ephemeral and records are not:
+// a recorder must treat disconnects as timestamp updates, never as
+// deletions (#1437). The handler calls it best-effort — a recording
+// failure is logged and must not affect the live connection.
+type DeviceRecorder interface {
+	// RecordConnected upserts the device row for a successful
+	// authentication, stamping first-seen on new devices.
+	RecordConnected(account, clientID string, meta DeviceMetadata, at time.Time) error
+	// RecordCapabilities stores the most recently advertised capability
+	// manifest (opaque JSON) for the device.
+	RecordCapabilities(account, clientID string, manifest []byte, at time.Time) error
+	// RecordDisconnected stamps the disconnect time for the device.
+	RecordDisconnected(account, clientID string, at time.Time) error
+}
+
+// SetDeviceRecorder wires durable device-inventory recording into the
+// connection lifecycle. Optional: a nil recorder (the default) disables
+// persistence and the handler behaves as a pure live-connection
+// endpoint.
+func (h *Handler) SetDeviceRecorder(recorder DeviceRecorder) {
+	h.devices = recorder
+}
+
+// recordConnected persists the auth-time device upsert. Connections
+// without a client_id have no durable identity to key a row by; they
+// stay fully functional live but are deliberately not inventoried —
+// the contract published on #1437.
+func (h *Handler) recordConnected(p *Provider) {
+	if h.devices == nil {
+		return
+	}
+	if strings.TrimSpace(p.ClientID) == "" {
+		h.logger.Debug("companion connection has no client_id; not recorded in device inventory",
+			"provider_id", p.ID,
+			"account", p.Account,
+			"client_name", p.ClientName,
+		)
+		return
+	}
+	err := h.devices.RecordConnected(p.Account, p.ClientID, DeviceMetadata{
+		ClientName: p.ClientName,
+		Platform:   p.Platform,
+		AppVersion: p.AppVersion,
+		OSVersion:  p.OSVersion,
+	}, time.Now().UTC())
+	if err != nil {
+		h.logger.Warn("companion device inventory connect record failed",
+			"provider_id", p.ID,
+			"account", p.Account,
+			"client_id", p.ClientID,
+			"error", err,
+		)
+	}
+}
+
+// recordCapabilities persists the normalized capability manifest the
+// provider just registered.
+func (h *Handler) recordCapabilities(p *Provider) {
+	if h.devices == nil || strings.TrimSpace(p.ClientID) == "" {
+		return
+	}
+	manifest, err := json.Marshal(p.capabilitiesSnapshot())
+	if err != nil {
+		h.logger.Warn("companion device inventory manifest marshal failed",
+			"provider_id", p.ID,
+			"account", p.Account,
+			"client_id", p.ClientID,
+			"error", err,
+		)
+		return
+	}
+	if err := h.devices.RecordCapabilities(p.Account, p.ClientID, manifest, time.Now().UTC()); err != nil {
+		h.logger.Warn("companion device inventory capability record failed",
+			"provider_id", p.ID,
+			"account", p.Account,
+			"client_id", p.ClientID,
+			"error", err,
+		)
+	}
+}
+
+// recordDisconnected stamps the disconnect on the durable record.
+func (h *Handler) recordDisconnected(p *Provider) {
+	if h.devices == nil || strings.TrimSpace(p.ClientID) == "" {
+		return
+	}
+	if err := h.devices.RecordDisconnected(p.Account, p.ClientID, time.Now().UTC()); err != nil {
+		h.logger.Warn("companion device inventory disconnect record failed",
+			"provider_id", p.ID,
+			"account", p.Account,
+			"client_id", p.ClientID,
+			"error", err,
+		)
+	}
+}

--- a/internal/integrations/companion/devices.go
+++ b/internal/integrations/companion/devices.go
@@ -1,15 +1,27 @@
 package companion
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"time"
 )
 
+// deviceOpTimeout bounds each inventory write so a wedged database can
+// never back the recording queue up indefinitely.
+const deviceOpTimeout = 5 * time.Second
+
+// deviceOpQueueSize bounds the recording queue. Lifecycle events are
+// rare (one per connect, capability registration, and disconnect), so
+// a full queue means the database has been unhealthy for a while — at
+// that point dropping records is the honest best-effort behavior.
+const deviceOpQueueSize = 256
+
 // DeviceMetadata is the client-reported device description carried from
 // the auth handshake into the durable inventory. Every field is
 // optional; the inventory treats absent fields as "not reported", not
-// as an erasure of what the device said before.
+// as an erasure of what the device said before. Values are normalized
+// (trimmed) once, at authentication, and stored verbatim after that.
 type DeviceMetadata struct {
 	ClientName string
 	Platform   string
@@ -20,28 +32,59 @@ type DeviceMetadata struct {
 // DeviceRecorder receives durable device-inventory events from the
 // connection lifecycle. Connections are ephemeral and records are not:
 // a recorder must treat disconnects as timestamp updates, never as
-// deletions (#1437). The handler calls it best-effort — a recording
-// failure is logged and must not affect the live connection.
+// deletions (#1437). The handler calls it best-effort from a
+// dedicated goroutine — a recording failure is logged and must not
+// affect the live connection. The timestamps passed are event times,
+// captured when the lifecycle event happened, not when the write runs.
 type DeviceRecorder interface {
 	// RecordConnected upserts the device row for a successful
 	// authentication, stamping first-seen on new devices.
-	RecordConnected(account, clientID string, meta DeviceMetadata, at time.Time) error
+	RecordConnected(ctx context.Context, account, clientID string, meta DeviceMetadata, at time.Time) error
 	// RecordCapabilities stores the most recently advertised capability
 	// manifest (opaque JSON) for the device.
-	RecordCapabilities(account, clientID string, manifest []byte, at time.Time) error
+	RecordCapabilities(ctx context.Context, account, clientID string, manifest []byte, at time.Time) error
 	// RecordDisconnected stamps the disconnect time for the device.
-	RecordDisconnected(account, clientID string, at time.Time) error
+	RecordDisconnected(ctx context.Context, account, clientID string, at time.Time) error
 }
 
 // SetDeviceRecorder wires durable device-inventory recording into the
-// connection lifecycle. Optional: a nil recorder (the default) disables
-// persistence and the handler behaves as a pure live-connection
-// endpoint.
+// connection lifecycle and starts the recording goroutine. Optional: a
+// nil recorder (the default) disables persistence and the handler
+// behaves as a pure live-connection endpoint. Call before the handler
+// starts serving; the queue goroutine lives for the process lifetime.
 func (h *Handler) SetDeviceRecorder(recorder DeviceRecorder) {
 	h.devices = recorder
+	if recorder == nil || h.deviceOps != nil {
+		return
+	}
+	h.deviceOps = make(chan func(context.Context), deviceOpQueueSize)
+	go h.runDeviceOps()
 }
 
-// recordConnected persists the auth-time device upsert. Connections
+// runDeviceOps applies queued inventory writes in order. A single
+// consumer keeps each connection's connect → capabilities → disconnect
+// sequence ordered without ever putting a database write on the
+// WebSocket handshake or teardown path.
+func (h *Handler) runDeviceOps() {
+	for op := range h.deviceOps {
+		ctx, cancel := context.WithTimeout(context.Background(), deviceOpTimeout)
+		op(ctx)
+		cancel()
+	}
+}
+
+// enqueueDeviceOp hands a write to the recording goroutine without
+// blocking the connection path. Dropping on overflow is deliberate:
+// inventory is best-effort relative to live traffic.
+func (h *Handler) enqueueDeviceOp(op func(context.Context)) {
+	select {
+	case h.deviceOps <- op:
+	default:
+		h.logger.Warn("companion device inventory queue full; dropping record")
+	}
+}
+
+// recordConnected enqueues the auth-time device upsert. Connections
 // without a client_id have no durable identity to key a row by; they
 // stay fully functional live but are deliberately not inventoried —
 // the contract published on #1437.
@@ -57,24 +100,28 @@ func (h *Handler) recordConnected(p *Provider) {
 		)
 		return
 	}
-	err := h.devices.RecordConnected(p.Account, p.ClientID, DeviceMetadata{
-		ClientName: p.ClientName,
-		Platform:   p.Platform,
-		AppVersion: p.AppVersion,
-		OSVersion:  p.OSVersion,
-	}, time.Now().UTC())
-	if err != nil {
-		h.logger.Warn("companion device inventory connect record failed",
-			"provider_id", p.ID,
-			"account", p.Account,
-			"client_id", p.ClientID,
-			"error", err,
-		)
-	}
+	at := time.Now().UTC()
+	h.enqueueDeviceOp(func(ctx context.Context) {
+		err := h.devices.RecordConnected(ctx, p.Account, p.ClientID, DeviceMetadata{
+			ClientName: p.ClientName,
+			Platform:   p.Platform,
+			AppVersion: p.AppVersion,
+			OSVersion:  p.OSVersion,
+		}, at)
+		if err != nil {
+			h.logger.Warn("companion device inventory connect record failed",
+				"provider_id", p.ID,
+				"account", p.Account,
+				"client_id", p.ClientID,
+				"error", err,
+			)
+		}
+	})
 }
 
-// recordCapabilities persists the normalized capability manifest the
-// provider just registered.
+// recordCapabilities enqueues the normalized capability manifest the
+// provider just registered. The manifest is snapshotted now so a later
+// re-registration cannot mutate what this event advertises.
 func (h *Handler) recordCapabilities(p *Provider) {
 	if h.devices == nil || strings.TrimSpace(p.ClientID) == "" {
 		return
@@ -89,27 +136,34 @@ func (h *Handler) recordCapabilities(p *Provider) {
 		)
 		return
 	}
-	if err := h.devices.RecordCapabilities(p.Account, p.ClientID, manifest, time.Now().UTC()); err != nil {
-		h.logger.Warn("companion device inventory capability record failed",
-			"provider_id", p.ID,
-			"account", p.Account,
-			"client_id", p.ClientID,
-			"error", err,
-		)
-	}
+	at := time.Now().UTC()
+	h.enqueueDeviceOp(func(ctx context.Context) {
+		if err := h.devices.RecordCapabilities(ctx, p.Account, p.ClientID, manifest, at); err != nil {
+			h.logger.Warn("companion device inventory capability record failed",
+				"provider_id", p.ID,
+				"account", p.Account,
+				"client_id", p.ClientID,
+				"error", err,
+			)
+		}
+	})
 }
 
-// recordDisconnected stamps the disconnect on the durable record.
+// recordDisconnected enqueues the disconnect stamp for the durable
+// record.
 func (h *Handler) recordDisconnected(p *Provider) {
 	if h.devices == nil || strings.TrimSpace(p.ClientID) == "" {
 		return
 	}
-	if err := h.devices.RecordDisconnected(p.Account, p.ClientID, time.Now().UTC()); err != nil {
-		h.logger.Warn("companion device inventory disconnect record failed",
-			"provider_id", p.ID,
-			"account", p.Account,
-			"client_id", p.ClientID,
-			"error", err,
-		)
-	}
+	at := time.Now().UTC()
+	h.enqueueDeviceOp(func(ctx context.Context) {
+		if err := h.devices.RecordDisconnected(ctx, p.Account, p.ClientID, at); err != nil {
+			h.logger.Warn("companion device inventory disconnect record failed",
+				"provider_id", p.ID,
+				"account", p.Account,
+				"client_id", p.ClientID,
+				"error", err,
+			)
+		}
+	})
 }

--- a/internal/integrations/companion/devices_test.go
+++ b/internal/integrations/companion/devices_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -75,11 +76,13 @@ func waitFor(t *testing.T, cond func() bool) {
 }
 
 // dialWithRecorder is dialTestServer with a device recorder wired in.
+// The recording goroutine is torn down with the test.
 func dialWithRecorder(t *testing.T, recorder DeviceRecorder) (*httptest.Server, *websocket.Conn) {
 	t.Helper()
 	registry := NewRegistry(nil)
 	handler := NewHandler(testTokenIndex(), registry, nil)
 	handler.SetDeviceRecorder(recorder)
+	t.Cleanup(handler.CloseDeviceRecorder)
 	srv := httptest.NewServer(handler)
 	wsURL := "ws" + srv.URL[len("http"):]
 	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
@@ -177,13 +180,14 @@ func TestDeviceRecorderFullLifecycle(t *testing.T) {
 // a connection without a client_id stays fully functional live but is
 // never recorded in the durable inventory. The assertion is
 // deterministic: the wrapped handler signals when connection teardown
-// (the last recorder call site) has fully returned, and a barrier op
-// drains the recording queue behind anything mistakenly enqueued.
+// (the last recorder call site) has fully returned, and closing the
+// recorder drains the queue behind anything mistakenly enqueued.
 func TestDeviceRecorderSkipsAnonymousClients(t *testing.T) {
 	recorder := &fakeDeviceRecorder{}
 	registry := NewRegistry(nil)
 	handler := NewHandler(testTokenIndex(), registry, nil)
 	handler.SetDeviceRecorder(recorder)
+	t.Cleanup(handler.CloseDeviceRecorder)
 
 	teardown := make(chan struct{})
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -220,18 +224,39 @@ func TestDeviceRecorderSkipsAnonymousClients(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("handler teardown did not complete")
 	}
-	drained := make(chan struct{})
-	handler.enqueueDeviceOp(func(context.Context) { close(drained) })
-	select {
-	case <-drained:
-	case <-time.After(5 * time.Second):
-		t.Fatal("device op queue did not drain")
-	}
+	// Close drains: anything mistakenly enqueued has run by the time it
+	// returns.
+	handler.CloseDeviceRecorder()
 
 	c, caps, d := recorder.snapshot()
 	if c != 0 || caps != 0 || d != 0 {
 		t.Errorf("anonymous client was recorded: connected=%d capabilities=%d disconnected=%d", c, caps, d)
 	}
+}
+
+// TestCloseDeviceRecorderDrains pins the shutdown contract: close
+// waits for queued writes to land, and later lifecycle events are
+// dropped rather than sent to a recorder whose database may be gone.
+func TestCloseDeviceRecorderDrains(t *testing.T) {
+	registry := NewRegistry(nil)
+	handler := NewHandler(testTokenIndex(), registry, nil)
+	recorder := &fakeDeviceRecorder{}
+	handler.SetDeviceRecorder(recorder)
+
+	var ran atomic.Bool
+	handler.enqueueDeviceOp(func(context.Context) {
+		time.Sleep(50 * time.Millisecond)
+		ran.Store(true)
+	})
+	handler.CloseDeviceRecorder()
+	if !ran.Load() {
+		t.Error("CloseDeviceRecorder returned before the queued write landed")
+	}
+
+	// Enqueue after close is a silent drop, never a panic; a second
+	// close is a no-op.
+	handler.enqueueDeviceOp(func(context.Context) { t.Error("op ran after close") })
+	handler.CloseDeviceRecorder()
 }
 
 // TestAuthCarriesDeviceMetadata pins the optional auth fields onto the

--- a/internal/integrations/companion/devices_test.go
+++ b/internal/integrations/companion/devices_test.go
@@ -1,0 +1,240 @@
+package companion
+
+import (
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// fakeDeviceRecorder captures inventory events for assertions.
+type fakeDeviceRecorder struct {
+	mu           sync.Mutex
+	connected    []recordedDevice
+	capabilities []recordedManifest
+	disconnected []recordedDevice
+}
+
+type recordedDevice struct {
+	Account  string
+	ClientID string
+	Meta     DeviceMetadata
+}
+
+type recordedManifest struct {
+	Account  string
+	ClientID string
+	Manifest string
+}
+
+func (f *fakeDeviceRecorder) RecordConnected(account, clientID string, meta DeviceMetadata, _ time.Time) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.connected = append(f.connected, recordedDevice{account, clientID, meta})
+	return nil
+}
+
+func (f *fakeDeviceRecorder) RecordCapabilities(account, clientID string, manifest []byte, _ time.Time) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.capabilities = append(f.capabilities, recordedManifest{account, clientID, string(manifest)})
+	return nil
+}
+
+func (f *fakeDeviceRecorder) RecordDisconnected(account, clientID string, _ time.Time) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.disconnected = append(f.disconnected, recordedDevice{Account: account, ClientID: clientID})
+	return nil
+}
+
+func (f *fakeDeviceRecorder) snapshot() (connected, capabilities, disconnected int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.connected), len(f.capabilities), len(f.disconnected)
+}
+
+// waitFor polls until cond returns true or the deadline expires. The
+// disconnect record is written by the handler goroutine after the
+// client closes, so assertions on it need a grace window.
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("condition not met before deadline")
+}
+
+// dialWithRecorder is dialTestServer with a device recorder wired in.
+func dialWithRecorder(t *testing.T, recorder DeviceRecorder) (*httptest.Server, *websocket.Conn) {
+	t.Helper()
+	registry := NewRegistry(nil)
+	handler := NewHandler(testTokenIndex(), registry, nil)
+	handler.SetDeviceRecorder(recorder)
+	srv := httptest.NewServer(handler)
+	wsURL := "ws" + srv.URL[len("http"):]
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		srv.Close()
+		t.Fatalf("dial: %v", err)
+	}
+	return srv, conn
+}
+
+// authAs completes the handshake with the given identity fields.
+func authAs(t *testing.T, conn *websocket.Conn, msg authMessage) {
+	t.Helper()
+	var authReq authRequired
+	readJSON(t, conn, &authReq)
+	conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	msg.Type = typeAuth
+	msg.Token = "test-secret"
+	if err := conn.WriteJSON(msg); err != nil {
+		t.Fatalf("send auth: %v", err)
+	}
+	var ok authOK
+	readJSON(t, conn, &ok)
+	if ok.Type != typeAuthOK {
+		t.Fatalf("expected auth_ok, got %q", ok.Type)
+	}
+}
+
+func TestDeviceRecorderFullLifecycle(t *testing.T) {
+	recorder := &fakeDeviceRecorder{}
+	srv, conn := dialWithRecorder(t, recorder)
+	defer srv.Close()
+	defer conn.Close()
+
+	authAs(t, conn, authMessage{
+		ClientName: "Test iPhone",
+		ClientID:   "device-uuid-1",
+		Platform:   "ios",
+		AppVersion: "1.2.0",
+		OSVersion:  "26.0",
+	})
+
+	// Authentication upserts the device with its reported metadata.
+	waitFor(t, func() bool { c, _, _ := recorder.snapshot(); return c == 1 })
+	recorder.mu.Lock()
+	got := recorder.connected[0]
+	recorder.mu.Unlock()
+	if got.Account != "nugget" || got.ClientID != "device-uuid-1" {
+		t.Errorf("connected identity = %s/%s", got.Account, got.ClientID)
+	}
+	if got.Meta.Platform != "ios" || got.Meta.AppVersion != "1.2.0" || got.Meta.OSVersion != "26.0" || got.Meta.ClientName != "Test iPhone" {
+		t.Errorf("connected metadata = %+v", got.Meta)
+	}
+
+	// Capability registration persists the normalized manifest.
+	conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	if err := conn.WriteJSON(registerCapabilitiesMessage{
+		ID:   1,
+		Type: typeRegisterCaps,
+		Capabilities: []Capability{
+			{Name: "location", Version: "1", Methods: []string{"current"}},
+		},
+	}); err != nil {
+		t.Fatalf("send register_capabilities: %v", err)
+	}
+	var result Message
+	readJSON(t, conn, &result)
+	if !result.Success {
+		t.Fatalf("capability registration failed: %+v", result)
+	}
+	waitFor(t, func() bool { _, c, _ := recorder.snapshot(); return c == 1 })
+	recorder.mu.Lock()
+	manifest := recorder.capabilities[0]
+	recorder.mu.Unlock()
+	if manifest.Account != "nugget" || manifest.ClientID != "device-uuid-1" {
+		t.Errorf("manifest identity = %s/%s", manifest.Account, manifest.ClientID)
+	}
+	if !strings.Contains(manifest.Manifest, `"location"`) {
+		t.Errorf("manifest missing capability: %s", manifest.Manifest)
+	}
+
+	// Disconnect stamps the record; the registry removal and inventory
+	// stamp share the connection-teardown path.
+	conn.Close()
+	waitFor(t, func() bool { _, _, d := recorder.snapshot(); return d == 1 })
+	recorder.mu.Lock()
+	gone := recorder.disconnected[0]
+	recorder.mu.Unlock()
+	if gone.Account != "nugget" || gone.ClientID != "device-uuid-1" {
+		t.Errorf("disconnected identity = %s/%s", gone.Account, gone.ClientID)
+	}
+}
+
+// TestDeviceRecorderSkipsAnonymousClients pins the published contract:
+// a connection without a client_id stays fully functional live but is
+// never recorded in the durable inventory.
+func TestDeviceRecorderSkipsAnonymousClients(t *testing.T) {
+	recorder := &fakeDeviceRecorder{}
+	srv, conn := dialWithRecorder(t, recorder)
+	defer srv.Close()
+	defer conn.Close()
+
+	authAs(t, conn, authMessage{ClientName: "Legacy Mac"})
+
+	conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	if err := conn.WriteJSON(registerCapabilitiesMessage{
+		ID:           1,
+		Type:         typeRegisterCaps,
+		Capabilities: []Capability{{Name: "calendar", Methods: []string{"events"}}},
+	}); err != nil {
+		t.Fatalf("send register_capabilities: %v", err)
+	}
+	var result Message
+	readJSON(t, conn, &result)
+	if !result.Success {
+		t.Fatalf("capability registration failed: %+v", result)
+	}
+	conn.Close()
+
+	// The disconnect path is the last recorder call site; give the
+	// teardown goroutine time to run before asserting silence.
+	time.Sleep(100 * time.Millisecond)
+	c, caps, d := recorder.snapshot()
+	if c != 0 || caps != 0 || d != 0 {
+		t.Errorf("anonymous client was recorded: connected=%d capabilities=%d disconnected=%d", c, caps, d)
+	}
+}
+
+// TestAuthCarriesDeviceMetadata pins the optional auth fields onto the
+// provider snapshot, where the registry (and later the joined context
+// view) reads them.
+func TestAuthCarriesDeviceMetadata(t *testing.T) {
+	registry := NewRegistry(nil)
+	handler := NewHandler(testTokenIndex(), registry, nil)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+	wsURL := "ws" + srv.URL[len("http"):]
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	authAs(t, conn, authMessage{
+		ClientName: "Test iPhone",
+		ClientID:   "device-uuid-2",
+		Platform:   "ios",
+		AppVersion: "1.2.0",
+		OSVersion:  "26.0",
+	})
+
+	infos := registry.List()
+	if len(infos) != 1 {
+		t.Fatalf("registry has %d providers, want 1", len(infos))
+	}
+	info := infos[0]
+	if info.Platform != "ios" || info.AppVersion != "1.2.0" || info.OSVersion != "26.0" {
+		t.Errorf("provider metadata = platform=%q app=%q os=%q", info.Platform, info.AppVersion, info.OSVersion)
+	}
+}

--- a/internal/integrations/companion/devices_test.go
+++ b/internal/integrations/companion/devices_test.go
@@ -1,6 +1,8 @@
 package companion
 
 import (
+	"context"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
@@ -30,21 +32,21 @@ type recordedManifest struct {
 	Manifest string
 }
 
-func (f *fakeDeviceRecorder) RecordConnected(account, clientID string, meta DeviceMetadata, _ time.Time) error {
+func (f *fakeDeviceRecorder) RecordConnected(_ context.Context, account, clientID string, meta DeviceMetadata, _ time.Time) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.connected = append(f.connected, recordedDevice{account, clientID, meta})
 	return nil
 }
 
-func (f *fakeDeviceRecorder) RecordCapabilities(account, clientID string, manifest []byte, _ time.Time) error {
+func (f *fakeDeviceRecorder) RecordCapabilities(_ context.Context, account, clientID string, manifest []byte, _ time.Time) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.capabilities = append(f.capabilities, recordedManifest{account, clientID, string(manifest)})
 	return nil
 }
 
-func (f *fakeDeviceRecorder) RecordDisconnected(account, clientID string, _ time.Time) error {
+func (f *fakeDeviceRecorder) RecordDisconnected(_ context.Context, account, clientID string, _ time.Time) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.disconnected = append(f.disconnected, recordedDevice{Account: account, ClientID: clientID})
@@ -173,11 +175,27 @@ func TestDeviceRecorderFullLifecycle(t *testing.T) {
 
 // TestDeviceRecorderSkipsAnonymousClients pins the published contract:
 // a connection without a client_id stays fully functional live but is
-// never recorded in the durable inventory.
+// never recorded in the durable inventory. The assertion is
+// deterministic: the wrapped handler signals when connection teardown
+// (the last recorder call site) has fully returned, and a barrier op
+// drains the recording queue behind anything mistakenly enqueued.
 func TestDeviceRecorderSkipsAnonymousClients(t *testing.T) {
 	recorder := &fakeDeviceRecorder{}
-	srv, conn := dialWithRecorder(t, recorder)
+	registry := NewRegistry(nil)
+	handler := NewHandler(testTokenIndex(), registry, nil)
+	handler.SetDeviceRecorder(recorder)
+
+	teardown := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handler.ServeHTTP(w, r)
+		close(teardown)
+	}))
 	defer srv.Close()
+	wsURL := "ws" + srv.URL[len("http"):]
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
 	defer conn.Close()
 
 	authAs(t, conn, authMessage{ClientName: "Legacy Mac"})
@@ -197,9 +215,19 @@ func TestDeviceRecorderSkipsAnonymousClients(t *testing.T) {
 	}
 	conn.Close()
 
-	// The disconnect path is the last recorder call site; give the
-	// teardown goroutine time to run before asserting silence.
-	time.Sleep(100 * time.Millisecond)
+	select {
+	case <-teardown:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler teardown did not complete")
+	}
+	drained := make(chan struct{})
+	handler.enqueueDeviceOp(func(context.Context) { close(drained) })
+	select {
+	case <-drained:
+	case <-time.After(5 * time.Second):
+		t.Fatal("device op queue did not drain")
+	}
+
 	c, caps, d := recorder.snapshot()
 	if c != 0 || caps != 0 || d != 0 {
 		t.Errorf("anonymous client was recorded: connected=%d capabilities=%d disconnected=%d", c, caps, d)

--- a/internal/integrations/companion/handler.go
+++ b/internal/integrations/companion/handler.go
@@ -1,9 +1,11 @@
 package companion
 
 import (
+	"context"
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -45,7 +47,8 @@ var upgrader = websocket.Upgrader{
 type Handler struct {
 	tokenIndex map[string]string // token → account name
 	registry   *Registry
-	devices    DeviceRecorder // optional durable inventory sink; nil disables
+	devices    DeviceRecorder             // optional durable inventory sink; nil disables
+	deviceOps  chan func(context.Context) // ordered async inventory writes
 	logger     *slog.Logger
 }
 
@@ -121,9 +124,11 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Register the provider before confirming to the client, so the
 	// registry is consistent by the time the client reads auth_ok. The
-	// durable inventory upsert rides the same moment; the disconnect
-	// stamp mirrors it on the way out — timestamps only, the record
-	// itself outlives the connection (#1437).
+	// durable inventory upsert is stamped at the same moment but
+	// written asynchronously so a slow database can never delay the
+	// handshake; the disconnect stamp mirrors it on the way out —
+	// timestamps only, the record itself outlives the connection
+	// (#1437).
 	h.registry.Add(provider)
 	h.recordConnected(provider)
 	defer func() {
@@ -204,15 +209,18 @@ func (h *Handler) authenticate(conn *websocket.Conn, requestType string) (*Provi
 
 	// Build the provider — auth_ok is sent by ServeHTTP after
 	// the provider is registered, ensuring registry consistency.
+	// Identity and metadata are normalized (trimmed) exactly once,
+	// here; the registry and the durable inventory both hold these
+	// bytes verbatim so the durable/live join always lines up.
 	providerID := generateProviderID()
 	return &Provider{
 		ID:          providerID,
 		Account:     account,
-		ClientName:  msg.ClientName,
-		ClientID:    msg.ClientID,
-		Platform:    msg.Platform,
-		AppVersion:  msg.AppVersion,
-		OSVersion:   msg.OSVersion,
+		ClientName:  strings.TrimSpace(msg.ClientName),
+		ClientID:    strings.TrimSpace(msg.ClientID),
+		Platform:    strings.TrimSpace(msg.Platform),
+		AppVersion:  strings.TrimSpace(msg.AppVersion),
+		OSVersion:   strings.TrimSpace(msg.OSVersion),
 		Conn:        conn,
 		ConnectedAt: time.Now(),
 		requestType: requestType,

--- a/internal/integrations/companion/handler.go
+++ b/internal/integrations/companion/handler.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -50,6 +51,10 @@ type Handler struct {
 	devices    DeviceRecorder             // optional durable inventory sink; nil disables
 	deviceOps  chan func(context.Context) // ordered async inventory writes
 	logger     *slog.Logger
+
+	deviceOpsMu     sync.Mutex    // guards enqueue vs. close
+	deviceOpsClosed bool          // no new ops accepted once set
+	deviceOpsDone   chan struct{} // closed when the recording goroutine exits
 }
 
 // NewHandler creates a new companion WebSocket handler. The tokenIndex

--- a/internal/integrations/companion/handler.go
+++ b/internal/integrations/companion/handler.go
@@ -45,6 +45,7 @@ var upgrader = websocket.Upgrader{
 type Handler struct {
 	tokenIndex map[string]string // token → account name
 	registry   *Registry
+	devices    DeviceRecorder // optional durable inventory sink; nil disables
 	logger     *slog.Logger
 }
 
@@ -119,10 +120,15 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Register the provider before confirming to the client, so the
-	// registry is consistent by the time the client reads auth_ok.
+	// registry is consistent by the time the client reads auth_ok. The
+	// durable inventory upsert rides the same moment; the disconnect
+	// stamp mirrors it on the way out — timestamps only, the record
+	// itself outlives the connection (#1437).
 	h.registry.Add(provider)
+	h.recordConnected(provider)
 	defer func() {
 		h.registry.Remove(provider.ID)
+		h.recordDisconnected(provider)
 		close(provider.done)
 		conn.Close()
 	}()
@@ -204,6 +210,9 @@ func (h *Handler) authenticate(conn *websocket.Conn, requestType string) (*Provi
 		Account:     account,
 		ClientName:  msg.ClientName,
 		ClientID:    msg.ClientID,
+		Platform:    msg.Platform,
+		AppVersion:  msg.AppVersion,
+		OSVersion:   msg.OSVersion,
 		Conn:        conn,
 		ConnectedAt: time.Now(),
 		requestType: requestType,
@@ -333,6 +342,9 @@ func (h *Handler) handleRegisterCapabilities(p *Provider, id int64, payload []by
 		h.writeErrorResult(p, id, "provider_not_found", err.Error())
 		return
 	}
+	// Persist the normalized manifest as the device's most recently
+	// advertised capability set.
+	h.recordCapabilities(p)
 
 	if err := p.writeJSON(Message{
 		ID:      id,

--- a/internal/integrations/companion/message.go
+++ b/internal/integrations/companion/message.go
@@ -64,12 +64,21 @@ type authRequired struct {
 }
 
 // authMessage is the client's response to authRequired.
+//
+// ClientID is the device's durable identity claim: stable across
+// launches, opaque, and reused identically by every transport the
+// device speaks. Platform, AppVersion, and OSVersion are optional
+// device metadata recorded in the durable inventory when supplied
+// (#1437); clients that omit them lose nothing at the protocol level.
 type authMessage struct {
 	Type       string `json:"type"`
 	Token      string `json:"token"`
 	ClientName string `json:"client_name"`
 	ClientID   string `json:"client_id"`
 	Protocol   string `json:"protocol,omitempty"`
+	Platform   string `json:"platform,omitempty"`
+	AppVersion string `json:"app_version,omitempty"`
+	OSVersion  string `json:"os_version,omitempty"`
 }
 
 // authOK confirms successful authentication, assigns a provider ID, and

--- a/internal/integrations/companion/provider.go
+++ b/internal/integrations/companion/provider.go
@@ -26,11 +26,16 @@ type capabilityState struct {
 
 // Provider represents a connected companion app (e.g. a macOS app instance).
 // Account is the server-assigned identity resolved from the token at auth time.
+// Platform, AppVersion, and OSVersion are optional client-reported device
+// metadata carried through to the durable inventory.
 type Provider struct {
 	ID          string
 	Account     string
 	ClientName  string
 	ClientID    string
+	Platform    string
+	AppVersion  string
+	OSVersion   string
 	Conn        *websocket.Conn
 	ConnectedAt time.Time
 	requestType string
@@ -55,6 +60,9 @@ type ProviderInfo struct {
 	Account      string       `json:"account"`
 	ClientName   string       `json:"client_name"`
 	ClientID     string       `json:"client_id"`
+	Platform     string       `json:"platform,omitempty"`
+	AppVersion   string       `json:"app_version,omitempty"`
+	OSVersion    string       `json:"os_version,omitempty"`
 	ConnectedAt  time.Time    `json:"connected_at"`
 	Capabilities []Capability `json:"capabilities,omitempty"`
 }
@@ -620,6 +628,9 @@ func providerToInfo(p *Provider) ProviderInfo {
 		Account:      p.Account,
 		ClientName:   p.ClientName,
 		ClientID:     p.ClientID,
+		Platform:     p.Platform,
+		AppVersion:   p.AppVersion,
+		OSVersion:    p.OSVersion,
 		ConnectedAt:  p.ConnectedAt,
 		Capabilities: p.capabilitiesSnapshot(),
 	}

--- a/internal/state/companions/schema.go
+++ b/internal/state/companions/schema.go
@@ -3,22 +3,27 @@ package companions
 import "github.com/nugget/thane-ai-agent/internal/platform/database"
 
 // devicesSchema declares the companion_devices table: the durable
-// companion-device inventory, keyed by (account, client_id) — the
-// authenticated account plus the stable identity a companion claims
-// about itself, never the per-connection provider ID (#1437).
+// companion-device inventory (#1437).
+//
+// device_id is the immutable server-assigned primary key, minted once
+// when a device is first seen. (account, client_id) is how devices are
+// looked up today — the authenticated account plus the stable identity
+// a companion claims about itself, never the per-connection provider
+// ID — but it is a credential mapping, not the identity itself: the
+// enrollment arc (#1444) makes key replacement and re-enrollment
+// normal, so anything that must survive credential rotation (future
+// observation rows included) references device_id, and rotating a
+// claim re-points the mapping instead of minting a second device.
 //
 // Rows outlive connections by design. A WebSocket disconnect updates
 // timestamps; nothing in the connection lifecycle deletes a row.
-// client_id is opaque: today it is the UUID companion apps persist
-// locally, and the column deliberately carries no format so a future
-// enrollment arc (#1444) can key devices by an attested key
-// fingerprint without a schema break.
 var devicesSchema = database.Schema{
 	Name: "companions/devices",
 	Steps: []database.MigrationStep{
 		database.TableCreate{
 			Table: "companion_devices",
 			SQL: `CREATE TABLE IF NOT EXISTS companion_devices (
+				device_id            TEXT NOT NULL PRIMARY KEY,
 				account              TEXT NOT NULL,
 				client_id            TEXT NOT NULL,
 				client_name          TEXT NOT NULL DEFAULT '',
@@ -32,7 +37,7 @@ var devicesSchema = database.Schema{
 				capabilities         TEXT NOT NULL DEFAULT '[]',
 				capabilities_recorded_at TIMESTAMP,
 				state                TEXT NOT NULL DEFAULT 'active',
-				PRIMARY KEY (account, client_id)
+				UNIQUE (account, client_id)
 			)`,
 		},
 	},

--- a/internal/state/companions/schema.go
+++ b/internal/state/companions/schema.go
@@ -1,0 +1,38 @@
+package companions
+
+import "github.com/nugget/thane-ai-agent/internal/platform/database"
+
+// devicesSchema declares the companion_devices table: the durable
+// companion-device inventory, keyed by (account, client_id) — the
+// authenticated account plus the stable identity a companion claims
+// about itself, never the per-connection provider ID (#1437).
+//
+// Rows outlive connections by design. A WebSocket disconnect updates
+// timestamps; nothing in the connection lifecycle deletes a row.
+// client_id is opaque: today it is the UUID companion apps persist
+// locally, and the column deliberately carries no format so a future
+// enrollment arc (#1444) can key devices by an attested key
+// fingerprint without a schema break.
+var devicesSchema = database.Schema{
+	Name: "companions/devices",
+	Steps: []database.MigrationStep{
+		database.TableCreate{
+			Table: "companion_devices",
+			SQL: `CREATE TABLE IF NOT EXISTS companion_devices (
+				account              TEXT NOT NULL,
+				client_id            TEXT NOT NULL,
+				client_name          TEXT NOT NULL DEFAULT '',
+				platform             TEXT NOT NULL DEFAULT '',
+				app_version          TEXT NOT NULL DEFAULT '',
+				os_version           TEXT NOT NULL DEFAULT '',
+				first_seen_at        TIMESTAMP NOT NULL,
+				last_seen_at         TIMESTAMP NOT NULL,
+				last_connected_at    TIMESTAMP,
+				last_disconnected_at TIMESTAMP,
+				capabilities         TEXT NOT NULL DEFAULT '[]',
+				state                TEXT NOT NULL DEFAULT 'active',
+				PRIMARY KEY (account, client_id)
+			)`,
+		},
+	},
+}

--- a/internal/state/companions/schema.go
+++ b/internal/state/companions/schema.go
@@ -30,6 +30,7 @@ var devicesSchema = database.Schema{
 				last_connected_at    TIMESTAMP,
 				last_disconnected_at TIMESTAMP,
 				capabilities         TEXT NOT NULL DEFAULT '[]',
+				capabilities_recorded_at TIMESTAMP,
 				state                TEXT NOT NULL DEFAULT 'active',
 				PRIMARY KEY (account, client_id)
 			)`,

--- a/internal/state/companions/store.go
+++ b/internal/state/companions/store.go
@@ -17,7 +17,9 @@ package companions
 
 import (
 	"context"
+	"crypto/rand"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -35,6 +37,12 @@ const DeviceStateActive = "active"
 
 // Device is one durable companion-device record.
 type Device struct {
+	// DeviceID is the immutable server-assigned identity, minted when
+	// the device is first seen and stable across credential changes.
+	// Account and ClientID are the current lookup claim mapped to it
+	// (#1444's enrollment arc re-points that mapping on key rotation).
+	DeviceID string
+
 	Account    string
 	ClientID   string
 	ClientName string
@@ -93,12 +101,22 @@ func (s *Store) RecordConnected(ctx context.Context, account, clientID string, m
 	}
 	at = normalizeTime(at)
 
-	_, err := s.db.ExecContext(ctx, `
+	deviceID, err := generateDeviceID()
+	if err != nil {
+		return fmt.Errorf("record companion connect %s/%s: %w", account, clientID, err)
+	}
+	// The freshly minted device_id is discarded when the claim already
+	// maps to a device — the conflict update never touches it.
+	// first_seen_at is MIN-guarded for the same reason the others are
+	// MAX-guarded: async recording can land a connection's write after
+	// a later connection's, and the earliest event time is the truth.
+	_, err = s.db.ExecContext(ctx, `
 		INSERT INTO companion_devices (
-			account, client_id, client_name, platform, app_version, os_version,
+			device_id, account, client_id, client_name, platform, app_version, os_version,
 			first_seen_at, last_seen_at, last_connected_at, state
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(account, client_id) DO UPDATE SET
+			first_seen_at = MIN(companion_devices.first_seen_at, excluded.first_seen_at),
 			client_name = CASE WHEN excluded.client_name != ''
 					AND (companion_devices.client_name = '' OR excluded.last_connected_at >= companion_devices.last_connected_at)
 				THEN excluded.client_name ELSE companion_devices.client_name END,
@@ -113,7 +131,7 @@ func (s *Store) RecordConnected(ctx context.Context, account, clientID string, m
 				THEN excluded.os_version ELSE companion_devices.os_version END,
 			last_seen_at      = MAX(companion_devices.last_seen_at, excluded.last_seen_at),
 			last_connected_at = MAX(companion_devices.last_connected_at, excluded.last_connected_at)
-	`, account, clientID,
+	`, deviceID, account, clientID,
 		meta.ClientName, meta.Platform, meta.AppVersion, meta.OSVersion,
 		at, at, at, DeviceStateActive)
 	if err != nil {
@@ -218,7 +236,7 @@ func (s *Store) Get(ctx context.Context, account, clientID string) (Device, bool
 		return Device{}, false, err
 	}
 	devices, err := s.scanDevices(ctx, `
-		SELECT account, client_id, client_name, platform, app_version, os_version,
+		SELECT device_id, account, client_id, client_name, platform, app_version, os_version,
 		       first_seen_at, last_seen_at, last_connected_at, last_disconnected_at,
 		       capabilities, capabilities_recorded_at, state
 		FROM companion_devices
@@ -237,7 +255,7 @@ func (s *Store) Get(ctx context.Context, account, clientID string) (Device, bool
 // so consumers render a stable shape across calls.
 func (s *Store) List(ctx context.Context) ([]Device, error) {
 	return s.scanDevices(ctx, `
-		SELECT account, client_id, client_name, platform, app_version, os_version,
+		SELECT device_id, account, client_id, client_name, platform, app_version, os_version,
 		       first_seen_at, last_seen_at, last_connected_at, last_disconnected_at,
 		       capabilities, capabilities_recorded_at, state
 		FROM companion_devices
@@ -262,7 +280,7 @@ func (s *Store) scanDevices(ctx context.Context, query string, args ...any) ([]D
 			capsJSON     string
 		)
 		if err := rows.Scan(
-			&d.Account, &d.ClientID, &d.ClientName, &d.Platform, &d.AppVersion, &d.OSVersion,
+			&d.DeviceID, &d.Account, &d.ClientID, &d.ClientName, &d.Platform, &d.AppVersion, &d.OSVersion,
 			&d.FirstSeenAt, &d.LastSeenAt, &connected, &disconnected,
 			&capsJSON, &capsAt, &d.State,
 		); err != nil {
@@ -304,4 +322,14 @@ func normalizeTime(at time.Time) time.Time {
 		return time.Now().UTC()
 	}
 	return at.UTC()
+}
+
+// generateDeviceID mints an immutable server-assigned device identity
+// with the dev_ prefix and a random hex suffix.
+func generateDeviceID() (string, error) {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate device_id: %w", err)
+	}
+	return "dev_" + hex.EncodeToString(b), nil
 }

--- a/internal/state/companions/store.go
+++ b/internal/state/companions/store.go
@@ -1,0 +1,256 @@
+// Package companions persists the durable companion-device inventory:
+// which operator-owned companion apps exist, when they were last seen,
+// and what they most recently advertised. A device record and its live
+// WebSocket connection have different lifetimes — the connection is
+// ephemeral transport, the record survives disconnects and process
+// restarts (#1437). Reachability is never persisted here; it stays
+// derived from the in-memory provider registry.
+package companions
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/companion"
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
+)
+
+// DeviceStateActive is the lifecycle state every row carries today.
+// The column exists so a future forget/retire flow has somewhere to
+// record its decision; nothing in this slice writes any other value.
+const DeviceStateActive = "active"
+
+// Device is one durable companion-device record.
+type Device struct {
+	Account    string
+	ClientID   string
+	ClientName string
+	Platform   string
+	AppVersion string
+	OSVersion  string
+
+	FirstSeenAt time.Time
+	LastSeenAt  time.Time
+	// LastConnectedAt and LastDisconnectedAt are zero when the event has
+	// never happened (a row can exist before its first full connection
+	// cycle completes).
+	LastConnectedAt    time.Time
+	LastDisconnectedAt time.Time
+
+	// Capabilities is the most recently advertised capability manifest,
+	// stored verbatim as JSON. It describes what the device offered when
+	// last heard from — not what is callable now.
+	Capabilities json.RawMessage
+
+	State string
+}
+
+// Store persists companion devices in the primary Thane database.
+type Store struct {
+	db     *sql.DB
+	logger *slog.Logger
+}
+
+// NewStore creates a companion-device store, running migrations on
+// first use. The db handle is borrowed (the memory store owns it).
+func NewStore(db *sql.DB, logger *slog.Logger) (*Store, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if err := database.Migrate(db, devicesSchema, logger); err != nil {
+		return nil, err
+	}
+	return &Store{db: db, logger: logger}, nil
+}
+
+// RecordConnected upserts the device row for a successful companion
+// authentication. A new device gets its first_seen_at anchored; a
+// returning device keeps it. Metadata updates are non-empty-wins so a
+// client that omits a field on one connection cannot erase what it
+// reported before. Implements [companion.DeviceRecorder].
+func (s *Store) RecordConnected(account, clientID string, meta companion.DeviceMetadata, at time.Time) error {
+	account, clientID, err := normalizeKey(account, clientID)
+	if err != nil {
+		return err
+	}
+	at = normalizeTime(at)
+
+	_, err = s.db.Exec(`
+		INSERT INTO companion_devices (
+			account, client_id, client_name, platform, app_version, os_version,
+			first_seen_at, last_seen_at, last_connected_at, state
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(account, client_id) DO UPDATE SET
+			client_name       = CASE WHEN excluded.client_name != '' THEN excluded.client_name ELSE client_name END,
+			platform          = CASE WHEN excluded.platform != '' THEN excluded.platform ELSE platform END,
+			app_version       = CASE WHEN excluded.app_version != '' THEN excluded.app_version ELSE app_version END,
+			os_version        = CASE WHEN excluded.os_version != '' THEN excluded.os_version ELSE os_version END,
+			last_seen_at      = excluded.last_seen_at,
+			last_connected_at = excluded.last_connected_at
+	`, account, clientID,
+		strings.TrimSpace(meta.ClientName), strings.TrimSpace(meta.Platform),
+		strings.TrimSpace(meta.AppVersion), strings.TrimSpace(meta.OSVersion),
+		at, at, at, DeviceStateActive)
+	if err != nil {
+		return fmt.Errorf("record companion connect %s/%s: %w", account, clientID, err)
+	}
+	return nil
+}
+
+// RecordCapabilities stores the most recently advertised capability
+// manifest for a known device and bumps last_seen_at. The manifest is
+// opaque JSON authored by the registration path; an empty manifest is
+// stored as an empty JSON array. Registering capabilities for a device
+// that was never recorded is an error — connection recording precedes
+// capability registration in the protocol. Implements
+// [companion.DeviceRecorder].
+func (s *Store) RecordCapabilities(account, clientID string, manifest []byte, at time.Time) error {
+	account, clientID, err := normalizeKey(account, clientID)
+	if err != nil {
+		return err
+	}
+	at = normalizeTime(at)
+	if len(manifest) == 0 {
+		manifest = []byte("[]")
+	}
+	if !json.Valid(manifest) {
+		return fmt.Errorf("record companion capabilities %s/%s: manifest is not valid JSON", account, clientID)
+	}
+
+	res, err := s.db.Exec(`
+		UPDATE companion_devices
+		SET capabilities = ?, last_seen_at = ?
+		WHERE account = ? AND client_id = ?
+	`, string(manifest), at, account, clientID)
+	if err != nil {
+		return fmt.Errorf("record companion capabilities %s/%s: %w", account, clientID, err)
+	}
+	return requireRow(res, "record companion capabilities", account, clientID)
+}
+
+// RecordDisconnected stamps the disconnect time for a known device. It
+// only updates timestamps — a disconnect must never delete or degrade
+// the record; that separation is the point of the inventory (#1437).
+// Implements [companion.DeviceRecorder].
+func (s *Store) RecordDisconnected(account, clientID string, at time.Time) error {
+	account, clientID, err := normalizeKey(account, clientID)
+	if err != nil {
+		return err
+	}
+	at = normalizeTime(at)
+
+	res, err := s.db.Exec(`
+		UPDATE companion_devices
+		SET last_disconnected_at = ?, last_seen_at = ?
+		WHERE account = ? AND client_id = ?
+	`, at, at, account, clientID)
+	if err != nil {
+		return fmt.Errorf("record companion disconnect %s/%s: %w", account, clientID, err)
+	}
+	return requireRow(res, "record companion disconnect", account, clientID)
+}
+
+// Get returns one device record. The boolean reports whether the
+// device exists; a missing device is not an error.
+func (s *Store) Get(account, clientID string) (Device, bool, error) {
+	account, clientID, err := normalizeKey(account, clientID)
+	if err != nil {
+		return Device{}, false, err
+	}
+	devices, err := s.scanDevices(`
+		SELECT account, client_id, client_name, platform, app_version, os_version,
+		       first_seen_at, last_seen_at, last_connected_at, last_disconnected_at,
+		       capabilities, state
+		FROM companion_devices
+		WHERE account = ? AND client_id = ?
+	`, account, clientID)
+	if err != nil {
+		return Device{}, false, err
+	}
+	if len(devices) == 0 {
+		return Device{}, false, nil
+	}
+	return devices[0], true, nil
+}
+
+// List returns every device record, ordered by account then client ID
+// so consumers render a stable shape across calls.
+func (s *Store) List() ([]Device, error) {
+	return s.scanDevices(`
+		SELECT account, client_id, client_name, platform, app_version, os_version,
+		       first_seen_at, last_seen_at, last_connected_at, last_disconnected_at,
+		       capabilities, state
+		FROM companion_devices
+		ORDER BY account ASC, client_id ASC
+	`)
+}
+
+func (s *Store) scanDevices(query string, args ...any) ([]Device, error) {
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var devices []Device
+	for rows.Next() {
+		var (
+			d            Device
+			connected    sql.NullTime
+			disconnected sql.NullTime
+			capsJSON     string
+		)
+		if err := rows.Scan(
+			&d.Account, &d.ClientID, &d.ClientName, &d.Platform, &d.AppVersion, &d.OSVersion,
+			&d.FirstSeenAt, &d.LastSeenAt, &connected, &disconnected,
+			&capsJSON, &d.State,
+		); err != nil {
+			return nil, err
+		}
+		if connected.Valid {
+			d.LastConnectedAt = connected.Time.UTC()
+		}
+		if disconnected.Valid {
+			d.LastDisconnectedAt = disconnected.Time.UTC()
+		}
+		d.FirstSeenAt = d.FirstSeenAt.UTC()
+		d.LastSeenAt = d.LastSeenAt.UTC()
+		d.Capabilities = json.RawMessage(capsJSON)
+		devices = append(devices, d)
+	}
+	return devices, rows.Err()
+}
+
+func normalizeKey(account, clientID string) (string, string, error) {
+	account = strings.TrimSpace(account)
+	clientID = strings.TrimSpace(clientID)
+	if account == "" {
+		return "", "", fmt.Errorf("account is required")
+	}
+	if clientID == "" {
+		return "", "", fmt.Errorf("client_id is required")
+	}
+	return account, clientID, nil
+}
+
+func normalizeTime(at time.Time) time.Time {
+	if at.IsZero() {
+		return time.Now().UTC()
+	}
+	return at.UTC()
+}
+
+func requireRow(res sql.Result, op, account, clientID string) error {
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("%s %s/%s: %w", op, account, clientID, err)
+	}
+	if n == 0 {
+		return fmt.Errorf("%s %s/%s: device not recorded", op, account, clientID)
+	}
+	return nil
+}

--- a/internal/state/companions/store.go
+++ b/internal/state/companions/store.go
@@ -5,9 +5,18 @@
 // ephemeral transport, the record survives disconnects and process
 // restarts (#1437). Reachability is never persisted here; it stays
 // derived from the in-memory provider registry.
+//
+// Overlapping connections for the same durable identity are legal (a
+// reconnecting phone races its own dying socket), so every write is
+// guarded to be monotonic: timestamps never regress and an older write
+// cannot replace newer state. The guards compare timestamps in SQL,
+// which is sound because the driver stores them in the canonical text
+// layout and this store normalizes every value to UTC — uniform-offset
+// canonical text compares bytewise in chronological order.
 package companions
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -43,8 +52,11 @@ type Device struct {
 
 	// Capabilities is the most recently advertised capability manifest,
 	// stored verbatim as JSON. It describes what the device offered when
-	// last heard from — not what is callable now.
-	Capabilities json.RawMessage
+	// last heard from — not what is callable now. CapabilitiesRecordedAt
+	// is when that advertisement happened; zero when the device has
+	// never registered capabilities.
+	Capabilities           json.RawMessage
+	CapabilitiesRecordedAt time.Time
 
 	State string
 }
@@ -69,31 +81,40 @@ func NewStore(db *sql.DB, logger *slog.Logger) (*Store, error) {
 
 // RecordConnected upserts the device row for a successful companion
 // authentication. A new device gets its first_seen_at anchored; a
-// returning device keeps it. Metadata updates are non-empty-wins so a
-// client that omits a field on one connection cannot erase what it
-// reported before. Implements [companion.DeviceRecorder].
-func (s *Store) RecordConnected(account, clientID string, meta companion.DeviceMetadata, at time.Time) error {
-	account, clientID, err := normalizeKey(account, clientID)
-	if err != nil {
+// returning device keeps it. Timestamps are monotonic, and metadata
+// replacement is gated on the connect being at least as new as the
+// stored one — an older racing write can only fill fields that are
+// still empty, never overwrite what a newer connection reported.
+// Metadata is stored verbatim; the auth handshake is the one place
+// values are normalized. Implements [companion.DeviceRecorder].
+func (s *Store) RecordConnected(ctx context.Context, account, clientID string, meta companion.DeviceMetadata, at time.Time) error {
+	if err := validateKey(account, clientID); err != nil {
 		return err
 	}
 	at = normalizeTime(at)
 
-	_, err = s.db.Exec(`
+	_, err := s.db.ExecContext(ctx, `
 		INSERT INTO companion_devices (
 			account, client_id, client_name, platform, app_version, os_version,
 			first_seen_at, last_seen_at, last_connected_at, state
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(account, client_id) DO UPDATE SET
-			client_name       = CASE WHEN excluded.client_name != '' THEN excluded.client_name ELSE client_name END,
-			platform          = CASE WHEN excluded.platform != '' THEN excluded.platform ELSE platform END,
-			app_version       = CASE WHEN excluded.app_version != '' THEN excluded.app_version ELSE app_version END,
-			os_version        = CASE WHEN excluded.os_version != '' THEN excluded.os_version ELSE os_version END,
-			last_seen_at      = excluded.last_seen_at,
-			last_connected_at = excluded.last_connected_at
+			client_name = CASE WHEN excluded.client_name != ''
+					AND (companion_devices.client_name = '' OR excluded.last_connected_at >= companion_devices.last_connected_at)
+				THEN excluded.client_name ELSE companion_devices.client_name END,
+			platform = CASE WHEN excluded.platform != ''
+					AND (companion_devices.platform = '' OR excluded.last_connected_at >= companion_devices.last_connected_at)
+				THEN excluded.platform ELSE companion_devices.platform END,
+			app_version = CASE WHEN excluded.app_version != ''
+					AND (companion_devices.app_version = '' OR excluded.last_connected_at >= companion_devices.last_connected_at)
+				THEN excluded.app_version ELSE companion_devices.app_version END,
+			os_version = CASE WHEN excluded.os_version != ''
+					AND (companion_devices.os_version = '' OR excluded.last_connected_at >= companion_devices.last_connected_at)
+				THEN excluded.os_version ELSE companion_devices.os_version END,
+			last_seen_at      = MAX(companion_devices.last_seen_at, excluded.last_seen_at),
+			last_connected_at = MAX(companion_devices.last_connected_at, excluded.last_connected_at)
 	`, account, clientID,
-		strings.TrimSpace(meta.ClientName), strings.TrimSpace(meta.Platform),
-		strings.TrimSpace(meta.AppVersion), strings.TrimSpace(meta.OSVersion),
+		meta.ClientName, meta.Platform, meta.AppVersion, meta.OSVersion,
 		at, at, at, DeviceStateActive)
 	if err != nil {
 		return fmt.Errorf("record companion connect %s/%s: %w", account, clientID, err)
@@ -101,16 +122,17 @@ func (s *Store) RecordConnected(account, clientID string, meta companion.DeviceM
 	return nil
 }
 
-// RecordCapabilities stores the most recently advertised capability
-// manifest for a known device and bumps last_seen_at. The manifest is
-// opaque JSON authored by the registration path; an empty manifest is
-// stored as an empty JSON array. Registering capabilities for a device
-// that was never recorded is an error — connection recording precedes
-// capability registration in the protocol. Implements
-// [companion.DeviceRecorder].
-func (s *Store) RecordCapabilities(account, clientID string, manifest []byte, at time.Time) error {
-	account, clientID, err := normalizeKey(account, clientID)
-	if err != nil {
+// RecordCapabilities stores the advertised capability manifest for a
+// known device, but only when it is at least as new as the one already
+// stored — overlapping providers with the same durable identity may
+// race, and "most recently advertised" must survive out-of-order
+// writes. A stale write is dropped silently (the newer manifest is
+// already the correct outcome); an unknown device is an error, since
+// connection recording precedes capability registration in the
+// protocol. An empty manifest is stored as an empty JSON array.
+// Implements [companion.DeviceRecorder].
+func (s *Store) RecordCapabilities(ctx context.Context, account, clientID string, manifest []byte, at time.Time) error {
+	if err := validateKey(account, clientID); err != nil {
 		return err
 	}
 	at = normalizeTime(at)
@@ -121,50 +143,84 @@ func (s *Store) RecordCapabilities(account, clientID string, manifest []byte, at
 		return fmt.Errorf("record companion capabilities %s/%s: manifest is not valid JSON", account, clientID)
 	}
 
-	res, err := s.db.Exec(`
+	res, err := s.db.ExecContext(ctx, `
 		UPDATE companion_devices
-		SET capabilities = ?, last_seen_at = ?
+		SET capabilities = ?, capabilities_recorded_at = ?, last_seen_at = MAX(last_seen_at, ?)
 		WHERE account = ? AND client_id = ?
-	`, string(manifest), at, account, clientID)
+		  AND (capabilities_recorded_at IS NULL OR capabilities_recorded_at <= ?)
+	`, string(manifest), at, at, account, clientID, at)
 	if err != nil {
 		return fmt.Errorf("record companion capabilities %s/%s: %w", account, clientID, err)
 	}
-	return requireRow(res, "record companion capabilities", account, clientID)
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("record companion capabilities %s/%s: %w", account, clientID, err)
+	}
+	if n > 0 {
+		return nil
+	}
+
+	var exists bool
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT EXISTS(SELECT 1 FROM companion_devices WHERE account = ? AND client_id = ?)`,
+		account, clientID,
+	).Scan(&exists); err != nil {
+		return fmt.Errorf("record companion capabilities %s/%s: %w", account, clientID, err)
+	}
+	if exists {
+		s.logger.Debug("stale companion capability manifest ignored",
+			"account", account,
+			"client_id", clientID,
+			"recorded_at", at,
+		)
+		return nil
+	}
+	return fmt.Errorf("record companion capabilities %s/%s: device not recorded", account, clientID)
 }
 
-// RecordDisconnected stamps the disconnect time for a known device. It
-// only updates timestamps — a disconnect must never delete or degrade
-// the record; that separation is the point of the inventory (#1437).
-// Implements [companion.DeviceRecorder].
-func (s *Store) RecordDisconnected(account, clientID string, at time.Time) error {
-	account, clientID, err := normalizeKey(account, clientID)
-	if err != nil {
+// RecordDisconnected stamps the disconnect on a known device without
+// deleting or degrading anything else — that separation is the point
+// of the inventory (#1437). It also advances last_seen_at: the
+// connection was live evidence of the device until the moment it tore
+// down, so teardown is the last proof of liveness (with skew bounded
+// by the heartbeat read timeout when the transport died silently).
+// Both stamps are monotonic for overlapping teardowns. Implements
+// [companion.DeviceRecorder].
+func (s *Store) RecordDisconnected(ctx context.Context, account, clientID string, at time.Time) error {
+	if err := validateKey(account, clientID); err != nil {
 		return err
 	}
 	at = normalizeTime(at)
 
-	res, err := s.db.Exec(`
+	res, err := s.db.ExecContext(ctx, `
 		UPDATE companion_devices
-		SET last_disconnected_at = ?, last_seen_at = ?
+		SET last_disconnected_at = MAX(COALESCE(last_disconnected_at, ?), ?),
+		    last_seen_at = MAX(last_seen_at, ?)
 		WHERE account = ? AND client_id = ?
-	`, at, at, account, clientID)
+	`, at, at, at, account, clientID)
 	if err != nil {
 		return fmt.Errorf("record companion disconnect %s/%s: %w", account, clientID, err)
 	}
-	return requireRow(res, "record companion disconnect", account, clientID)
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("record companion disconnect %s/%s: %w", account, clientID, err)
+	}
+	if n == 0 {
+		return fmt.Errorf("record companion disconnect %s/%s: device not recorded", account, clientID)
+	}
+	return nil
 }
 
 // Get returns one device record. The boolean reports whether the
 // device exists; a missing device is not an error.
-func (s *Store) Get(account, clientID string) (Device, bool, error) {
-	account, clientID, err := normalizeKey(account, clientID)
-	if err != nil {
+func (s *Store) Get(ctx context.Context, account, clientID string) (Device, bool, error) {
+	if err := validateKey(account, clientID); err != nil {
 		return Device{}, false, err
 	}
-	devices, err := s.scanDevices(`
+	devices, err := s.scanDevices(ctx, `
 		SELECT account, client_id, client_name, platform, app_version, os_version,
 		       first_seen_at, last_seen_at, last_connected_at, last_disconnected_at,
-		       capabilities, state
+		       capabilities, capabilities_recorded_at, state
 		FROM companion_devices
 		WHERE account = ? AND client_id = ?
 	`, account, clientID)
@@ -179,18 +235,18 @@ func (s *Store) Get(account, clientID string) (Device, bool, error) {
 
 // List returns every device record, ordered by account then client ID
 // so consumers render a stable shape across calls.
-func (s *Store) List() ([]Device, error) {
-	return s.scanDevices(`
+func (s *Store) List(ctx context.Context) ([]Device, error) {
+	return s.scanDevices(ctx, `
 		SELECT account, client_id, client_name, platform, app_version, os_version,
 		       first_seen_at, last_seen_at, last_connected_at, last_disconnected_at,
-		       capabilities, state
+		       capabilities, capabilities_recorded_at, state
 		FROM companion_devices
 		ORDER BY account ASC, client_id ASC
 	`)
 }
 
-func (s *Store) scanDevices(query string, args ...any) ([]Device, error) {
-	rows, err := s.db.Query(query, args...)
+func (s *Store) scanDevices(ctx context.Context, query string, args ...any) ([]Device, error) {
+	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -202,12 +258,13 @@ func (s *Store) scanDevices(query string, args ...any) ([]Device, error) {
 			d            Device
 			connected    sql.NullTime
 			disconnected sql.NullTime
+			capsAt       sql.NullTime
 			capsJSON     string
 		)
 		if err := rows.Scan(
 			&d.Account, &d.ClientID, &d.ClientName, &d.Platform, &d.AppVersion, &d.OSVersion,
 			&d.FirstSeenAt, &d.LastSeenAt, &connected, &disconnected,
-			&capsJSON, &d.State,
+			&capsJSON, &capsAt, &d.State,
 		); err != nil {
 			return nil, err
 		}
@@ -217,6 +274,9 @@ func (s *Store) scanDevices(query string, args ...any) ([]Device, error) {
 		if disconnected.Valid {
 			d.LastDisconnectedAt = disconnected.Time.UTC()
 		}
+		if capsAt.Valid {
+			d.CapabilitiesRecordedAt = capsAt.Time.UTC()
+		}
 		d.FirstSeenAt = d.FirstSeenAt.UTC()
 		d.LastSeenAt = d.LastSeenAt.UTC()
 		d.Capabilities = json.RawMessage(capsJSON)
@@ -225,16 +285,18 @@ func (s *Store) scanDevices(query string, args ...any) ([]Device, error) {
 	return devices, rows.Err()
 }
 
-func normalizeKey(account, clientID string) (string, string, error) {
-	account = strings.TrimSpace(account)
-	clientID = strings.TrimSpace(clientID)
-	if account == "" {
-		return "", "", fmt.Errorf("account is required")
+// validateKey rejects identities that are empty after trimming, but
+// never rewrites them: client_id is an opaque claim, and the stored
+// bytes must match what the live registry holds or the durable/live
+// join cannot line up. Normalization is the auth handshake's job.
+func validateKey(account, clientID string) error {
+	if strings.TrimSpace(account) == "" {
+		return fmt.Errorf("account is required")
 	}
-	if clientID == "" {
-		return "", "", fmt.Errorf("client_id is required")
+	if strings.TrimSpace(clientID) == "" {
+		return fmt.Errorf("client_id is required")
 	}
-	return account, clientID, nil
+	return nil
 }
 
 func normalizeTime(at time.Time) time.Time {
@@ -242,15 +304,4 @@ func normalizeTime(at time.Time) time.Time {
 		return time.Now().UTC()
 	}
 	return at.UTC()
-}
-
-func requireRow(res sql.Result, op, account, clientID string) error {
-	n, err := res.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("%s %s/%s: %w", op, account, clientID, err)
-	}
-	if n == 0 {
-		return fmt.Errorf("%s %s/%s: device not recorded", op, account, clientID)
-	}
-	return nil
 }

--- a/internal/state/companions/store_test.go
+++ b/internal/state/companions/store_test.go
@@ -1,0 +1,277 @@
+package companions
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/companion"
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
+)
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("open memory db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	store, err := NewStore(db, nil)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	return store
+}
+
+var (
+	t0 = time.Date(2026, 8, 30, 12, 0, 0, 0, time.UTC)
+	t1 = t0.Add(1 * time.Hour)
+	t2 = t0.Add(2 * time.Hour)
+)
+
+func TestRecordConnectedCreatesDevice(t *testing.T) {
+	store := newTestStore(t)
+
+	meta := companion.DeviceMetadata{
+		ClientName: "Alice's iPhone",
+		Platform:   "ios",
+		AppVersion: "1.2.0",
+		OSVersion:  "26.0",
+	}
+	if err := store.RecordConnected("alice", "device-1", meta, t0); err != nil {
+		t.Fatalf("RecordConnected: %v", err)
+	}
+
+	d, ok, err := store.Get("alice", "device-1")
+	if err != nil || !ok {
+		t.Fatalf("Get: ok=%v err=%v", ok, err)
+	}
+	if d.ClientName != meta.ClientName || d.Platform != "ios" || d.AppVersion != "1.2.0" || d.OSVersion != "26.0" {
+		t.Errorf("metadata mismatch: %+v", d)
+	}
+	if !d.FirstSeenAt.Equal(t0) || !d.LastSeenAt.Equal(t0) || !d.LastConnectedAt.Equal(t0) {
+		t.Errorf("timestamps mismatch: first=%v last=%v connected=%v", d.FirstSeenAt, d.LastSeenAt, d.LastConnectedAt)
+	}
+	if !d.LastDisconnectedAt.IsZero() {
+		t.Errorf("never-disconnected device has LastDisconnectedAt=%v", d.LastDisconnectedAt)
+	}
+	if d.State != DeviceStateActive {
+		t.Errorf("state = %q, want %q", d.State, DeviceStateActive)
+	}
+	if string(d.Capabilities) != "[]" {
+		t.Errorf("fresh device capabilities = %q, want []", d.Capabilities)
+	}
+}
+
+func TestRecordConnectedPreservesFirstSeenAndMetadata(t *testing.T) {
+	store := newTestStore(t)
+
+	full := companion.DeviceMetadata{ClientName: "Alice's Mac", Platform: "macos", AppVersion: "1.0", OSVersion: "15.6"}
+	if err := store.RecordConnected("alice", "device-1", full, t0); err != nil {
+		t.Fatalf("first connect: %v", err)
+	}
+	// Reconnect reporting only a new app version: absent fields must not
+	// erase what the device said before; the present one must update.
+	partial := companion.DeviceMetadata{AppVersion: "1.1"}
+	if err := store.RecordConnected("alice", "device-1", partial, t1); err != nil {
+		t.Fatalf("reconnect: %v", err)
+	}
+
+	d, ok, err := store.Get("alice", "device-1")
+	if err != nil || !ok {
+		t.Fatalf("Get: ok=%v err=%v", ok, err)
+	}
+	if !d.FirstSeenAt.Equal(t0) {
+		t.Errorf("FirstSeenAt = %v, want preserved %v", d.FirstSeenAt, t0)
+	}
+	if !d.LastConnectedAt.Equal(t1) || !d.LastSeenAt.Equal(t1) {
+		t.Errorf("reconnect timestamps not updated: connected=%v seen=%v", d.LastConnectedAt, d.LastSeenAt)
+	}
+	if d.ClientName != "Alice's Mac" || d.Platform != "macos" || d.OSVersion != "15.6" {
+		t.Errorf("absent metadata fields were erased: %+v", d)
+	}
+	if d.AppVersion != "1.1" {
+		t.Errorf("AppVersion = %q, want updated 1.1", d.AppVersion)
+	}
+}
+
+func TestRecordCapabilities(t *testing.T) {
+	store := newTestStore(t)
+	if err := store.RecordConnected("alice", "device-1", companion.DeviceMetadata{}, t0); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+
+	manifest := []byte(`[{"name":"location","methods":["current"]}]`)
+	if err := store.RecordCapabilities("alice", "device-1", manifest, t1); err != nil {
+		t.Fatalf("RecordCapabilities: %v", err)
+	}
+
+	d, _, err := store.Get("alice", "device-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(d.Capabilities) != string(manifest) {
+		t.Errorf("capabilities = %s, want %s", d.Capabilities, manifest)
+	}
+	if !d.LastSeenAt.Equal(t1) {
+		t.Errorf("LastSeenAt = %v, want bumped to %v", d.LastSeenAt, t1)
+	}
+
+	if err := store.RecordCapabilities("alice", "device-1", nil, t2); err != nil {
+		t.Fatalf("empty manifest: %v", err)
+	}
+	d, _, _ = store.Get("alice", "device-1")
+	if string(d.Capabilities) != "[]" {
+		t.Errorf("empty manifest stored as %q, want []", d.Capabilities)
+	}
+}
+
+func TestRecordCapabilitiesRejectsInvalid(t *testing.T) {
+	store := newTestStore(t)
+	if err := store.RecordConnected("alice", "device-1", companion.DeviceMetadata{}, t0); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	if err := store.RecordCapabilities("alice", "device-1", []byte("{not json"), t1); err == nil {
+		t.Error("invalid JSON manifest accepted")
+	}
+	if err := store.RecordCapabilities("alice", "unknown-device", []byte("[]"), t1); err == nil {
+		t.Error("capabilities for unrecorded device accepted")
+	}
+}
+
+func TestRecordDisconnectedPreservesRecord(t *testing.T) {
+	store := newTestStore(t)
+	meta := companion.DeviceMetadata{ClientName: "Alice's iPhone", Platform: "ios"}
+	if err := store.RecordConnected("alice", "device-1", meta, t0); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	if err := store.RecordDisconnected("alice", "device-1", t1); err != nil {
+		t.Fatalf("RecordDisconnected: %v", err)
+	}
+
+	d, ok, err := store.Get("alice", "device-1")
+	if err != nil || !ok {
+		t.Fatalf("device deleted by disconnect: ok=%v err=%v", ok, err)
+	}
+	if !d.LastDisconnectedAt.Equal(t1) || !d.LastSeenAt.Equal(t1) {
+		t.Errorf("disconnect timestamps: disconnected=%v seen=%v, want both %v", d.LastDisconnectedAt, d.LastSeenAt, t1)
+	}
+	if !d.LastConnectedAt.Equal(t0) {
+		t.Errorf("LastConnectedAt = %v, want preserved %v", d.LastConnectedAt, t0)
+	}
+	if d.ClientName != "Alice's iPhone" {
+		t.Errorf("metadata degraded on disconnect: %+v", d)
+	}
+
+	if err := store.RecordDisconnected("alice", "unknown-device", t1); err == nil {
+		t.Error("disconnect for unrecorded device accepted")
+	}
+}
+
+func TestKeyValidation(t *testing.T) {
+	store := newTestStore(t)
+	cases := []struct {
+		name     string
+		account  string
+		clientID string
+	}{
+		{"empty account", "", "device-1"},
+		{"empty client_id", "alice", ""},
+		{"whitespace client_id", "alice", "   "},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := store.RecordConnected(tc.account, tc.clientID, companion.DeviceMetadata{}, t0); err == nil {
+				t.Error("RecordConnected accepted invalid key")
+			}
+			if err := store.RecordCapabilities(tc.account, tc.clientID, []byte("[]"), t0); err == nil {
+				t.Error("RecordCapabilities accepted invalid key")
+			}
+			if err := store.RecordDisconnected(tc.account, tc.clientID, t0); err == nil {
+				t.Error("RecordDisconnected accepted invalid key")
+			}
+		})
+	}
+}
+
+func TestListOrdersByAccountThenClient(t *testing.T) {
+	store := newTestStore(t)
+	for _, key := range [][2]string{{"bob", "device-2"}, {"alice", "device-2"}, {"alice", "device-1"}} {
+		if err := store.RecordConnected(key[0], key[1], companion.DeviceMetadata{}, t0); err != nil {
+			t.Fatalf("connect %v: %v", key, err)
+		}
+	}
+	devices, err := store.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	var got [][2]string
+	for _, d := range devices {
+		got = append(got, [2]string{d.Account, d.ClientID})
+	}
+	want := [][2]string{{"alice", "device-1"}, {"alice", "device-2"}, {"bob", "device-2"}}
+	if len(got) != len(want) {
+		t.Fatalf("List returned %d devices, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("List[%d] = %v, want %v", i, got[i], want[i])
+		}
+	}
+}
+
+// TestSurvivesReopen is the restart-survival contract (#1437): known
+// companion identity persists across a process restart, and the schema
+// migration is idempotent on the second open.
+func TestSurvivesReopen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "thane.db")
+
+	db, err := database.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	store, err := NewStore(db, nil)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	meta := companion.DeviceMetadata{ClientName: "Alice's iPhone", Platform: "ios", AppVersion: "1.2.0"}
+	if err := store.RecordConnected("alice", "device-1", meta, t0); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	manifest := []byte(`[{"name":"location"}]`)
+	if err := store.RecordCapabilities("alice", "device-1", manifest, t0); err != nil {
+		t.Fatalf("capabilities: %v", err)
+	}
+	if err := store.RecordDisconnected("alice", "device-1", t1); err != nil {
+		t.Fatalf("disconnect: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	db2, err := database.Open(path)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer db2.Close()
+	store2, err := NewStore(db2, nil)
+	if err != nil {
+		t.Fatalf("second migration not idempotent: %v", err)
+	}
+
+	d, ok, err := store2.Get("alice", "device-1")
+	if err != nil || !ok {
+		t.Fatalf("device lost across restart: ok=%v err=%v", ok, err)
+	}
+	if d.ClientName != "Alice's iPhone" || d.Platform != "ios" || d.AppVersion != "1.2.0" {
+		t.Errorf("metadata lost across restart: %+v", d)
+	}
+	if !d.FirstSeenAt.Equal(t0) || !d.LastDisconnectedAt.Equal(t1) {
+		t.Errorf("timestamps lost across restart: first=%v disconnected=%v", d.FirstSeenAt, d.LastDisconnectedAt)
+	}
+	var caps []map[string]any
+	if err := json.Unmarshal(d.Capabilities, &caps); err != nil || len(caps) != 1 {
+		t.Errorf("capabilities lost across restart: %s (err=%v)", d.Capabilities, err)
+	}
+}

--- a/internal/state/companions/store_test.go
+++ b/internal/state/companions/store_test.go
@@ -1,6 +1,7 @@
 package companions
 
 import (
+	"context"
 	"encoding/json"
 	"path/filepath"
 	"testing"
@@ -9,6 +10,8 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/integrations/companion"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 )
+
+var ctx = context.Background()
 
 func newTestStore(t *testing.T) *Store {
 	t.Helper()
@@ -39,11 +42,11 @@ func TestRecordConnectedCreatesDevice(t *testing.T) {
 		AppVersion: "1.2.0",
 		OSVersion:  "26.0",
 	}
-	if err := store.RecordConnected("alice", "device-1", meta, t0); err != nil {
+	if err := store.RecordConnected(ctx, "alice", "device-1", meta, t0); err != nil {
 		t.Fatalf("RecordConnected: %v", err)
 	}
 
-	d, ok, err := store.Get("alice", "device-1")
+	d, ok, err := store.Get(ctx, "alice", "device-1")
 	if err != nil || !ok {
 		t.Fatalf("Get: ok=%v err=%v", ok, err)
 	}
@@ -68,17 +71,17 @@ func TestRecordConnectedPreservesFirstSeenAndMetadata(t *testing.T) {
 	store := newTestStore(t)
 
 	full := companion.DeviceMetadata{ClientName: "Alice's Mac", Platform: "macos", AppVersion: "1.0", OSVersion: "15.6"}
-	if err := store.RecordConnected("alice", "device-1", full, t0); err != nil {
+	if err := store.RecordConnected(ctx, "alice", "device-1", full, t0); err != nil {
 		t.Fatalf("first connect: %v", err)
 	}
 	// Reconnect reporting only a new app version: absent fields must not
 	// erase what the device said before; the present one must update.
 	partial := companion.DeviceMetadata{AppVersion: "1.1"}
-	if err := store.RecordConnected("alice", "device-1", partial, t1); err != nil {
+	if err := store.RecordConnected(ctx, "alice", "device-1", partial, t1); err != nil {
 		t.Fatalf("reconnect: %v", err)
 	}
 
-	d, ok, err := store.Get("alice", "device-1")
+	d, ok, err := store.Get(ctx, "alice", "device-1")
 	if err != nil || !ok {
 		t.Fatalf("Get: ok=%v err=%v", ok, err)
 	}
@@ -98,16 +101,16 @@ func TestRecordConnectedPreservesFirstSeenAndMetadata(t *testing.T) {
 
 func TestRecordCapabilities(t *testing.T) {
 	store := newTestStore(t)
-	if err := store.RecordConnected("alice", "device-1", companion.DeviceMetadata{}, t0); err != nil {
+	if err := store.RecordConnected(ctx, "alice", "device-1", companion.DeviceMetadata{}, t0); err != nil {
 		t.Fatalf("connect: %v", err)
 	}
 
 	manifest := []byte(`[{"name":"location","methods":["current"]}]`)
-	if err := store.RecordCapabilities("alice", "device-1", manifest, t1); err != nil {
+	if err := store.RecordCapabilities(ctx, "alice", "device-1", manifest, t1); err != nil {
 		t.Fatalf("RecordCapabilities: %v", err)
 	}
 
-	d, _, err := store.Get("alice", "device-1")
+	d, _, err := store.Get(ctx, "alice", "device-1")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
@@ -118,10 +121,10 @@ func TestRecordCapabilities(t *testing.T) {
 		t.Errorf("LastSeenAt = %v, want bumped to %v", d.LastSeenAt, t1)
 	}
 
-	if err := store.RecordCapabilities("alice", "device-1", nil, t2); err != nil {
+	if err := store.RecordCapabilities(ctx, "alice", "device-1", nil, t2); err != nil {
 		t.Fatalf("empty manifest: %v", err)
 	}
-	d, _, _ = store.Get("alice", "device-1")
+	d, _, _ = store.Get(ctx, "alice", "device-1")
 	if string(d.Capabilities) != "[]" {
 		t.Errorf("empty manifest stored as %q, want []", d.Capabilities)
 	}
@@ -129,13 +132,13 @@ func TestRecordCapabilities(t *testing.T) {
 
 func TestRecordCapabilitiesRejectsInvalid(t *testing.T) {
 	store := newTestStore(t)
-	if err := store.RecordConnected("alice", "device-1", companion.DeviceMetadata{}, t0); err != nil {
+	if err := store.RecordConnected(ctx, "alice", "device-1", companion.DeviceMetadata{}, t0); err != nil {
 		t.Fatalf("connect: %v", err)
 	}
-	if err := store.RecordCapabilities("alice", "device-1", []byte("{not json"), t1); err == nil {
+	if err := store.RecordCapabilities(ctx, "alice", "device-1", []byte("{not json"), t1); err == nil {
 		t.Error("invalid JSON manifest accepted")
 	}
-	if err := store.RecordCapabilities("alice", "unknown-device", []byte("[]"), t1); err == nil {
+	if err := store.RecordCapabilities(ctx, "alice", "unknown-device", []byte("[]"), t1); err == nil {
 		t.Error("capabilities for unrecorded device accepted")
 	}
 }
@@ -143,14 +146,14 @@ func TestRecordCapabilitiesRejectsInvalid(t *testing.T) {
 func TestRecordDisconnectedPreservesRecord(t *testing.T) {
 	store := newTestStore(t)
 	meta := companion.DeviceMetadata{ClientName: "Alice's iPhone", Platform: "ios"}
-	if err := store.RecordConnected("alice", "device-1", meta, t0); err != nil {
+	if err := store.RecordConnected(ctx, "alice", "device-1", meta, t0); err != nil {
 		t.Fatalf("connect: %v", err)
 	}
-	if err := store.RecordDisconnected("alice", "device-1", t1); err != nil {
+	if err := store.RecordDisconnected(ctx, "alice", "device-1", t1); err != nil {
 		t.Fatalf("RecordDisconnected: %v", err)
 	}
 
-	d, ok, err := store.Get("alice", "device-1")
+	d, ok, err := store.Get(ctx, "alice", "device-1")
 	if err != nil || !ok {
 		t.Fatalf("device deleted by disconnect: ok=%v err=%v", ok, err)
 	}
@@ -164,8 +167,119 @@ func TestRecordDisconnectedPreservesRecord(t *testing.T) {
 		t.Errorf("metadata degraded on disconnect: %+v", d)
 	}
 
-	if err := store.RecordDisconnected("alice", "unknown-device", t1); err == nil {
+	if err := store.RecordDisconnected(ctx, "alice", "unknown-device", t1); err == nil {
 		t.Error("disconnect for unrecorded device accepted")
+	}
+}
+
+// TestOutOfOrderConnectWrites pins the monotonic guards: overlapping
+// connections for the same durable identity may land their writes out
+// of timestamp order, and an older write must neither regress
+// timestamps nor overwrite newer metadata — it may only fill fields
+// the newer write left empty.
+func TestOutOfOrderConnectWrites(t *testing.T) {
+	store := newTestStore(t)
+
+	newer := companion.DeviceMetadata{ClientName: "Alice's iPhone", AppVersion: "2.0"}
+	if err := store.RecordConnected(ctx, "alice", "device-1", newer, t1); err != nil {
+		t.Fatalf("newer connect: %v", err)
+	}
+	// The older connect arrives late with different metadata and a
+	// platform the newer write did not report.
+	older := companion.DeviceMetadata{ClientName: "Old Name", AppVersion: "1.0", Platform: "ios"}
+	if err := store.RecordConnected(ctx, "alice", "device-1", older, t0); err != nil {
+		t.Fatalf("older connect: %v", err)
+	}
+
+	d, _, err := store.Get(ctx, "alice", "device-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !d.LastConnectedAt.Equal(t1) || !d.LastSeenAt.Equal(t1) {
+		t.Errorf("timestamps regressed: connected=%v seen=%v, want %v", d.LastConnectedAt, d.LastSeenAt, t1)
+	}
+	if d.ClientName != "Alice's iPhone" || d.AppVersion != "2.0" {
+		t.Errorf("older write overwrote newer metadata: %+v", d)
+	}
+	if d.Platform != "ios" {
+		t.Errorf("older write did not fill empty field: platform=%q", d.Platform)
+	}
+	// first_seen_at reflects the earliest write that created the row —
+	// with out-of-order arrival that is the newer event's time, which is
+	// the honest floor for "known since".
+	if !d.FirstSeenAt.Equal(t1) {
+		t.Errorf("FirstSeenAt = %v, want anchor %v", d.FirstSeenAt, t1)
+	}
+}
+
+// TestStaleCapabilitiesIgnored pins "most recently advertised" against
+// out-of-order manifest writes: an older registration is dropped
+// without error once a newer one is stored.
+func TestStaleCapabilitiesIgnored(t *testing.T) {
+	store := newTestStore(t)
+	if err := store.RecordConnected(ctx, "alice", "device-1", companion.DeviceMetadata{}, t0); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+
+	newer := []byte(`[{"name":"location"}]`)
+	if err := store.RecordCapabilities(ctx, "alice", "device-1", newer, t2); err != nil {
+		t.Fatalf("newer manifest: %v", err)
+	}
+	older := []byte(`[{"name":"calendar"}]`)
+	if err := store.RecordCapabilities(ctx, "alice", "device-1", older, t1); err != nil {
+		t.Fatalf("stale manifest must drop silently, got: %v", err)
+	}
+
+	d, _, err := store.Get(ctx, "alice", "device-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(d.Capabilities) != string(newer) {
+		t.Errorf("stale manifest replaced newer one: %s", d.Capabilities)
+	}
+	if !d.CapabilitiesRecordedAt.Equal(t2) {
+		t.Errorf("CapabilitiesRecordedAt = %v, want %v", d.CapabilitiesRecordedAt, t2)
+	}
+}
+
+// TestDisconnectMonotonic pins overlapping teardowns: an older
+// disconnect landing after a newer one must not walk either timestamp
+// backwards.
+func TestDisconnectMonotonic(t *testing.T) {
+	store := newTestStore(t)
+	if err := store.RecordConnected(ctx, "alice", "device-1", companion.DeviceMetadata{}, t0); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	if err := store.RecordDisconnected(ctx, "alice", "device-1", t2); err != nil {
+		t.Fatalf("newer disconnect: %v", err)
+	}
+	if err := store.RecordDisconnected(ctx, "alice", "device-1", t1); err != nil {
+		t.Fatalf("older disconnect: %v", err)
+	}
+
+	d, _, err := store.Get(ctx, "alice", "device-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !d.LastDisconnectedAt.Equal(t2) || !d.LastSeenAt.Equal(t2) {
+		t.Errorf("disconnect regressed: disconnected=%v seen=%v, want %v", d.LastDisconnectedAt, d.LastSeenAt, t2)
+	}
+}
+
+// TestClientIDStoredVerbatim pins opacity: the store validates that an
+// identity is non-empty but never rewrites its bytes, so a claim with
+// surrounding whitespace is stored exactly as given (normalization is
+// the auth handshake's job).
+func TestClientIDStoredVerbatim(t *testing.T) {
+	store := newTestStore(t)
+	if err := store.RecordConnected(ctx, "alice", " device-1 ", companion.DeviceMetadata{}, t0); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	if _, ok, err := store.Get(ctx, "alice", " device-1 "); err != nil || !ok {
+		t.Fatalf("verbatim key not found: ok=%v err=%v", ok, err)
+	}
+	if _, ok, _ := store.Get(ctx, "alice", "device-1"); ok {
+		t.Error("trimmed key matched a verbatim claim — store rewrote the identity")
 	}
 }
 
@@ -182,13 +296,13 @@ func TestKeyValidation(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if err := store.RecordConnected(tc.account, tc.clientID, companion.DeviceMetadata{}, t0); err == nil {
+			if err := store.RecordConnected(ctx, tc.account, tc.clientID, companion.DeviceMetadata{}, t0); err == nil {
 				t.Error("RecordConnected accepted invalid key")
 			}
-			if err := store.RecordCapabilities(tc.account, tc.clientID, []byte("[]"), t0); err == nil {
+			if err := store.RecordCapabilities(ctx, tc.account, tc.clientID, []byte("[]"), t0); err == nil {
 				t.Error("RecordCapabilities accepted invalid key")
 			}
-			if err := store.RecordDisconnected(tc.account, tc.clientID, t0); err == nil {
+			if err := store.RecordDisconnected(ctx, tc.account, tc.clientID, t0); err == nil {
 				t.Error("RecordDisconnected accepted invalid key")
 			}
 		})
@@ -198,11 +312,11 @@ func TestKeyValidation(t *testing.T) {
 func TestListOrdersByAccountThenClient(t *testing.T) {
 	store := newTestStore(t)
 	for _, key := range [][2]string{{"bob", "device-2"}, {"alice", "device-2"}, {"alice", "device-1"}} {
-		if err := store.RecordConnected(key[0], key[1], companion.DeviceMetadata{}, t0); err != nil {
+		if err := store.RecordConnected(ctx, key[0], key[1], companion.DeviceMetadata{}, t0); err != nil {
 			t.Fatalf("connect %v: %v", key, err)
 		}
 	}
-	devices, err := store.List()
+	devices, err := store.List(ctx)
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
@@ -236,14 +350,14 @@ func TestSurvivesReopen(t *testing.T) {
 		t.Fatalf("new store: %v", err)
 	}
 	meta := companion.DeviceMetadata{ClientName: "Alice's iPhone", Platform: "ios", AppVersion: "1.2.0"}
-	if err := store.RecordConnected("alice", "device-1", meta, t0); err != nil {
+	if err := store.RecordConnected(ctx, "alice", "device-1", meta, t0); err != nil {
 		t.Fatalf("connect: %v", err)
 	}
 	manifest := []byte(`[{"name":"location"}]`)
-	if err := store.RecordCapabilities("alice", "device-1", manifest, t0); err != nil {
+	if err := store.RecordCapabilities(ctx, "alice", "device-1", manifest, t0); err != nil {
 		t.Fatalf("capabilities: %v", err)
 	}
-	if err := store.RecordDisconnected("alice", "device-1", t1); err != nil {
+	if err := store.RecordDisconnected(ctx, "alice", "device-1", t1); err != nil {
 		t.Fatalf("disconnect: %v", err)
 	}
 	if err := db.Close(); err != nil {
@@ -260,7 +374,7 @@ func TestSurvivesReopen(t *testing.T) {
 		t.Fatalf("second migration not idempotent: %v", err)
 	}
 
-	d, ok, err := store2.Get("alice", "device-1")
+	d, ok, err := store2.Get(ctx, "alice", "device-1")
 	if err != nil || !ok {
 		t.Fatalf("device lost across restart: ok=%v err=%v", ok, err)
 	}

--- a/internal/state/companions/store_test.go
+++ b/internal/state/companions/store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -204,11 +205,39 @@ func TestOutOfOrderConnectWrites(t *testing.T) {
 	if d.Platform != "ios" {
 		t.Errorf("older write did not fill empty field: platform=%q", d.Platform)
 	}
-	// first_seen_at reflects the earliest write that created the row —
-	// with out-of-order arrival that is the newer event's time, which is
-	// the honest floor for "known since".
-	if !d.FirstSeenAt.Equal(t1) {
-		t.Errorf("FirstSeenAt = %v, want anchor %v", d.FirstSeenAt, t1)
+	// first_seen_at is MIN-guarded: the earliest event time is when the
+	// server first observed the device, regardless of which write landed
+	// first.
+	if !d.FirstSeenAt.Equal(t0) {
+		t.Errorf("FirstSeenAt = %v, want earliest event time %v", d.FirstSeenAt, t0)
+	}
+}
+
+// TestDeviceIDStableAcrossReconnects pins the immutable server-side
+// identity: the row's device_id is minted once and survives later
+// connects, so rows that reference it (future observations) keep their
+// continuity when the lookup claim eventually rotates (#1444).
+func TestDeviceIDStableAcrossReconnects(t *testing.T) {
+	store := newTestStore(t)
+	if err := store.RecordConnected(ctx, "alice", "device-1", companion.DeviceMetadata{}, t0); err != nil {
+		t.Fatalf("first connect: %v", err)
+	}
+	first, _, err := store.Get(ctx, "alice", "device-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if first.DeviceID == "" || !strings.HasPrefix(first.DeviceID, "dev_") {
+		t.Fatalf("DeviceID = %q, want dev_-prefixed identity", first.DeviceID)
+	}
+	if err := store.RecordConnected(ctx, "alice", "device-1", companion.DeviceMetadata{}, t1); err != nil {
+		t.Fatalf("reconnect: %v", err)
+	}
+	second, _, err := store.Get(ctx, "alice", "device-1")
+	if err != nil {
+		t.Fatalf("Get after reconnect: %v", err)
+	}
+	if second.DeviceID != first.DeviceID {
+		t.Errorf("DeviceID changed across reconnect: %q → %q", first.DeviceID, second.DeviceID)
 	}
 }
 

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
-packages=68
-interfaces=83
+packages=69
+interfaces=84
 large_files=58
-set_mutators=118
+set_mutators=119
 database_opens=9


### PR DESCRIPTION
First slice of #1437, per the sequencing posted there: the durable device inventory. A companion device and its WebSocket connection have different lifetimes, and until now the server conflated them — `Registry.Remove` erased every trace of a device the moment iOS backgrounded the app or a Mac went to sleep. This PR gives the first two of the issue's three states (known companion, live connection) their separate lifetimes; latest observations arrive in the next slice.

## What ships

**`internal/state/companions`** persists devices in the primary Thane database under an immutable server-assigned `device_id` primary key, minted once when a device is first seen. `(account, client_id)` — the authenticated account plus the stable identity the companion claims about itself, never the per-connection `provider_id` — is the UNIQUE lookup that maps a claim to its device. That separation is what makes the #1444 seam real: the enrollment arc makes key replacement and re-enrollment normal, so rotating a credential re-points the mapping while everything that must survive rotation (future observation rows included) references `device_id` and keeps its continuity. The schema is the standard declarative idempotent `database.Schema`; the store borrows the memory store's `thane.db` handle like its siblings.

**Lifecycle recording** hangs off the existing connection path through a new `DeviceRecorder` seam on the WebSocket handler, but never runs on it: writes are enqueued to a single ordered recording goroutine with a bounded queue, a per-write timeout, and an explicit shutdown drain registered on the app's LIFO closer stack ahead of the database owner — a slow database cannot delay `auth_ok` or teardown, and a restart cannot lose a just-recorded event or write into a closed handle. Authentication upserts the record — `first_seen_at` anchored exactly once, metadata non-empty-wins so a client that omits a field on one connection cannot erase what it reported before. Capability registration stores the most recently advertised manifest (the normalized snapshot, verbatim JSON — what the device *offered when last heard from*, not what is callable now), stamped with `capabilities_recorded_at`. Disconnect stamps `last_disconnected_at` and advances `last_seen_at` — the connection was live evidence of the device until it tore down — and never deletes or degrades the record. Because a reconnecting phone can race its own dying socket, every write is monotonic: timestamps never regress, an older racing write can only fill still-empty metadata fields, and a stale capability manifest is dropped in favor of the newer one. Recording is best-effort by design; a persistence failure logs a warning and never disturbs the live connection.

**The auth handshake grows optional device metadata** — `platform`, `app_version`, `os_version` — carried onto the provider snapshot and into the inventory. Additive and backward-compatible: clients that omit them lose nothing at the protocol level.

**The anonymous-client policy** published on #1437 is now enforced and pinned by test: a connection without a `client_id` stays fully functional live but is not inventoried. No durable identity claim, no durable row.

## What deliberately does not ship

Reachability is never persisted — `online` stays derived from the in-memory registry, exactly as the issue requires. The `state` column exists (default `active`) so a future forget/retire flow has somewhere to record its decision, but nothing writes any other value yet. No model-facing surface changes: the joined context view and reachability-semantics fix are slice 3, the last-known-location tool is slice 4.

## Verification

- [x] Known companion identity survives a process restart (`TestSurvivesReopen`: record, close, reopen, second migration idempotent, metadata and timestamps intact)
- [x] Disconnect records state without deleting it (`TestRecordDisconnectedPreservesRecord`, `TestDeviceRecorderFullLifecycle`)
- [x] Identity is keyed by account + stable `client_id`; `provider_id` never touches the store
- [x] Reconnect preserves `first_seen_at` and previously reported metadata (`TestRecordConnectedPreservesFirstSeenAndMetadata`)
- [x] Anonymous clients (no `client_id`) are never inventoried (`TestDeviceRecorderSkipsAnonymousClients`)
- [x] `just ci` passes locally (fmt, tidy, config-generate, architecture, links, lint, openapi lint, full test suite)

Refs #1437

🤖 Generated with [Claude Code](https://claude.com/claude-code)
