### PR TITLE
feat(companion): background observation ingestion over authenticated HTTPS

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -101,6 +101,7 @@ filesystem paths, signer principals, or the contents of `.allowed_signers`.
 | `DELETE` | `/v1/checkpoints/{id}` | Delete a checkpoint. |
 | `POST` | `/v1/checkpoints/{id}/restore` | Restore from a checkpoint. |
 | `GET` | `/v1/realtime/ws` | First-party realtime WebSocket (canonical). |
+| `POST` | `/v1/companion/observations` | Background observation ingestion from companion devices (bearer-authenticated; enforced today). |
 | `GET` | `/v1/companion/ws` | Realtime WebSocket — legacy alias (deprecated; see below). |
 | `GET` | `/v1/platform/ws` | Realtime WebSocket — legacy alias (deprecated; see below). |
 

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -284,6 +284,17 @@ func (a *App) initServers(s *newState) error {
 		a.onClose("companion-device-recorder", handler.CloseDeviceRecorder)
 		server.SetCompanionHandler(handler)
 
+		// Background observation ingestion (#1437): the authenticated
+		// HTTPS path for devices that cannot hold a WebSocket. Bearer
+		// auth rides behind the authenticator seam so the enrollment
+		// arc (#1444) can swap in signature verification without
+		// touching ingestion.
+		server.SetCompanionObservationsHandler(companion.NewObservationsHandler(
+			companion.NewTokenAuthenticator(cfg.Companion.TokenIndex()),
+			a.companionDevices,
+			logger,
+		))
+
 		a.connMgr.Watch(s.ctx, connwatch.WatcherConfig{
 			Name: "companion",
 			Probe: func(_ context.Context) error {

--- a/internal/integrations/companion/observations.go
+++ b/internal/integrations/companion/observations.go
@@ -1,0 +1,325 @@
+package companion
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Ingestion limits. Companion batches are outbox drains, not bulk
+// imports: a phone waking from a background event uploads a handful of
+// observations. The caps below are documented API contract
+// (native.yaml carries the same numbers).
+const (
+	// maxObservationBodyBytes caps the request body.
+	maxObservationBodyBytes = 256 << 10 // 256 KiB
+	// maxObservationBatch caps events per request.
+	maxObservationBatch = 64
+	// maxObservationPayloadBytes caps one event's payload.
+	maxObservationPayloadBytes = 16 << 10 // 16 KiB
+	// maxObservationEventIDBytes caps the idempotency key.
+	maxObservationEventIDBytes = 128
+	// maxObservedAtFutureSkew is how far ahead of server time a
+	// device-supplied observation time may claim to be before it is
+	// rejected as implausible. Past times are legal at any distance —
+	// draining a long-offline outbox is the point of the endpoint.
+	maxObservedAtFutureSkew = 5 * time.Minute
+)
+
+// observedAtFloor rejects device clocks that are nonsensically far in
+// the past (an unset clock reporting the epoch must not become a
+// "latest" observation that nothing newer can supersede... backwards).
+var observedAtFloor = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// observationKindRE constrains observation kinds to a compact
+// namespace-friendly token (e.g. "ios.location").
+var observationKindRE = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]{0,63}$`)
+
+// ObservationEvent is one wire-format event in an ingestion batch.
+// ObservedAt is a string so one malformed timestamp invalidates one
+// event, not the whole batch.
+type ObservationEvent struct {
+	EventID       string          `json:"event_id"`
+	Kind          string          `json:"kind"`
+	SchemaVersion int             `json:"schema_version"`
+	ObservedAt    string          `json:"observed_at"`
+	Withdrawn     bool            `json:"withdrawn,omitempty"`
+	Payload       json.RawMessage `json:"payload,omitempty"`
+}
+
+// Observation is a validated event bound for storage. ObservedAt is
+// the device's claim about when the observation happened; ReceivedAt
+// is the server's authoritative receipt time. The two are never
+// conflated (#1437).
+type Observation struct {
+	EventID       string
+	Kind          string
+	SchemaVersion int
+	ObservedAt    time.Time
+	ReceivedAt    time.Time
+	Withdrawn     bool
+	Payload       json.RawMessage
+}
+
+// ObservationOutcome is a storage verdict for one event. Every outcome
+// is terminal for the client's outbox entry: applied means stored,
+// duplicate means this exact event was already accepted, superseded
+// means a newer observation of the same kind is already stored.
+type ObservationOutcome string
+
+const (
+	ObservationApplied    ObservationOutcome = "applied"
+	ObservationDuplicate  ObservationOutcome = "duplicate"
+	ObservationSuperseded ObservationOutcome = "superseded"
+)
+
+// ObservationSink stores validated observations. Implemented by the
+// companions device store; the ingestion layer never touches SQL.
+type ObservationSink interface {
+	// EnsureDevice resolves (account, client_id) to the immutable
+	// device_id, creating the inventory row when a device pushes its
+	// first observation before ever connecting a WebSocket, and
+	// bumping last-seen either way.
+	EnsureDevice(ctx context.Context, account, clientID string, seenAt time.Time) (string, error)
+	// UpsertObservation applies latest-only semantics for one
+	// (device, kind) and reports what happened.
+	UpsertObservation(ctx context.Context, deviceID string, obs Observation) (ObservationOutcome, error)
+}
+
+// ObservationAuthenticator resolves a request's bearer credential to
+// an account. This is the seam the enrollment arc (#1444) replaces
+// with signature verification; ingestion itself never sees the
+// credential material.
+type ObservationAuthenticator interface {
+	Authenticate(r *http.Request) (account string, ok bool)
+}
+
+// observationBatch is the wire request shape.
+type observationBatch struct {
+	ClientID string             `json:"client_id"`
+	Events   []ObservationEvent `json:"events"`
+}
+
+// observationResult is the wire verdict for one event.
+type observationResult struct {
+	EventID string `json:"event_id"`
+	Status  string `json:"status"`
+	Error   string `json:"error,omitempty"`
+}
+
+// observationResponse is the wire response shape.
+type observationResponse struct {
+	Results []observationResult `json:"results"`
+}
+
+// ObservationsHandler serves POST /v1/companion/observations: the
+// authenticated HTTPS path a companion uses to push observations when
+// it cannot hold a WebSocket — iOS waking briefly for a background
+// event is the motivating client (#1437). The batch → validate →
+// EnsureDevice → UpsertObservation core is transport-independent; a
+// future WebSocket observation message reuses everything below the
+// HTTP decode.
+type ObservationsHandler struct {
+	auth   ObservationAuthenticator
+	sink   ObservationSink
+	logger *slog.Logger
+}
+
+// NewObservationsHandler creates the ingestion handler.
+func NewObservationsHandler(auth ObservationAuthenticator, sink ObservationSink, logger *slog.Logger) *ObservationsHandler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &ObservationsHandler{auth: auth, sink: sink, logger: logger}
+}
+
+func (h *ObservationsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if h.auth == nil || h.sink == nil {
+		http.Error(w, `{"error":"observation ingestion not configured"}`, http.StatusServiceUnavailable)
+		return
+	}
+
+	account, ok := h.auth.Authenticate(r)
+	if !ok {
+		w.Header().Set("WWW-Authenticate", `Bearer realm="companion"`)
+		http.Error(w, `{"error":"invalid or missing companion token"}`, http.StatusUnauthorized)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxObservationBodyBytes)
+	var batch observationBatch
+	if err := json.NewDecoder(r.Body).Decode(&batch); err != nil {
+		var tooLarge *http.MaxBytesError
+		if errors.As(err, &tooLarge) {
+			writeObservationError(w, http.StatusRequestEntityTooLarge,
+				fmt.Sprintf("request body exceeds %d bytes", maxObservationBodyBytes))
+			return
+		}
+		writeObservationError(w, http.StatusBadRequest, "malformed JSON body")
+		return
+	}
+
+	clientID := strings.TrimSpace(batch.ClientID)
+	if clientID == "" {
+		writeObservationError(w, http.StatusBadRequest, "client_id is required")
+		return
+	}
+	if len(batch.Events) == 0 {
+		writeObservationError(w, http.StatusBadRequest, "events must not be empty")
+		return
+	}
+	if len(batch.Events) > maxObservationBatch {
+		writeObservationError(w, http.StatusBadRequest,
+			fmt.Sprintf("batch exceeds %d events", maxObservationBatch))
+		return
+	}
+
+	received := time.Now().UTC()
+	deviceID, err := h.sink.EnsureDevice(r.Context(), account, clientID, received)
+	if err != nil {
+		h.logger.Error("companion observation device resolve failed",
+			"account", account,
+			"client_id", clientID,
+			"error", err,
+		)
+		writeObservationError(w, http.StatusInternalServerError, "device resolution failed")
+		return
+	}
+
+	results := make([]observationResult, 0, len(batch.Events))
+	applied := 0
+	for _, event := range batch.Events {
+		obs, verr := validateObservationEvent(event, received)
+		if verr != "" {
+			results = append(results, observationResult{
+				EventID: event.EventID,
+				Status:  "invalid",
+				Error:   verr,
+			})
+			continue
+		}
+		outcome, err := h.sink.UpsertObservation(r.Context(), deviceID, obs)
+		if err != nil {
+			// A storage failure is the one non-terminal case: fail the
+			// whole batch so the client retries it verbatim — the
+			// idempotency contract is exactly what makes that safe.
+			h.logger.Error("companion observation store failed",
+				"account", account,
+				"client_id", clientID,
+				"kind", obs.Kind,
+				"error", err,
+			)
+			writeObservationError(w, http.StatusInternalServerError, "observation storage failed")
+			return
+		}
+		if outcome == ObservationApplied {
+			applied++
+		}
+		results = append(results, observationResult{
+			EventID: event.EventID,
+			Status:  string(outcome),
+		})
+	}
+
+	// Counts and kinds are loggable; payloads never are (#1437 requires
+	// precise location stay out of logs).
+	h.logger.Info("companion observations ingested",
+		"account", account,
+		"client_id", clientID,
+		"events", len(batch.Events),
+		"applied", applied,
+	)
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(observationResponse{Results: results}); err != nil {
+		h.logger.Debug("companion observation response write failed", "error", err)
+	}
+}
+
+// validateObservationEvent turns one wire event into a storable
+// observation, or a terminal per-event rejection reason. Rejections
+// are terminal by design: a malformed event will not improve on retry,
+// and the client should drop it from its outbox rather than wedge on it.
+func validateObservationEvent(event ObservationEvent, received time.Time) (Observation, string) {
+	eventID := strings.TrimSpace(event.EventID)
+	if eventID == "" {
+		return Observation{}, "event_id is required"
+	}
+	if len(eventID) > maxObservationEventIDBytes {
+		return Observation{}, fmt.Sprintf("event_id exceeds %d bytes", maxObservationEventIDBytes)
+	}
+	if !observationKindRE.MatchString(event.Kind) {
+		return Observation{}, "kind must match " + observationKindRE.String()
+	}
+	if event.SchemaVersion < 1 {
+		return Observation{}, "schema_version must be >= 1"
+	}
+
+	observedAt, err := time.Parse(time.RFC3339, event.ObservedAt)
+	if err != nil {
+		return Observation{}, "observed_at must be RFC 3339"
+	}
+	observedAt = observedAt.UTC()
+	if observedAt.After(received.Add(maxObservedAtFutureSkew)) {
+		return Observation{}, "observed_at is implausibly in the future"
+	}
+	if observedAt.Before(observedAtFloor) {
+		return Observation{}, "observed_at is implausibly old"
+	}
+
+	payload := event.Payload
+	if event.Withdrawn {
+		// A withdrawal erases; it must not smuggle data in.
+		if len(payload) != 0 && string(payload) != "null" {
+			return Observation{}, "a withdrawn event must not carry a payload"
+		}
+		payload = nil
+	} else {
+		if len(payload) == 0 || string(payload) == "null" {
+			return Observation{}, "payload is required"
+		}
+		if len(payload) > maxObservationPayloadBytes {
+			return Observation{}, fmt.Sprintf("payload exceeds %d bytes", maxObservationPayloadBytes)
+		}
+		if !json.Valid(payload) || payload[firstNonSpace(payload)] != '{' {
+			return Observation{}, "payload must be a JSON object"
+		}
+	}
+
+	return Observation{
+		EventID:       eventID,
+		Kind:          event.Kind,
+		SchemaVersion: event.SchemaVersion,
+		ObservedAt:    observedAt,
+		ReceivedAt:    received,
+		Withdrawn:     event.Withdrawn,
+		Payload:       payload,
+	}, ""
+}
+
+// firstNonSpace returns the index of the first non-whitespace byte
+// (JSON whitespace per RFC 8259). Callers pass payloads json.Valid
+// already accepted, so a non-space byte exists.
+func firstNonSpace(b []byte) int {
+	for i, c := range b {
+		switch c {
+		case ' ', '\t', '\n', '\r':
+			continue
+		default:
+			return i
+		}
+	}
+	return 0
+}
+
+func writeObservationError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}

--- a/internal/integrations/companion/observations_auth.go
+++ b/internal/integrations/companion/observations_auth.go
@@ -1,0 +1,51 @@
+package companion
+
+import (
+	"crypto/subtle"
+	"net/http"
+	"strings"
+)
+
+// TokenAuthenticator authenticates observation uploads against the
+// configured companion tokens (token → account, the same index the
+// WebSocket handshake uses). It implements [ObservationAuthenticator]
+// as the bearer-token half of the auth seam; the enrollment arc
+// (#1444) supplies a signature-based implementation later without
+// touching ingestion.
+type TokenAuthenticator struct {
+	tokenIndex map[string]string
+}
+
+// NewTokenAuthenticator creates a bearer-token authenticator over the
+// companion token index.
+func NewTokenAuthenticator(tokenIndex map[string]string) *TokenAuthenticator {
+	return &TokenAuthenticator{tokenIndex: tokenIndex}
+}
+
+// Authenticate resolves the Authorization header to an account.
+//
+// Unlike the WebSocket handshake — an in-band message on a private
+// connection — this credential rides an HTTP header on every request,
+// so each configured token is compared in constant time and the scan
+// never breaks early on a match. What can still vary with timing is
+// the number of configured tokens and their lengths, neither of which
+// is secret material.
+func (a *TokenAuthenticator) Authenticate(r *http.Request) (string, bool) {
+	token, ok := strings.CutPrefix(r.Header.Get("Authorization"), "Bearer ")
+	if !ok || token == "" {
+		return "", false
+	}
+
+	var (
+		account string
+		found   bool
+	)
+	for candidate, acct := range a.tokenIndex {
+		if len(candidate) == len(token) &&
+			subtle.ConstantTimeCompare([]byte(candidate), []byte(token)) == 1 {
+			account = acct
+			found = true
+		}
+	}
+	return account, found
+}

--- a/internal/integrations/companion/observations_test.go
+++ b/internal/integrations/companion/observations_test.go
@@ -1,0 +1,269 @@
+package companion
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeObservationSink records ingestion calls and returns canned
+// outcomes.
+type fakeObservationSink struct {
+	mu           sync.Mutex
+	ensured      []string // "account/client_id"
+	observations []Observation
+	upsertErr    error
+	outcome      ObservationOutcome
+}
+
+func (f *fakeObservationSink) EnsureDevice(_ context.Context, account, clientID string, _ time.Time) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ensured = append(f.ensured, account+"/"+clientID)
+	return "dev_test", nil
+}
+
+func (f *fakeObservationSink) UpsertObservation(_ context.Context, _ string, obs Observation) (ObservationOutcome, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.upsertErr != nil {
+		return "", f.upsertErr
+	}
+	f.observations = append(f.observations, obs)
+	if f.outcome == "" {
+		return ObservationApplied, nil
+	}
+	return f.outcome, nil
+}
+
+func newObservationsServer(t *testing.T, sink ObservationSink) *httptest.Server {
+	t.Helper()
+	auth := NewTokenAuthenticator(map[string]string{"alice-token": "alice", "bob-token": "bob"})
+	srv := httptest.NewServer(NewObservationsHandler(auth, sink, nil))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func postObservations(t *testing.T, url, token, body string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader([]byte(body)))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	t.Cleanup(func() { resp.Body.Close() })
+	return resp
+}
+
+func validEvent(id string) string {
+	return fmt.Sprintf(`{
+		"event_id": %q,
+		"kind": "ios.location",
+		"schema_version": 1,
+		"observed_at": "2026-08-29T19:42:00Z",
+		"payload": {"latitude": 41.0, "longitude": -87.0, "horizontal_accuracy_m": 24.0}
+	}`, id)
+}
+
+func decodeResults(t *testing.T, resp *http.Response) []observationResult {
+	t.Helper()
+	var out observationResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return out.Results
+}
+
+func TestObservationsRejectsBadAuth(t *testing.T) {
+	sink := &fakeObservationSink{}
+	srv := newObservationsServer(t, sink)
+	body := `{"client_id":"device-1","events":[` + validEvent("evt-1") + `]}`
+
+	for _, tc := range []struct {
+		name  string
+		token string
+	}{
+		{"missing token", ""},
+		{"wrong token", "not-a-token"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := postObservations(t, srv.URL, tc.token, body)
+			if resp.StatusCode != http.StatusUnauthorized {
+				t.Fatalf("status = %d, want 401", resp.StatusCode)
+			}
+			if resp.Header.Get("WWW-Authenticate") == "" {
+				t.Error("missing WWW-Authenticate header")
+			}
+		})
+	}
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	if len(sink.ensured) != 0 || len(sink.observations) != 0 {
+		t.Error("unauthenticated request reached the sink")
+	}
+}
+
+func TestObservationsBindsAccountFromToken(t *testing.T) {
+	sink := &fakeObservationSink{}
+	srv := newObservationsServer(t, sink)
+	body := `{"client_id":"device-1","events":[` + validEvent("evt-1") + `]}`
+
+	resp := postObservations(t, srv.URL, "bob-token", body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	results := decodeResults(t, resp)
+	if len(results) != 1 || results[0].Status != "applied" {
+		t.Fatalf("results = %+v", results)
+	}
+
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	// The token, never the body, decides the account: bob's token can
+	// only write devices under bob.
+	if len(sink.ensured) != 1 || sink.ensured[0] != "bob/device-1" {
+		t.Errorf("ensured = %v, want [bob/device-1]", sink.ensured)
+	}
+	obs := sink.observations[0]
+	if obs.EventID != "evt-1" || obs.Kind != "ios.location" || obs.SchemaVersion != 1 {
+		t.Errorf("observation = %+v", obs)
+	}
+	want := time.Date(2026, 8, 29, 19, 42, 0, 0, time.UTC)
+	if !obs.ObservedAt.Equal(want) {
+		t.Errorf("ObservedAt = %v, want %v", obs.ObservedAt, want)
+	}
+	if !obs.ReceivedAt.After(want) {
+		t.Errorf("ReceivedAt = %v, want server receipt time after the observation", obs.ReceivedAt)
+	}
+}
+
+func TestObservationsBatchValidation(t *testing.T) {
+	sink := &fakeObservationSink{}
+	srv := newObservationsServer(t, sink)
+
+	manyEvents := make([]string, maxObservationBatch+1)
+	for i := range manyEvents {
+		manyEvents[i] = validEvent(fmt.Sprintf("evt-%d", i))
+	}
+
+	cases := []struct {
+		name string
+		body string
+		want int
+	}{
+		{"malformed JSON", `{not json`, http.StatusBadRequest},
+		{"missing client_id", `{"events":[` + validEvent("e") + `]}`, http.StatusBadRequest},
+		{"empty events", `{"client_id":"device-1","events":[]}`, http.StatusBadRequest},
+		{"too many events", `{"client_id":"device-1","events":[` + strings.Join(manyEvents, ",") + `]}`, http.StatusBadRequest},
+		{"oversize body", `{"client_id":"device-1","events":[{"payload":"` + strings.Repeat("x", maxObservationBodyBytes) + `"}]}`, http.StatusRequestEntityTooLarge},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := postObservations(t, srv.URL, "alice-token", tc.body)
+			if resp.StatusCode != tc.want {
+				t.Fatalf("status = %d, want %d", resp.StatusCode, tc.want)
+			}
+		})
+	}
+}
+
+func TestObservationsPerEventValidation(t *testing.T) {
+	sink := &fakeObservationSink{}
+	srv := newObservationsServer(t, sink)
+
+	future := time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
+	events := []string{
+		validEvent("evt-good"),
+		`{"event_id":"","kind":"ios.location","schema_version":1,"observed_at":"2026-08-29T19:42:00Z","payload":{}}`,
+		`{"event_id":"evt-badkind","kind":"IOS LOCATION","schema_version":1,"observed_at":"2026-08-29T19:42:00Z","payload":{"a":1}}`,
+		`{"event_id":"evt-badver","kind":"ios.location","schema_version":0,"observed_at":"2026-08-29T19:42:00Z","payload":{"a":1}}`,
+		`{"event_id":"evt-badtime","kind":"ios.location","schema_version":1,"observed_at":"yesterday-ish","payload":{"a":1}}`,
+		`{"event_id":"evt-future","kind":"ios.location","schema_version":1,"observed_at":"` + future + `","payload":{"a":1}}`,
+		`{"event_id":"evt-ancient","kind":"ios.location","schema_version":1,"observed_at":"1999-12-31T23:59:00Z","payload":{"a":1}}`,
+		`{"event_id":"evt-nopayload","kind":"ios.location","schema_version":1,"observed_at":"2026-08-29T19:42:00Z"}`,
+		`{"event_id":"evt-arraypayload","kind":"ios.location","schema_version":1,"observed_at":"2026-08-29T19:42:00Z","payload":[1,2]}`,
+		`{"event_id":"evt-armed-withdrawal","kind":"ios.location","schema_version":1,"observed_at":"2026-08-29T19:42:00Z","withdrawn":true,"payload":{"a":1}}`,
+		`{"event_id":"evt-withdrawal","kind":"ios.location","schema_version":1,"observed_at":"2026-08-29T19:42:00Z","withdrawn":true}`,
+	}
+	body := `{"client_id":"device-1","events":[` + strings.Join(events, ",") + `]}`
+
+	resp := postObservations(t, srv.URL, "alice-token", body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	results := decodeResults(t, resp)
+	if len(results) != len(events) {
+		t.Fatalf("got %d results for %d events", len(results), len(events))
+	}
+	wantStatus := map[string]string{
+		"evt-good":             "applied",
+		"":                     "invalid",
+		"evt-badkind":          "invalid",
+		"evt-badver":           "invalid",
+		"evt-badtime":          "invalid",
+		"evt-future":           "invalid",
+		"evt-ancient":          "invalid",
+		"evt-nopayload":        "invalid",
+		"evt-arraypayload":     "invalid",
+		"evt-armed-withdrawal": "invalid",
+		"evt-withdrawal":       "applied",
+	}
+	for _, res := range results {
+		if want := wantStatus[res.EventID]; res.Status != want {
+			t.Errorf("event %q status = %q (%s), want %q", res.EventID, res.Status, res.Error, want)
+		}
+		if res.Status == "invalid" && res.Error == "" {
+			t.Errorf("event %q invalid without a reason", res.EventID)
+		}
+	}
+
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	if len(sink.observations) != 2 {
+		t.Fatalf("sink received %d observations, want 2 (valid + withdrawal)", len(sink.observations))
+	}
+	withdrawal := sink.observations[1]
+	if !withdrawal.Withdrawn || len(withdrawal.Payload) != 0 {
+		t.Errorf("withdrawal = %+v, want Withdrawn with no payload", withdrawal)
+	}
+}
+
+func TestObservationsStorageErrorFailsBatch(t *testing.T) {
+	sink := &fakeObservationSink{upsertErr: fmt.Errorf("disk on fire")}
+	srv := newObservationsServer(t, sink)
+	body := `{"client_id":"device-1","events":[` + validEvent("evt-1") + `]}`
+
+	resp := postObservations(t, srv.URL, "alice-token", body)
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 so the client retries the batch", resp.StatusCode)
+	}
+}
+
+func TestObservationOutcomesPassThrough(t *testing.T) {
+	sink := &fakeObservationSink{outcome: ObservationSuperseded}
+	srv := newObservationsServer(t, sink)
+	body := `{"client_id":"device-1","events":[` + validEvent("evt-old") + `]}`
+
+	resp := postObservations(t, srv.URL, "alice-token", body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	results := decodeResults(t, resp)
+	if len(results) != 1 || results[0].Status != "superseded" {
+		t.Fatalf("results = %+v, want superseded", results)
+	}
+}

--- a/internal/server/api/server.go
+++ b/internal/server/api/server.go
@@ -86,6 +86,7 @@ type Server struct {
 	owuTracker                         *OWUTracker
 	webServer                          WebServerRegistrar
 	companionHandler                   http.Handler
+	companionObservationsHandler       http.Handler
 	modelRegistry                      *fleet.Registry
 	contactStore                       *contacts.Store
 	loopDefinitionRegistry             *looppkg.DefinitionRegistry
@@ -158,6 +159,13 @@ func (s *Server) SetWebServer(ws WebServerRegistrar) {
 // companion app connections.
 func (s *Server) SetCompanionHandler(h http.Handler) {
 	s.companionHandler = h
+}
+
+// SetCompanionObservationsHandler configures the authenticated
+// observation-ingestion endpoint for companion devices that cannot
+// hold a WebSocket (#1437).
+func (s *Server) SetCompanionObservationsHandler(h http.Handler) {
+	s.companionObservationsHandler = h
 }
 
 // UseContactStore configures the native contact-directory API.
@@ -538,6 +546,15 @@ func (s *Server) Start(ctx context.Context) error {
 	// so the routes, the coverage allowlist, and the sunset gate share
 	// one source of truth (#1084). The handler emits deprecation signals
 	// and usage telemetry when a connection arrives on an alias.
+	// Companion background ingestion: bearer-authenticated pushes from
+	// devices that are offline in WebSocket terms (a phone waking for a
+	// background event). Unlike the rest of the native surface, this
+	// route enforces its own authentication — it is designed to be
+	// reachable by roaming devices.
+	if s.companionObservationsHandler != nil {
+		mux.Handle("POST /v1/companion/observations", s.companionObservationsHandler)
+	}
+
 	if s.companionHandler != nil {
 		mux.Handle("GET /v1/realtime/ws", s.companionHandler)
 		for _, alias := range legacyroute.Aliases {

--- a/internal/server/openapi/native.yaml
+++ b/internal/server/openapi/native.yaml
@@ -21,7 +21,10 @@ info:
     Each operation below carries an `x-thane-scope` extension naming the
     permission it will require once authorization is enforced. Today the API is
     open behind the network boundary; the contract is declared first so the
-    explorer, the UIs, and the eventual middleware all agree on the shape.
+    explorer, the UIs, and the eventual middleware all agree on the shape. One
+    exception enforces authentication already: `POST /v1/companion/observations`
+    requires a companion device token, because it is designed to be reachable
+    by roaming devices.
 
     - **AuthN:** bearer token (`Authorization: Bearer <token>`). The scheme is
       written OIDC-ready; tokens are minted directly for now.
@@ -31,7 +34,7 @@ info:
       `archive:read`,
       `checkpoints:read`, `checkpoints:write`, `models:read`, `models:admin`,
       `telemetry:read`, `contacts:read`, `contacts:write`, `identity:read`,
-      `system:read`.
+      `system:read`, `companion:ingest`.
     - **Roles** bundle scopes: `observer` (all `:read`), `operator`
       (observer + `definitions:write`, `sessions:write`, `checkpoints:write`),
       `admin` (everything, incl. `models:admin`, `contacts:write`).
@@ -86,6 +89,8 @@ tags:
     description: Durable instance identity and core provenance evidence.
   - name: Realtime
     description: WebSocket channel for first-party live interaction.
+  - name: Companion
+    description: Companion-device surfaces that work while the device is offline in WebSocket terms.
 
 externalDocs:
   description: Source, architecture, and contributor guides on GitHub.
@@ -105,7 +110,7 @@ x-tagGroups:
   - name: Integrations & Data
     tags: [Contacts]
   - name: Runtime
-    tags: [Identity, System, Realtime]
+    tags: [Identity, System, Realtime, Companion]
 
 paths:
   # --------------------------------------------------------------- Identity
@@ -1223,6 +1228,58 @@ paths:
       responses:
         "101": { description: Switching Protocols (WebSocket). }
 
+  # -------------------------------------------------------------- Companion
+  /v1/companion/observations:
+    post:
+      tags: [Companion]
+      operationId: ingestCompanionObservations
+      summary: Ingest background observations from a companion device
+      description: |
+        Authenticated HTTPS push path for companion devices that cannot hold a
+        WebSocket — an iPhone waking briefly for a background system event
+        drains its observation outbox here. Unlike the rest of the native
+        surface, this operation enforces its bearer token today: the token is
+        a companion token (`companion.providers.<account>.tokens[]`), it alone
+        determines the account, and every accepted `client_id` is bound to
+        that account. A successful upload means the device was recently seen;
+        it does not make the device live or remotely callable.
+
+        Limits: body ≤ 262144 bytes, ≤ 64 events per batch, ≤ 16384 bytes per
+        event payload. Events are validated individually — one bad event earns
+        an `invalid` verdict without failing its batch — and every per-event
+        verdict is terminal for the client's outbox entry. Replaying an
+        accepted `event_id` is idempotent (`duplicate`), and an event older
+        than the stored observation of its kind is `superseded`, so retrying a
+        whole batch after a 5xx is always safe.
+      x-thane-scope: companion:ingest
+      requestBody:
+        required: true
+        description: A bounded batch of observations from one device.
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/CompanionObservationBatch" }
+            example:
+              client_id: 6A0C3F62-6E1B-4E1E-9A3C-2B6F16E6D0A4
+              events:
+                - event_id: 0d1f8a6e-4c2b-4b7e-9f00-3a7d0e2c9b41
+                  kind: ios.location
+                  schema_version: 1
+                  observed_at: "2026-08-29T19:42:00Z"
+                  payload: { latitude: 41.0, longitude: -87.0, horizontal_accuracy_m: 24.0 }
+      responses:
+        "200":
+          description: Per-event verdicts, in batch order.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/CompanionObservationResults" }
+              example:
+                results:
+                  - event_id: 0d1f8a6e-4c2b-4b7e-9f00-3a7d0e2c9b41
+                    status: applied
+        "400": { description: "Malformed body, missing client_id, empty batch, or too many events." }
+        "401": { description: Invalid or missing companion token. }
+        "413": { description: Request body exceeds the documented limit. }
+
 components:
   securitySchemes:
     bearerAuth:
@@ -1283,6 +1340,88 @@ components:
           schema: { $ref: "#/components/schemas/Error" }
 
   schemas:
+    CompanionObservationBatch:
+      type: object
+      required: [client_id, events]
+      example:
+        client_id: 6A0C3F62-6E1B-4E1E-9A3C-2B6F16E6D0A4
+        events:
+          - event_id: 0d1f8a6e-4c2b-4b7e-9f00-3a7d0e2c9b41
+            kind: ios.location
+            schema_version: 1
+            observed_at: "2026-08-29T19:42:00Z"
+            payload: { latitude: 41.0, longitude: -87.0, horizontal_accuracy_m: 24.0 }
+      properties:
+        client_id:
+          type: string
+          description: The device's stable identity claim — the same value it presents during WebSocket authentication.
+          example: 6A0C3F62-6E1B-4E1E-9A3C-2B6F16E6D0A4
+        events:
+          type: array
+          minItems: 1
+          maxItems: 64
+          description: The observations to ingest, at most 64 per request.
+          example:
+            - event_id: 0d1f8a6e-4c2b-4b7e-9f00-3a7d0e2c9b41
+              kind: ios.location
+              schema_version: 1
+              observed_at: "2026-08-29T19:42:00Z"
+              payload: { latitude: 41.0, longitude: -87.0 }
+          items: { $ref: "#/components/schemas/CompanionObservationEvent" }
+    CompanionObservationEvent:
+      type: object
+      required: [event_id, kind, schema_version, observed_at]
+      properties:
+        event_id:
+          type: string
+          maxLength: 128
+          description: Client-generated idempotency key for this event; replays are acknowledged as duplicates.
+          example: 0d1f8a6e-4c2b-4b7e-9f00-3a7d0e2c9b41
+        kind:
+          type: string
+          description: "Observation kind, matching `[a-z0-9][a-z0-9._-]{0,63}`."
+          example: ios.location
+        schema_version:
+          type: integer
+          minimum: 1
+          description: Version of the payload schema for this kind.
+          example: 1
+        observed_at:
+          type: string
+          format: date-time
+          description: Device-supplied observation time (RFC 3339). Recorded independently from the server's authoritative receipt time; may not claim more than 5 minutes into the future, and arbitrarily old catch-up uploads are legal.
+          example: "2026-08-29T19:42:00Z"
+        withdrawn:
+          type: boolean
+          description: "True erases the stored observation of this kind — sharing was disabled or OS permission became insufficient. A withdrawn event must not carry a payload."
+        payload:
+          type: object
+          additionalProperties: true
+          description: Observation data, ≤ 16384 bytes. Required unless withdrawn.
+          example: { latitude: 41.0, longitude: -87.0, horizontal_accuracy_m: 24.0 }
+    CompanionObservationResults:
+      type: object
+      required: [results]
+      properties:
+        results:
+          type: array
+          description: One verdict per submitted event, in batch order. Every verdict is terminal for the client's outbox entry.
+          example:
+            - event_id: 0d1f8a6e-4c2b-4b7e-9f00-3a7d0e2c9b41
+              status: applied
+          items:
+            type: object
+            required: [event_id, status]
+            properties:
+              event_id: { type: string, example: 0d1f8a6e-4c2b-4b7e-9f00-3a7d0e2c9b41 }
+              status:
+                type: string
+                enum: [applied, duplicate, superseded, invalid]
+                description: applied = stored as the latest observation of its kind; duplicate = this event_id was already accepted; superseded = a newer observation is already stored; invalid = the event failed validation and will not improve on retry.
+                example: applied
+              error:
+                type: string
+                description: Validation failure reason; present only for invalid events.
     Error:
       type: object
       description: Standard error envelope returned for any 4xx/5xx response.

--- a/internal/state/companions/observations.go
+++ b/internal/state/companions/observations.go
@@ -1,0 +1,211 @@
+package companions
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/companion"
+)
+
+// Observation status values. A withdrawn row keeps its provenance
+// (kind, times, event id) but its payload is cleared — previously
+// stored data must not continue to appear available after the operator
+// or the OS revokes sharing (#1437).
+const (
+	ObservationStatusPresent   = "present"
+	ObservationStatusWithdrawn = "withdrawn"
+)
+
+// StoredObservation is the latest observation of one kind from one
+// device. ObservedAt is the device's claim; ReceivedAt is the server's
+// authoritative receipt time. Withdrawn rows carry an empty payload.
+type StoredObservation struct {
+	DeviceID      string
+	Kind          string
+	EventID       string
+	SchemaVersion int
+	ObservedAt    time.Time
+	ReceivedAt    time.Time
+	Withdrawn     bool
+	Payload       json.RawMessage
+}
+
+// EnsureDevice resolves (account, client_id) to the immutable
+// device_id, creating the inventory row if the device has never been
+// seen — a companion may push its first background observation before
+// it ever connects a WebSocket — and MIN/MAX-guarding the seen
+// timestamps either way. It never stamps connection times: an HTTPS
+// upload means "recently seen", not "connected" (#1437). Implements
+// [companion.ObservationSink].
+func (s *Store) EnsureDevice(ctx context.Context, account, clientID string, seenAt time.Time) (string, error) {
+	if err := validateKey(account, clientID); err != nil {
+		return "", err
+	}
+	seenAt = normalizeTime(seenAt)
+
+	deviceID, err := generateDeviceID()
+	if err != nil {
+		return "", fmt.Errorf("ensure companion device %s/%s: %w", account, clientID, err)
+	}
+	if _, err := s.db.ExecContext(ctx, `
+		INSERT INTO companion_devices (
+			device_id, account, client_id, first_seen_at, last_seen_at, state
+		) VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(account, client_id) DO UPDATE SET
+			first_seen_at = MIN(companion_devices.first_seen_at, excluded.first_seen_at),
+			last_seen_at  = MAX(companion_devices.last_seen_at, excluded.last_seen_at)
+	`, deviceID, account, clientID, seenAt, seenAt, DeviceStateActive); err != nil {
+		return "", fmt.Errorf("ensure companion device %s/%s: %w", account, clientID, err)
+	}
+
+	var stored string
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT device_id FROM companion_devices WHERE account = ? AND client_id = ?`,
+		account, clientID,
+	).Scan(&stored); err != nil {
+		return "", fmt.Errorf("ensure companion device %s/%s: %w", account, clientID, err)
+	}
+	return stored, nil
+}
+
+// UpsertObservation applies latest-only semantics for one
+// (device, kind): the newest observation by device-claimed observed_at
+// wins, an exact event_id replay is a duplicate, and anything older
+// than (or tied with) the stored observation is superseded. Verdicts
+// are decided and written inside one transaction so racing uploads
+// serialize. Implements [companion.ObservationSink].
+func (s *Store) UpsertObservation(ctx context.Context, deviceID string, obs companion.Observation) (companion.ObservationOutcome, error) {
+	deviceID = strings.TrimSpace(deviceID)
+	if deviceID == "" {
+		return "", fmt.Errorf("device_id is required")
+	}
+	if strings.TrimSpace(obs.EventID) == "" || strings.TrimSpace(obs.Kind) == "" {
+		return "", fmt.Errorf("event_id and kind are required")
+	}
+	obs.ObservedAt = normalizeTime(obs.ObservedAt)
+	obs.ReceivedAt = normalizeTime(obs.ReceivedAt)
+
+	status := ObservationStatusPresent
+	payload := string(obs.Payload)
+	if obs.Withdrawn {
+		status = ObservationStatusWithdrawn
+		payload = "{}"
+	} else if payload == "" {
+		payload = "{}"
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return "", fmt.Errorf("upsert observation %s/%s: %w", deviceID, obs.Kind, err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var (
+		storedEventID    string
+		storedObservedAt time.Time
+	)
+	err = tx.QueryRowContext(ctx,
+		`SELECT event_id, observed_at FROM companion_observations WHERE device_id = ? AND kind = ?`,
+		deviceID, obs.Kind,
+	).Scan(&storedEventID, &storedObservedAt)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO companion_observations (
+				device_id, kind, event_id, schema_version,
+				observed_at, received_at, payload, status
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		`, deviceID, obs.Kind, obs.EventID, obs.SchemaVersion,
+			obs.ObservedAt, obs.ReceivedAt, payload, status); err != nil {
+			return "", fmt.Errorf("insert observation %s/%s: %w", deviceID, obs.Kind, err)
+		}
+	case err != nil:
+		return "", fmt.Errorf("read observation %s/%s: %w", deviceID, obs.Kind, err)
+	case storedEventID == obs.EventID:
+		// Replay of an accepted event: idempotent, nothing to write.
+		return companion.ObservationDuplicate, nil
+	case obs.ObservedAt.After(storedObservedAt.UTC()):
+		if _, err := tx.ExecContext(ctx, `
+			UPDATE companion_observations
+			SET event_id = ?, schema_version = ?, observed_at = ?,
+			    received_at = ?, payload = ?, status = ?
+			WHERE device_id = ? AND kind = ?
+		`, obs.EventID, obs.SchemaVersion, obs.ObservedAt,
+			obs.ReceivedAt, payload, status, deviceID, obs.Kind); err != nil {
+			return "", fmt.Errorf("update observation %s/%s: %w", deviceID, obs.Kind, err)
+		}
+	default:
+		// Older than the stored observation, or a distinct event tied
+		// with it — either way the stored row is at least as current.
+		return companion.ObservationSuperseded, nil
+	}
+
+	if err := tx.Commit(); err != nil {
+		return "", fmt.Errorf("commit observation %s/%s: %w", deviceID, obs.Kind, err)
+	}
+	return companion.ObservationApplied, nil
+}
+
+// GetObservation returns the latest observation of one kind for a
+// device. The boolean reports existence; a missing row is not an error.
+func (s *Store) GetObservation(ctx context.Context, deviceID, kind string) (StoredObservation, bool, error) {
+	rows, err := s.scanObservations(ctx, `
+		SELECT device_id, kind, event_id, schema_version,
+		       observed_at, received_at, payload, status
+		FROM companion_observations
+		WHERE device_id = ? AND kind = ?
+	`, deviceID, kind)
+	if err != nil {
+		return StoredObservation{}, false, err
+	}
+	if len(rows) == 0 {
+		return StoredObservation{}, false, nil
+	}
+	return rows[0], true, nil
+}
+
+// ListObservations returns every latest observation for a device,
+// ordered by kind for a stable shape.
+func (s *Store) ListObservations(ctx context.Context, deviceID string) ([]StoredObservation, error) {
+	return s.scanObservations(ctx, `
+		SELECT device_id, kind, event_id, schema_version,
+		       observed_at, received_at, payload, status
+		FROM companion_observations
+		WHERE device_id = ?
+		ORDER BY kind ASC
+	`, deviceID)
+}
+
+func (s *Store) scanObservations(ctx context.Context, query string, args ...any) ([]StoredObservation, error) {
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []StoredObservation
+	for rows.Next() {
+		var (
+			o       StoredObservation
+			payload string
+			status  string
+		)
+		if err := rows.Scan(
+			&o.DeviceID, &o.Kind, &o.EventID, &o.SchemaVersion,
+			&o.ObservedAt, &o.ReceivedAt, &payload, &status,
+		); err != nil {
+			return nil, err
+		}
+		o.ObservedAt = o.ObservedAt.UTC()
+		o.ReceivedAt = o.ReceivedAt.UTC()
+		o.Withdrawn = status == ObservationStatusWithdrawn
+		o.Payload = json.RawMessage(payload)
+		out = append(out, o)
+	}
+	return out, rows.Err()
+}

--- a/internal/state/companions/observations_test.go
+++ b/internal/state/companions/observations_test.go
@@ -1,0 +1,209 @@
+package companions
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/companion"
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
+)
+
+func testObservation(eventID string, observedAt time.Time) companion.Observation {
+	return companion.Observation{
+		EventID:       eventID,
+		Kind:          "ios.location",
+		SchemaVersion: 1,
+		ObservedAt:    observedAt,
+		ReceivedAt:    observedAt.Add(time.Minute),
+		Payload:       []byte(`{"latitude":41.0,"longitude":-87.0}`),
+	}
+}
+
+func TestEnsureDeviceCreatesAndReuses(t *testing.T) {
+	store := newTestStore(t)
+
+	// First contact over HTTPS: the row is created with seen stamps
+	// only — an upload is not a connection.
+	id1, err := store.EnsureDevice(ctx, "alice", "device-1", t0)
+	if err != nil {
+		t.Fatalf("EnsureDevice: %v", err)
+	}
+	d, ok, err := store.Get(ctx, "alice", "device-1")
+	if err != nil || !ok {
+		t.Fatalf("Get: ok=%v err=%v", ok, err)
+	}
+	if d.DeviceID != id1 {
+		t.Errorf("DeviceID = %q, want %q", d.DeviceID, id1)
+	}
+	if !d.FirstSeenAt.Equal(t0) || !d.LastSeenAt.Equal(t0) {
+		t.Errorf("seen stamps: first=%v last=%v, want %v", d.FirstSeenAt, d.LastSeenAt, t0)
+	}
+	if !d.LastConnectedAt.IsZero() {
+		t.Errorf("EnsureDevice stamped a connection time: %v", d.LastConnectedAt)
+	}
+
+	// A later upload reuses the identity and bumps last_seen.
+	id2, err := store.EnsureDevice(ctx, "alice", "device-1", t1)
+	if err != nil {
+		t.Fatalf("EnsureDevice again: %v", err)
+	}
+	if id2 != id1 {
+		t.Errorf("device identity changed across uploads: %q → %q", id1, id2)
+	}
+	d, _, _ = store.Get(ctx, "alice", "device-1")
+	if !d.FirstSeenAt.Equal(t0) || !d.LastSeenAt.Equal(t1) {
+		t.Errorf("seen stamps after second upload: first=%v last=%v", d.FirstSeenAt, d.LastSeenAt)
+	}
+}
+
+func TestEnsureDeviceMatchesConnectedDevice(t *testing.T) {
+	store := newTestStore(t)
+	if err := store.RecordConnected(ctx, "alice", "device-1", companion.DeviceMetadata{Platform: "ios"}, t0); err != nil {
+		t.Fatalf("RecordConnected: %v", err)
+	}
+	viaWS, _, err := store.Get(ctx, "alice", "device-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	viaHTTP, err := store.EnsureDevice(ctx, "alice", "device-1", t1)
+	if err != nil {
+		t.Fatalf("EnsureDevice: %v", err)
+	}
+	if viaHTTP != viaWS.DeviceID {
+		t.Errorf("HTTPS upload resolved a different device: %q vs %q", viaHTTP, viaWS.DeviceID)
+	}
+}
+
+func TestUpsertObservationLatestOnly(t *testing.T) {
+	store := newTestStore(t)
+	deviceID, err := store.EnsureDevice(ctx, "alice", "device-1", t0)
+	if err != nil {
+		t.Fatalf("EnsureDevice: %v", err)
+	}
+
+	// First observation applies.
+	out, err := store.UpsertObservation(ctx, deviceID, testObservation("evt-1", t0))
+	if err != nil || out != companion.ObservationApplied {
+		t.Fatalf("first upsert: outcome=%v err=%v", out, err)
+	}
+
+	// Exact replay is a duplicate and writes nothing.
+	out, err = store.UpsertObservation(ctx, deviceID, testObservation("evt-1", t0))
+	if err != nil || out != companion.ObservationDuplicate {
+		t.Fatalf("replay: outcome=%v err=%v", out, err)
+	}
+
+	// A newer observation replaces the row.
+	newer := testObservation("evt-2", t1)
+	newer.Payload = []byte(`{"latitude":42.0,"longitude":-88.0}`)
+	out, err = store.UpsertObservation(ctx, deviceID, newer)
+	if err != nil || out != companion.ObservationApplied {
+		t.Fatalf("newer upsert: outcome=%v err=%v", out, err)
+	}
+
+	// An older distinct event is superseded and cannot regress state.
+	out, err = store.UpsertObservation(ctx, deviceID, testObservation("evt-0", t0))
+	if err != nil || out != companion.ObservationSuperseded {
+		t.Fatalf("older upsert: outcome=%v err=%v", out, err)
+	}
+
+	obs, ok, err := store.GetObservation(ctx, deviceID, "ios.location")
+	if err != nil || !ok {
+		t.Fatalf("GetObservation: ok=%v err=%v", ok, err)
+	}
+	if obs.EventID != "evt-2" || !obs.ObservedAt.Equal(t1) {
+		t.Errorf("stored observation = %s @ %v, want evt-2 @ %v", obs.EventID, obs.ObservedAt, t1)
+	}
+	if string(obs.Payload) != `{"latitude":42.0,"longitude":-88.0}` {
+		t.Errorf("payload = %s", obs.Payload)
+	}
+	if !obs.ReceivedAt.Equal(t1.Add(time.Minute)) {
+		t.Errorf("ReceivedAt = %v, want independent receipt time %v", obs.ReceivedAt, t1.Add(time.Minute))
+	}
+}
+
+func TestWithdrawalClearsPayload(t *testing.T) {
+	store := newTestStore(t)
+	deviceID, err := store.EnsureDevice(ctx, "alice", "device-1", t0)
+	if err != nil {
+		t.Fatalf("EnsureDevice: %v", err)
+	}
+	if _, err := store.UpsertObservation(ctx, deviceID, testObservation("evt-1", t0)); err != nil {
+		t.Fatalf("seed observation: %v", err)
+	}
+
+	withdrawal := companion.Observation{
+		EventID:       "evt-2",
+		Kind:          "ios.location",
+		SchemaVersion: 1,
+		ObservedAt:    t1,
+		ReceivedAt:    t1,
+		Withdrawn:     true,
+	}
+	out, err := store.UpsertObservation(ctx, deviceID, withdrawal)
+	if err != nil || out != companion.ObservationApplied {
+		t.Fatalf("withdrawal: outcome=%v err=%v", out, err)
+	}
+
+	obs, ok, err := store.GetObservation(ctx, deviceID, "ios.location")
+	if err != nil || !ok {
+		t.Fatalf("GetObservation: ok=%v err=%v", ok, err)
+	}
+	if !obs.Withdrawn {
+		t.Error("observation not marked withdrawn")
+	}
+	if string(obs.Payload) != "{}" {
+		t.Errorf("withdrawn payload = %s, want cleared", obs.Payload)
+	}
+
+	// Sharing re-enabled: a newer present observation resurrects data.
+	restored := testObservation("evt-3", t2)
+	out, err = store.UpsertObservation(ctx, deviceID, restored)
+	if err != nil || out != companion.ObservationApplied {
+		t.Fatalf("restore: outcome=%v err=%v", out, err)
+	}
+	obs, _, _ = store.GetObservation(ctx, deviceID, "ios.location")
+	if obs.Withdrawn || string(obs.Payload) == "{}" {
+		t.Errorf("restore did not take: withdrawn=%v payload=%s", obs.Withdrawn, obs.Payload)
+	}
+}
+
+func TestObservationsSurviveReopen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "thane.db")
+	db, err := database.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	store, err := NewStore(db, nil)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	deviceID, err := store.EnsureDevice(ctx, "alice", "device-1", t0)
+	if err != nil {
+		t.Fatalf("EnsureDevice: %v", err)
+	}
+	if _, err := store.UpsertObservation(ctx, deviceID, testObservation("evt-1", t0)); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	db2, err := database.Open(path)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer db2.Close()
+	store2, err := NewStore(db2, nil)
+	if err != nil {
+		t.Fatalf("remigrate: %v", err)
+	}
+	obs, ok, err := store2.GetObservation(ctx, deviceID, "ios.location")
+	if err != nil || !ok {
+		t.Fatalf("observation lost across restart: ok=%v err=%v", ok, err)
+	}
+	if obs.EventID != "evt-1" || !obs.ObservedAt.Equal(t0) {
+		t.Errorf("observation degraded across restart: %+v", obs)
+	}
+}

--- a/internal/state/companions/schema.go
+++ b/internal/state/companions/schema.go
@@ -40,5 +40,26 @@ var devicesSchema = database.Schema{
 				UNIQUE (account, client_id)
 			)`,
 		},
+		// companion_observations holds the latest observation per
+		// (device, kind) — one current record, not a history (#1437's
+		// deliberate retention contract). Rows reference the immutable
+		// device_id so they survive credential rotation (#1444).
+		// observed_at is the device's claim, received_at the server's
+		// receipt time; status 'withdrawn' keeps provenance while the
+		// payload is cleared.
+		database.TableCreate{
+			Table: "companion_observations",
+			SQL: `CREATE TABLE IF NOT EXISTS companion_observations (
+				device_id      TEXT NOT NULL,
+				kind           TEXT NOT NULL,
+				event_id       TEXT NOT NULL,
+				schema_version INTEGER NOT NULL,
+				observed_at    TIMESTAMP NOT NULL,
+				received_at    TIMESTAMP NOT NULL,
+				payload        TEXT NOT NULL DEFAULT '{}',
+				status         TEXT NOT NULL DEFAULT 'present',
+				PRIMARY KEY (device_id, kind)
+			)`,
+		},
 	},
 }

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=69
-interfaces=84
+interfaces=86
 large_files=58
-set_mutators=119
+set_mutators=120
 database_opens=9


### PR DESCRIPTION
Second slice of #1437, and the critical path for `thane-agent-ios`: an offline companion can now push observations without holding a WebSocket. iOS wakes the app for an approved system event, the app drains its durable outbox to `POST /v1/companion/observations`, and Thane remembers what the phone last reported — with observation time and receipt time recorded independently and never conflated. Builds directly on #1445's inventory: observation rows reference the immutable `device_id`, so they survive the credential rotation #1444 will make routine.

## The store

`companion_observations` keeps one current record per `(device, kind)` — a latest-observation store, not a location history, per the issue's deliberate retention contract. Verdicts are decided inside a transaction with latest-only semantics: the newest device-claimed `observed_at` wins, an exact `event_id` replay is a `duplicate`, and anything older (or tied with a distinct event) is `superseded`. Every verdict is terminal for the client's outbox entry, which makes the retry story trivial: a batch that hits a 5xx is retried verbatim, and idempotency absorbs it.

A withdrawal event clears the stored payload while keeping provenance (kind, times, event id) — revoked sharing must not leave precise location looking available — and a newer present observation resurrects the kind when sharing returns.

`EnsureDevice` gives background-only devices an inventory row: a phone that pushes before ever connecting a WebSocket still becomes a known companion, with MIN/MAX-guarded seen timestamps but no connection stamps. A successful upload means *recently seen*, never *live*.

## The endpoint

Ingestion is transport-independent behind two seams, exactly as promised on the issue. The `ObservationSink` interface is the storage contract; the `ObservationAuthenticator` interface resolves a bearer credential to an account — and this is deliberately the **first enforced authentication on a native route**, because unlike the rest of the surface this endpoint is designed to be reachable by roaming devices. The bearer implementation compares every configured companion token in constant time and never breaks early on a match; #1444 swaps in RFC 9421 signature verification behind the same interface without touching ingestion. The token alone determines the account; every accepted `client_id` is bound to it; the request body never gets a vote.

Limits are documented API contract, carried identically in code and `native.yaml`: body ≤ 256 KiB, ≤ 64 events per batch, ≤ 16 KiB per payload. Events validate individually — a malformed timestamp, a clock claiming the future beyond 5 minutes of skew, a clock reporting 1999, a non-object payload, or a withdrawal smuggling data each earn a terminal `invalid` verdict with a reason, without failing the batch around them. `observed_at` is wire-typed as a string precisely so one bad timestamp invalidates one event rather than the whole decode. Logs carry accounts, counts, and kinds; never payloads, never tokens.

## Contract surfaces

`native.yaml` declares the route with the new `companion:ingest` scope, a new `Companion` tag, full request/response schemas with examples, and an honest note that this one operation enforces authentication today. `docs/reference/api.md` carries the row. The route-coverage bijection and the OpenAPI lint gate both hold.

## For the iOS agent

The wire contract matches the issue's sketch with these specifics: `observed_at` is RFC 3339; per-event verdicts come back as `applied` / `duplicate` / `superseded` / `invalid`, all terminal (delete the outbox entry on any of them); batch-level failures are 400 (malformed, terminal), 401 (token), 413 (too big — split the batch), and 5xx (retry the batch verbatim). Withdrawals are `"withdrawn": true` with no payload. The `client_id` must be the same stable value used for WebSocket auth.

## Verification

- [x] An authenticated offline companion can submit a bounded batch over HTTPS (handler tests, full flow)
- [x] Replaying an accepted `event_id` is idempotent and cannot duplicate or regress state (`TestUpsertObservationLatestOnly`)
- [x] `received_at` recorded independently from `observed_at`; malformed and implausible timestamps handled explicitly (`TestObservationsPerEventValidation`)
- [x] A withdrawal prevents previously stored precise location from appearing available (`TestWithdrawalClearsPayload`)
- [x] One account cannot create, overwrite, or read another account's device data — the token determines the account, the body never does (`TestObservationsBindsAccountFromToken`)
- [x] Body, event-count, and payload limits documented and enforced (`TestObservationsBatchValidation`)
- [x] Observations survive a process restart (`TestObservationsSurviveReopen`)
- [x] Logs and errors expose no bearer tokens or precise payloads
- [x] Mux registration, `native.yaml`, and `docs/reference/api.md` describe the same route and schemas (coverage bijection + vacuum lint)
- [x] `just ci` passes locally

Refs #1437

🤖 Generated with [Claude Code](https://claude.com/claude-code)
