### PR TITLE
feat(identity): counterparty bindings — devices learn whose they are

### DIFF
--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -139,14 +139,27 @@ enable it to sync contacts with macOS/iOS/Thunderbird.
 companion:
   enabled: true
   providers:
-    nugget:
+    alice:
       tokens:
         - your-shared-token
+      contact: 0d1f8a6e-4c2b-4b7e-9f00-3a7d0e2c9b41
 ```
 
 Optional. Companion apps connect inward to Thane and expose local host
 capabilities, such as macOS Calendar access from
 [thane-agent-macos](https://github.com/nugget/thane-agent-macos).
+
+`contact` (optional) binds every device that authenticates through the
+account to one contact record, by contact UUID — the counterparty
+layer's person attribution. Devices then present and report as that
+contact's devices, and inherit authority from the contact's trust zone
+at read time, so a zone change reaches every bound device immediately.
+Configuration is deliberately the only place this binding can be made:
+bindings confer inherited trust, and neither they nor trust zones are
+writable through model-facing contact tools. A malformed (non-UUID)
+value is rejected at config load; a UUID that matches no contact fails
+closed at render time — the devices degrade to account-only
+attribution and a warning names the unresolved binding.
 Use `companion:`. A top-level `platform:` section is rejected at config
 load with an actionable error and must be renamed to `companion:` (the
 field shape is unchanged).

--- a/internal/app/adapters_test.go
+++ b/internal/app/adapters_test.go
@@ -297,8 +297,18 @@ func TestContactChannelBindingResolverCachesConfiguredOwnerContact(t *testing.T)
 	}
 
 	tools := contacts.NewTools(store)
-	if _, err := tools.SaveContact(`{"name":"Aimee","kind":"individual","trust_zone":"admin","facts":{"email":"aimee@example.com"}}`); err != nil {
+	if _, err := tools.SaveContact(`{"name":"Aimee","kind":"individual","facts":{"email":"aimee@example.com"}}`); err != nil {
 		t.Fatalf("SaveContact: %v", err)
+	}
+	// Zones are operator custody (#1450): seed through the store, the
+	// path contact_save deliberately refuses.
+	aimee, err := store.FindByName("Aimee")
+	if err != nil {
+		t.Fatalf("FindByName: %v", err)
+	}
+	aimee.TrustZone = contacts.ZoneAdmin
+	if _, err := store.Upsert(aimee); err != nil {
+		t.Fatalf("Upsert zone: %v", err)
 	}
 
 	resolver := &contactChannelBindingResolver{

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -8,6 +8,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/nugget/thane-ai-agent/internal/channels/mqtt"
 	"github.com/nugget/thane-ai-agent/internal/connwatch"
 	"github.com/nugget/thane-ai-agent/internal/integrations/companion"
@@ -290,7 +292,50 @@ func (a *App) initServers(s *newState) error {
 		// with live connectivity, so an iPhone that locked stays visible
 		// as an offline device with honest freshness instead of
 		// vanishing. Uncached live state.
-		a.loop.RegisterTagContextProvider("companion", companions.NewContextProvider(a.companionDevices, a.companionRegistry.List))
+		deviceContext := companions.NewContextProvider(a.companionDevices, a.companionRegistry.List)
+
+		// Counterparty attribution (#1450): each account's configured
+		// contact binding resolves at read time — never copied onto
+		// device rows — so a trust-zone change on the contact reaches
+		// every bound device instantly. Resolution fails closed: an
+		// unknown or deleted contact degrades the device to
+		// account-only attribution, loudly.
+		contactBindings := make(map[string]uuid.UUID, len(cfg.Companion.Providers))
+		for account, provider := range cfg.Companion.Providers {
+			if provider.Contact == "" {
+				continue
+			}
+			id, err := uuid.Parse(provider.Contact)
+			if err != nil {
+				// Config validation rejects non-UUIDs; defensive only.
+				logger.Error("companion contact binding is not a UUID", "account", account)
+				continue
+			}
+			contactBindings[account] = id
+		}
+		if len(contactBindings) > 0 && a.contactStore != nil {
+			deviceContext.SetContactResolver(func(_ context.Context, account string) (companions.ContactBinding, bool) {
+				id, ok := contactBindings[account]
+				if !ok {
+					return companions.ContactBinding{}, false
+				}
+				contact, err := a.contactStore.Get(id)
+				if err != nil || contact == nil {
+					logger.Warn("companion contact binding did not resolve",
+						"account", account,
+						"contact_id", id.String(),
+						"error", err,
+					)
+					return companions.ContactBinding{}, false
+				}
+				return companions.ContactBinding{
+					ContactID: contact.ID.String(),
+					Name:      contact.FormattedName,
+					TrustZone: contact.TrustZone,
+				}, true
+			})
+		}
+		a.loop.RegisterTagContextProvider("companion", deviceContext)
 
 		handler := companion.NewHandler(cfg.Companion.TokenIndex(), a.companionRegistry, logger)
 		// Durable inventory: authentication upserts the device record,

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -36,6 +36,8 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/google/uuid"
+
 	"github.com/nugget/thane-ai-agent/internal/channels/email"
 	"github.com/nugget/thane-ai-agent/internal/channels/messages"
 	"github.com/nugget/thane-ai-agent/internal/integrations/search"
@@ -803,6 +805,15 @@ type MemoryGuardConfig struct {
 // companion app (e.g. thane-agent-macos on a laptop vs desktop).
 type CompanionProviderConfig struct {
 	Tokens []string `yaml:"tokens"`
+
+	// Contact binds every device authenticating through this account to
+	// one contact record (a contact UUID): the counterparty layer's
+	// person attribution (#1450). The account names a credential
+	// namespace; this names whose devices those are. Optional — empty
+	// means unbound, and devices degrade to account-only attribution.
+	// Living in config is deliberate custody: bindings confer inherited
+	// trust and must not be writable through contact-editing tools.
+	Contact string `yaml:"contact"`
 }
 
 // Configured reports whether the companion endpoint is enabled
@@ -832,6 +843,11 @@ func (c CompanionConfig) Validate() error {
 	hasToken := false
 	seen := make(map[string]string) // token → account
 	for account, p := range c.Providers {
+		if p.Contact != "" {
+			if _, err := uuid.Parse(p.Contact); err != nil {
+				return fmt.Errorf("companion: account %q contact binding %q is not a contact UUID", account, p.Contact)
+			}
+		}
 		for _, tok := range p.Tokens {
 			if tok == "" {
 				continue

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -1720,3 +1720,44 @@ homeassistant:
 		t.Errorf("error %q should name the retired block and the replacement", err)
 	}
 }
+
+// TestCompanionContactBindingValidation pins the boot-time gate on the
+// counterparty binding (#1450): a contact binding must be a UUID, and a
+// valid one loads cleanly. This validation is a security boundary — the
+// binding confers inherited device authority — so its rejection path
+// must not regress silently.
+func TestCompanionContactBindingValidation(t *testing.T) {
+	valid := CompanionConfig{
+		Enabled: true,
+		Providers: map[string]CompanionProviderConfig{
+			"alice": {Tokens: []string{"tok-1"}, Contact: "0d1f8a6e-4c2b-4b7e-9f00-3a7d0e2c9b41"},
+		},
+	}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("valid contact binding rejected: %v", err)
+	}
+
+	unbound := CompanionConfig{
+		Enabled: true,
+		Providers: map[string]CompanionProviderConfig{
+			"alice": {Tokens: []string{"tok-1"}},
+		},
+	}
+	if err := unbound.Validate(); err != nil {
+		t.Fatalf("unbound account rejected: %v", err)
+	}
+
+	malformed := CompanionConfig{
+		Enabled: true,
+		Providers: map[string]CompanionProviderConfig{
+			"alice": {Tokens: []string{"tok-1"}, Contact: "not-a-uuid"},
+		},
+	}
+	err := malformed.Validate()
+	if err == nil {
+		t.Fatal("malformed contact binding accepted")
+	}
+	if !strings.Contains(err.Error(), "alice") || !strings.Contains(err.Error(), "not-a-uuid") {
+		t.Errorf("rejection should name the account and value: %v", err)
+	}
+}

--- a/internal/state/companions/context.go
+++ b/internal/state/companions/context.go
@@ -17,6 +17,24 @@ import (
 // silently dropping devices.
 const maxContextDevices = 32
 
+// ContactBinding is the resolved counterparty attribution for a
+// companion account: whose devices these are, and the trust zone that
+// authority derives from (#1450). Resolution happens at read time —
+// the binding lives in operator-custodied config and the contact
+// record, never copied onto device rows, so a zone change propagates
+// instantly and there is no second store of authority to drift.
+type ContactBinding struct {
+	ContactID string
+	Name      string
+	TrustZone string
+}
+
+// ContactResolver maps a companion account to its bound contact, when
+// one is configured. Implementations must fail closed: an unknown,
+// unbound, or deleted contact resolves to nothing, degrading the
+// device to account-only attribution.
+type ContactResolver func(ctx context.Context, account string) (ContactBinding, bool)
+
 // ContextProvider renders the joined companion-device view: every
 // paired device from the durable inventory merged with the live
 // provider registry. A known companion, its current reachability, and
@@ -39,6 +57,15 @@ type ContextProvider struct {
 	live func() []companion.ProviderInfo
 	// now is a clock seam for deterministic tests.
 	now func() time.Time
+	// contacts resolves account → counterparty attribution; nil means
+	// the binding layer is not wired and rows stay account-only.
+	contacts ContactResolver
+}
+
+// SetContactResolver wires counterparty attribution (#1450) into the
+// device view.
+func (p *ContextProvider) SetContactResolver(resolver ContactResolver) {
+	p.contacts = resolver
 }
 
 // NewContextProvider creates the joined companion-device context
@@ -75,6 +102,12 @@ type deviceContextJSON struct {
 	DeviceID string `json:"device_id,omitempty"`
 	ClientID string `json:"client_id,omitempty"`
 	Platform string `json:"platform,omitempty"`
+
+	// Contact is the bound counterparty's display name and
+	// ContactTrustZone the trust zone device authority derives from;
+	// absent when the account is unbound (#1450).
+	Contact          string `json:"contact,omitempty"`
+	ContactTrustZone string `json:"contact_trust_zone,omitempty"`
 
 	// Availability is "online" (a live connection is open; Tools are
 	// callable now) or "offline" (paired but not currently connected).
@@ -174,6 +207,10 @@ func (p *ContextProvider) TagContext(ctx context.Context, _ agentctx.ContextRequ
 			Availability: "offline",
 			Observations: obsByDevice[d.DeviceID],
 		}
+		if binding, ok := p.resolveContact(ctx, d.Account); ok {
+			row.Contact = binding.Name
+			row.ContactTrustZone = binding.TrustZone
+		}
 		if !d.LastSeenAt.IsZero() {
 			row.LastSeenAgo = promptfmt.FormatDeltaOnly(d.LastSeenAt, now)
 		}
@@ -212,7 +249,7 @@ func (p *ContextProvider) TagContext(ctx context.Context, _ agentctx.ContextRequ
 		liveUnjoined = append(liveUnjoined, matches...)
 	}
 	for _, info := range liveUnjoined {
-		rows = append(rows, deviceContextJSON{
+		row := deviceContextJSON{
 			Account:      info.Account,
 			ClientName:   info.ClientName,
 			ClientID:     info.ClientID,
@@ -220,7 +257,12 @@ func (p *ContextProvider) TagContext(ctx context.Context, _ agentctx.ContextRequ
 			Availability: "online",
 			ConnectedAgo: promptfmt.FormatDeltaOnly(info.ConnectedAt, now),
 			Tools:        liveToolNames([]companion.ProviderInfo{info}),
-		})
+		}
+		if binding, ok := p.resolveContact(ctx, info.Account); ok {
+			row.Contact = binding.Name
+			row.ContactTrustZone = binding.TrustZone
+		}
+		rows = append(rows, row)
 	}
 
 	// Deterministic order across turns so the model can compare without
@@ -270,4 +312,12 @@ func liveToolNames(infos []companion.ProviderInfo) []string {
 	}
 	sort.Strings(names)
 	return names
+}
+
+// resolveContact applies the optional counterparty resolver.
+func (p *ContextProvider) resolveContact(ctx context.Context, account string) (ContactBinding, bool) {
+	if p.contacts == nil {
+		return ContactBinding{}, false
+	}
+	return p.contacts(ctx, account)
 }

--- a/internal/state/companions/context_test.go
+++ b/internal/state/companions/context_test.go
@@ -1,6 +1,7 @@
 package companions
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -424,4 +425,47 @@ func mustContext(t *testing.T, p *ContextProvider) string {
 		t.Fatalf("TagContext: %v", err)
 	}
 	return block
+}
+
+// TestContextProviderContactAttribution pins the counterparty layer's
+// first presentation surface (#1450): a bound account's devices carry
+// the contact name and the trust zone authority derives from — on
+// durable and live-only rows alike — and resolution fails closed to
+// account-only attribution.
+func TestContextProviderContactAttribution(t *testing.T) {
+	store := newTestStore(t)
+	now := time.Now().UTC()
+	if err := store.RecordConnected(ctx, "alice", "device-1", companion.DeviceMetadata{}, now.Add(-time.Hour)); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+
+	p := NewContextProvider(store, func() []companion.ProviderInfo {
+		return []companion.ProviderInfo{
+			{Account: "alice", ClientID: "device-new", ConnectedAt: now}, // live, no durable row
+			{Account: "bob", ClientID: "device-b", ConnectedAt: now},     // unbound account
+		}
+	})
+	p.SetContactResolver(func(_ context.Context, account string) (ContactBinding, bool) {
+		if account == "alice" {
+			return ContactBinding{ContactID: "c-1", Name: "Alice Operator", TrustZone: "admin"}, true
+		}
+		return ContactBinding{}, false
+	})
+
+	out := decodeDeviceContext(t, mustContext(t, p))
+	if len(out.Devices) != 3 {
+		t.Fatalf("got %d devices, want 3", len(out.Devices))
+	}
+	for _, d := range out.Devices {
+		switch d.Account {
+		case "alice":
+			if d.Contact != "Alice Operator" || d.ContactTrustZone != "admin" {
+				t.Errorf("alice device %q attribution = %q/%q", d.ClientID, d.Contact, d.ContactTrustZone)
+			}
+		case "bob":
+			if d.Contact != "" || d.ContactTrustZone != "" {
+				t.Errorf("unbound account carries attribution: %+v", d)
+			}
+		}
+	}
 }

--- a/internal/state/contacts/counterparty.go
+++ b/internal/state/contacts/counterparty.go
@@ -4,10 +4,15 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/google/uuid"
 )
+
+// haPersonEntityRE pins the full domain.object_id shape — a bare
+// "person." or a dotted suffix is not a valid Home Assistant entity.
+var haPersonEntityRE = regexp.MustCompile(`^person\.[a-z0-9_]+$`)
 
 // SetHAPersonEntity binds a contact to a Home Assistant person entity
 // (e.g. "person.alice") — the counterparty edge presence flows through
@@ -19,14 +24,20 @@ import (
 // or operator-initiated code.
 func (s *Store) SetHAPersonEntity(id uuid.UUID, entity string) error {
 	entity = strings.TrimSpace(entity)
-	if entity != "" && !strings.HasPrefix(entity, "person.") {
-		return fmt.Errorf("ha person entity must be a person.* entity id, got %q", entity)
+	if entity != "" && !haPersonEntityRE.MatchString(entity) {
+		return fmt.Errorf("ha person entity must match person.<object_id> (lowercase letters, digits, underscores), got %q", entity)
 	}
 	res, err := s.db.Exec(
 		`UPDATE contacts SET ha_person_entity = ? WHERE id = ? AND deleted_at IS NULL`,
 		entity, id.String(),
 	)
 	if err != nil {
+		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
+			if claimant, ferr := s.FindByHAPersonEntity(entity); ferr == nil && claimant != nil {
+				return fmt.Errorf("ha person entity %q is already bound to contact %q (%s); clear that binding first — presence must attach to exactly one counterparty", entity, claimant.FormattedName, claimant.ID)
+			}
+			return fmt.Errorf("ha person entity %q is already bound to another contact; clear that binding first", entity)
+		}
 		return fmt.Errorf("set ha person entity for %s: %w", id, err)
 	}
 	n, err := res.RowsAffected()

--- a/internal/state/contacts/counterparty.go
+++ b/internal/state/contacts/counterparty.go
@@ -1,0 +1,83 @@
+package contacts
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// SetHAPersonEntity binds a contact to a Home Assistant person entity
+// (e.g. "person.alice") — the counterparty edge presence flows through
+// (#1450). An empty entity clears the binding.
+//
+// Custody: no model-facing tool exposes this mutation, deliberately.
+// Bindings participate in counterparty attribution, and their write
+// paths stay operator-gated; wire this only from configuration-driven
+// or operator-initiated code.
+func (s *Store) SetHAPersonEntity(id uuid.UUID, entity string) error {
+	entity = strings.TrimSpace(entity)
+	if entity != "" && !strings.HasPrefix(entity, "person.") {
+		return fmt.Errorf("ha person entity must be a person.* entity id, got %q", entity)
+	}
+	res, err := s.db.Exec(
+		`UPDATE contacts SET ha_person_entity = ? WHERE id = ? AND deleted_at IS NULL`,
+		entity, id.String(),
+	)
+	if err != nil {
+		return fmt.Errorf("set ha person entity for %s: %w", id, err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("set ha person entity for %s: %w", id, err)
+	}
+	if n == 0 {
+		return fmt.Errorf("set ha person entity for %s: contact not found", id)
+	}
+	return nil
+}
+
+// HAPersonEntity returns the contact's bound Home Assistant person
+// entity; empty when unbound. A missing contact is not an error — the
+// boolean reports existence.
+func (s *Store) HAPersonEntity(id uuid.UUID) (string, bool, error) {
+	var entity sql.NullString
+	err := s.db.QueryRow(
+		`SELECT ha_person_entity FROM contacts WHERE id = ? AND deleted_at IS NULL`,
+		id.String(),
+	).Scan(&entity)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("ha person entity for %s: %w", id, err)
+	}
+	return entity.String, true, nil
+}
+
+// FindByHAPersonEntity returns the contact bound to the given Home
+// Assistant person entity, or nil when no contact claims it.
+func (s *Store) FindByHAPersonEntity(entity string) (*Contact, error) {
+	entity = strings.TrimSpace(entity)
+	if entity == "" {
+		return nil, fmt.Errorf("entity is required")
+	}
+	var id string
+	err := s.db.QueryRow(
+		`SELECT id FROM contacts WHERE ha_person_entity = ? AND deleted_at IS NULL`,
+		entity,
+	).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("find contact by ha person entity %q: %w", entity, err)
+	}
+	parsed, err := uuid.Parse(id)
+	if err != nil {
+		return nil, fmt.Errorf("find contact by ha person entity %q: %w", entity, err)
+	}
+	return s.Get(parsed)
+}

--- a/internal/state/contacts/counterparty_test.go
+++ b/internal/state/contacts/counterparty_test.go
@@ -1,6 +1,7 @@
 package contacts
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -66,10 +67,45 @@ func TestHAPersonEntityValidation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("upsert: %v", err)
 	}
-	if err := store.SetHAPersonEntity(contact.ID, "device_tracker.phone"); err == nil {
-		t.Error("non-person entity accepted")
+	for _, bad := range []string{"device_tracker.phone", "person.", "person.alice.extra", "Person.Alice", "person.Alice"} {
+		if err := store.SetHAPersonEntity(contact.ID, bad); err == nil {
+			t.Errorf("malformed entity %q accepted", bad)
+		}
 	}
 	if err := store.SetHAPersonEntity(uuid.New(), "person.ghost"); err == nil {
 		t.Error("binding to a missing contact accepted")
+	}
+}
+
+// TestHAPersonEntityUniqueness pins the storage-boundary guarantee the
+// reverse lookup depends on: presence attaches to exactly one active
+// counterparty, and a second claimant is refused with the current
+// holder named.
+func TestHAPersonEntityUniqueness(t *testing.T) {
+	store := newCounterpartyTestStore(t)
+	alice, err := store.Upsert(&Contact{FormattedName: "Alice Operator"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	bob, err := store.Upsert(&Contact{FormattedName: "Bob Guest"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetHAPersonEntity(alice.ID, "person.alice"); err != nil {
+		t.Fatalf("first binding: %v", err)
+	}
+	err = store.SetHAPersonEntity(bob.ID, "person.alice")
+	if err == nil {
+		t.Fatal("duplicate claim accepted; reverse lookup is now arbitrary")
+	}
+	if !strings.Contains(err.Error(), "Alice Operator") {
+		t.Errorf("conflict error should name the current holder: %v", err)
+	}
+	// Rebinding: clear, then the other contact may claim it.
+	if err := store.SetHAPersonEntity(alice.ID, ""); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	if err := store.SetHAPersonEntity(bob.ID, "person.alice"); err != nil {
+		t.Fatalf("rebind after clear: %v", err)
 	}
 }

--- a/internal/state/contacts/counterparty_test.go
+++ b/internal/state/contacts/counterparty_test.go
@@ -1,0 +1,75 @@
+package contacts
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
+)
+
+func newCounterpartyTestStore(t *testing.T) *Store {
+	t.Helper()
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("open memory db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	store, err := NewStore(db, nil)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	return store
+}
+
+func TestHAPersonEntityBinding(t *testing.T) {
+	store := newCounterpartyTestStore(t)
+	contact, err := store.Upsert(&Contact{FormattedName: "Alice Operator", TrustZone: ZoneAdmin})
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	// Unbound reads as empty, present.
+	entity, ok, err := store.HAPersonEntity(contact.ID)
+	if err != nil || !ok || entity != "" {
+		t.Fatalf("fresh contact binding = %q ok=%v err=%v", entity, ok, err)
+	}
+
+	if err := store.SetHAPersonEntity(contact.ID, "person.alice"); err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+	entity, ok, err = store.HAPersonEntity(contact.ID)
+	if err != nil || !ok || entity != "person.alice" {
+		t.Fatalf("bound = %q ok=%v err=%v", entity, ok, err)
+	}
+
+	found, err := store.FindByHAPersonEntity("person.alice")
+	if err != nil || found == nil || found.ID != contact.ID {
+		t.Fatalf("reverse lookup = %+v err=%v", found, err)
+	}
+	if missing, err := store.FindByHAPersonEntity("person.nobody"); err != nil || missing != nil {
+		t.Fatalf("unclaimed entity lookup = %+v err=%v", missing, err)
+	}
+
+	// Clearing the binding.
+	if err := store.SetHAPersonEntity(contact.ID, ""); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	entity, _, _ = store.HAPersonEntity(contact.ID)
+	if entity != "" {
+		t.Errorf("binding not cleared: %q", entity)
+	}
+}
+
+func TestHAPersonEntityValidation(t *testing.T) {
+	store := newCounterpartyTestStore(t)
+	contact, err := store.Upsert(&Contact{FormattedName: "Alice Operator"})
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if err := store.SetHAPersonEntity(contact.ID, "device_tracker.phone"); err == nil {
+		t.Error("non-person entity accepted")
+	}
+	if err := store.SetHAPersonEntity(uuid.New(), "person.ghost"); err == nil {
+		t.Error("binding to a missing contact accepted")
+	}
+}

--- a/internal/state/contacts/schema.go
+++ b/internal/state/contacts/schema.go
@@ -46,6 +46,13 @@ var schema = database.Schema{
 		database.IndexCreate{Name: "idx_contacts_fn", SQL: `CREATE INDEX IF NOT EXISTS idx_contacts_fn ON contacts(formatted_name)`},
 		database.IndexCreate{Name: "idx_contacts_deleted", SQL: `CREATE INDEX IF NOT EXISTS idx_contacts_deleted ON contacts(deleted_at)`},
 		database.IndexCreate{Name: "idx_contacts_trust_zone", SQL: `CREATE INDEX IF NOT EXISTS idx_contacts_trust_zone ON contacts(trust_zone)`},
+		// ha_person_entity is the durable contact → Home Assistant
+		// person binding (#1450): the counterparty edge presence flows
+		// through. Deliberately declared ONLY here (not in the CREATE
+		// TABLE above) so the column has a single source of truth; the
+		// idempotent ColumnAdd serves fresh and existing databases
+		// alike.
+		database.ColumnAdd{Table: "contacts", Column: "ha_person_entity", Typedef: "TEXT"},
 		database.TableCreate{
 			Table: "contact_properties",
 			SQL: `CREATE TABLE IF NOT EXISTS contact_properties (

--- a/internal/state/contacts/schema.go
+++ b/internal/state/contacts/schema.go
@@ -53,6 +53,12 @@ var schema = database.Schema{
 		// idempotent ColumnAdd serves fresh and existing databases
 		// alike.
 		database.ColumnAdd{Table: "contacts", Column: "ha_person_entity", Typedef: "TEXT"},
+		// Presence must attach to exactly one counterparty: at most one
+		// active contact may claim a given HA person entity, enforced at
+		// the storage boundary rather than by caller discipline.
+		database.IndexCreate{Name: "idx_contacts_ha_person_unique", SQL: `CREATE UNIQUE INDEX IF NOT EXISTS idx_contacts_ha_person_unique
+			ON contacts(ha_person_entity)
+			WHERE ha_person_entity IS NOT NULL AND ha_person_entity != '' AND deleted_at IS NULL`},
 		database.TableCreate{
 			Table: "contact_properties",
 			SQL: `CREATE TABLE IF NOT EXISTS contact_properties (

--- a/internal/state/contacts/tools.go
+++ b/internal/state/contacts/tools.go
@@ -213,6 +213,15 @@ func (t *Tools) SaveContact(argsJSON string) (string, error) {
 		return "", fmt.Errorf("name is required")
 	}
 
+	// Trust zones are operator custody, not contact data: a zone now
+	// confers inherited authority on every companion device bound to
+	// the contact (#1450), so the everyday save path must never be a
+	// promotion path. The operator assigns zones through CardDAV
+	// (X-THANE-TRUST-ZONE) or direct curation.
+	if args.TrustZone != "" {
+		return "", fmt.Errorf("trust_zone cannot be set through contact_save: zones are operator-custodied and confer device authority (#1450); ask the operator to assign the zone, then retry without trust_zone")
+	}
+
 	// Look for existing contact by name.
 	existing, err := t.store.FindByName(args.Name)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
@@ -223,9 +232,6 @@ func (t *Tools) SaveContact(argsJSON string) (string, error) {
 		// Update existing contact — only non-empty fields overwrite.
 		if args.Kind != "" {
 			existing.Kind = args.Kind
-		}
-		if args.TrustZone != "" {
-			existing.TrustZone = args.TrustZone
 		}
 		if args.GivenName != "" {
 			existing.GivenName = args.GivenName
@@ -273,7 +279,6 @@ func (t *Tools) SaveContact(argsJSON string) (string, error) {
 	c := &Contact{
 		FormattedName: args.Name,
 		Kind:          args.Kind,
-		TrustZone:     args.TrustZone,
 		GivenName:     args.GivenName,
 		FamilyName:    args.FamilyName,
 		Nickname:      args.Nickname,
@@ -768,6 +773,15 @@ func (t *Tools) ImportVCF(argsJSON string) (string, error) {
 
 	for i, incoming := range decoded {
 		props := allProps[i]
+
+		// Trust zone is operator custody, not importable data (#1450):
+		// a zone confers inherited authority on bound companion devices,
+		// so a model-supplied vCard must not mint an elevated contact
+		// through X-THANE-TRUST-ZONE. New contacts always start at the
+		// default zone; the merge path already never overwrites an
+		// existing zone. The operator sets zones through CardDAV, whose
+		// backend decodes the same header on an authenticated surface.
+		incoming.TrustZone = ZoneKnown
 
 		// Try to find existing contact for merge.
 		var existing *Contact

--- a/internal/state/contacts/tools_test.go
+++ b/internal/state/contacts/tools_test.go
@@ -630,90 +630,66 @@ func TestListContacts_Empty(t *testing.T) {
 	}
 }
 
-func TestSaveContact_TrustZone(t *testing.T) {
-	tools := newTestTools(t)
+// TestSaveContact_TrustZoneIsOperatorCustody pins the #1450 security
+// boundary: trust zones confer inherited authority on every companion
+// device bound to a contact, so the everyday save path must never be a
+// promotion path. Any attempt is a hard, teaching error — for create
+// and update alike — and a zone the operator assigned survives every
+// tool-driven update untouched.
 
-	_, err := tools.SaveContact(`{"name":"Trusted Pal","kind":"individual","trust_zone":"trusted"}`)
+// setZone assigns a trust zone through the store directly — the
+// operator-custody path — since contact_save refuses zone mutation by
+// design (#1450).
+func setZone(t *testing.T, tools *Tools, name, zone string) {
+	t.Helper()
+	c, err := tools.store.FindByName(name)
 	if err != nil {
-		t.Fatalf("SaveContact() error = %v", err)
+		t.Fatalf("setZone find %s: %v", name, err)
 	}
-
-	c, err := tools.store.FindByName("Trusted Pal")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if c.TrustZone != "trusted" {
-		t.Errorf("TrustZone = %q, want %q", c.TrustZone, "trusted")
+	c.TrustZone = zone
+	if _, err := tools.store.Upsert(c); err != nil {
+		t.Fatalf("setZone upsert %s: %v", name, err)
 	}
 }
 
-func TestSaveContact_TrustZoneUpdate(t *testing.T) {
+func TestSaveContact_TrustZoneIsOperatorCustody(t *testing.T) {
 	tools := newTestTools(t)
 
-	_, err := tools.SaveContact(`{"name":"Zone Updater","kind":"individual"}`)
-	if err != nil {
-		t.Fatal(err)
+	_, err := tools.SaveContact(`{"name":"Trusted Pal","kind":"individual","trust_zone":"trusted"}`)
+	if err == nil || !strings.Contains(err.Error(), "operator-custodied") {
+		t.Fatalf("zone set on create must be refused with custody teaching, got %v", err)
 	}
 
-	c, err := tools.store.FindByName("Zone Updater")
+	if _, err := tools.SaveContact(`{"name":"Zone Holder","kind":"individual"}`); err != nil {
+		t.Fatal(err)
+	}
+	c, err := tools.store.FindByName("Zone Holder")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if c.TrustZone != "known" {
-		t.Fatalf("initial TrustZone = %q, want %q", c.TrustZone, "known")
+		t.Fatalf("create default TrustZone = %q, want %q", c.TrustZone, "known")
 	}
 
-	_, err = tools.SaveContact(`{"name":"Zone Updater","trust_zone":"trusted"}`)
+	_, err = tools.SaveContact(`{"name":"Zone Holder","trust_zone":"admin"}`)
+	if err == nil || !strings.Contains(err.Error(), "operator-custodied") {
+		t.Fatalf("zone promotion via update must be refused, got %v", err)
+	}
+
+	// Operator-assigned zones survive tool-driven updates untouched.
+	c.TrustZone = ZoneTrusted
+	if _, err := tools.store.Upsert(c); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tools.SaveContact(`{"name":"Zone Holder","ai_summary":"New summary"}`); err != nil {
+		t.Fatal(err)
+	}
+	c, err = tools.store.FindByName("Zone Holder")
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	c, err = tools.store.FindByName("Zone Updater")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if c.TrustZone != "trusted" {
-		t.Errorf("updated TrustZone = %q, want %q", c.TrustZone, "trusted")
-	}
-
-	// Update with empty trust_zone should preserve the existing value.
-	_, err = tools.SaveContact(`{"name":"Zone Updater","ai_summary":"New summary"}`)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	c, err = tools.store.FindByName("Zone Updater")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if c.TrustZone != "trusted" {
-		t.Errorf("TrustZone after empty update = %q, want %q (should be preserved)", c.TrustZone, "trusted")
-	}
-}
-
-func TestSaveContact_TrustZoneNotRescuedAsFact(t *testing.T) {
-	tools := newTestTools(t)
-
-	_, err := tools.SaveContact(`{"name":"Zone Not Fact","trust_zone":"admin"}`)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	c, err := tools.store.FindByName("Zone Not Fact")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	propsMap, err := tools.store.GetPropertiesMap(c.ID)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if _, exists := propsMap["trust_zone"]; exists {
-		t.Error("trust_zone should not be rescued as a property")
-	}
-	if c.TrustZone != "admin" {
-		t.Errorf("TrustZone = %q, want %q", c.TrustZone, "admin")
+	if c.TrustZone != ZoneTrusted {
+		t.Errorf("TrustZone after unrelated update = %q, want preserved %q", c.TrustZone, ZoneTrusted)
 	}
 }
 
@@ -869,10 +845,11 @@ func TestExportVCF_SelfContact(t *testing.T) {
 	tools := newTestTools(t)
 	tools.SetSelfContactName("Thane Agent")
 
-	_, err := tools.SaveContact(`{"name":"Thane Agent","kind":"individual","trust_zone":"admin","facts":{"email":"thane@example.com"}}`)
+	_, err := tools.SaveContact(`{"name":"Thane Agent","kind":"individual","facts":{"email":"thane@example.com"}}`)
 	if err != nil {
 		t.Fatal(err)
 	}
+	setZone(t, tools, "Thane Agent", "admin")
 
 	result, err := tools.ExportVCF(`{"name":"self","format":"text"}`)
 	if err != nil {
@@ -899,10 +876,11 @@ func TestExportVCF_SelfWithTrustZoneFilter(t *testing.T) {
 	tools := newTestTools(t)
 	tools.SetSelfContactName("Agent Self")
 
-	_, err := tools.SaveContact(`{"name":"Agent Self","kind":"individual","trust_zone":"admin","facts":{"email":"agent@example.com","phone":"555-0000"}}`)
+	_, err := tools.SaveContact(`{"name":"Agent Self","kind":"individual","facts":{"email":"agent@example.com","phone":"555-0000"}}`)
 	if err != nil {
 		t.Fatal(err)
 	}
+	setZone(t, tools, "Agent Self", "admin")
 
 	// Export for unknown zone — should strip email and phone.
 	result, err := tools.ExportVCF(`{"name":"self","format":"text","recipient_trust_zone":"unknown"}`)
@@ -921,10 +899,11 @@ func TestOwnerContact_ConfiguredName(t *testing.T) {
 	tools := newTestTools(t)
 	tools.SetOwnerContactName("Aimee")
 
-	_, err := tools.SaveContact(`{"name":"Aimee","kind":"individual","trust_zone":"household","facts":{"email":"aimee@example.com"}}`)
+	_, err := tools.SaveContact(`{"name":"Aimee","kind":"individual","facts":{"email":"aimee@example.com"}}`)
 	if err != nil {
 		t.Fatal(err)
 	}
+	setZone(t, tools, "Aimee", "household")
 
 	result, err := tools.OwnerContact(`{}`)
 	if err != nil {
@@ -941,10 +920,11 @@ func TestOwnerContact_ConfiguredName(t *testing.T) {
 func TestOwnerContact_FallsBackToSoleAdmin(t *testing.T) {
 	tools := newTestTools(t)
 
-	_, err := tools.SaveContact(`{"name":"Nugget","kind":"individual","trust_zone":"admin","facts":{"phone":"+15551234567"}}`)
+	_, err := tools.SaveContact(`{"name":"Nugget","kind":"individual","facts":{"phone":"+15551234567"}}`)
 	if err != nil {
 		t.Fatal(err)
 	}
+	setZone(t, tools, "Nugget", "admin")
 
 	result, err := tools.OwnerContact(`{}`)
 	if err != nil {
@@ -980,10 +960,11 @@ func TestOwnerContact_IncludesActiveOwnerChannels(t *testing.T) {
 		}
 	})
 
-	_, err := tools.SaveContact(`{"name":"Aimee","kind":"individual","trust_zone":"household","facts":{"email":"aimee@example.com"}}`)
+	_, err := tools.SaveContact(`{"name":"Aimee","kind":"individual","facts":{"email":"aimee@example.com"}}`)
 	if err != nil {
 		t.Fatal(err)
 	}
+	setZone(t, tools, "Aimee", "household")
 
 	result, err := tools.OwnerContact(`{}`)
 	if err != nil {
@@ -1004,10 +985,11 @@ func TestOwnerContact_AmbiguousAdminRequiresConfig(t *testing.T) {
 	tools := newTestTools(t)
 
 	for _, name := range []string{"Aimee", "Nugget"} {
-		_, err := tools.SaveContact(fmt.Sprintf(`{"name":%q,"kind":"individual","trust_zone":"admin"}`, name))
+		_, err := tools.SaveContact(fmt.Sprintf(`{"name":%q,"kind":"individual"}`, name))
 		if err != nil {
 			t.Fatal(err)
 		}
+		setZone(t, tools, name, "admin")
 	}
 
 	_, err := tools.OwnerContact(`{}`)
@@ -1035,11 +1017,12 @@ func TestOwnerContact_LimitsOwnerActivitySummary(t *testing.T) {
 		return out
 	})
 
-	if _, err := tools.SaveContact(`{"name":"Aimee","kind":"individual","trust_zone":"household","facts":{"email":"aimee@example.com"}}`); err != nil {
+	if _, err := tools.SaveContact(`{"name":"Aimee","kind":"individual","facts":{"email":"aimee@example.com"}}`); err != nil {
 		t.Fatal(err)
 	}
 
 	result, err := tools.OwnerContact(`{}`)
+	setZone(t, tools, "Aimee", "household")
 	if err != nil {
 		t.Fatalf("OwnerContact() error = %v", err)
 	}
@@ -1132,8 +1115,10 @@ func TestExportAllVCF_FilterByKind(t *testing.T) {
 func TestExportAllVCF_FilterByTrustZone(t *testing.T) {
 	tools := newTestTools(t)
 
-	_, _ = tools.SaveContact(`{"name":"TZ A","kind":"individual","trust_zone":"trusted"}`)
-	_, _ = tools.SaveContact(`{"name":"TZ B","kind":"individual","trust_zone":"known"}`)
+	_, _ = tools.SaveContact(`{"name":"TZ A","kind":"individual"}`)
+	setZone(t, tools, "TZ A", "trusted")
+	_, _ = tools.SaveContact(`{"name":"TZ B","kind":"individual"}`)
+	setZone(t, tools, "TZ B", "known")
 
 	result, err := tools.ExportAllVCF(`{"trust_zone":"trusted"}`)
 	if err != nil {
@@ -1149,9 +1134,12 @@ func TestExportAllVCF_FilterByTrustZone(t *testing.T) {
 func TestExportAllVCF_FilterBothKindAndTrustZone(t *testing.T) {
 	tools := newTestTools(t)
 
-	_, _ = tools.SaveContact(`{"name":"Both A","kind":"individual","trust_zone":"trusted"}`)
-	_, _ = tools.SaveContact(`{"name":"Both B","kind":"org","trust_zone":"trusted"}`)
-	_, _ = tools.SaveContact(`{"name":"Both C","kind":"individual","trust_zone":"known"}`)
+	_, _ = tools.SaveContact(`{"name":"Both A","kind":"individual"}`)
+	setZone(t, tools, "Both A", "trusted")
+	_, _ = tools.SaveContact(`{"name":"Both B","kind":"org"}`)
+	setZone(t, tools, "Both B", "trusted")
+	_, _ = tools.SaveContact(`{"name":"Both C","kind":"individual"}`)
+	setZone(t, tools, "Both C", "known")
 
 	result, err := tools.ExportAllVCF(`{"kind":"individual","trust_zone":"trusted"}`)
 	if err != nil {
@@ -1202,10 +1190,11 @@ func TestImportVCF_MergeByEmail(t *testing.T) {
 	tools := newTestTools(t)
 
 	// Pre-existing contact with email.
-	_, err := tools.SaveContact(`{"name":"Existing Bob","kind":"individual","trust_zone":"trusted","ai_summary":"Original summary","facts":{"email":"bob@example.com"}}`)
+	_, err := tools.SaveContact(`{"name":"Existing Bob","kind":"individual","ai_summary":"Original summary","facts":{"email":"bob@example.com"}}`)
 	if err != nil {
 		t.Fatal(err)
 	}
+	setZone(t, tools, "Existing Bob", "trusted")
 
 	// Import a vCard with same email but different name and added fields.
 	vcardText := "BEGIN:VCARD\r\nVERSION:4.0\r\nFN:Robert Smith\r\nN:Smith;Robert;;;\r\nEMAIL:bob@example.com\r\nORG:Acme Corp\r\nEND:VCARD"
@@ -1445,5 +1434,31 @@ func TestImportExportVCF_RoundTrip(t *testing.T) {
 	}
 	if c.GivenName != "Round" {
 		t.Errorf("GivenName = %q, want %q", c.GivenName, "Round")
+	}
+}
+
+// TestImportVCF_TrustZoneNotImportable pins the #1450 custody boundary
+// on the sibling import path: a model-supplied vCard cannot mint an
+// elevated contact through X-THANE-TRUST-ZONE — new contacts start at
+// the default zone regardless of the header, on both the merge:false
+// and unique-name create branches.
+func TestImportVCF_TrustZoneNotImportable(t *testing.T) {
+	tools := newTestTools(t)
+
+	vcf := "BEGIN:VCARD\nVERSION:4.0\nFN:Mallory Escalation\nX-THANE-TRUST-ZONE:admin\nEND:VCARD"
+	for _, merge := range []bool{false, true} {
+		payload, _ := json.Marshal(map[string]any{"text": vcf, "merge": merge})
+		if _, err := tools.ImportVCF(string(payload)); err != nil {
+			t.Fatalf("ImportVCF(merge=%v): %v", merge, err)
+		}
+		c, err := tools.store.FindByName("Mallory Escalation")
+		if err != nil {
+			t.Fatalf("find imported (merge=%v): %v", merge, err)
+		}
+		if c.TrustZone != ZoneKnown {
+			t.Errorf("merge=%v: imported contact zone = %q, want %q — X-THANE-TRUST-ZONE must not confer authority via a model tool", merge, c.TrustZone, ZoneKnown)
+		}
+		// Clean up so the second iteration exercises the create branch too.
+		_ = tools.store.Delete(c.ID)
 	}
 }

--- a/internal/tools/contact_tools.go
+++ b/internal/tools/contact_tools.go
@@ -34,11 +34,6 @@ func (r *Registry) registerContactTools() {
 					"enum":        []string{"individual", "group", "org", "location"},
 					"description": "Type of contact (default: individual)",
 				},
-				"trust_zone": map[string]any{
-					"type":        "string",
-					"enum":        []string{"admin", "household", "trusted", "known"},
-					"description": "Trust zone for this contact. Gates model access, tool permissions, and send policy. admin=full access, household=family members, trusted=established relationship, known=default/gated.",
-				},
 				"given_name": map[string]any{
 					"type":        "string",
 					"description": "First/given name (vCard N given-name component)",
@@ -261,7 +256,7 @@ func (r *Registry) registerContactTools() {
 
 	r.Register(&Tool{
 		Name:        "contact_import_vcf",
-		Description: "Import contacts from a vCard (.vcf) file or text. Supports single and multi-contact vCards. By default, merges with existing contacts matched by email or name — only empty fields are filled, TrustZone and AISummary are never overwritten. Use dry_run to preview changes.",
+		Description: "Import contacts from a vCard (.vcf) file or text. Supports single and multi-contact vCards. By default, merges with existing contacts matched by email or name — only empty fields are filled, and TrustZone and AISummary are never overwritten. New contacts are always created at the default trust zone; a vCard X-THANE-TRUST-ZONE is ignored on import (trust zones are operator-assigned). Use dry_run to preview changes.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=69
 interfaces=86
 large_files=58
-set_mutators=120
+set_mutators=122
 database_opens=9


### PR DESCRIPTION
First slice of #1450, stacked on #1449 and part of the single production push the #1437 roadmap now describes.

**The binding**: `companion.providers.<account>` gains a `contact` field (a contact UUID) binding every device authenticating through that account to one contact record. Config is the custody point by design — bindings confer inherited trust, config lives in signed core history, and contact-editing tools must never be a privilege-escalation path. Validation rejects non-UUID bindings at boot.

**Read-time inheritance, never copied**: the context provider resolves account → contact per render through a `ContactResolver` seam. A trust-zone change on the contact reaches every bound device instantly; there is no second store of authority to drift. Resolution fails closed — unknown or deleted contacts degrade devices to account-only attribution with a warning. Device rows in the companion block now carry `contact` and `contact_trust_zone`, on durable and live-only rows alike (pinned by `TestContextProviderContactAttribution`).

**The second edge**: `contacts.ha_person_entity` — the durable contact → HA person binding the fusion view (#1450 slice C) will pull bermuda presence through. Single-sourced via idempotent `ColumnAdd` (the observation-schema review's lesson), validated to `person.*` ids, exposed only through accessors no model-facing tool reaches (`TestHAPersonEntityBinding`, `TestHAPersonEntityValidation`).

Slice 4 (`ios_last_known_location`) builds on this so its answers are born person-aware.

- [x] `just ci` passes locally

Refs #1450
Refs #1437

🤖 Generated with [Claude Code](https://claude.com/claude-code)