### PR TITLE
fix(signal): declare message provenance per turn shape

### DIFF
--- a/internal/app/adapters.go
+++ b/internal/app/adapters.go
@@ -1059,6 +1059,7 @@ func compileLoopAgentRequest(req looppkg.Request) *agent.Request {
 	msgs := make([]agent.Message, len(req.Messages))
 	for i, m := range req.Messages {
 		msgs[i] = agent.Message{
+			Origin:  m.Origin,
 			Role:    m.Role,
 			Content: m.Content,
 			Images:  append([]llm.ImageContent(nil), m.Images...),

--- a/internal/channels/messaging/signal/bridge.go
+++ b/internal/channels/messaging/signal/bridge.go
@@ -766,7 +766,11 @@ func (b *Bridge) prepareSignalMailboxTurn(ctx context.Context, sender string, it
 		"signal_batch_turn": len(items) > 1,
 	}
 	if notifySummary := loop.FormatNotifyEnvelopes(notifies); notifySummary != "" {
-		msgs = append(msgs, loop.Message{Role: "user", Content: notifySummary})
+		// Origin wake on the message itself: the notify summary rides a
+		// contact turn but is not counterparty traffic, and a channel-
+		// stamped row here would sit adjacent to the inbound rows and
+		// masquerade as the previous contact.
+		msgs = append(msgs, loop.Message{Role: "user", Content: notifySummary, Origin: memory.OriginWake})
 		summary["notification_count"] = len(notifies)
 	}
 	skipped := 0
@@ -823,10 +827,16 @@ func (b *Bridge) prepareSignalMailboxTurn(ctx context.Context, sender string, it
 		}
 		scaffold.opts = b.requestOptions(sender, hints)
 	}
-	// OriginChannel even when notify envelopes ride along: a mailbox
-	// turn exists because counterparty traffic arrived, and the single
-	// per-request stamp describes the turn's contact-bearing shape.
-	turn := b.agentTurnMessages(scaffold.convID, scaffold.channelBinding, msgs, scaffold.opts, summary, memory.OriginChannel)
+	// The request stamp follows what actually survived rendering: any
+	// counterparty message makes this a contact turn, while a turn
+	// reduced to the notify summary alone (every mailbox item skipped)
+	// is a wake in contact clothing and must not read as new contact.
+	// The notify row itself carries its own wake override either way.
+	origin := memory.OriginWake
+	if messageCount > 0 {
+		origin = memory.OriginChannel
+	}
+	turn := b.agentTurnMessages(scaffold.convID, scaffold.channelBinding, msgs, scaffold.opts, summary, origin)
 	// Mid-turn input merge (#1221): let the loop pull messages that arrive
 	// while this turn is composing, rendered in channel voice. The loop owns
 	// delta-gating, the drain budget, and the ack; this only renders. Close
@@ -1075,16 +1085,19 @@ func (b *Bridge) agentTurn(convID string, binding *memory.ChannelBinding, conten
 // this bridge produces. origin is the provenance stamped onto the
 // turn's messages (memory.Origin* constants) and each caller declares
 // its own truth: turns carrying counterparty traffic — inbound
-// envelopes, reactions, mailbox batches — declare OriginChannel, and
-// the pure loop-notification wake declares OriginWake. One stamp for
-// every bridge turn would poison the conversation-timing narrative in
-// one direction or the other: a wake stamped channel renders the
-// contact branch on a turn with no new message and moves the previous
-// contact, erasing the very silence the next turn should report.
-// RuntimeTags stays message_channel on every shape — the tag is what
-// keeps the channel context (including the wake branch of the timing
-// narrative) active, and it is runtime-only, so it must be asserted
-// here or not at all.
+// envelopes, reactions, mailbox batches with surviving messages —
+// declare OriginChannel, and turns that are wakes in substance (the
+// pure loop notification, a mailbox turn reduced to its notify summary)
+// declare OriginWake. A message may carry its own Origin override for
+// mixed turns — the notify summary rides a contact turn as a wake row.
+// One stamp for every bridge turn would poison the conversation-timing
+// narrative in one direction or the other: a wake stamped channel
+// renders the contact branch on a turn with no new message and moves
+// the previous contact, erasing the very silence the next turn should
+// report. RuntimeTags stays message_channel on every shape — the tag is
+// what keeps the channel context (including the wake branch of the
+// timing narrative) active, and it is runtime-only, so it must be
+// asserted here or not at all.
 func (b *Bridge) agentTurnMessages(convID string, binding *memory.ChannelBinding, msgs []loop.Message, opts router.RequestOptions, summary map[string]any, origin string) *loop.AgentTurn {
 	fallbackContent := prompts.InteractiveEmptyResponseFallback
 	return &loop.AgentTurn{

--- a/internal/channels/messaging/signal/bridge.go
+++ b/internal/channels/messaging/signal/bridge.go
@@ -751,7 +751,7 @@ func (b *Bridge) prepareSignalTurn(ctx context.Context, env *Envelope) (*loop.Ag
 	if err != nil || !ok {
 		return nil, err
 	}
-	return b.agentTurnMessages(scaffold.convID, scaffold.channelBinding, []loop.Message{msg}, scaffold.opts, summary), nil
+	return b.agentTurnMessages(scaffold.convID, scaffold.channelBinding, []loop.Message{msg}, scaffold.opts, summary, memory.OriginChannel), nil
 }
 
 func (b *Bridge) prepareSignalMailboxTurn(ctx context.Context, sender string, items []loop.MailboxItem, notifies []messages.Envelope) (*loop.AgentTurn, error) {
@@ -823,7 +823,10 @@ func (b *Bridge) prepareSignalMailboxTurn(ctx context.Context, sender string, it
 		}
 		scaffold.opts = b.requestOptions(sender, hints)
 	}
-	turn := b.agentTurnMessages(scaffold.convID, scaffold.channelBinding, msgs, scaffold.opts, summary)
+	// OriginChannel even when notify envelopes ride along: a mailbox
+	// turn exists because counterparty traffic arrived, and the single
+	// per-request stamp describes the turn's contact-bearing shape.
+	turn := b.agentTurnMessages(scaffold.convID, scaffold.channelBinding, msgs, scaffold.opts, summary, memory.OriginChannel)
 	// Mid-turn input merge (#1221): let the loop pull messages that arrive
 	// while this turn is composing, rendered in channel voice. The loop owns
 	// delta-gating, the drain budget, and the ack; this only renders. Close
@@ -857,13 +860,17 @@ func (b *Bridge) prepareLoopNotificationTurn(ctx context.Context, sender string,
 		"sender":      sender,
 		"wake_reason": "core_attention",
 	})
+	// OriginWake: this turn has no new counterparty message. Stamping
+	// it channel would render the contact branch of the timing
+	// narrative and advance the previous contact — a wake erasing the
+	// very silence it is asking the model to weigh.
 	turn := b.agentTurn(convID, channelBinding, content, opts, map[string]any{
 		"event_type":          "loop_notification",
 		"sender":              sender,
 		"notification_count":  len(envs),
 		"core_attention_wake": true,
 		"fallback_suppressed": true,
-	})
+	}, memory.OriginWake)
 	turn.Request.FallbackContent = ""
 
 	log := b.logger.With(
@@ -1057,14 +1064,28 @@ func (b *Bridge) prepareReactionTurn(_ context.Context, env *Envelope) (*loop.Ag
 	if err != nil || !ok {
 		return nil, err
 	}
-	return b.agentTurnMessages(scaffold.convID, scaffold.channelBinding, []loop.Message{msg}, scaffold.opts, summary), nil
+	return b.agentTurnMessages(scaffold.convID, scaffold.channelBinding, []loop.Message{msg}, scaffold.opts, summary, memory.OriginChannel), nil
 }
 
-func (b *Bridge) agentTurn(convID string, binding *memory.ChannelBinding, content string, opts router.RequestOptions, summary map[string]any) *loop.AgentTurn {
-	return b.agentTurnMessages(convID, binding, []loop.Message{{Role: "user", Content: content}}, opts, summary)
+func (b *Bridge) agentTurn(convID string, binding *memory.ChannelBinding, content string, opts router.RequestOptions, summary map[string]any, origin string) *loop.AgentTurn {
+	return b.agentTurnMessages(convID, binding, []loop.Message{{Role: "user", Content: content}}, opts, summary, origin)
 }
 
-func (b *Bridge) agentTurnMessages(convID string, binding *memory.ChannelBinding, msgs []loop.Message, opts router.RequestOptions, summary map[string]any) *loop.AgentTurn {
+// agentTurnMessages assembles the shared turn shape for every request
+// this bridge produces. origin is the provenance stamped onto the
+// turn's messages (memory.Origin* constants) and each caller declares
+// its own truth: turns carrying counterparty traffic — inbound
+// envelopes, reactions, mailbox batches — declare OriginChannel, and
+// the pure loop-notification wake declares OriginWake. One stamp for
+// every bridge turn would poison the conversation-timing narrative in
+// one direction or the other: a wake stamped channel renders the
+// contact branch on a turn with no new message and moves the previous
+// contact, erasing the very silence the next turn should report.
+// RuntimeTags stays message_channel on every shape — the tag is what
+// keeps the channel context (including the wake branch of the timing
+// narrative) active, and it is runtime-only, so it must be asserted
+// here or not at all.
+func (b *Bridge) agentTurnMessages(convID string, binding *memory.ChannelBinding, msgs []loop.Message, opts router.RequestOptions, summary map[string]any, origin string) *loop.AgentTurn {
 	fallbackContent := prompts.InteractiveEmptyResponseFallback
 	return &loop.AgentTurn{
 		Request: loop.Request{
@@ -1077,7 +1098,7 @@ func (b *Bridge) agentTurnMessages(convID string, binding *memory.ChannelBinding
 			ExcludeTools:     opts.ExcludeTools,
 			InitialTags:      []string{"signal"},
 			RuntimeTags:      []string{"message_channel"},
-			MessageOrigin:    memory.OriginChannel,
+			MessageOrigin:    origin,
 			FallbackContent:  fallbackContent,
 		},
 		Summary: summary,

--- a/internal/channels/messaging/signal/bridge_test.go
+++ b/internal/channels/messaging/signal/bridge_test.go
@@ -2060,3 +2060,87 @@ func TestMergeInitialTags(t *testing.T) {
 		})
 	}
 }
+
+// TestBridge_TurnShapeDeclaresMessageOrigin pins the per-shape
+// provenance contract at the routing seam: a turn that exists because
+// counterparty traffic arrived declares OriginChannel, and the pure
+// loop-notification wake declares OriginWake. One stamp for every
+// bridge turn poisons the conversation-timing narrative in one
+// direction or the other — a wake stamped channel renders the contact
+// branch on a turn with no new message and advances the previous
+// contact, erasing the silence the next turn should report.
+func TestBridge_TurnShapeDeclaresMessageOrigin(t *testing.T) {
+	bridge, _, _, _ := bridgeHelper(t)
+
+	mkItem := func(message string, ts int64) loop.MailboxItem {
+		t.Helper()
+		env := &Envelope{
+			Source:      "+15551234567",
+			SourceName:  "Alice",
+			Timestamp:   ts,
+			DataMessage: &DataMessage{Timestamp: ts, Message: message},
+		}
+		payload, err := json.Marshal(env)
+		if err != nil {
+			t.Fatalf("marshal envelope: %v", err)
+		}
+		return loop.MailboxItem{ID: fmt.Sprintf("signal:%d", ts), Payload: payload}
+	}
+	notify, err := (messages.Envelope{
+		From: messages.Identity{Kind: messages.IdentityLoop, ID: "loop-42", Name: "garage-watch"},
+		To: messages.Destination{
+			Kind:     messages.DestinationLoop,
+			Target:   "signal",
+			Selector: messages.SelectorName,
+		},
+		Type:    messages.TypeSignal,
+		Scope:   []string{loop.CoreAttentionScope},
+		Payload: messages.LoopNotifyPayload{Kind: loop.CoreAttentionRequestKind, Concern: "The reading looks wrong."},
+	}).Normalize(time.Now())
+	if err != nil {
+		t.Fatalf("normalize notification: %v", err)
+	}
+
+	tests := []struct {
+		name  string
+		input loop.TurnInput
+		want  string
+	}{
+		{
+			name:  "mailbox traffic is channel contact",
+			input: loop.TurnInput{MailboxItems: []loop.MailboxItem{mkItem("hello", 1700000000000)}},
+			want:  memory.OriginChannel,
+		},
+		{
+			name: "mailbox traffic with notify riding along stays channel",
+			input: loop.TurnInput{
+				MailboxItems:    []loop.MailboxItem{mkItem("hello", 1700000000000)},
+				NotifyEnvelopes: []messages.Envelope{notify},
+			},
+			want: memory.OriginChannel,
+		},
+		{
+			name:  "pure loop notification is a wake",
+			input: loop.TurnInput{NotifyEnvelopes: []messages.Envelope{notify}},
+			want:  memory.OriginWake,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			turn, err := bridge.buildSignalTurn(context.Background(), "+15551234567", tt.input)
+			if err != nil {
+				t.Fatalf("buildSignalTurn: %v", err)
+			}
+			if turn == nil {
+				t.Fatal("turn is nil")
+			}
+			if turn.Request.MessageOrigin != tt.want {
+				t.Errorf("MessageOrigin = %q, want %q", turn.Request.MessageOrigin, tt.want)
+			}
+			if len(turn.Request.RuntimeTags) != 1 || turn.Request.RuntimeTags[0] != "message_channel" {
+				t.Errorf("RuntimeTags = %#v — the tag that keeps channel context (and the wake narrative) active must survive every shape", turn.Request.RuntimeTags)
+			}
+		})
+	}
+}

--- a/internal/channels/messaging/signal/bridge_test.go
+++ b/internal/channels/messaging/signal/bridge_test.go
@@ -2102,22 +2102,34 @@ func TestBridge_TurnShapeDeclaresMessageOrigin(t *testing.T) {
 	}
 
 	tests := []struct {
-		name  string
-		input loop.TurnInput
-		want  string
+		name           string
+		input          loop.TurnInput
+		want           string
+		wantMsgOrigins []string // per-message Origin overrides, nil to skip
 	}{
 		{
-			name:  "mailbox traffic is channel contact",
-			input: loop.TurnInput{MailboxItems: []loop.MailboxItem{mkItem("hello", 1700000000000)}},
-			want:  memory.OriginChannel,
+			name:           "mailbox traffic is channel contact",
+			input:          loop.TurnInput{MailboxItems: []loop.MailboxItem{mkItem("hello", 1700000000000)}},
+			want:           memory.OriginChannel,
+			wantMsgOrigins: []string{""},
 		},
 		{
-			name: "mailbox traffic with notify riding along stays channel",
+			name: "mailbox traffic with notify riding along stays channel, notify row overrides to wake",
 			input: loop.TurnInput{
 				MailboxItems:    []loop.MailboxItem{mkItem("hello", 1700000000000)},
 				NotifyEnvelopes: []messages.Envelope{notify},
 			},
-			want: memory.OriginChannel,
+			want:           memory.OriginChannel,
+			wantMsgOrigins: []string{memory.OriginWake, ""},
+		},
+		{
+			name: "mailbox turn reduced to its notify summary is a wake",
+			input: loop.TurnInput{
+				MailboxItems:    []loop.MailboxItem{{ID: "signal:bad", Payload: []byte("{not json")}},
+				NotifyEnvelopes: []messages.Envelope{notify},
+			},
+			want:           memory.OriginWake,
+			wantMsgOrigins: []string{memory.OriginWake},
 		},
 		{
 			name:  "pure loop notification is a wake",
@@ -2137,6 +2149,16 @@ func TestBridge_TurnShapeDeclaresMessageOrigin(t *testing.T) {
 			}
 			if turn.Request.MessageOrigin != tt.want {
 				t.Errorf("MessageOrigin = %q, want %q", turn.Request.MessageOrigin, tt.want)
+			}
+			if tt.wantMsgOrigins != nil {
+				if len(turn.Request.Messages) != len(tt.wantMsgOrigins) {
+					t.Fatalf("messages len = %d, want %d", len(turn.Request.Messages), len(tt.wantMsgOrigins))
+				}
+				for i, want := range tt.wantMsgOrigins {
+					if got := turn.Request.Messages[i].Origin; got != want {
+						t.Errorf("message %d Origin = %q, want %q — the notify row must not persist as channel contact", i, got, want)
+					}
+				}
 			}
 			if len(turn.Request.RuntimeTags) != 1 || turn.Request.RuntimeTags[0] != "message_channel" {
 				t.Errorf("RuntimeTags = %#v — the tag that keeps channel context (and the wake narrative) active must survive every shape", turn.Request.RuntimeTags)

--- a/internal/runtime/agent/conversation_scope_seam_test.go
+++ b/internal/runtime/agent/conversation_scope_seam_test.go
@@ -96,3 +96,47 @@ func TestConversationScopeReachesContextProvidersEveryIteration(t *testing.T) {
 	}
 	t.Logf("provider invoked %d times, all fully scoped", len(provider.seen))
 }
+
+// TestPerMessageOriginOverridesRequestStamp pins the storage half of
+// mixed-provenance turns: a message carrying its own Origin is recorded
+// with it, while its siblings inherit the request stamp. Without the
+// override, a notify summary riding a Signal mailbox turn persists as
+// channel contact and can masquerade as the previous contact in the
+// conversation-timing narrative.
+func TestPerMessageOriginOverridesRequestStamp(t *testing.T) {
+	mock := &mockLLM{
+		responses: []*llm.ChatResponse{
+			{
+				Model:       "test-model",
+				Message:     llm.Message{Role: "assistant", Content: "Done."},
+				InputTokens: 100, OutputTokens: 10,
+			},
+		},
+	}
+	loop := buildTestLoop(mock, nil)
+	mem := loop.memory.(*mockMem)
+
+	if _, err := loop.Run(context.Background(), &Request{
+		Messages: []Message{
+			{Role: "user", Content: "notify summary", Origin: memory.OriginWake},
+			{Role: "user", Content: "inbound message"},
+		},
+		ConversationID: "conv-mixed",
+		MessageOrigin:  memory.OriginChannel,
+	}, nil); err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	got := map[string]string{}
+	for _, m := range mem.msgs["conv-mixed"] {
+		if m.Role == "user" {
+			got[m.Content] = m.Origin
+		}
+	}
+	if got["notify summary"] != memory.OriginWake {
+		t.Errorf("override row origin = %q, want %q", got["notify summary"], memory.OriginWake)
+	}
+	if got["inbound message"] != memory.OriginChannel {
+		t.Errorf("inheriting row origin = %q, want %q", got["inbound message"], memory.OriginChannel)
+	}
+}

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -42,6 +42,10 @@ type Message struct {
 	Role    string             `json:"role"` // system, user, assistant
 	Content string             `json:"content"`
 	Images  []llm.ImageContent `json:"-"`
+	// Origin optionally overrides Request.MessageOrigin for this one
+	// message when it is recorded in conversation memory (memory.Origin*
+	// constants). Empty inherits the request stamp.
+	Origin string `json:"-"`
 }
 
 // Request represents an incoming agent request.
@@ -62,7 +66,9 @@ type Request struct {
 	// memory.Origin* constants). Channel bridges declare
 	// memory.OriginChannel, API surfaces memory.OriginAPI; turn-builder
 	// wake requests that declare nothing default to memory.OriginWake in
-	// the loop runtime's request preparation. Empty means unstamped.
+	// the loop runtime's request preparation. Empty means unstamped. A
+	// message carrying its own Message.Origin overrides this stamp for
+	// that one row.
 	MessageOrigin   string                              `json:"-"`
 	SkipContext     bool                                `json:"-"` // Skip memory, tools, and context injection (for lightweight completions)
 	AllowedTools    []string                            `json:"-"` // Optional allowlist of tools visible for this run
@@ -1653,11 +1659,20 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 	if !req.SkipContext {
 		history = l.memory.GetMessages(convID)
 
+		// Per-message Origin overrides the request stamp so one turn can
+		// carry mixed provenance — a notify summary riding a mailbox
+		// batch is a wake row even though the turn is contact.
+		originFor := func(m Message) string {
+			if m.Origin != "" {
+				return m.Origin
+			}
+			return req.MessageOrigin
+		}
 		if strings.HasPrefix(convID, "owu-") {
 			// External client (Open WebUI): only add the last user message
 			for i := len(req.Messages) - 1; i >= 0; i-- {
 				if req.Messages[i].Role == "user" {
-					if err := l.memory.AddMessage(convID, "user", req.Messages[i].Content, req.MessageOrigin); err != nil {
+					if err := l.memory.AddMessage(convID, "user", req.Messages[i].Content, originFor(req.Messages[i])); err != nil {
 						log.Warn("failed to store message", "error", err)
 					}
 					break
@@ -1666,7 +1681,7 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 		} else {
 			// Internal/API clients: store all messages
 			for _, m := range req.Messages {
-				if err := l.memory.AddMessage(convID, m.Role, m.Content, req.MessageOrigin); err != nil {
+				if err := l.memory.AddMessage(convID, m.Role, m.Content, originFor(m)); err != nil {
 					log.Warn("failed to store message", "error", err)
 				}
 			}

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -121,6 +121,14 @@ type Message struct {
 	// runtime-only because persisted loop specs should stay textual and
 	// portable; HTTP ingress paths such as OWU populate it per request.
 	Images []llm.ImageContent `yaml:"-" json:"-"`
+
+	// Origin optionally overrides the request's MessageOrigin for this
+	// one message when it is recorded in conversation memory
+	// (memory.Origin* constants). Turn builders that mix provenance in
+	// a single request use it — a notify summary riding a mailbox turn
+	// is a wake even though the turn is contact. Empty inherits the
+	// request stamp.
+	Origin string `yaml:"-" json:"-"`
 }
 
 // RunMessage is a compatibility alias for [Message], the primary

--- a/internal/server/api/agent_loop_bridge.go
+++ b/internal/server/api/agent_loop_bridge.go
@@ -18,6 +18,7 @@ func loopRequestFromAgent(req *agent.Request) loop.Request {
 			Role:    msg.Role,
 			Content: msg.Content,
 			Images:  append(msg.Images[:0:0], msg.Images...),
+			Origin:  msg.Origin,
 		}
 	}
 	runtimeTools := make([]loop.RuntimeTool, 0, len(req.RuntimeTools))


### PR DESCRIPTION
## Summary

Third and final PR of #1440: the Signal bridge declares message provenance **per turn shape** instead of stamping every turn `channel`. Turns that exist because counterparty traffic arrived — inbound envelopes, reactions, mailbox batches (with or without notify envelopes riding along) — keep `OriginChannel`; the pure loop-notification wake (`prepareLoopNotificationTurn`, the core-attention path) now declares `OriginWake`.

## Why

Production verification of the conversation-timing narrative surfaced this before any wake actually hit the channel: the bridge funneled all turn shapes through `agentTurnMessages` with an unconditional `MessageOrigin: channel`. When a core-attention wake fired into the Signal conversation, that single stamp would have poisoned the narrative in both directions at once — the turn would render the **contact** branch ("the conversation is continuing…") on a turn with no new message, inviting the model to reply to a message that doesn't exist, and the wake prompt would be stored as a contact row, advancing the previous contact and erasing the very silence the next turn's narrative should report.

The fix is where the truth lives: each turn builder knows its own shape, so `agentTurnMessages` takes the origin as an explicit parameter and every caller declares. `RuntimeTags: message_channel` stays on every shape — the tag is runtime-only (WakeTags can't assert it), and it is precisely what keeps the channel context, including the wake branch of the timing narrative, active on wake turns. With this PR the wake branch becomes reachable *and* truthful: a core-attention wake renders "This turn is an internal wake, not a message from them. The previous contact was about 3 hours ago."

No production rows need cleanup — verification confirmed no wake has landed on a channel conversation since the arc deployed, so no mislabeled contact rows exist.

## Test plan

- [x] Turn-shape table test at the routing seam (`buildSignalTurn`): mailbox traffic → `channel`, mailbox with notify riding along → `channel`, pure loop notification → `wake`; `message_channel` survives every shape
- [x] `just ci` green

Closes #1440
