### PR TITLE
feat(identity): contact_whereabouts — the fused counterparty view

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -265,6 +265,7 @@ being reimplemented in each loop prompt.
 |------|-------------|
 | `contact_save` | Create or update a contact with vCard properties. |
 | `contact_lookup` | Search by name, query, kind, or property. |
+| `contact_whereabouts` | Fuse a contact's room, HA zone, and bound-device location sources with provenance and freshness. |
 | `contact_forget` | Delete a contact. |
 | `contact_list` | List and filter contacts. |
 | `contact_export_vcf` | Export one contact as a vCard. |
@@ -525,6 +526,8 @@ tools for Signal-specific workflows.
 
 | Tool | Description |
 |------|-------------|
+| `contact_whereabouts` | Resolve a person first, then rank their presence and bound-device location sources. |
+| `companion_last_known_location` | Read one device's durable last location with provenance and freshness. |
 | `macos_calendar_events` | Query the local macOS Calendar (companion app required). |
 
 ## `models` — model registry and routing

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -377,15 +377,7 @@ func (a *App) initServers(s *newState) error {
 	// channel enrichment join and the fused whereabouts tool. Config
 	// may spell a binding in any form uuid.Parse accepts; lookups
 	// compare against contact.ID.String().
-	accountsByContact := make(map[string][]string)
-	for account, provider := range cfg.Companion.Providers {
-		if provider.Contact == "" {
-			continue
-		}
-		if id, err := uuid.Parse(provider.Contact); err == nil {
-			accountsByContact[id.String()] = append(accountsByContact[id.String()], account)
-		}
-	}
+	accountsByContact := companionAccountsByContact(cfg.Companion)
 
 	if s.contactLookup != nil {
 		if s.personTracker != nil {
@@ -903,4 +895,25 @@ func (a *App) initServers(s *newState) error {
 	}
 
 	return nil
+}
+
+// companionAccountsByContact exposes counterparty bindings only while the
+// companion source is configured. Provider entries may remain in disabled
+// config, but they must not keep persisted companion data reachable through
+// contact joins after the operator disables the integration.
+func companionAccountsByContact(cfg config.CompanionConfig) map[string][]string {
+	if !cfg.Configured() {
+		return nil
+	}
+	accountsByContact := make(map[string][]string)
+	for account, provider := range cfg.Providers {
+		if provider.Contact == "" {
+			continue
+		}
+		if id, err := uuid.Parse(provider.Contact); err == nil {
+			canonicalID := id.String()
+			accountsByContact[canonicalID] = append(accountsByContact[canonicalID], account)
+		}
+	}
+	return accountsByContact
 }

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -373,6 +373,20 @@ func (a *App) initServers(s *newState) error {
 	// and rides the HA person binding, so it must not require companion
 	// apps to be configured — and both degrade to absence when their
 	// source is missing.
+	// Canonical contact-UUID → bound companion accounts, shared by the
+	// channel enrichment join and the fused whereabouts tool. Config
+	// may spell a binding in any form uuid.Parse accepts; lookups
+	// compare against contact.ID.String().
+	accountsByContact := make(map[string][]string)
+	for account, provider := range cfg.Companion.Providers {
+		if provider.Contact == "" {
+			continue
+		}
+		if id, err := uuid.Parse(provider.Contact); err == nil {
+			accountsByContact[id.String()] = append(accountsByContact[id.String()], account)
+		}
+	}
+
 	if s.contactLookup != nil {
 		if s.personTracker != nil {
 			tracker := s.personTracker
@@ -397,20 +411,6 @@ func (a *App) initServers(s *newState) error {
 				}
 				return view
 			}
-		}
-		// Device reachability keys by canonical contact UUID — the
-		// config may spell a binding in any form uuid.Parse accepts,
-		// and lookups compare against contact.ID.String().
-		accountsByContact := make(map[string][]string)
-		for account, provider := range cfg.Companion.Providers {
-			if provider.Contact == "" {
-				continue
-			}
-			id, err := uuid.Parse(provider.Contact)
-			if err != nil {
-				continue // config validation rejects these; defensive only
-			}
-			accountsByContact[id.String()] = append(accountsByContact[id.String()], account)
 		}
 		if len(accountsByContact) > 0 && a.companionDevices != nil {
 			s.contactLookup.devicesFor = func(ctx context.Context, contactID string) []agent.CounterpartyDevice {
@@ -456,6 +456,36 @@ func (a *App) initServers(s *newState) error {
 				return views
 			}
 		}
+	}
+
+	// Fused counterparty view (#1450 slice C): contact_whereabouts
+	// composes every whereabouts source the contact record roots.
+	// Registered whenever contacts exist — a presence-only household
+	// without companion apps still gets the fused answer.
+	if a.contactStore != nil {
+		deps := tools.CounterpartyToolDeps{
+			Contacts:   a.contactStore,
+			Companions: a.companionDevices,
+		}
+		if s.personTracker != nil {
+			deps.Presence = s.personTracker.Snapshot
+		}
+		if len(accountsByContact) > 0 {
+			deps.AccountsForContact = func(contactID string) []string {
+				return accountsByContact[contactID]
+			}
+		}
+		if a.companionRegistry != nil {
+			registry := a.companionRegistry
+			deps.LiveIdentities = func() map[[2]string]bool {
+				live := make(map[[2]string]bool)
+				for _, info := range registry.List() {
+					live[[2]string{info.Account, info.ClientID}] = true
+				}
+				return live
+			}
+		}
+		a.loop.Tools().EnableCounterpartyTools(deps)
 	}
 
 	// --- CardDAV server ---

--- a/internal/app/new_servers_test.go
+++ b/internal/app/new_servers_test.go
@@ -1,0 +1,60 @@
+package app
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/config"
+)
+
+func TestCompanionAccountsByContactRequiresConfiguredSource(t *testing.T) {
+	const contactID = "8A1F50A7-91C1-4DE5-90D3-B239719D29A8"
+	tests := []struct {
+		name string
+		cfg  config.CompanionConfig
+		want map[string][]string
+	}{
+		{
+			name: "disabled with retained provider",
+			cfg: config.CompanionConfig{
+				Providers: map[string]config.CompanionProviderConfig{
+					"alice": {Tokens: []string{"token"}, Contact: contactID},
+				},
+			},
+		},
+		{
+			name: "enabled without token",
+			cfg: config.CompanionConfig{
+				Enabled: true,
+				Providers: map[string]config.CompanionProviderConfig{
+					"alice": {Contact: contactID},
+				},
+			},
+		},
+		{
+			name: "configured",
+			cfg: config.CompanionConfig{
+				Enabled: true,
+				Providers: map[string]config.CompanionProviderConfig{
+					"alice": {Tokens: []string{"token"}, Contact: contactID},
+				},
+			},
+			want: map[string][]string{
+				"8a1f50a7-91c1-4de5-90d3-b239719d29a8": {"alice"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := companionAccountsByContact(tt.cfg)
+			if len(got) != len(tt.want) {
+				t.Fatalf("bindings = %#v, want %#v", got, tt.want)
+			}
+			for contactID, wantAccounts := range tt.want {
+				if !slices.Equal(got[contactID], wantAccounts) {
+					t.Errorf("accounts for %s = %#v, want %#v", contactID, got[contactID], wantAccounts)
+				}
+			}
+		})
+	}
+}

--- a/internal/model/toolcatalog/catalog.go
+++ b/internal/model/toolcatalog/catalog.go
@@ -305,6 +305,7 @@ var builtinToolSpecs = map[string]BuiltinToolSpec{
 	"request_human_escalation":      {CanonicalID: "native:request_human_escalation", Source: NativeToolSource, Tags: []string{"notifications"}},
 	"resolve_actionable":            {CanonicalID: "native:resolve_actionable", Source: NativeToolSource, Tags: []string{"notifications"}},
 	"contact_save":                  {CanonicalID: "native:contact_save", Source: NativeToolSource, Tags: []string{"contacts"}},
+	"contact_whereabouts":           {CanonicalID: "native:contact_whereabouts", Source: NativeToolSource, Tags: []string{"contacts", "companion"}},
 	"task_schedule":                 {CanonicalID: "native:task_schedule", Source: NativeToolSource, Tags: []string{"scheduler"}},
 	"send_reaction":                 {CanonicalID: "native:send_reaction", Source: NativeToolSource, Tags: []string{"message_channel"}},
 	"session_checkpoint":            {CanonicalID: "native:session_checkpoint", Source: NativeToolSource, Tags: []string{"session"}},

--- a/internal/state/companions/observations.go
+++ b/internal/state/companions/observations.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/integrations/companion"
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
 )
 
 // ResolveObservationIdentity maps the current account/client claim onto the
@@ -293,4 +294,43 @@ func scanLatestObservation(row *sql.Rows) (companion.LatestObservation, error) {
 		observation.Payload = json.RawMessage(payload.String)
 	}
 	return observation, nil
+}
+
+// LatestObservationsByKind returns the latest observation of one kind
+// for every device belonging to the given accounts, ordered by
+// account/client for a stable shape. Scoped at the query so a caller
+// joining one counterparty never reads every account's every kind
+// (#1450 slice C).
+func (s *Store) LatestObservationsByKind(ctx context.Context, kind string, accounts []string) ([]companion.LatestObservation, error) {
+	kind = strings.TrimSpace(kind)
+	if kind == "" || len(accounts) == 0 {
+		return nil, nil
+	}
+	args := make([]any, 0, len(accounts)+1)
+	args = append(args, kind)
+	for _, acct := range accounts {
+		args = append(args, acct)
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT d.account, o.device_id, d.client_id, o.kind, o.event_id,
+		       o.schema_version, o.status, o.observed_at, o.received_at, o.payload
+		FROM companion_latest_observations o
+		JOIN companion_devices d ON d.device_id = o.device_id
+		WHERE o.kind = ? AND d.account IN (`+database.Placeholders(len(accounts))+`)
+		ORDER BY d.account, d.client_id
+	`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list %s observations for accounts: %w", kind, err)
+	}
+	defer rows.Close()
+
+	var observations []companion.LatestObservation
+	for rows.Next() {
+		observation, err := scanLatestObservation(rows)
+		if err != nil {
+			return nil, err
+		}
+		observations = append(observations, observation)
+	}
+	return observations, rows.Err()
 }

--- a/internal/state/companions/observations_test.go
+++ b/internal/state/companions/observations_test.go
@@ -379,3 +379,23 @@ func TestObservationsSurviveDatabaseReopen(t *testing.T) {
 		t.Fatalf("restored latest = %+v", latest)
 	}
 }
+
+// TestLatestObservationsByKindScopes pins the counterparty-scoped
+// query: only the requested kind and accounts come back.
+func TestLatestObservationsByKindScopes(t *testing.T) {
+	store := newTestStore(t)
+	seedObservation(t, store, "alice", "device-1", "ios.location", companion.ObservationAvailable, t0, t0.Add(time.Minute))
+	seedObservation(t, store, "alice", "device-1", "ios.system-context", companion.ObservationAvailable, t0, t0.Add(time.Minute))
+	seedObservation(t, store, "bob", "device-2", "ios.location", companion.ObservationAvailable, t1, t1.Add(time.Minute))
+
+	got, err := store.LatestObservationsByKind(ctx, "ios.location", []string{"alice"})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(got) != 1 || got[0].Account != "alice" || got[0].Kind != "ios.location" {
+		t.Fatalf("scoped query returned %+v", got)
+	}
+	if empty, err := store.LatestObservationsByKind(ctx, "ios.location", nil); err != nil || empty != nil {
+		t.Errorf("no accounts should return nothing: %v %v", empty, err)
+	}
+}

--- a/internal/tools/counterparty_tools.go
+++ b/internal/tools/counterparty_tools.go
@@ -1,0 +1,261 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
+	"github.com/nugget/thane-ai-agent/internal/state/companions"
+	"github.com/nugget/thane-ai-agent/internal/state/contacts"
+)
+
+// CounterpartyToolDeps are the join sources the fused counterparty
+// view composes (#1450). Every optional source degrades to absence.
+type CounterpartyToolDeps struct {
+	Contacts   *contacts.Store
+	Companions *companions.Store
+	// Presence returns the live tracker snapshot for an HA person
+	// entity; nil when no tracker is configured.
+	Presence func(entity string) (contacts.PersonSnapshot, bool)
+	// AccountsForContact maps a canonical contact UUID string to the
+	// companion accounts bound to it; nil when no bindings exist.
+	AccountsForContact func(contactID string) []string
+	// LiveIdentities reports which (account, client_id) pairs have an
+	// open connection right now; nil when companions are unconfigured.
+	LiveIdentities func() map[[2]string]bool
+}
+
+// EnableCounterpartyTools adds the fused counterparty view: one call
+// that answers "what do we know about where this person is" from every
+// source the contact record roots — HA person zone state, bermuda room
+// while home, and companion location observations — ranked, with
+// provenance and freshness per source.
+func (r *Registry) EnableCounterpartyTools(deps CounterpartyToolDeps) {
+	if deps.Contacts == nil {
+		return
+	}
+
+	r.Register(&Tool{
+		Name: "contact_whereabouts",
+		Description: "Report everything known about where a contact is, fused from every source their " +
+			"contact record roots and ranked best-first: room-level presence while they are home, their " +
+			"freshest companion-device location when away, and zone-level person state as the floor. Each " +
+			"source carries its own provenance and freshness — nothing is blended into a single guess. " +
+			"This is the first door for \"where is <person>\" questions; reach for " +
+			"companion_last_known_location only when you need one specific device's stored fix. " +
+			"Pass name (resolved like other contact tools) or contact_id (UUID). A contact with no HA " +
+			"person binding and no bound companion devices returns an error saying so — that is a " +
+			"configuration gap, not an unknown location.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"name": map[string]any{
+					"type":        "string",
+					"description": "Contact name (formatted name or nickname; resolved with the standard contact cascade).",
+				},
+				"contact_id": map[string]any{
+					"type":        "string",
+					"description": "Exact contact UUID; takes precedence over name when both are given.",
+				},
+			},
+		},
+		Handler: func(ctx context.Context, args map[string]any) (string, error) {
+			name, _ := args["name"].(string)
+			id, _ := args["contact_id"].(string)
+			return handleContactWhereabouts(ctx, deps, strings.TrimSpace(name), strings.TrimSpace(id))
+		},
+	})
+}
+
+// whereaboutsSource is one provenance-carrying entry in the fused
+// view. Entries are ordered best-first by the ranking the tool
+// description promises; rank is the order, not a numeric field.
+type whereaboutsSource struct {
+	// Source identifies the provenance: "bermuda_room",
+	// "ha_person_zone", or "companion_location".
+	Source string `json:"source"`
+
+	// Zone/room fields (presence sources).
+	State     string `json:"state,omitempty"`
+	Room      string `json:"room,omitempty"`
+	RoomVia   string `json:"room_via,omitempty"`
+	Since     string `json:"since,omitempty"`
+	RoomSince string `json:"room_since,omitempty"`
+
+	// Device fields (companion_location sources).
+	Device       string          `json:"device,omitempty"`
+	Platform     string          `json:"platform,omitempty"`
+	Availability string          `json:"availability,omitempty"`
+	Status       string          `json:"status,omitempty"`
+	Freshness    string          `json:"freshness,omitempty"`
+	ObservedAgo  string          `json:"observed_ago,omitempty"`
+	ReceivedAgo  string          `json:"received_ago,omitempty"`
+	Location     json.RawMessage `json:"location,omitempty"`
+}
+
+type whereaboutsResult struct {
+	Contact   string `json:"contact"`
+	ContactID string `json:"contact_id"`
+	TrustZone string `json:"trust_zone"`
+	// BestSource names the leading entry of Sources and Basis says why
+	// it leads — precomputed so the model does not re-derive the
+	// ranking.
+	BestSource string              `json:"best_source,omitempty"`
+	Basis      string              `json:"basis,omitempty"`
+	Sources    []whereaboutsSource `json:"sources"`
+}
+
+func handleContactWhereabouts(ctx context.Context, deps CounterpartyToolDeps, name, id string) (string, error) {
+	contact, err := resolveWhereaboutsContact(deps.Contacts, name, id)
+	if err != nil {
+		return "", err
+	}
+
+	now := time.Now().UTC()
+	var presenceSources, deviceSources []whereaboutsSource
+	home := false
+
+	// HA person presence, through the contact's binding.
+	if deps.Presence != nil {
+		if entity, ok, err := deps.Contacts.HAPersonEntity(contact.ID); err == nil && ok && entity != "" {
+			if snap, tracked := deps.Presence(entity); tracked {
+				home = strings.EqualFold(snap.State, "home")
+				zone := whereaboutsSource{Source: "ha_person_zone", State: snap.State}
+				if !snap.Since.IsZero() {
+					zone.Since = promptfmt.FormatDeltaOnly(snap.Since, now)
+				}
+				if home && snap.Room != "" {
+					room := whereaboutsSource{Source: "bermuda_room", Room: snap.Room, RoomVia: snap.RoomSource}
+					if !snap.RoomSince.IsZero() {
+						room.RoomSince = promptfmt.FormatDeltaOnly(snap.RoomSince, now)
+					}
+					presenceSources = append(presenceSources, room)
+				}
+				presenceSources = append(presenceSources, zone)
+			}
+		}
+	}
+
+	// Companion location observations from every bound device.
+	type timedSource struct {
+		entry      whereaboutsSource
+		observedAt time.Time
+		available  bool
+	}
+	var timedDevices []timedSource
+	if deps.Companions != nil && deps.AccountsForContact != nil {
+		owned := make(map[string]bool)
+		for _, acct := range deps.AccountsForContact(contact.ID.String()) {
+			owned[acct] = true
+		}
+		if len(owned) > 0 {
+			observations, err := deps.Companions.ListLatestObservations(ctx)
+			if err != nil {
+				return "", fmt.Errorf("read companion observations: %w", err)
+			}
+			var live map[[2]string]bool
+			if deps.LiveIdentities != nil {
+				live = deps.LiveIdentities()
+			}
+			for _, obs := range observations {
+				if !owned[obs.Account] || obs.Kind != "ios.location" {
+					continue
+				}
+				entry := whereaboutsSource{
+					Source:      "companion_location",
+					Status:      string(obs.Status),
+					ObservedAgo: promptfmt.FormatDeltaOnly(obs.ObservedAt, now),
+					ReceivedAgo: promptfmt.FormatDeltaOnly(obs.ReceivedAt, now),
+				}
+				if device, ok, err := deps.Companions.Get(ctx, obs.Account, obs.ClientID); err == nil && ok {
+					entry.Device = device.ClientName
+					entry.Platform = device.Platform
+				}
+				entry.Availability = "offline"
+				if live[[2]string{obs.Account, obs.ClientID}] {
+					entry.Availability = "online"
+				}
+				available := obs.Status == "available"
+				if available {
+					entry.Location = obs.Payload
+					entry.Freshness = "fresh"
+					if now.Sub(obs.ObservedAt) > companionLocationStaleAfter {
+						entry.Freshness = "stale"
+					}
+				}
+				timedDevices = append(timedDevices, timedSource{entry: entry, observedAt: obs.ObservedAt, available: available})
+			}
+			// Freshest observation first; withdrawn entries sink.
+			sort.SliceStable(timedDevices, func(i, j int) bool {
+				if timedDevices[i].available != timedDevices[j].available {
+					return timedDevices[i].available
+				}
+				return timedDevices[i].observedAt.After(timedDevices[j].observedAt)
+			})
+			for _, ts := range timedDevices {
+				deviceSources = append(deviceSources, ts.entry)
+			}
+		}
+	}
+
+	if len(presenceSources) == 0 && len(deviceSources) == 0 {
+		return "", fmt.Errorf("contact %q has no HA person binding and no bound companion devices — there is no whereabouts source to consult; the operator binds a person entity via the X-THANE-HA-PERSON contact field and companion accounts via companion.providers.<account>.contact", contact.FormattedName)
+	}
+
+	// Ranking: while home, room-level BLE is the most specific truth
+	// and presence leads; away, the freshest device fix beats the zone
+	// floor.
+	result := whereaboutsResult{
+		Contact:   contact.FormattedName,
+		ContactID: contact.ID.String(),
+		TrustZone: contact.TrustZone,
+	}
+	if home {
+		result.Sources = append(presenceSources, deviceSources...)
+		result.Basis = "home per person entity; room-level presence is the most specific source while home"
+	} else {
+		result.Sources = append(deviceSources, presenceSources...)
+		result.Basis = "not home per person entity; the freshest device location leads and zone state is the floor"
+	}
+	if len(presenceSources) == 0 {
+		result.Basis = "no presence tracking for this contact; device locations only"
+	}
+	if len(deviceSources) == 0 {
+		result.Basis = "no bound companion devices; presence only"
+	}
+	result.BestSource = result.Sources[0].Source
+
+	out, err := json.Marshal(result)
+	if err != nil {
+		return "", fmt.Errorf("marshal whereabouts: %w", err)
+	}
+	return string(out), nil
+}
+
+func resolveWhereaboutsContact(store *contacts.Store, name, id string) (*contacts.Contact, error) {
+	if id != "" {
+		parsed, err := uuid.Parse(id)
+		if err != nil {
+			return nil, fmt.Errorf("contact_id %q is not a UUID; pass the id from contact context or use name instead", id)
+		}
+		c, err := store.Get(parsed)
+		if err != nil {
+			return nil, fmt.Errorf("no contact with id %q; use name to resolve by display name", id)
+		}
+		return c, nil
+	}
+	if name == "" {
+		return nil, errors.New("pass name or contact_id — whose whereabouts?")
+	}
+	c, err := store.ResolveContact(name)
+	if err != nil {
+		return nil, fmt.Errorf("no contact matched %q; try the exact formatted name or a nickname, or search with contact tools first", name)
+	}
+	return c, nil
+}

--- a/internal/tools/counterparty_tools.go
+++ b/internal/tools/counterparty_tools.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,6 +15,10 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/state/companions"
 	"github.com/nugget/thane-ai-agent/internal/state/contacts"
 )
+
+// maxWhereaboutsSources caps the fused view's entry count; truncation
+// is reported explicitly. Far above any real fleet.
+const maxWhereaboutsSources = 16
 
 // CounterpartyToolDeps are the join sources the fused counterparty
 // view composes (#1450). Every optional source degrades to absence.
@@ -47,6 +52,9 @@ func (r *Registry) EnableCounterpartyTools(deps CounterpartyToolDeps) {
 			"contact record roots and ranked best-first: room-level presence while they are home, their " +
 			"freshest companion-device location when away, and zone-level person state as the floor. Each " +
 			"source carries its own provenance and freshness — nothing is blended into a single guess. " +
+			"Only the leading available device fix includes its location payload; every device entry " +
+			"carries account, client_id, and device_id, so fetch any other device's payload with " +
+			"companion_last_known_location. " +
 			"This is the first door for \"where is <person>\" questions; reach for " +
 			"companion_last_known_location only when you need one specific device's stored fix. " +
 			"Pass name (resolved like other contact tools) or contact_id (UUID). A contact with no HA " +
@@ -88,8 +96,13 @@ type whereaboutsSource struct {
 	Since     string `json:"since,omitempty"`
 	RoomSince string `json:"room_since,omitempty"`
 
-	// Device fields (companion_location sources).
+	// Device fields (companion_location sources). Account, ClientID,
+	// and DeviceID make each entry uniquely identifiable and let the
+	// result chain into companion_last_known_location without guessing.
 	Device       string          `json:"device,omitempty"`
+	Account      string          `json:"account,omitempty"`
+	ClientID     string          `json:"client_id,omitempty"`
+	DeviceID     string          `json:"device_id,omitempty"`
 	Platform     string          `json:"platform,omitempty"`
 	Availability string          `json:"availability,omitempty"`
 	Status       string          `json:"status,omitempty"`
@@ -103,6 +116,9 @@ type whereaboutsResult struct {
 	Contact   string `json:"contact"`
 	ContactID string `json:"contact_id"`
 	TrustZone string `json:"trust_zone"`
+	// TruncatedDevices counts device entries dropped by the result
+	// cap; zero (omitted) means every bound device is listed.
+	TruncatedDevices int `json:"truncated_devices,omitempty"`
 	// BestSource names the leading entry of Sources and Basis says why
 	// it leads — precomputed so the model does not re-derive the
 	// ranking.
@@ -118,14 +134,21 @@ func handleContactWhereabouts(ctx context.Context, deps CounterpartyToolDeps, na
 	}
 
 	now := time.Now().UTC()
-	var presenceSources, deviceSources []whereaboutsSource
-	home := false
+	var presenceSources []whereaboutsSource
+	// Presence is three-state: home, confirmed away (not_home or a
+	// named zone), or unknown — the tracker seeds Unknown and HA can
+	// report unavailable, and the basis must not claim "not home" on
+	// either of those.
+	home, presenceUnknown := false, true
+	hasHABinding := false
 
-	// HA person presence, through the contact's binding.
-	if deps.Presence != nil {
-		if entity, ok, err := deps.Contacts.HAPersonEntity(contact.ID); err == nil && ok && entity != "" {
+	if entity, ok, err := deps.Contacts.HAPersonEntity(contact.ID); err == nil && ok && entity != "" {
+		hasHABinding = true
+		if deps.Presence != nil {
 			if snap, tracked := deps.Presence(entity); tracked {
-				home = strings.EqualFold(snap.State, "home")
+				state := strings.ToLower(strings.TrimSpace(snap.State))
+				home = state == "home"
+				presenceUnknown = state == "" || state == "unknown" || state == "unavailable"
 				zone := whereaboutsSource{Source: "ha_person_zone", State: snap.State}
 				if !snap.Since.IsZero() {
 					zone.Since = promptfmt.FormatDeltaOnly(snap.Since, now)
@@ -142,92 +165,136 @@ func handleContactWhereabouts(ctx context.Context, deps CounterpartyToolDeps, na
 		}
 	}
 
-	// Companion location observations from every bound device.
+	// Companion location observations, scoped at the query to this
+	// contact's bound accounts. Available and withdrawn entries are
+	// partitioned: withdrawn rows must trail even the zone floor.
 	type timedSource struct {
 		entry      whereaboutsSource
 		observedAt time.Time
-		available  bool
 	}
-	var timedDevices []timedSource
-	if deps.Companions != nil && deps.AccountsForContact != nil {
-		owned := make(map[string]bool)
-		for _, acct := range deps.AccountsForContact(contact.ID.String()) {
-			owned[acct] = true
+	var availableDevices, withdrawnDevices []timedSource
+	var boundAccounts []string
+	if deps.AccountsForContact != nil {
+		boundAccounts = deps.AccountsForContact(contact.ID.String())
+	}
+	if deps.Companions != nil && len(boundAccounts) > 0 {
+		observations, err := deps.Companions.LatestObservationsByKind(ctx, "ios.location", boundAccounts)
+		if err != nil {
+			return "", fmt.Errorf("read companion observations: %w", err)
 		}
-		if len(owned) > 0 {
-			observations, err := deps.Companions.ListLatestObservations(ctx)
-			if err != nil {
-				return "", fmt.Errorf("read companion observations: %w", err)
+		var live map[[2]string]bool
+		if deps.LiveIdentities != nil {
+			live = deps.LiveIdentities()
+		}
+		for _, obs := range observations {
+			entry := whereaboutsSource{
+				Source:      "companion_location",
+				Account:     obs.Account,
+				ClientID:    obs.ClientID,
+				DeviceID:    obs.DeviceID,
+				Status:      string(obs.Status),
+				ObservedAgo: promptfmt.FormatDeltaOnly(obs.ObservedAt, now),
+				ReceivedAgo: promptfmt.FormatDeltaOnly(obs.ReceivedAt, now),
 			}
-			var live map[[2]string]bool
-			if deps.LiveIdentities != nil {
-				live = deps.LiveIdentities()
+			if device, ok, err := deps.Companions.Get(ctx, obs.Account, obs.ClientID); err == nil && ok {
+				entry.Device = device.ClientName
+				entry.Platform = device.Platform
 			}
-			for _, obs := range observations {
-				if !owned[obs.Account] || obs.Kind != "ios.location" {
-					continue
-				}
-				entry := whereaboutsSource{
-					Source:      "companion_location",
-					Status:      string(obs.Status),
-					ObservedAgo: promptfmt.FormatDeltaOnly(obs.ObservedAt, now),
-					ReceivedAgo: promptfmt.FormatDeltaOnly(obs.ReceivedAt, now),
-				}
-				if device, ok, err := deps.Companions.Get(ctx, obs.Account, obs.ClientID); err == nil && ok {
-					entry.Device = device.ClientName
-					entry.Platform = device.Platform
-				}
-				entry.Availability = "offline"
-				if live[[2]string{obs.Account, obs.ClientID}] {
-					entry.Availability = "online"
-				}
-				available := obs.Status == "available"
-				if available {
-					entry.Location = obs.Payload
-					entry.Freshness = "fresh"
-					if now.Sub(obs.ObservedAt) > companionLocationStaleAfter {
-						entry.Freshness = "stale"
-					}
-				}
-				timedDevices = append(timedDevices, timedSource{entry: entry, observedAt: obs.ObservedAt, available: available})
+			entry.Availability = "offline"
+			if live[[2]string{obs.Account, obs.ClientID}] {
+				entry.Availability = "online"
 			}
-			// Freshest observation first; withdrawn entries sink.
-			sort.SliceStable(timedDevices, func(i, j int) bool {
-				if timedDevices[i].available != timedDevices[j].available {
-					return timedDevices[i].available
+			if obs.Status == "available" {
+				entry.Location = obs.Payload
+				entry.Freshness = "fresh"
+				if now.Sub(obs.ObservedAt) > companionLocationStaleAfter {
+					entry.Freshness = "stale"
 				}
-				return timedDevices[i].observedAt.After(timedDevices[j].observedAt)
-			})
-			for _, ts := range timedDevices {
-				deviceSources = append(deviceSources, ts.entry)
+				availableDevices = append(availableDevices, timedSource{entry: entry, observedAt: obs.ObservedAt})
+			} else {
+				withdrawnDevices = append(withdrawnDevices, timedSource{entry: entry, observedAt: obs.ObservedAt})
 			}
 		}
+		sort.SliceStable(availableDevices, func(i, j int) bool {
+			return availableDevices[i].observedAt.After(availableDevices[j].observedAt)
+		})
+		sort.SliceStable(withdrawnDevices, func(i, j int) bool {
+			return withdrawnDevices[i].observedAt.After(withdrawnDevices[j].observedAt)
+		})
 	}
 
-	if len(presenceSources) == 0 && len(deviceSources) == 0 {
+	// The configuration-gap error is reserved for the genuinely
+	// unbound contact. A bound contact whose sources yielded nothing
+	// gets a valid empty result whose basis says exactly which binding
+	// produced nothing — bound-but-silent is not misconfigured.
+	if !hasHABinding && len(boundAccounts) == 0 {
 		return "", fmt.Errorf("contact %q has no HA person binding and no bound companion devices — there is no whereabouts source to consult; the operator binds a person entity via the X-THANE-HA-PERSON contact field and companion accounts via companion.providers.<account>.contact", contact.FormattedName)
 	}
 
-	// Ranking: while home, room-level BLE is the most specific truth
-	// and presence leads; away, the freshest device fix beats the zone
-	// floor.
 	result := whereaboutsResult{
 		Contact:   contact.FormattedName,
 		ContactID: contact.ID.String(),
 		TrustZone: contact.TrustZone,
 	}
-	if home {
-		result.Sources = append(presenceSources, deviceSources...)
-		result.Basis = "home per person entity; room-level presence is the most specific source while home"
-	} else {
-		result.Sources = append(deviceSources, presenceSources...)
-		result.Basis = "not home per person entity; the freshest device location leads and zone state is the floor"
+
+	// Only the leading available fix carries its payload: the result
+	// stays bounded across any fleet, and other payloads are one
+	// companion_last_known_location call away by device identity.
+	for i := range availableDevices {
+		if i > 0 {
+			availableDevices[i].entry.Location = nil
+		}
 	}
-	if len(presenceSources) == 0 {
+	available := make([]whereaboutsSource, 0, len(availableDevices))
+	for _, ts := range availableDevices {
+		available = append(available, ts.entry)
+	}
+	withdrawn := make([]whereaboutsSource, 0, len(withdrawnDevices))
+	for _, ts := range withdrawnDevices {
+		withdrawn = append(withdrawn, ts.entry)
+	}
+
+	// Ranking: room-level truth leads while home; the freshest device
+	// fix leads while away; unknown presence never asserts either, so
+	// the freshest fix leads with the unknown zone state listed after.
+	// Withdrawn entries always trail the zone floor.
+	switch {
+	case home:
+		result.Sources = append(append(presenceSources, available...), withdrawn...)
+		result.Basis = "home per person entity; room-level presence is the most specific source while home"
+	case presenceUnknown && len(presenceSources) > 0:
+		result.Sources = append(append(available, presenceSources...), withdrawn...)
+		result.Basis = "presence state is unknown; the freshest device location leads without asserting home or away"
+	case len(presenceSources) > 0:
+		result.Sources = append(append(available, presenceSources...), withdrawn...)
+		result.Basis = "not home per person entity; the freshest device location leads and zone state is the floor"
+	default:
+		result.Sources = append(available, withdrawn...)
 		result.Basis = "no presence tracking for this contact; device locations only"
 	}
-	if len(deviceSources) == 0 {
-		result.Basis = "no bound companion devices; presence only"
+	if len(available) == 0 && len(presenceSources) > 0 && len(withdrawn) == 0 {
+		result.Basis = "no bound companion devices have published a location; presence only"
+	}
+
+	if len(result.Sources) == 0 {
+		switch {
+		case hasHABinding && len(boundAccounts) > 0:
+			result.Basis = "bound, but silent: the person entity is not tracked (check person.track) and no bound device has published a location"
+		case hasHABinding:
+			result.Basis = "bound to a person entity that the presence tracker does not track (check person.track); no companion devices bound"
+		default:
+			result.Basis = "companion accounts are bound but no device has published a location yet"
+		}
+		out, err := json.Marshal(result)
+		if err != nil {
+			return "", fmt.Errorf("marshal whereabouts: %w", err)
+		}
+		return string(out), nil
+	}
+
+	if len(result.Sources) > maxWhereaboutsSources {
+		result.TruncatedDevices = len(result.Sources) - maxWhereaboutsSources
+		result.Sources = result.Sources[:maxWhereaboutsSources]
 	}
 	result.BestSource = result.Sources[0].Source
 
@@ -245,8 +312,11 @@ func resolveWhereaboutsContact(store *contacts.Store, name, id string) (*contact
 			return nil, fmt.Errorf("contact_id %q is not a UUID; pass the id from contact context or use name instead", id)
 		}
 		c, err := store.Get(parsed)
-		if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, fmt.Errorf("no contact with id %q; use name to resolve by display name", id)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("look up contact %q: %w", id, err)
 		}
 		return c, nil
 	}
@@ -254,8 +324,11 @@ func resolveWhereaboutsContact(store *contacts.Store, name, id string) (*contact
 		return nil, errors.New("pass name or contact_id — whose whereabouts?")
 	}
 	c, err := store.ResolveContact(name)
-	if err != nil {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, fmt.Errorf("no contact matched %q; try the exact formatted name or a nickname, or search with contact tools first", name)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("resolve contact %q: %w", name, err)
 	}
 	return c, nil
 }

--- a/internal/tools/counterparty_tools.go
+++ b/internal/tools/counterparty_tools.go
@@ -21,7 +21,8 @@ import (
 const maxWhereaboutsSources = 16
 
 // CounterpartyToolDeps are the join sources the fused counterparty
-// view composes (#1450). Every optional source degrades to absence.
+// view composes (#1450). An unconfigured optional source degrades to
+// absence; a configured source that fails is reported to the caller.
 type CounterpartyToolDeps struct {
 	Contacts   *contacts.Store
 	Companions *companions.Store
@@ -119,9 +120,9 @@ type whereaboutsResult struct {
 	// TruncatedDevices counts device entries dropped by the result
 	// cap; zero (omitted) means every bound device is listed.
 	TruncatedDevices int `json:"truncated_devices,omitempty"`
-	// BestSource names the leading entry of Sources and Basis says why
-	// it leads — precomputed so the model does not re-derive the
-	// ranking.
+	// BestSource names the leading usable entry of Sources and Basis says
+	// why it leads — precomputed so the model does not re-derive the
+	// ranking. It is omitted when every source is withdrawn provenance.
 	BestSource string              `json:"best_source,omitempty"`
 	Basis      string              `json:"basis,omitempty"`
 	Sources    []whereaboutsSource `json:"sources"`
@@ -142,7 +143,11 @@ func handleContactWhereabouts(ctx context.Context, deps CounterpartyToolDeps, na
 	home, presenceUnknown := false, true
 	hasHABinding := false
 
-	if entity, ok, err := deps.Contacts.HAPersonEntity(contact.ID); err == nil && ok && entity != "" {
+	entity, hasEntity, err := deps.Contacts.HAPersonEntity(contact.ID)
+	if err != nil {
+		return "", fmt.Errorf("read HA person binding for contact %q: %w", contact.FormattedName, err)
+	}
+	if hasEntity && entity != "" {
 		hasHABinding = true
 		if deps.Presence != nil {
 			if snap, tracked := deps.Presence(entity); tracked {
@@ -196,7 +201,11 @@ func handleContactWhereabouts(ctx context.Context, deps CounterpartyToolDeps, na
 				ObservedAgo: promptfmt.FormatDeltaOnly(obs.ObservedAt, now),
 				ReceivedAgo: promptfmt.FormatDeltaOnly(obs.ReceivedAt, now),
 			}
-			if device, ok, err := deps.Companions.Get(ctx, obs.Account, obs.ClientID); err == nil && ok {
+			device, ok, err := deps.Companions.Get(ctx, obs.Account, obs.ClientID)
+			if err != nil {
+				return "", fmt.Errorf("read companion device metadata for %s/%s: %w", obs.Account, obs.ClientID, err)
+			}
+			if ok {
 				entry.Device = device.ClientName
 				entry.Platform = device.Platform
 			}
@@ -254,26 +263,66 @@ func handleContactWhereabouts(ctx context.Context, deps CounterpartyToolDeps, na
 		withdrawn = append(withdrawn, ts.entry)
 	}
 
+	// Presence is a semantic floor, not another fleet entry. Reserve its
+	// slots before capping device sources so a large fleet cannot truncate
+	// away the HA zone (or miscount that zone as a truncated device).
+	totalDevices := len(available) + len(withdrawn)
+	deviceBudget := maxWhereaboutsSources - len(presenceSources)
+	if deviceBudget < 0 {
+		deviceBudget = 0
+	}
+	if len(available) > deviceBudget {
+		available = available[:deviceBudget]
+		withdrawn = nil
+	} else if remaining := deviceBudget - len(available); len(withdrawn) > remaining {
+		withdrawn = withdrawn[:remaining]
+	}
+	result.TruncatedDevices = totalDevices - len(available) - len(withdrawn)
+
 	// Ranking: room-level truth leads while home; the freshest device
 	// fix leads while away; unknown presence never asserts either, so
 	// the freshest fix leads with the unknown zone state listed after.
 	// Withdrawn entries always trail the zone floor.
 	switch {
 	case home:
-		result.Sources = append(append(presenceSources, available...), withdrawn...)
-		result.Basis = "home per person entity; room-level presence is the most specific source while home"
+		result.Sources = append(result.Sources, presenceSources...)
+		result.Sources = append(result.Sources, available...)
+		result.Sources = append(result.Sources, withdrawn...)
+		if len(presenceSources) > 0 && presenceSources[0].Source == "bermuda_room" {
+			result.Basis = "home per person entity; room-level presence leads as the most specific source while home"
+		} else {
+			result.Basis = "home per person entity; zone state leads because no room-level presence is available"
+		}
 	case presenceUnknown && len(presenceSources) > 0:
-		result.Sources = append(append(available, presenceSources...), withdrawn...)
-		result.Basis = "presence state is unknown; the freshest device location leads without asserting home or away"
+		result.Sources = append(result.Sources, available...)
+		result.Sources = append(result.Sources, presenceSources...)
+		result.Sources = append(result.Sources, withdrawn...)
+		if len(available) > 0 {
+			result.Basis = "presence state is unknown; the freshest device location leads without asserting home or away"
+		} else if len(withdrawn) > 0 {
+			result.Basis = "presence state is unknown; zone state leads because no available device location exists; withdrawn device entries are not locations"
+		} else {
+			result.Basis = "no bound companion device has published a location; unknown presence state is the only whereabouts source"
+		}
 	case len(presenceSources) > 0:
-		result.Sources = append(append(available, presenceSources...), withdrawn...)
-		result.Basis = "not home per person entity; the freshest device location leads and zone state is the floor"
+		result.Sources = append(result.Sources, available...)
+		result.Sources = append(result.Sources, presenceSources...)
+		result.Sources = append(result.Sources, withdrawn...)
+		if len(available) > 0 {
+			result.Basis = "not home per person entity; the freshest device location leads and zone state is the floor"
+		} else if len(withdrawn) > 0 {
+			result.Basis = "not home per person entity; zone state leads because no available device location exists; withdrawn device entries are not locations"
+		} else {
+			result.Basis = "no bound companion device has published a location; person-entity zone state is the only whereabouts source"
+		}
 	default:
-		result.Sources = append(available, withdrawn...)
-		result.Basis = "no presence tracking for this contact; device locations only"
-	}
-	if len(available) == 0 && len(presenceSources) > 0 && len(withdrawn) == 0 {
-		result.Basis = "no bound companion devices have published a location; presence only"
+		result.Sources = append(result.Sources, available...)
+		result.Sources = append(result.Sources, withdrawn...)
+		if len(available) > 0 {
+			result.Basis = "no presence tracking for this contact; device locations only"
+		} else {
+			result.Basis = "no available whereabouts source; bound devices have withdrawn location sharing, so their entries are provenance only"
+		}
 	}
 
 	if len(result.Sources) == 0 {
@@ -292,11 +341,9 @@ func handleContactWhereabouts(ctx context.Context, deps CounterpartyToolDeps, na
 		return string(out), nil
 	}
 
-	if len(result.Sources) > maxWhereaboutsSources {
-		result.TruncatedDevices = len(result.Sources) - maxWhereaboutsSources
-		result.Sources = result.Sources[:maxWhereaboutsSources]
+	if result.Sources[0].Status != "withdrawn" {
+		result.BestSource = result.Sources[0].Source
 	}
-	result.BestSource = result.Sources[0].Source
 
 	out, err := json.Marshal(result)
 	if err != nil {

--- a/internal/tools/counterparty_tools_test.go
+++ b/internal/tools/counterparty_tools_test.go
@@ -3,10 +3,12 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/nugget/thane-ai-agent/internal/integrations/companion"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 	"github.com/nugget/thane-ai-agent/internal/state/contacts"
@@ -208,6 +210,118 @@ func TestContactWhereaboutsWithdrawnTrailsZoneFloor(t *testing.T) {
 	}
 	if last := res.Sources[len(res.Sources)-1]; last.Source != "companion_location" || last.Status != "withdrawn" {
 		t.Errorf("withdrawn entry does not trail: %+v", res.Sources)
+	}
+	if strings.Contains(res.Basis, "device location leads") || !strings.Contains(res.Basis, "zone state leads") {
+		t.Errorf("basis contradicts the zone-floor ranking: %q", res.Basis)
+	}
+}
+
+func TestContactWhereaboutsWithdrawnOnlyBasis(t *testing.T) {
+	tests := []struct {
+		name  string
+		state string
+	}{
+		{name: "away", state: "not_home"},
+		{name: "unknown", state: "Unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fx := newWhereaboutsFixture(t, tt.state, "", map[string]companion.ObservationStatus{
+				"device-1": companion.ObservationWithdrawn,
+			})
+			out, err := handleContactWhereabouts(context.Background(), fx.deps, "Alice Operator", "")
+			if err != nil {
+				t.Fatalf("handler: %v", err)
+			}
+			res := decodeWhereabouts(t, out)
+			if res.BestSource != "ha_person_zone" {
+				t.Errorf("BestSource = %q, want zone state", res.BestSource)
+			}
+			if strings.Contains(res.Basis, "device location leads") || !strings.Contains(res.Basis, "zone state leads") {
+				t.Errorf("basis contradicts withdrawn-only ranking: %q", res.Basis)
+			}
+		})
+	}
+}
+
+func TestContactWhereaboutsDeviceCapPreservesZoneFloor(t *testing.T) {
+	observations := make(map[string]companion.ObservationStatus, maxWhereaboutsSources+4)
+	for i := 0; i < maxWhereaboutsSources+4; i++ {
+		observations[fmt.Sprintf("device-%02d", i)] = companion.ObservationAvailable
+	}
+	fx := newWhereaboutsFixture(t, "not_home", "", observations)
+	out, err := handleContactWhereabouts(context.Background(), fx.deps, "Alice Operator", "")
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	res := decodeWhereabouts(t, out)
+	if len(res.Sources) != maxWhereaboutsSources {
+		t.Fatalf("sources = %d, want cap %d", len(res.Sources), maxWhereaboutsSources)
+	}
+	if res.TruncatedDevices != 5 {
+		t.Errorf("TruncatedDevices = %d, want 5 device entries", res.TruncatedDevices)
+	}
+	deviceSources := 0
+	zoneSources := 0
+	for _, src := range res.Sources {
+		switch src.Source {
+		case "companion_location":
+			deviceSources++
+		case "ha_person_zone":
+			zoneSources++
+		}
+	}
+	if deviceSources != maxWhereaboutsSources-1 || zoneSources != 1 {
+		t.Errorf("capped sources = %d devices/%d zones, want %d/1", deviceSources, zoneSources, maxWhereaboutsSources-1)
+	}
+	if last := res.Sources[len(res.Sources)-1]; last.Source != "ha_person_zone" {
+		t.Errorf("zone floor was not preserved at the end: %+v", res.Sources)
+	}
+}
+
+func TestContactWhereaboutsWithdrawnWithoutPresenceHasNoBestSource(t *testing.T) {
+	fx := newWhereaboutsFixture(t, "not_home", "", map[string]companion.ObservationStatus{
+		"device-1": companion.ObservationWithdrawn,
+	})
+	if err := fx.deps.Contacts.SetHAPersonEntity(uuid.MustParse(fx.contactID), ""); err != nil {
+		t.Fatalf("clear HA binding: %v", err)
+	}
+	out, err := handleContactWhereabouts(context.Background(), fx.deps, "Alice Operator", "")
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	res := decodeWhereabouts(t, out)
+	if res.BestSource != "" {
+		t.Errorf("BestSource = %q, want none when every source is withdrawn", res.BestSource)
+	}
+	if !strings.Contains(res.Basis, "no available whereabouts source") {
+		t.Errorf("basis treats withdrawn provenance as a location: %q", res.Basis)
+	}
+}
+
+func TestContactWhereaboutsHABindingReadFailure(t *testing.T) {
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	store, err := contacts.NewStore(db, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Upsert(&contacts.Contact{FormattedName: "Alice Operator"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`DROP INDEX idx_contacts_ha_person_unique`); err != nil {
+		t.Fatalf("drop HA binding index: %v", err)
+	}
+	if _, err := db.Exec(`ALTER TABLE contacts DROP COLUMN ha_person_entity`); err != nil {
+		t.Fatalf("drop HA binding column: %v", err)
+	}
+
+	_, err = handleContactWhereabouts(context.Background(), CounterpartyToolDeps{Contacts: store}, "Alice Operator", "")
+	if err == nil || !strings.Contains(err.Error(), "read HA person binding") {
+		t.Fatalf("binding read failure was collapsed into absence: %v", err)
 	}
 }
 

--- a/internal/tools/counterparty_tools_test.go
+++ b/internal/tools/counterparty_tools_test.go
@@ -191,3 +191,102 @@ func TestContactWhereaboutsResolution(t *testing.T) {
 		t.Errorf("by-id result = %+v", res)
 	}
 }
+
+// TestContactWhereaboutsWithdrawnTrailsZoneFloor pins the fixed
+// ranking: withdrawn entries trail even the zone floor, so an
+// all-withdrawn fleet can never make a payload-less device entry the
+// best source.
+func TestContactWhereaboutsWithdrawnTrailsZoneFloor(t *testing.T) {
+	fx := newWhereaboutsFixture(t, "not_home", "", map[string]companion.ObservationStatus{"device-1": companion.ObservationWithdrawn})
+	out, err := handleContactWhereabouts(context.Background(), fx.deps, "Alice Operator", "")
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	res := decodeWhereabouts(t, out)
+	if res.BestSource != "ha_person_zone" {
+		t.Errorf("BestSource = %q, want the zone floor when every fix is withdrawn", res.BestSource)
+	}
+	if last := res.Sources[len(res.Sources)-1]; last.Source != "companion_location" || last.Status != "withdrawn" {
+		t.Errorf("withdrawn entry does not trail: %+v", res.Sources)
+	}
+}
+
+// TestContactWhereaboutsUnknownPresence pins the three-state fix: an
+// Unknown tracker state must not claim away ranking's basis.
+func TestContactWhereaboutsUnknownPresence(t *testing.T) {
+	fx := newWhereaboutsFixture(t, "Unknown", "", map[string]companion.ObservationStatus{"device-1": companion.ObservationAvailable})
+	out, err := handleContactWhereabouts(context.Background(), fx.deps, "Alice Operator", "")
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	res := decodeWhereabouts(t, out)
+	if res.Sources[0].Source != "companion_location" {
+		t.Errorf("unknown presence should lead with the device fix: %+v", res.Sources[0])
+	}
+	if !strings.Contains(res.Basis, "unknown") || strings.Contains(res.Basis, "not home") {
+		t.Errorf("basis asserts unsupported location: %q", res.Basis)
+	}
+}
+
+// TestContactWhereaboutsBoundButSilent pins the C3 distinction: a
+// bound contact whose sources yielded nothing gets a valid empty
+// result explaining which binding was silent — never the
+// configuration-gap error.
+func TestContactWhereaboutsBoundButSilent(t *testing.T) {
+	cdb, err := database.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { cdb.Close() })
+	store, err := contacts.NewStore(cdb, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	alice, err := store.Upsert(&contacts.Contact{FormattedName: "Alice Operator"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetHAPersonEntity(alice.ID, "person.alice"); err != nil {
+		t.Fatal(err)
+	}
+	deps := CounterpartyToolDeps{
+		Contacts: store,
+		Presence: func(string) (contacts.PersonSnapshot, bool) { return contacts.PersonSnapshot{}, false }, // untracked
+	}
+	out, err := handleContactWhereabouts(context.Background(), deps, "Alice Operator", "")
+	if err != nil {
+		t.Fatalf("bound-but-silent must not error: %v", err)
+	}
+	res := decodeWhereabouts(t, out)
+	if len(res.Sources) != 0 || !strings.Contains(res.Basis, "person.track") {
+		t.Errorf("silent result should teach the tracking gap: %+v", res)
+	}
+}
+
+// TestContactWhereaboutsLeadingPayloadOnly pins the result bound: only
+// the freshest available fix carries its payload; the rest chain by
+// identity into companion_last_known_location.
+func TestContactWhereaboutsLeadingPayloadOnly(t *testing.T) {
+	fx := newWhereaboutsFixture(t, "not_home", "", nil)
+	now := time.Now().UTC()
+	store := fx.deps.Companions
+	seedLocation(t, store, "alice-acct", "device-old", companion.ObservationAvailable, now.Add(-3*time.Hour))
+	seedLocation(t, store, "alice-acct", "device-fresh", companion.ObservationAvailable, now.Add(-10*time.Minute))
+
+	out, err := handleContactWhereabouts(context.Background(), fx.deps, "Alice Operator", "")
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	res := decodeWhereabouts(t, out)
+	if res.Sources[0].ClientID != "device-fresh" || res.Sources[0].Location == nil {
+		t.Errorf("leading fix wrong or payload-less: %+v", res.Sources[0])
+	}
+	if res.Sources[1].Source != "companion_location" || res.Sources[1].Location != nil {
+		t.Errorf("non-leading fix must not carry a payload: %+v", res.Sources[1])
+	}
+	for _, src := range res.Sources[:2] {
+		if src.Account == "" || src.ClientID == "" || src.DeviceID == "" {
+			t.Errorf("chaining identity missing: %+v", src)
+		}
+	}
+}

--- a/internal/tools/counterparty_tools_test.go
+++ b/internal/tools/counterparty_tools_test.go
@@ -1,0 +1,193 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/companion"
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
+	"github.com/nugget/thane-ai-agent/internal/state/contacts"
+)
+
+type whereaboutsFixture struct {
+	deps      CounterpartyToolDeps
+	contactID string
+}
+
+// newWhereaboutsFixture builds a contact ("Alice Operator") with an HA
+// person binding, one bound companion account carrying the given
+// observations, and a fake presence snapshot.
+func newWhereaboutsFixture(t *testing.T, state, room string, observations map[string]companion.ObservationStatus) whereaboutsFixture {
+	t.Helper()
+	cdb, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("contacts db: %v", err)
+	}
+	t.Cleanup(func() { cdb.Close() })
+	contactStore, err := contacts.NewStore(cdb, nil)
+	if err != nil {
+		t.Fatalf("contacts store: %v", err)
+	}
+	alice, err := contactStore.Upsert(&contacts.Contact{FormattedName: "Alice Operator"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := contactStore.SetHAPersonEntity(alice.ID, "person.alice"); err != nil {
+		t.Fatal(err)
+	}
+
+	companionStore := newObservationToolStore(t)
+	now := time.Now().UTC()
+	i := 0
+	for device, status := range observations {
+		seedLocation(t, companionStore, "alice-acct", device, status, now.Add(-time.Duration(30+i*30)*time.Minute))
+		i++
+	}
+
+	deps := CounterpartyToolDeps{
+		Contacts:   contactStore,
+		Companions: companionStore,
+		Presence: func(entity string) (contacts.PersonSnapshot, bool) {
+			if entity != "person.alice" {
+				return contacts.PersonSnapshot{}, false
+			}
+			snap := contacts.PersonSnapshot{EntityID: entity, State: state, Since: now.Add(-2 * time.Hour)}
+			if room != "" {
+				snap.Room = room
+				snap.RoomSource = "bermuda"
+				snap.RoomSince = now.Add(-20 * time.Minute)
+			}
+			return snap, true
+		},
+		AccountsForContact: func(id string) []string {
+			if id == alice.ID.String() {
+				return []string{"alice-acct"}
+			}
+			return nil
+		},
+		LiveIdentities: func() map[[2]string]bool { return nil },
+	}
+	return whereaboutsFixture{deps: deps, contactID: alice.ID.String()}
+}
+
+func decodeWhereabouts(t *testing.T, out string) whereaboutsResult {
+	t.Helper()
+	var res whereaboutsResult
+	if err := json.Unmarshal([]byte(out), &res); err != nil {
+		t.Fatalf("decode: %v\n%s", err, out)
+	}
+	return res
+}
+
+func TestContactWhereaboutsHomeRanking(t *testing.T) {
+	fx := newWhereaboutsFixture(t, "home", "office", map[string]companion.ObservationStatus{"device-1": companion.ObservationAvailable})
+	out, err := handleContactWhereabouts(context.Background(), fx.deps, "Alice Operator", "")
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	res := decodeWhereabouts(t, out)
+	if res.Contact != "Alice Operator" || res.ContactID != fx.contactID {
+		t.Errorf("identity = %q/%q", res.Contact, res.ContactID)
+	}
+	if len(res.Sources) != 3 {
+		t.Fatalf("sources = %+v, want room + zone + device", res.Sources)
+	}
+	if res.Sources[0].Source != "bermuda_room" || res.Sources[0].Room != "office" || res.Sources[0].RoomVia != "bermuda" {
+		t.Errorf("home ranking: leading source = %+v, want bermuda room", res.Sources[0])
+	}
+	if res.Sources[1].Source != "ha_person_zone" || res.Sources[2].Source != "companion_location" {
+		t.Errorf("home order = %s, %s", res.Sources[1].Source, res.Sources[2].Source)
+	}
+	if res.BestSource != "bermuda_room" || !strings.Contains(res.Basis, "home") {
+		t.Errorf("verdict = %q / %q", res.BestSource, res.Basis)
+	}
+}
+
+func TestContactWhereaboutsAwayRanking(t *testing.T) {
+	fx := newWhereaboutsFixture(t, "not_home", "", map[string]companion.ObservationStatus{"device-1": companion.ObservationAvailable})
+	out, err := handleContactWhereabouts(context.Background(), fx.deps, "Alice Operator", "")
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	res := decodeWhereabouts(t, out)
+	if res.Sources[0].Source != "companion_location" {
+		t.Errorf("away ranking: leading source = %+v, want device location", res.Sources[0])
+	}
+	if res.Sources[0].Location == nil || !strings.Contains(string(res.Sources[0].Location), "latitude") {
+		t.Errorf("device payload missing: %+v", res.Sources[0])
+	}
+	last := res.Sources[len(res.Sources)-1]
+	if last.Source != "ha_person_zone" || last.State != "not_home" {
+		t.Errorf("zone floor = %+v", last)
+	}
+	if res.BestSource != "companion_location" {
+		t.Errorf("BestSource = %q", res.BestSource)
+	}
+}
+
+func TestContactWhereaboutsWithdrawnSinks(t *testing.T) {
+	fx := newWhereaboutsFixture(t, "not_home", "", map[string]companion.ObservationStatus{
+		"device-1": companion.ObservationWithdrawn,
+		"device-2": companion.ObservationAvailable,
+	})
+	out, err := handleContactWhereabouts(context.Background(), fx.deps, "Alice Operator", "")
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	res := decodeWhereabouts(t, out)
+	var deviceEntries []whereaboutsSource
+	for _, src := range res.Sources {
+		if src.Source == "companion_location" {
+			deviceEntries = append(deviceEntries, src)
+		}
+	}
+	if len(deviceEntries) != 2 {
+		t.Fatalf("device entries = %+v", deviceEntries)
+	}
+	if deviceEntries[0].Status != "available" || deviceEntries[1].Status != "withdrawn" {
+		t.Errorf("withdrawn did not sink: %+v", deviceEntries)
+	}
+	if deviceEntries[1].Location != nil {
+		t.Errorf("withdrawn entry leaked payload: %+v", deviceEntries[1])
+	}
+}
+
+func TestContactWhereaboutsNoSources(t *testing.T) {
+	cdb, err := database.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { cdb.Close() })
+	store, err := contacts.NewStore(cdb, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Upsert(&contacts.Contact{FormattedName: "Bob Guest"}); err != nil {
+		t.Fatal(err)
+	}
+	deps := CounterpartyToolDeps{Contacts: store}
+	_, err = handleContactWhereabouts(context.Background(), deps, "Bob Guest", "")
+	if err == nil || !strings.Contains(err.Error(), "no whereabouts source") {
+		t.Fatalf("unbound contact must explain the configuration gap: %v", err)
+	}
+}
+
+func TestContactWhereaboutsResolution(t *testing.T) {
+	fx := newWhereaboutsFixture(t, "home", "", nil)
+	if _, err := handleContactWhereabouts(context.Background(), fx.deps, "", ""); err == nil {
+		t.Error("empty selector accepted")
+	}
+	if _, err := handleContactWhereabouts(context.Background(), fx.deps, "Nobody Real", ""); err == nil || !strings.Contains(err.Error(), "Nobody Real") {
+		t.Errorf("unknown name error must echo the selection: %v", err)
+	}
+	out, err := handleContactWhereabouts(context.Background(), fx.deps, "", fx.contactID)
+	if err != nil {
+		t.Fatalf("by-id: %v", err)
+	}
+	if res := decodeWhereabouts(t, out); res.BestSource == "" {
+		t.Errorf("by-id result = %+v", res)
+	}
+}

--- a/talents/companion.md
+++ b/talents/companion.md
@@ -39,12 +39,14 @@ Reading the device block:
 
 How to work here:
 
-- Asked where someone is, or about their phone's last whereabouts?
-  `companion_last_known_location` answers from stored data even while
-  the phone is offline or asleep, and says whose device it was, how
-  old the fix is, and whether it has gone stale. Reach for a device's
-  own live location tool only when the device block shows it online
-  and you need a fresh fix right now.
+- Asked where someone is? `contact_whereabouts` is the first door: it
+  fuses every source that person's contact record roots — room-level
+  presence while home, their freshest device location when away, zone
+  state as the floor — ranked, with provenance and freshness per
+  source. Reach for `companion_last_known_location` only when you need
+  one specific device's stored fix, and a device's own live location
+  tool only when the device block shows it online and you need a
+  fresh fix right now.
 - A connected device authors its own tools, so their exact names come
   from it, not from a fixed list. Use the tool whose name and
   description match the data you need; `macos_calendar_events` lists

--- a/talents/contacts.md
+++ b/talents/contacts.md
@@ -468,3 +468,7 @@ keeps the encoded vCard small enough to scan reliably. As with
 - For "merge two contacts" — there's no native merge tool. The
   workflow above (save absorbs, forget removes) is the supported
   pattern.
+
+- Asked where a contact is, `contact_whereabouts` fuses their
+  presence and device locations into one ranked, provenance-carrying
+  answer — start there rather than assembling it yourself.

--- a/talents/contacts.md
+++ b/talents/contacts.md
@@ -43,8 +43,8 @@ document-shaped, it isn't a memory fact either — push to documents.
   shortcut for asserting "who is this host's primary user."
 
 - **You're creating, updating, or removing a contact** — activate
-  `contacts_save`. This is also where the trust-zone decision lives,
-  and trust zones gate downstream tools.
+  `contacts_save`. Trust-zone assignment is operator-custodied and is
+  deliberately outside these everyday mutation tools.
 
 - **You're exchanging vCard data** — activate `contacts_vcf`. Import
   from external sources, export records for sharing (with trust-zone-
@@ -52,7 +52,7 @@ document-shaped, it isn't a memory fact either — push to documents.
 
 ## Constants across all branches
 
-- **Trust zones gate downstream tools.** Every contact carries a zone:
+- **Trust zones drive downstream policy.** Every contact carries a zone:
   `admin` (full access), `household` (family-level), `trusted`
   (established relationship), `known` (default; lower-privilege gated
   access). The zone is what `email_send`'s recipient gate reads and
@@ -60,7 +60,8 @@ document-shaped, it isn't a memory fact either — push to documents.
   filtering on vCard exports is a separate axis — it uses the
   *recipient*'s trust zone passed at export time, and only when
   exporting the agent's own card via `name: "self"`. Assigning a
-  zone is a policy decision, not a metadata field.
+  zone is a policy decision, not a metadata field, and
+  `contact_save` cannot assign or change it.
 
 - **save merges; forget soft-deletes.** `contact_save` with an
   existing name merges into the current record — non-empty scalar
@@ -206,19 +207,23 @@ right now."
 name: contacts_save
 tags: [contacts_save]
 kind: trailhead
-teaser: "Create or update a contact — the trust-zone decision is the central call."
+teaser: "Create, update, or remove ordinary contact data; trust zones remain operator-custodied."
 ---
 
 # Save
 
-You're mutating the directory. Two tools — one to write, one to
-delete — and one big decision: what trust zone does this contact
-belong in.
+You're mutating ordinary directory data. Two tools cover this surface:
+one writes and one deletes. Trust zones and identity bindings are not
+ordinary contact data and cannot be changed here.
 
-## The trust-zone decision
+## Trust-zone custody
 
-`contact_save` assigns a `trust_zone`, and that zone gates downstream
-tool access. The four zones:
+`contact_save` rejects `trust_zone`. A zone now confers inherited
+authority on bound companion devices, so only the operator may assign
+or change it through the authenticated CardDAV field
+`X-THANE-TRUST-ZONE` or direct curation. If a request needs a different
+zone, ask the operator to make that policy decision rather than trying
+to smuggle it through ordinary contact facts. The four zones are:
 
 - **`admin`** — full access. The host's primary user(s). Mail sends
   through, channels resolve, owner-scoped tools work. Almost always
@@ -234,21 +239,20 @@ tool access. The four zones:
   `known` recipient is **rejected** by the trust gate until
   explicitly promoted or authorized.
 
-When uncertain, **`known` is the safe default**: the record exists,
-the contact is recognized inbound, but no outbound action goes through
-without a deliberate decision. Promoting to `trusted` later is easy;
-demoting after the contact has been used for sends is messy.
+New contacts default to **`known`**: the record exists and the contact
+is recognized inbound, but no outbound action goes through without a
+deliberate operator decision. The operator can promote it later through
+the custody path.
 
 ## Create or update a person
 
-`contact_save` with `name` and `trust_zone`. Properties are person
-attributes; the merge semantics let you add details incrementally:
+`contact_save` takes `name` plus ordinary person attributes; the merge
+semantics let you add details incrementally:
 
 ```json
 {
   "name": "Frank Smith",
   "kind": "individual",
-  "trust_zone": "trusted",
   "given_name": "Frank",
   "family_name": "Smith",
   "org": "Anthropic",
@@ -346,8 +350,9 @@ within the tool surface.
 - Before saving, almost always do a `contacts_lookup` first — the
   merge semantics mean partial duplicates are easy to create through
   typos in the name.
-- After a save assigns a trust zone, the `email` send gate reads
-  that zone immediately — no extra step needed.
+- After the operator changes a trust zone through its custody path,
+  the `email` send gate reads that zone immediately — no extra step
+  or contact rewrite is needed.
 - For "I want to remember a project decision but the natural place
   is a person record," that's a smell that you actually want
   `memory` (`remember_fact`) instead.
@@ -387,9 +392,9 @@ create duplicates.
 Trust-zone semantics on import: **`trust_zone` and `ai_summary` are
 never overwritten by import.** The import can fill missing fields, but
 it cannot demote a `trusted` contact to `known` just because the
-incoming vCard didn't carry a zone. Promoting/demoting a contact's
-trust is a deliberate `contact_save` action, not a side effect of
-import.
+incoming vCard didn't carry a zone. Promoting or demoting a contact's
+trust is an operator-custodied action, not a side effect of import or
+an ordinary `contact_save`.
 
 ## Export one contact as a vCard
 


### PR DESCRIPTION
## Summary

- Add `contact_whereabouts`, a fused contact-rooted projection over Bermuda room presence, Home Assistant person-zone state, and bound companion-device locations.
- Rank sources best-first without blending them: room then zone while home; freshest available device then zone while away or unknown; withdrawn observations remain payload-free provenance and never outrank usable truth.
- Preserve canonical account, client, and device identifiers for chaining into `companion_last_known_location`, with explicit freshness, availability, source bounds, and truncation counts.
- Wire the tool through both `contacts` and `companion`, and update the corresponding model teaching and operator tool reference.

## Why

The contact record is #1450's counterparty root, but the model previously had to join presence and device-location surfaces itself. That repeated identity resolution, encouraged ad hoc ranking, and made it easy to treat stale or withdrawn data as current truth. This slice gives Go ownership of that composition and leaves each source's provenance intact.

## User impact

"Where is this person?" now has one first-door tool. It accepts a contact name or UUID, explains why its leading usable source wins, preserves the HA zone as a semantic floor even when the device fleet is truncated, and reports configuration gaps separately from bound-but-silent or failed storage reads. Exact device payload follow-up remains available through `companion_last_known_location`.

This does not retire the UniFi location poller. That remains a separate reversible change after the fused view demonstrates production parity.

## Test plan

- [x] `just ci`
- [x] Home ranking: Bermuda room, HA zone, then device sources
- [x] Away and unknown ranking: available device first, HA zone floor retained
- [x] Withdrawn-only inputs cannot claim a device location leads
- [x] A withdrawn-only fleet without presence exposes no `best_source`
- [x] Large device fleets remain capped without truncating or miscounting the HA zone
- [x] Bound-but-silent and genuinely unbound contacts remain distinct
- [x] HA-binding and companion-store failures surface instead of degrading to false absence
- [x] Disabled companion configuration severs contact-account joins even when provider entries remain
- [x] Name and UUID resolution preserve actionable not-found, ambiguity, and upstream errors

Refs #1450

