### PR TITLE
fix(identity): preserve truthful room provenance

### DIFF
--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -162,8 +162,9 @@ closed at render time — the devices degrade to account-only
 attribution and a warning names the unresolved binding.
 
 The second counterparty edge — binding a contact to its Home Assistant
-person entity, through which zone state and room presence flow into
-that contact's channel context — is set on the contact card itself:
+person entity, through which zone state and separately resolved,
+provider-attributed room presence flow into that contact's channel
+context — is set on the contact card itself:
 add an `X-THANE-HA-PERSON` field (e.g. `person.alice`) via CardDAV,
 which is the operator-authenticated surface and the only one that
 honors the header. Model-facing vCard import ignores it, at most one
@@ -171,6 +172,10 @@ active contact may claim a given person entity, and removing the field
 clears the binding. Presence flows only for entities the tracker
 watches: the same entity must also be listed under `person.track`, or
 the binding resolves but the presence join has nothing to report.
+The person binding itself does not infer a room from Home Assistant
+device-tracker attributes. Today room observations come from the
+configured UniFi poller, and model-facing output identifies `unifi` as
+the provider plus the AP name as source evidence.
 Use `companion:`. A top-level `platform:` section is rejected at config
 load with an actionable error and must be renamed to `companion:` (the
 field shape is unchanged).

--- a/internal/app/loop_definition_hydration_test.go
+++ b/internal/app/loop_definition_hydration_test.go
@@ -54,7 +54,7 @@ type testRoomUpdater struct {
 	updates int
 }
 
-func (u *testRoomUpdater) UpdateRoom(entityID, room, source string) {
+func (u *testRoomUpdater) UpdateRoom(entityID, room, provider, source string) {
 	u.updates++
 }
 

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/channels/mqtt"
 	"github.com/nugget/thane-ai-agent/internal/connwatch"
 	"github.com/nugget/thane-ai-agent/internal/integrations/companion"
+	"github.com/nugget/thane-ai-agent/internal/integrations/unifi"
 	"github.com/nugget/thane-ai-agent/internal/model/fleet"
 	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
 	"github.com/nugget/thane-ai-agent/internal/platform/checkpoint"
@@ -387,21 +388,7 @@ func (a *App) initServers(s *newState) error {
 				if !ok {
 					return nil
 				}
-				now := time.Now()
-				view := &agent.CounterpartyPresence{State: snap.State}
-				if !snap.Since.IsZero() {
-					view.Since = promptfmt.FormatDeltaOnly(snap.Since, now)
-				}
-				// The tracker clears rooms only on not_home, so a direct
-				// home → zone transition can leave a stale room behind;
-				// room-level detail is only truthful while home.
-				if strings.EqualFold(snap.State, "home") {
-					view.Room = snap.Room
-					if !snap.RoomSince.IsZero() {
-						view.RoomSince = promptfmt.FormatDeltaOnly(snap.RoomSince, now)
-					}
-				}
-				return view
+				return counterpartyPresenceView(snap, time.Now())
 			}
 		}
 		if len(accountsByContact) > 0 && a.companionDevices != nil {
@@ -707,7 +694,12 @@ func (a *App) initServers(s *newState) error {
 		a.mqttPub.RegisterSensors(apSensors)
 
 		// Route room changes from person tracker to MQTT publishes.
-		s.personTracker.OnRoomChange(func(entityID, room, source string) {
+		s.personTracker.OnRoomChange(func(entityID, room, provider, source string) {
+			// This legacy MQTT sensor specifically represents UniFi AP
+			// association. Other room providers must not masquerade as AP data.
+			if provider != unifi.RoomProvider {
+				return
+			}
 			shortName := entityID
 			if idx := strings.IndexByte(entityID, '.'); idx >= 0 {
 				shortName = entityID[idx+1:]
@@ -716,6 +708,7 @@ func (a *App) initServers(s *newState) error {
 
 			attrs, err := json.Marshal(map[string]string{
 				"ap_name":      source,
+				"provider":     provider,
 				"last_changed": time.Now().Format(time.RFC3339),
 			})
 			if err != nil {
@@ -732,7 +725,8 @@ func (a *App) initServers(s *newState) error {
 					"entity_id", entityID, "room", room, "error", err)
 			} else {
 				logger.Debug("mqtt AP presence published",
-					"entity_id", entityID, "room", room, "source", source)
+					"entity_id", entityID, "room", room,
+					"room_provider", provider, "room_source", source)
 			}
 		})
 
@@ -895,6 +889,26 @@ func (a *App) initServers(s *newState) error {
 	}
 
 	return nil
+}
+
+// counterpartyPresenceView renders the contact-context presence join. The
+// tracker clears rooms on not_home but can retain one across a direct home to
+// named-zone transition, so room detail and its provenance are truthful only
+// while the person state is home.
+func counterpartyPresenceView(snap contacts.PersonSnapshot, now time.Time) *agent.CounterpartyPresence {
+	view := &agent.CounterpartyPresence{State: snap.State}
+	if !snap.Since.IsZero() {
+		view.Since = promptfmt.FormatDeltaOnly(snap.Since, now)
+	}
+	if strings.EqualFold(snap.State, "home") && snap.Room != "" {
+		view.Room = snap.Room
+		view.RoomProvider = snap.RoomProvider
+		view.RoomSource = snap.RoomSource
+		if !snap.RoomSince.IsZero() {
+			view.RoomSince = promptfmt.FormatDeltaOnly(snap.RoomSince, now)
+		}
+	}
+	return view
 }
 
 // companionAccountsByContact exposes counterparty bindings only while the

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -697,7 +697,7 @@ func (a *App) initServers(s *newState) error {
 		s.personTracker.OnRoomChange(func(entityID, room, provider, source string) {
 			// This legacy MQTT sensor specifically represents UniFi AP
 			// association. Other room providers must not masquerade as AP data.
-			if provider != unifi.RoomProvider {
+			if !shouldPublishUnifiAPRoom(room, provider) {
 				return
 			}
 			shortName := entityID
@@ -889,6 +889,12 @@ func (a *App) initServers(s *newState) error {
 	}
 
 	return nil
+}
+
+// shouldPublishUnifiAPRoom keeps populated observations provider-specific but
+// permits normalized clears, whose provider is intentionally empty.
+func shouldPublishUnifiAPRoom(room, provider string) bool {
+	return room == "" || provider == unifi.RoomProvider
 }
 
 // counterpartyPresenceView renders the contact-context presence join. The

--- a/internal/app/new_servers_test.go
+++ b/internal/app/new_servers_test.go
@@ -3,9 +3,57 @@ package app
 import (
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
+	"github.com/nugget/thane-ai-agent/internal/state/contacts"
 )
+
+func TestCounterpartyPresenceView(t *testing.T) {
+	now := time.Date(2026, 8, 30, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name               string
+		state              string
+		wantRoom           string
+		wantRoomProvider   string
+		wantRoomSource     string
+		wantRoomSinceEmpty bool
+	}{
+		{
+			name:             "home keeps attributed room",
+			state:            "home",
+			wantRoom:         "office",
+			wantRoomProvider: "unifi",
+			wantRoomSource:   "ap-office",
+		},
+		{
+			name:               "named zone hides retained room",
+			state:              "work",
+			wantRoomSinceEmpty: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			view := counterpartyPresenceView(contacts.PersonSnapshot{
+				State:        tt.state,
+				Since:        now.Add(-2 * time.Hour),
+				Room:         "office",
+				RoomSince:    now.Add(-20 * time.Minute),
+				RoomProvider: "unifi",
+				RoomSource:   "ap-office",
+			}, now)
+			if view.Room != tt.wantRoom || view.RoomProvider != tt.wantRoomProvider || view.RoomSource != tt.wantRoomSource {
+				t.Errorf("room view = %+v", view)
+			}
+			if (view.RoomSince == "") != tt.wantRoomSinceEmpty {
+				t.Errorf("RoomSince = %q, want empty=%v", view.RoomSince, tt.wantRoomSinceEmpty)
+			}
+			if view.Since != "-2h" {
+				t.Errorf("Since = %q, want -2h", view.Since)
+			}
+		})
+	}
+}
 
 func TestCompanionAccountsByContactRequiresConfiguredSource(t *testing.T) {
 	const contactID = "8A1F50A7-91C1-4DE5-90D3-B239719D29A8"

--- a/internal/app/new_servers_test.go
+++ b/internal/app/new_servers_test.go
@@ -5,9 +5,30 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nugget/thane-ai-agent/internal/integrations/unifi"
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/state/contacts"
 )
+
+func TestShouldPublishUnifiAPRoom(t *testing.T) {
+	tests := []struct {
+		name     string
+		room     string
+		provider string
+		want     bool
+	}{
+		{name: "populated UniFi observation", room: "office", provider: unifi.RoomProvider, want: true},
+		{name: "populated non-UniFi observation", room: "office", provider: "bermuda", want: false},
+		{name: "normalized clear", room: "", provider: "", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldPublishUnifiAPRoom(tt.room, tt.provider); got != tt.want {
+				t.Errorf("shouldPublishUnifiAPRoom(%q, %q) = %v, want %v", tt.room, tt.provider, got, tt.want)
+			}
+		})
+	}
+}
 
 func TestCounterpartyPresenceView(t *testing.T) {
 	now := time.Date(2026, 8, 30, 12, 0, 0, 0, time.UTC)

--- a/internal/integrations/unifi/poller.go
+++ b/internal/integrations/unifi/poller.go
@@ -15,8 +15,12 @@ import (
 // poller to push room updates. Keeps the unifi package decoupled from
 // the person package.
 type RoomUpdater interface {
-	UpdateRoom(entityID, room, source string)
+	UpdateRoom(entityID, room, provider, source string)
 }
+
+// RoomProvider is the stable provider name attached to room observations
+// produced by the UniFi poller.
+const RoomProvider = "unifi"
 
 // PollerConfig configures the UniFi room presence poller.
 type PollerConfig struct {
@@ -175,7 +179,8 @@ func (p *Poller) Poll(ctx context.Context) error {
 			p.cfg.Logger.Debug("room change candidate",
 				"entity_id", entityID,
 				"candidate_room", best.room,
-				"source", best.source,
+				"room_provider", RoomProvider,
+				"room_source", best.source,
 			)
 			continue
 		}
@@ -183,12 +188,13 @@ func (p *Poller) Poll(ctx context.Context) error {
 		// Same candidate as last poll — increment.
 		pend.count++
 		if pend.count >= debounceThreshold {
-			p.cfg.Updater.UpdateRoom(entityID, best.room, best.source)
+			p.cfg.Updater.UpdateRoom(entityID, best.room, RoomProvider, best.source)
 			roomsUpdated++
 			p.cfg.Logger.Log(ctx, slog.Level(-8), "room update committed", // config.LevelTrace
 				"entity_id", entityID,
 				"room", best.room,
-				"source", best.source,
+				"room_provider", RoomProvider,
+				"room_source", best.source,
 				"polls", pend.count,
 			)
 		} else {

--- a/internal/integrations/unifi/poller_test.go
+++ b/internal/integrations/unifi/poller_test.go
@@ -45,6 +45,7 @@ func (m *mockLocator) setErr(err error) {
 type roomUpdate struct {
 	entityID string
 	room     string
+	provider string
 	source   string
 }
 
@@ -53,10 +54,10 @@ type mockUpdater struct {
 	updates []roomUpdate
 }
 
-func (m *mockUpdater) UpdateRoom(entityID, room, source string) {
+func (m *mockUpdater) UpdateRoom(entityID, room, provider, source string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.updates = append(m.updates, roomUpdate{entityID, room, source})
+	m.updates = append(m.updates, roomUpdate{entityID, room, provider, source})
 }
 
 func (m *mockUpdater) getUpdates() []roomUpdate {
@@ -109,6 +110,9 @@ func TestPoller_BasicRoomUpdate(t *testing.T) {
 	}
 	if updates[0].room != "office" {
 		t.Errorf("expected room office, got %q", updates[0].room)
+	}
+	if updates[0].provider != RoomProvider {
+		t.Errorf("expected provider %q, got %q", RoomProvider, updates[0].provider)
 	}
 	if updates[0].source != "ap-office" {
 		t.Errorf("expected source ap-office, got %q", updates[0].source)

--- a/internal/runtime/agent/channel_provider.go
+++ b/internal/runtime/agent/channel_provider.go
@@ -41,13 +41,15 @@ type ContactContext struct {
 }
 
 // CounterpartyPresence is the compact whereabouts view joined from the
-// HA person binding: zone-level state, room when home (bermuda), and
-// deltas rather than timestamps.
+// HA person binding: zone-level state, provider-attributed room when home,
+// and deltas rather than timestamps.
 type CounterpartyPresence struct {
-	State     string `json:"state"`
-	Since     string `json:"since,omitempty"`
-	Room      string `json:"room,omitempty"`
-	RoomSince string `json:"room_since,omitempty"`
+	State        string `json:"state"`
+	Since        string `json:"since,omitempty"`
+	Room         string `json:"room,omitempty"`
+	RoomSince    string `json:"room_since,omitempty"`
+	RoomProvider string `json:"room_provider,omitempty"`
+	RoomSource   string `json:"room_source,omitempty"`
 }
 
 // CounterpartyDevice is one bound companion device, compactly: enough

--- a/internal/state/contacts/presence.go
+++ b/internal/state/contacts/presence.go
@@ -17,30 +17,37 @@ import (
 
 // PersonPresenceContext is the JSON structure emitted for each tracked
 // person in context output. Richer than the default entity JSON
-// because the tracker has room data from UniFi AP associations.
+// because the tracker has provider-attributed room data.
 type PersonPresenceContext struct {
-	Entity string `json:"entity"`
-	Name   string `json:"name"`
-	State  string `json:"state"`
-	Since  string `json:"since"`
-	Room   string `json:"room,omitempty"`
-	RoomSr string `json:"room_source,omitempty"`
+	Entity       string `json:"entity"`
+	Name         string `json:"name"`
+	State        string `json:"state"`
+	Since        string `json:"since"`
+	Room         string `json:"room,omitempty"`
+	RoomProvider string `json:"room_provider,omitempty"`
+	RoomSource   string `json:"room_source,omitempty"`
 }
 
 // FormatPersonPresence formats a tracked person as compact JSON with
 // delta-annotated timestamps.
-func FormatPersonPresence(entityID, name, state string, since time.Time, room, roomSource string, now time.Time) string {
+func FormatPersonPresence(
+	entityID, name, state string,
+	since time.Time,
+	room, roomProvider, roomSource string,
+	now time.Time,
+) string {
 	displayState := state
 	if strings.EqualFold(state, "not_home") {
 		displayState = "away"
 	}
 	pc := PersonPresenceContext{
-		Entity: entityID,
-		Name:   name,
-		State:  displayState,
-		Since:  promptfmt.FormatDeltaOnly(since, now),
-		Room:   room,
-		RoomSr: roomSource,
+		Entity:       entityID,
+		Name:         name,
+		State:        displayState,
+		Since:        promptfmt.FormatDeltaOnly(since, now),
+		Room:         room,
+		RoomProvider: roomProvider,
+		RoomSource:   roomSource,
 	}
 	return promptfmt.MarshalCompact(pc)
 }
@@ -55,9 +62,10 @@ type Person struct {
 	State        string
 	Since        time.Time
 	DeviceMACs   []string  // configured MAC addresses for this person
-	Room         string    // inferred from AP association (e.g., "office")
+	Room         string    // inferred room (e.g., "office")
 	RoomSince    time.Time // when the current room was first detected
-	RoomSource   string    // AP name that determined the room (e.g., "ap-hor-office")
+	RoomProvider string    // stable provider family (e.g., "unifi")
+	RoomSource   string    // provider-specific evidence (e.g., an AP name)
 }
 
 // StateGetter abstracts the Home Assistant REST client for fetching
@@ -67,11 +75,11 @@ type StateGetter interface {
 	GetState(ctx context.Context, entityID string) (*homeassistant.State, error)
 }
 
-// RoomObserver is called when a tracked person's room changes.
-// Parameters are the person's entity ID, the new room name (may be
-// empty when cleared), and the AP or source name that determined
-// the room. Observers are called outside the tracker's lock.
-type RoomObserver func(entityID, room, source string)
+// RoomObserver is called when a tracked person's room observation changes.
+// Parameters are the person's entity ID, the new room name (may be empty when
+// cleared), the stable provider family, and provider-specific source evidence.
+// Observers are called outside the tracker's lock.
+type RoomObserver func(entityID, room, provider, source string)
 
 // PresenceTracker maintains in-memory presence state for configured
 // person entities and provides a context block for system prompt
@@ -225,6 +233,7 @@ func (t *PresenceTracker) HandleStateChange(entityID, _, newState, _ string) {
 	if strings.EqualFold(newState, "not_home") {
 		p.Room = ""
 		p.RoomSince = time.Time{}
+		p.RoomProvider = ""
 		p.RoomSource = ""
 	}
 }
@@ -259,7 +268,7 @@ func (t *PresenceTracker) TagContext(_ context.Context, _ agentctx.ContextReques
 		} else {
 			sb.WriteString(FormatPersonPresence(
 				p.EntityID, displayName, p.State, p.Since,
-				p.Room, p.RoomSource, now,
+				p.Room, p.RoomProvider, p.RoomSource, now,
 			))
 			sb.WriteByte('\n')
 		}
@@ -268,9 +277,9 @@ func (t *PresenceTracker) TagContext(_ context.Context, _ agentctx.ContextReques
 	return sb.String(), nil
 }
 
-// OnRoomChange registers a callback that fires whenever a tracked
-// person's room changes. Observers are called outside the tracker's
-// lock so they may perform blocking I/O (e.g., MQTT publishes).
+// OnRoomChange registers a callback that fires whenever a tracked person's
+// room observation or its provenance changes. Observers are called outside
+// the tracker's lock so they may perform blocking I/O (e.g., MQTT publishes).
 // Must be called before the poller starts.
 func (t *PresenceTracker) OnRoomChange(fn RoomObserver) {
 	t.mu.Lock()
@@ -278,16 +287,20 @@ func (t *PresenceTracker) OnRoomChange(fn RoomObserver) {
 	t.observers = append(t.observers, fn)
 }
 
-// UpdateRoom sets the room for a tracked person. If the room is
-// unchanged, no update occurs. When a person transitions to not_home,
-// HandleStateChange clears room data automatically; callers may also
-// pass an empty room to clear it explicitly. The source is the AP name
-// or other identifier that determined the room.
+// UpdateRoom sets one provider-attributed room observation for a tracked
+// person. An exact duplicate is ignored. A provider or source-evidence change
+// is retained without resetting RoomSince when the room itself is unchanged.
+// When a person transitions to not_home, HandleStateChange clears room data
+// automatically; callers may also pass an empty room to clear it explicitly.
 //
 // Registered [RoomObserver] callbacks are invoked after the state
 // update, outside the lock, so they may perform blocking operations.
-func (t *PresenceTracker) UpdateRoom(entityID, room, source string) {
+func (t *PresenceTracker) UpdateRoom(entityID, room, provider, source string) {
 	var notify bool
+	if room == "" {
+		provider = ""
+		source = ""
+	}
 
 	t.mu.Lock()
 	p, ok := t.people[entityID]
@@ -296,24 +309,27 @@ func (t *PresenceTracker) UpdateRoom(entityID, room, source string) {
 		return
 	}
 
-	if p.Room == room {
+	if p.Room == room && p.RoomProvider == provider && p.RoomSource == source {
 		t.mu.Unlock()
 		return
 	}
+	roomChanged := p.Room != room
 
 	t.logger.Debug("person room changed",
 		"entity_id", entityID,
 		"friendly_name", p.FriendlyName,
 		"old_room", p.Room,
 		"new_room", room,
-		"source", source,
+		"room_provider", provider,
+		"room_source", source,
 	)
 
 	p.Room = room
+	p.RoomProvider = provider
 	p.RoomSource = source
-	if room != "" {
+	if room != "" && roomChanged {
 		p.RoomSince = time.Now()
-	} else {
+	} else if room == "" {
 		p.RoomSince = time.Time{}
 	}
 
@@ -326,7 +342,7 @@ func (t *PresenceTracker) UpdateRoom(entityID, room, source string) {
 
 	if notify {
 		for _, fn := range obs {
-			fn(entityID, room, source)
+			fn(entityID, room, provider, source)
 		}
 	}
 }
@@ -355,6 +371,7 @@ type PersonSnapshot struct {
 	Since        time.Time
 	Room         string
 	RoomSince    time.Time
+	RoomProvider string
 	RoomSource   string
 }
 
@@ -374,6 +391,7 @@ func (t *PresenceTracker) Snapshot(entityID string) (PersonSnapshot, bool) {
 		Since:        p.Since,
 		Room:         p.Room,
 		RoomSince:    p.RoomSince,
+		RoomProvider: p.RoomProvider,
 		RoomSource:   p.RoomSource,
 	}, true
 }

--- a/internal/state/contacts/presence.go
+++ b/internal/state/contacts/presence.go
@@ -40,6 +40,11 @@ func FormatPersonPresence(
 	if strings.EqualFold(state, "not_home") {
 		displayState = "away"
 	}
+	if !strings.EqualFold(state, "home") {
+		room = ""
+		roomProvider = ""
+		roomSource = ""
+	}
 	pc := PersonPresenceContext{
 		Entity:       entityID,
 		Name:         name,

--- a/internal/state/contacts/presence_test.go
+++ b/internal/state/contacts/presence_test.go
@@ -310,6 +310,43 @@ func TestTracker_GetContext_WithRoom(t *testing.T) {
 	}
 }
 
+func TestTracker_GetContext_NamedZoneSuppressesRetainedRoom(t *testing.T) {
+	now := time.Date(2026, 2, 15, 16, 30, 0, 0, time.UTC)
+	getter := &mockStateGetter{
+		states: map[string]*homeassistant.State{
+			"person.alice": {
+				EntityID:    "person.alice",
+				State:       "home",
+				Attributes:  map[string]any{"friendly_name": "Alice"},
+				LastChanged: now,
+			},
+		},
+	}
+
+	tracker := NewPresenceTracker([]string{"person.alice"}, "UTC", nil)
+	_ = tracker.Initialize(context.Background(), getter)
+	tracker.UpdateRoom("person.alice", "office", "unifi", "ap-hor-office")
+	tracker.HandleStateChange("person.alice", "home", "work", "")
+
+	result, _ := tracker.TagContext(context.Background(), agentctx.ContextRequest{UserMessage: ""})
+	if !strings.Contains(result, `"state":"work"`) {
+		t.Errorf("expected named zone state in JSON, got:\n%s", result)
+	}
+	for _, field := range []string{`"room"`, `"room_provider"`, `"room_source"`} {
+		if strings.Contains(result, field) {
+			t.Errorf("expected %s to be suppressed outside home, got:\n%s", field, result)
+		}
+	}
+
+	snap, ok := tracker.Snapshot("person.alice")
+	if !ok {
+		t.Fatal("expected person snapshot")
+	}
+	if snap.Room != "office" || snap.RoomProvider != "unifi" || snap.RoomSource != "ap-hor-office" {
+		t.Errorf("named-zone transition should retain tracker evidence, got %+v", snap)
+	}
+}
+
 func TestTracker_GetContext_WithoutRoom(t *testing.T) {
 	now := time.Date(2026, 2, 15, 16, 30, 0, 0, time.UTC)
 	getter := &mockStateGetter{

--- a/internal/state/contacts/presence_test.go
+++ b/internal/state/contacts/presence_test.go
@@ -210,7 +210,7 @@ func TestTracker_HandleStateChange_ClearsRoom(t *testing.T) {
 	_ = tracker.Initialize(context.Background(), getter)
 
 	// Set a room.
-	tracker.UpdateRoom("person.alice", "office", "ap-hor-office")
+	tracker.UpdateRoom("person.alice", "office", "unifi", "ap-hor-office")
 
 	result, _ := tracker.TagContext(context.Background(), agentctx.ContextRequest{UserMessage: ""})
 	if !strings.Contains(result, `"room":"office"`) {
@@ -294,13 +294,16 @@ func TestTracker_GetContext_WithRoom(t *testing.T) {
 
 	tracker := NewPresenceTracker([]string{"person.alice"}, "UTC", nil)
 	_ = tracker.Initialize(context.Background(), getter)
-	tracker.UpdateRoom("person.alice", "office", "ap-hor-office")
+	tracker.UpdateRoom("person.alice", "office", "unifi", "ap-hor-office")
 
 	result, _ := tracker.TagContext(context.Background(), agentctx.ContextRequest{UserMessage: ""})
 
 	// Verify room appears in JSON.
 	if !strings.Contains(result, `"room":"office"`) {
 		t.Errorf("expected room:office in JSON, got:\n%s", result)
+	}
+	if !strings.Contains(result, `"room_provider":"unifi"`) {
+		t.Errorf("expected explicit room_provider in JSON, got:\n%s", result)
 	}
 	if !strings.Contains(result, `"room_source":"ap-hor-office"`) {
 		t.Errorf("expected room_source in JSON, got:\n%s", result)
@@ -371,17 +374,21 @@ func TestTracker_GetContext_NotHome(t *testing.T) {
 func TestTracker_UpdateRoom(t *testing.T) {
 	tracker := NewPresenceTracker([]string{"person.alice"}, "UTC", nil)
 
-	tracker.UpdateRoom("person.alice", "office", "ap-hor-office")
+	tracker.UpdateRoom("person.alice", "office", "unifi", "ap-hor-office")
 
 	tracker.mu.RLock()
 	p := tracker.people["person.alice"]
 	room := p.Room
+	provider := p.RoomProvider
 	source := p.RoomSource
 	sinceZero := p.RoomSince.IsZero()
 	tracker.mu.RUnlock()
 
 	if room != "office" {
 		t.Errorf("expected room office, got %q", room)
+	}
+	if provider != "unifi" {
+		t.Errorf("expected provider unifi, got %q", provider)
 	}
 	if source != "ap-hor-office" {
 		t.Errorf("expected source ap-hor-office, got %q", source)
@@ -394,7 +401,7 @@ func TestTracker_UpdateRoom(t *testing.T) {
 func TestTracker_UpdateRoom_SameRoom(t *testing.T) {
 	tracker := NewPresenceTracker([]string{"person.alice"}, "UTC", nil)
 
-	tracker.UpdateRoom("person.alice", "office", "ap-hor-office")
+	tracker.UpdateRoom("person.alice", "office", "unifi", "ap-hor-office")
 
 	tracker.mu.RLock()
 	firstSince := tracker.people["person.alice"].RoomSince
@@ -402,7 +409,7 @@ func TestTracker_UpdateRoom_SameRoom(t *testing.T) {
 
 	// Same room — should not update RoomSince.
 	time.Sleep(time.Millisecond)
-	tracker.UpdateRoom("person.alice", "office", "ap-hor-office")
+	tracker.UpdateRoom("person.alice", "office", "unifi", "ap-hor-office")
 
 	tracker.mu.RLock()
 	secondSince := tracker.people["person.alice"].RoomSince
@@ -413,20 +420,49 @@ func TestTracker_UpdateRoom_SameRoom(t *testing.T) {
 	}
 }
 
+func TestTracker_UpdateRoom_SameRoomRefreshesProvenance(t *testing.T) {
+	tracker := NewPresenceTracker([]string{"person.alice"}, "UTC", nil)
+
+	tracker.UpdateRoom("person.alice", "office", "unifi", "ap-office-east")
+	first, ok := tracker.Snapshot("person.alice")
+	if !ok {
+		t.Fatal("tracked entity not found")
+	}
+
+	time.Sleep(time.Millisecond)
+	tracker.UpdateRoom("person.alice", "office", "unifi", "ap-office-west")
+	second, ok := tracker.Snapshot("person.alice")
+	if !ok {
+		t.Fatal("tracked entity not found")
+	}
+
+	if second.RoomProvider != "unifi" || second.RoomSource != "ap-office-west" {
+		t.Fatalf("refreshed provenance = %+v", second)
+	}
+	if !second.RoomSince.Equal(first.RoomSince) {
+		t.Errorf("same-room provenance refresh reset RoomSince: %v then %v", first.RoomSince, second.RoomSince)
+	}
+}
+
 func TestTracker_UpdateRoom_ClearsRoom(t *testing.T) {
 	tracker := NewPresenceTracker([]string{"person.alice"}, "UTC", nil)
 
-	tracker.UpdateRoom("person.alice", "office", "ap-hor-office")
-	tracker.UpdateRoom("person.alice", "", "")
+	tracker.UpdateRoom("person.alice", "office", "unifi", "ap-hor-office")
+	tracker.UpdateRoom("person.alice", "", "", "")
 
 	tracker.mu.RLock()
 	p := tracker.people["person.alice"]
 	room := p.Room
+	provider := p.RoomProvider
+	source := p.RoomSource
 	sinceZero := p.RoomSince.IsZero()
 	tracker.mu.RUnlock()
 
 	if room != "" {
 		t.Errorf("expected empty room, got %q", room)
+	}
+	if provider != "" || source != "" {
+		t.Errorf("expected cleared provenance, got provider=%q source=%q", provider, source)
 	}
 	if !sinceZero {
 		t.Error("expected RoomSince to be zero after clearing")
@@ -437,7 +473,7 @@ func TestTracker_UpdateRoom_IgnoresUntracked(t *testing.T) {
 	tracker := NewPresenceTracker([]string{"person.alice"}, "UTC", nil)
 
 	// Should not panic.
-	tracker.UpdateRoom("person.unknown", "office", "ap-hor-office")
+	tracker.UpdateRoom("person.unknown", "office", "unifi", "ap-hor-office")
 }
 
 func TestTracker_SetDeviceMACs(t *testing.T) {
@@ -521,7 +557,7 @@ func TestTracker_ConcurrentAccess(t *testing.T) {
 				if i%2 == 0 {
 					room = "bedroom"
 				}
-				tracker.UpdateRoom("person.alice", room, "ap-test")
+				tracker.UpdateRoom("person.alice", room, "unifi", "ap-test")
 			}
 		}()
 	}
@@ -598,16 +634,17 @@ func TestFriendlyNameFromEntityID(t *testing.T) {
 func TestTracker_RoomObserver(t *testing.T) {
 	tracker := NewPresenceTracker([]string{"person.alice"}, "", nil)
 
-	var gotEntity, gotRoom, gotSource string
+	var gotEntity, gotRoom, gotProvider, gotSource string
 	var callCount int
-	tracker.OnRoomChange(func(entityID, room, source string) {
+	tracker.OnRoomChange(func(entityID, room, provider, source string) {
 		gotEntity = entityID
 		gotRoom = room
+		gotProvider = provider
 		gotSource = source
 		callCount++
 	})
 
-	tracker.UpdateRoom("person.alice", "office", "ap-hor-office")
+	tracker.UpdateRoom("person.alice", "office", "unifi", "ap-hor-office")
 
 	if callCount != 1 {
 		t.Fatalf("observer called %d times, want 1", callCount)
@@ -618,6 +655,9 @@ func TestTracker_RoomObserver(t *testing.T) {
 	if gotRoom != "office" {
 		t.Errorf("room = %q, want %q", gotRoom, "office")
 	}
+	if gotProvider != "unifi" {
+		t.Errorf("provider = %q, want %q", gotProvider, "unifi")
+	}
 	if gotSource != "ap-hor-office" {
 		t.Errorf("source = %q, want %q", gotSource, "ap-hor-office")
 	}
@@ -627,24 +667,24 @@ func TestTracker_RoomObserverNotCalledOnNoOp(t *testing.T) {
 	tracker := NewPresenceTracker([]string{"person.alice"}, "", nil)
 
 	var callCount int
-	tracker.OnRoomChange(func(_, _, _ string) {
+	tracker.OnRoomChange(func(_, _, _, _ string) {
 		callCount++
 	})
 
 	// Set initial room.
-	tracker.UpdateRoom("person.alice", "office", "ap-hor-office")
+	tracker.UpdateRoom("person.alice", "office", "unifi", "ap-hor-office")
 	if callCount != 1 {
 		t.Fatalf("observer called %d times after first update, want 1", callCount)
 	}
 
 	// Same room — observer should not fire again.
-	tracker.UpdateRoom("person.alice", "office", "ap-hor-office")
+	tracker.UpdateRoom("person.alice", "office", "unifi", "ap-hor-office")
 	if callCount != 1 {
 		t.Errorf("observer called %d times after no-op update, want 1", callCount)
 	}
 
 	// Different room — observer should fire.
-	tracker.UpdateRoom("person.alice", "bedroom", "ap-hor-bedroom")
+	tracker.UpdateRoom("person.alice", "bedroom", "unifi", "ap-hor-bedroom")
 	if callCount != 2 {
 		t.Errorf("observer called %d times after room change, want 2", callCount)
 	}
@@ -655,14 +695,14 @@ func TestTracker_RoomObserverCalledOutsideLock(t *testing.T) {
 
 	// Register an observer that calls GetContext (which takes a read lock).
 	// If observers were called under the write lock this would deadlock.
-	tracker.OnRoomChange(func(_, _, _ string) {
+	tracker.OnRoomChange(func(_, _, _, _ string) {
 		_, _ = tracker.TagContext(context.Background(), agentctx.ContextRequest{UserMessage: ""})
 	})
 
 	// Should complete without deadlock.
 	done := make(chan struct{})
 	go func() {
-		tracker.UpdateRoom("person.alice", "kitchen", "ap-hor-kitchen")
+		tracker.UpdateRoom("person.alice", "kitchen", "unifi", "ap-hor-kitchen")
 		close(done)
 	}()
 
@@ -679,13 +719,13 @@ func TestTracker_RoomObserverCalledOutsideLock(t *testing.T) {
 func TestPresenceSnapshot(t *testing.T) {
 	tracker := NewPresenceTracker([]string{"person.alice"}, "UTC", nil)
 	tracker.HandleStateChange("person.alice", "", "home", "")
-	tracker.UpdateRoom("person.alice", "office", "bermuda")
+	tracker.UpdateRoom("person.alice", "office", "bermuda", "device_tracker.alice_bermuda")
 
 	snap, ok := tracker.Snapshot("person.alice")
 	if !ok {
 		t.Fatal("tracked entity not found")
 	}
-	if snap.Room != "office" || snap.RoomSource != "bermuda" {
+	if snap.Room != "office" || snap.RoomProvider != "bermuda" || snap.RoomSource != "device_tracker.alice_bermuda" {
 		t.Errorf("snapshot = %+v", snap)
 	}
 	if _, ok := tracker.Snapshot("person.nobody"); ok {

--- a/internal/tools/counterparty_tools.go
+++ b/internal/tools/counterparty_tools.go
@@ -39,8 +39,8 @@ type CounterpartyToolDeps struct {
 
 // EnableCounterpartyTools adds the fused counterparty view: one call
 // that answers "what do we know about where this person is" from every
-// source the contact record roots — HA person zone state, bermuda room
-// while home, and companion location observations — ranked, with
+// source the contact record roots — HA person zone state, provider-attributed
+// room presence while home, and companion location observations — ranked, with
 // provenance and freshness per source.
 func (r *Registry) EnableCounterpartyTools(deps CounterpartyToolDeps) {
 	if deps.Contacts == nil {
@@ -86,13 +86,14 @@ func (r *Registry) EnableCounterpartyTools(deps CounterpartyToolDeps) {
 // view. Entries are ordered best-first by the ranking the tool
 // description promises; rank is the order, not a numeric field.
 type whereaboutsSource struct {
-	// Source identifies the provenance: "bermuda_room",
-	// "ha_person_zone", or "companion_location".
+	// Source identifies the provenance: "unifi_room", "bermuda_room",
+	// neutral "room_presence", "ha_person_zone", or "companion_location".
 	Source string `json:"source"`
 
 	// Zone/room fields (presence sources).
-	State     string `json:"state,omitempty"`
-	Room      string `json:"room,omitempty"`
+	State string `json:"state,omitempty"`
+	Room  string `json:"room,omitempty"`
+	// RoomVia is provider-specific evidence, such as a UniFi AP name.
 	RoomVia   string `json:"room_via,omitempty"`
 	Since     string `json:"since,omitempty"`
 	RoomSince string `json:"room_since,omitempty"`
@@ -128,6 +129,20 @@ type whereaboutsResult struct {
 	Sources    []whereaboutsSource `json:"sources"`
 }
 
+// whereaboutsRoomSource keeps provider attribution honest without allowing an
+// arbitrary provider string to expand the model-facing source enum. Unknown or
+// legacy providers remain useful but explicitly neutral.
+func whereaboutsRoomSource(provider string) string {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "unifi":
+		return "unifi_room"
+	case "bermuda":
+		return "bermuda_room"
+	default:
+		return "room_presence"
+	}
+}
+
 func handleContactWhereabouts(ctx context.Context, deps CounterpartyToolDeps, name, id string) (string, error) {
 	contact, err := resolveWhereaboutsContact(deps.Contacts, name, id)
 	if err != nil {
@@ -159,7 +174,11 @@ func handleContactWhereabouts(ctx context.Context, deps CounterpartyToolDeps, na
 					zone.Since = promptfmt.FormatDeltaOnly(snap.Since, now)
 				}
 				if home && snap.Room != "" {
-					room := whereaboutsSource{Source: "bermuda_room", Room: snap.Room, RoomVia: snap.RoomSource}
+					room := whereaboutsSource{
+						Source:  whereaboutsRoomSource(snap.RoomProvider),
+						Room:    snap.Room,
+						RoomVia: snap.RoomSource,
+					}
 					if !snap.RoomSince.IsZero() {
 						room.RoomSince = promptfmt.FormatDeltaOnly(snap.RoomSince, now)
 					}
@@ -288,7 +307,7 @@ func handleContactWhereabouts(ctx context.Context, deps CounterpartyToolDeps, na
 		result.Sources = append(result.Sources, presenceSources...)
 		result.Sources = append(result.Sources, available...)
 		result.Sources = append(result.Sources, withdrawn...)
-		if len(presenceSources) > 0 && presenceSources[0].Source == "bermuda_room" {
+		if len(presenceSources) > 0 && presenceSources[0].Room != "" {
 			result.Basis = "home per person entity; room-level presence leads as the most specific source while home"
 		} else {
 			result.Basis = "home per person entity; zone state leads because no room-level presence is available"

--- a/internal/tools/counterparty_tools_test.go
+++ b/internal/tools/counterparty_tools_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/nugget/thane-ai-agent/internal/integrations/companion"
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 	"github.com/nugget/thane-ai-agent/internal/state/contacts"
 )
@@ -17,6 +18,16 @@ import (
 type whereaboutsFixture struct {
 	deps      CounterpartyToolDeps
 	contactID string
+}
+
+type staticWhereaboutsStateGetter map[string]*homeassistant.State
+
+func (g staticWhereaboutsStateGetter) GetState(_ context.Context, entityID string) (*homeassistant.State, error) {
+	state, ok := g[entityID]
+	if !ok {
+		return nil, fmt.Errorf("state %q not found", entityID)
+	}
+	return state, nil
 }
 
 // newWhereaboutsFixture builds a contact ("Alice Operator") with an HA
@@ -59,7 +70,8 @@ func newWhereaboutsFixture(t *testing.T, state, room string, observations map[st
 			snap := contacts.PersonSnapshot{EntityID: entity, State: state, Since: now.Add(-2 * time.Hour)}
 			if room != "" {
 				snap.Room = room
-				snap.RoomSource = "bermuda"
+				snap.RoomProvider = "unifi"
+				snap.RoomSource = "ap-office"
 				snap.RoomSince = now.Add(-20 * time.Minute)
 			}
 			return snap, true
@@ -97,14 +109,81 @@ func TestContactWhereaboutsHomeRanking(t *testing.T) {
 	if len(res.Sources) != 3 {
 		t.Fatalf("sources = %+v, want room + zone + device", res.Sources)
 	}
-	if res.Sources[0].Source != "bermuda_room" || res.Sources[0].Room != "office" || res.Sources[0].RoomVia != "bermuda" {
-		t.Errorf("home ranking: leading source = %+v, want bermuda room", res.Sources[0])
+	if res.Sources[0].Source != "unifi_room" || res.Sources[0].Room != "office" || res.Sources[0].RoomVia != "ap-office" {
+		t.Errorf("home ranking: leading source = %+v, want provider-attributed UniFi room", res.Sources[0])
 	}
 	if res.Sources[1].Source != "ha_person_zone" || res.Sources[2].Source != "companion_location" {
 		t.Errorf("home order = %s, %s", res.Sources[1].Source, res.Sources[2].Source)
 	}
-	if res.BestSource != "bermuda_room" || !strings.Contains(res.Basis, "home") {
+	if res.BestSource != "unifi_room" || !strings.Contains(res.Basis, "home") {
 		t.Errorf("verdict = %q / %q", res.BestSource, res.Basis)
+	}
+}
+
+// TestContactWhereaboutsProductionPersonShapePreservesRoomProvider mirrors the
+// material parts of a production HA person backed by regular and Bermuda
+// device trackers. The aggregate person's active source must not overwrite the
+// explicit provider that actually supplied Thane's room observation.
+func TestContactWhereaboutsProductionPersonShapePreservesRoomProvider(t *testing.T) {
+	now := time.Now().UTC()
+	getter := staticWhereaboutsStateGetter{
+		"person.alice": {
+			EntityID: "person.alice",
+			State:    "home",
+			Attributes: map[string]any{
+				"friendly_name": "Alice",
+				"source":        "device_tracker.alice_phone_bermuda_tracker",
+				"device_trackers": []any{
+					"device_tracker.alice_phone",
+					"device_tracker.alice_phone_bermuda_tracker",
+				},
+			},
+			LastChanged: now.Add(-24 * time.Hour),
+			LastUpdated: now,
+		},
+	}
+	tracker := contacts.NewPresenceTracker([]string{"person.alice"}, "UTC", nil)
+	if err := tracker.Initialize(context.Background(), getter); err != nil {
+		t.Fatal(err)
+	}
+	tracker.UpdateRoom("person.alice", "office", "unifi", "ap-office")
+
+	fx := newWhereaboutsFixture(t, "home", "", nil)
+	fx.deps.Presence = tracker.Snapshot
+	out, err := handleContactWhereabouts(context.Background(), fx.deps, "Alice Operator", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := decodeWhereabouts(t, out)
+	if len(res.Sources) < 2 {
+		t.Fatalf("sources = %+v, want room and zone", res.Sources)
+	}
+	room := res.Sources[0]
+	if room.Source != "unifi_room" || room.RoomVia != "ap-office" {
+		t.Fatalf("room source = %+v, want explicit UniFi provenance", room)
+	}
+	if strings.Contains(out, "bermuda_room") {
+		t.Fatalf("aggregate HA source fabricated Bermuda room provenance: %s", out)
+	}
+}
+
+func TestWhereaboutsRoomSource(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		want     string
+	}{
+		{name: "UniFi", provider: "unifi", want: "unifi_room"},
+		{name: "Bermuda normalized", provider: " Bermuda ", want: "bermuda_room"},
+		{name: "unknown", provider: "future-provider", want: "room_presence"},
+		{name: "legacy empty", provider: "", want: "room_presence"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := whereaboutsRoomSource(tt.provider); got != tt.want {
+				t.Errorf("whereaboutsRoomSource(%q) = %q, want %q", tt.provider, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/talents/companion.md
+++ b/talents/companion.md
@@ -40,10 +40,11 @@ Reading the device block:
 How to work here:
 
 - Asked where someone is? `contact_whereabouts` is the first door: it
-  fuses every source that person's contact record roots — room-level
-  presence while home, their freshest device location when away, zone
-  state as the floor — ranked, with provenance and freshness per
-  source. Reach for `companion_last_known_location` only when you need
+  fuses every source that person's contact record roots —
+  provider-attributed room-level presence while home, their freshest
+  device location when away, zone state as the floor — ranked, with
+  provenance and freshness per source. Reach for
+  `companion_last_known_location` only when you need
   one specific device's stored fix, and a device's own live location
   tool only when the device block shows it online and you need a
   fresh fix right now.


### PR DESCRIPTION
## Summary

- carry an explicit room provider and provider-specific source evidence through the presence tracker, ambient person context, and contact channel context
- make `contact_whereabouts` emit `unifi_room` for UniFi observations, retain `bermuda_room` only for explicitly Bermuda-attributed observations, and use neutral `room_presence` for unknown providers
- keep the legacy MQTT AP sensor UniFi-only and preserve AP evidence when the mapped room itself does not change
- add a regression fixture matching the production HA person shape with regular and Bermuda device trackers

## Why

The post-#1454 production audit found that Home Assistant has healthy Bermuda-backed person data, but Thane's only room updater is currently the UniFi poller. The merged fused tool hard-coded every populated room as `bermuda_room`, so it would have presented UniFi evidence as Bermuda evidence after deployment.

This PR establishes source truth before native Bermuda ingestion and shadow-parity work begin.

## User impact

The model now sees the actual room provider (`unifi`) and its evidence (the AP name) in both ambient and counterparty context. `contact_whereabouts` no longer fabricates Bermuda provenance. No production configuration or source ranking changes in this slice; native Bermuda room ingestion remains the next PR.

## Test plan

- [x] `just test`
- [x] `just ci`
- [x] production-shaped regression: HA person selects a Bermuda tracker while an explicit UniFi observation remains `unifi_room`
- [x] named-zone regression: retained room and provenance stay suppressed outside `home`
