### PR TITLE
feat(contacts): resolve multi-source room observations

### DIFF
--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -175,7 +175,11 @@ the binding resolves but the presence join has nothing to report.
 The person binding itself does not infer a room from Home Assistant
 device-tracker attributes. Today room observations come from the
 configured UniFi poller, and model-facing output identifies `unifi` as
-the provider plus the AP name as source evidence.
+the provider plus the AP name as source evidence. The presence tracker
+retains room observations by provider and source: observations that agree
+resolve to one room, while disagreement reports `room_conflict` and withholds
+a guessed room. This is the ingestion boundary future room providers join
+rather than a last-writer-wins slot.
 Use `companion:`. A top-level `platform:` section is rejected at config
 load with an actionable error and must be renamed to `companion:` (the
 field shape is unchanged).

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -265,7 +265,7 @@ being reimplemented in each loop prompt.
 |------|-------------|
 | `contact_save` | Create or update a contact with vCard properties. |
 | `contact_lookup` | Search by name, query, kind, or property. |
-| `contact_whereabouts` | Fuse a contact's room, HA zone, and bound-device location sources with provenance and freshness. |
+| `contact_whereabouts` | Fuse a contact's room, HA zone, and bound-device location sources with provenance, freshness, and explicit room conflicts. |
 | `contact_forget` | Delete a contact. |
 | `contact_list` | List and filter contacts. |
 | `contact_export_vcf` | Export one contact as a vCard. |
@@ -526,7 +526,7 @@ tools for Signal-specific workflows.
 
 | Tool | Description |
 |------|-------------|
-| `contact_whereabouts` | Resolve a person first, then rank their presence and bound-device location sources. |
+| `contact_whereabouts` | Resolve a person first, then rank their presence and bound-device location sources without guessing through room conflicts. |
 | `companion_last_known_location` | Read one device's durable last location with provenance and freshness. |
 | `macos_calendar_events` | Query the local macOS Calendar (companion app required). |
 

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -697,7 +697,7 @@ func (a *App) initServers(s *newState) error {
 		s.personTracker.OnRoomChange(func(entityID, room, provider, source string) {
 			// This legacy MQTT sensor specifically represents UniFi AP
 			// association. Other room providers must not masquerade as AP data.
-			if !shouldPublishUnifiAPRoom(room, provider) {
+			if !shouldPublishUnifiAPRoom(provider) {
 				return
 			}
 			shortName := entityID
@@ -706,8 +706,12 @@ func (a *App) initServers(s *newState) error {
 			}
 			suffix := shortName + "_ap"
 
+			apName := source
+			if room == "" {
+				apName = ""
+			}
 			attrs, err := json.Marshal(map[string]string{
-				"ap_name":      source,
+				"ap_name":      apName,
 				"provider":     provider,
 				"last_changed": time.Now().Format(time.RFC3339),
 			})
@@ -891,10 +895,10 @@ func (a *App) initServers(s *newState) error {
 	return nil
 }
 
-// shouldPublishUnifiAPRoom keeps populated observations provider-specific but
-// permits normalized clears, whose provider is intentionally empty.
-func shouldPublishUnifiAPRoom(room, provider string) bool {
-	return room == "" || provider == unifi.RoomProvider
+// shouldPublishUnifiAPRoom keeps the legacy AP sensor scoped to observation
+// changes and withdrawals from the UniFi provider.
+func shouldPublishUnifiAPRoom(provider string) bool {
+	return provider == unifi.RoomProvider
 }
 
 // counterpartyPresenceView renders the contact-context presence join. The
@@ -906,12 +910,15 @@ func counterpartyPresenceView(snap contacts.PersonSnapshot, now time.Time) *agen
 	if !snap.Since.IsZero() {
 		view.Since = promptfmt.FormatDeltaOnly(snap.Since, now)
 	}
-	if strings.EqualFold(snap.State, "home") && snap.Room != "" {
-		view.Room = snap.Room
-		view.RoomProvider = snap.RoomProvider
-		view.RoomSource = snap.RoomSource
-		if !snap.RoomSince.IsZero() {
-			view.RoomSince = promptfmt.FormatDeltaOnly(snap.RoomSince, now)
+	if strings.EqualFold(snap.State, "home") {
+		view.RoomConflict = snap.RoomConflict
+		if !snap.RoomConflict && snap.Room != "" {
+			view.Room = snap.Room
+			view.RoomProvider = snap.RoomProvider
+			view.RoomSource = snap.RoomSource
+			if !snap.RoomSince.IsZero() {
+				view.RoomSince = promptfmt.FormatDeltaOnly(snap.RoomSince, now)
+			}
 		}
 	}
 	return view

--- a/internal/app/new_servers_test.go
+++ b/internal/app/new_servers_test.go
@@ -13,18 +13,17 @@ import (
 func TestShouldPublishUnifiAPRoom(t *testing.T) {
 	tests := []struct {
 		name     string
-		room     string
 		provider string
 		want     bool
 	}{
-		{name: "populated UniFi observation", room: "office", provider: unifi.RoomProvider, want: true},
-		{name: "populated non-UniFi observation", room: "office", provider: "bermuda", want: false},
-		{name: "normalized clear", room: "", provider: "", want: true},
+		{name: "UniFi observation", provider: unifi.RoomProvider, want: true},
+		{name: "non-UniFi observation", provider: "bermuda", want: false},
+		{name: "legacy unidentified clear", provider: "", want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := shouldPublishUnifiAPRoom(tt.room, tt.provider); got != tt.want {
-				t.Errorf("shouldPublishUnifiAPRoom(%q, %q) = %v, want %v", tt.room, tt.provider, got, tt.want)
+			if got := shouldPublishUnifiAPRoom(tt.provider); got != tt.want {
+				t.Errorf("shouldPublishUnifiAPRoom(%q) = %v, want %v", tt.provider, got, tt.want)
 			}
 		})
 	}
@@ -38,6 +37,9 @@ func TestCounterpartyPresenceView(t *testing.T) {
 		wantRoom           string
 		wantRoomProvider   string
 		wantRoomSource     string
+		roomConflict       bool
+		wantRoomConflict   bool
+		retainRoom         bool
 		wantRoomSinceEmpty bool
 	}{
 		{
@@ -46,25 +48,43 @@ func TestCounterpartyPresenceView(t *testing.T) {
 			wantRoom:         "office",
 			wantRoomProvider: "unifi",
 			wantRoomSource:   "ap-office",
+			retainRoom:       true,
+		},
+		{
+			name:               "home reports conflict without room",
+			state:              "home",
+			roomConflict:       true,
+			wantRoomConflict:   true,
+			retainRoom:         true,
+			wantRoomSinceEmpty: true,
 		},
 		{
 			name:               "named zone hides retained room",
 			state:              "work",
+			roomConflict:       true,
+			retainRoom:         true,
 			wantRoomSinceEmpty: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			view := counterpartyPresenceView(contacts.PersonSnapshot{
+			snapshot := contacts.PersonSnapshot{
 				State:        tt.state,
 				Since:        now.Add(-2 * time.Hour),
-				Room:         "office",
-				RoomSince:    now.Add(-20 * time.Minute),
-				RoomProvider: "unifi",
-				RoomSource:   "ap-office",
-			}, now)
+				RoomConflict: tt.roomConflict,
+			}
+			if tt.retainRoom {
+				snapshot.Room = "office"
+				snapshot.RoomSince = now.Add(-20 * time.Minute)
+				snapshot.RoomProvider = "unifi"
+				snapshot.RoomSource = "ap-office"
+			}
+			view := counterpartyPresenceView(snapshot, now)
 			if view.Room != tt.wantRoom || view.RoomProvider != tt.wantRoomProvider || view.RoomSource != tt.wantRoomSource {
 				t.Errorf("room view = %+v", view)
+			}
+			if view.RoomConflict != tt.wantRoomConflict {
+				t.Errorf("RoomConflict = %v, want %v", view.RoomConflict, tt.wantRoomConflict)
 			}
 			if (view.RoomSince == "") != tt.wantRoomSinceEmpty {
 				t.Errorf("RoomSince = %q, want empty=%v", view.RoomSince, tt.wantRoomSinceEmpty)

--- a/internal/runtime/agent/channel_provider.go
+++ b/internal/runtime/agent/channel_provider.go
@@ -50,6 +50,7 @@ type CounterpartyPresence struct {
 	RoomSince    string `json:"room_since,omitempty"`
 	RoomProvider string `json:"room_provider,omitempty"`
 	RoomSource   string `json:"room_source,omitempty"`
+	RoomConflict bool   `json:"room_conflict,omitempty"`
 }
 
 // CounterpartyDevice is one bound companion device, compactly: enough

--- a/internal/state/contacts/presence.go
+++ b/internal/state/contacts/presence.go
@@ -26,6 +26,7 @@ type PersonPresenceContext struct {
 	Room         string `json:"room,omitempty"`
 	RoomProvider string `json:"room_provider,omitempty"`
 	RoomSource   string `json:"room_source,omitempty"`
+	RoomConflict bool   `json:"room_conflict,omitempty"`
 }
 
 // FormatPersonPresence formats a tracked person as compact JSON with
@@ -34,16 +35,20 @@ func FormatPersonPresence(
 	entityID, name, state string,
 	since time.Time,
 	room, roomProvider, roomSource string,
+	roomConflict bool,
 	now time.Time,
 ) string {
 	displayState := state
 	if strings.EqualFold(state, "not_home") {
 		displayState = "away"
 	}
-	if !strings.EqualFold(state, "home") {
+	if !strings.EqualFold(state, "home") || roomConflict {
 		room = ""
 		roomProvider = ""
 		roomSource = ""
+	}
+	if !strings.EqualFold(state, "home") {
+		roomConflict = false
 	}
 	pc := PersonPresenceContext{
 		Entity:       entityID,
@@ -53,6 +58,7 @@ func FormatPersonPresence(
 		Room:         room,
 		RoomProvider: roomProvider,
 		RoomSource:   roomSource,
+		RoomConflict: roomConflict,
 	}
 	return promptfmt.MarshalCompact(pc)
 }
@@ -67,10 +73,13 @@ type Person struct {
 	State        string
 	Since        time.Time
 	DeviceMACs   []string  // configured MAC addresses for this person
-	Room         string    // inferred room (e.g., "office")
-	RoomSince    time.Time // when the current room was first detected
-	RoomProvider string    // stable provider family (e.g., "unifi")
-	RoomSource   string    // provider-specific evidence (e.g., an AP name)
+	Room         string    // resolved room when current observations agree
+	RoomSince    time.Time // when the current resolved room began
+	RoomProvider string    // shared provider, empty for cross-provider consensus
+	RoomSource   string    // sole source, empty when multiple sources agree
+
+	roomObservations map[roomObservationKey]RoomObservation
+	roomConflict     bool
 }
 
 // StateGetter abstracts the Home Assistant REST client for fetching
@@ -81,9 +90,9 @@ type StateGetter interface {
 }
 
 // RoomObserver is called when a tracked person's room observation changes.
-// Parameters are the person's entity ID, the new room name (may be empty when
-// cleared), the stable provider family, and provider-specific source evidence.
-// Observers are called outside the tracker's lock.
+// A withdrawal carries an empty room and retains the provider and source of
+// the observation being removed. Observers are called outside the tracker's
+// lock.
 type RoomObserver func(entityID, room, provider, source string)
 
 // PresenceTracker maintains in-memory presence state for configured
@@ -123,9 +132,10 @@ func NewPresenceTracker(entityIDs []string, timezone string, logger *slog.Logger
 	order := make([]string, 0, len(entityIDs))
 	for _, id := range entityIDs {
 		people[id] = &Person{
-			EntityID:     id,
-			FriendlyName: friendlyNameFromEntityID(id),
-			State:        "Unknown",
+			EntityID:         id,
+			FriendlyName:     friendlyNameFromEntityID(id),
+			State:            "Unknown",
+			roomObservations: make(map[roomObservationKey]RoomObservation),
 		}
 		order = append(order, id)
 	}
@@ -212,14 +222,15 @@ func (t *PresenceTracker) Initialize(ctx context.Context, ha StateGetter) error 
 // transitions to "not_home".
 func (t *PresenceTracker) HandleStateChange(entityID, _, newState, _ string) {
 	t.mu.Lock()
-	defer t.mu.Unlock()
 
 	p, ok := t.people[entityID]
 	if !ok {
+		t.mu.Unlock()
 		return
 	}
 
 	if p.State == newState {
+		t.mu.Unlock()
 		return
 	}
 
@@ -233,13 +244,20 @@ func (t *PresenceTracker) HandleStateChange(entityID, _, newState, _ string) {
 	p.State = newState
 	p.Since = time.Now()
 
-	// Clear room data when person leaves home — room presence is
-	// only meaningful while at home.
+	var withdrawn []RoomObservation
+	var observers []RoomObserver
+	// Withdraw every room observation when the person leaves home. Retaining
+	// provider/source identity lets observers clear only their own projection.
 	if strings.EqualFold(newState, "not_home") {
-		p.Room = ""
-		p.RoomSince = time.Time{}
-		p.RoomProvider = ""
-		p.RoomSource = ""
+		withdrawn = sortedRoomObservations(p.roomObservations)
+		clear(p.roomObservations)
+		clearResolvedRoom(p, false)
+		observers = append([]RoomObserver(nil), t.observers...)
+	}
+	t.mu.Unlock()
+
+	for _, observation := range withdrawn {
+		t.notifyRoomObservers(observers, entityID, "", observation.Provider, observation.Source)
 	}
 }
 
@@ -273,83 +291,13 @@ func (t *PresenceTracker) TagContext(_ context.Context, _ agentctx.ContextReques
 		} else {
 			sb.WriteString(FormatPersonPresence(
 				p.EntityID, displayName, p.State, p.Since,
-				p.Room, p.RoomProvider, p.RoomSource, now,
+				p.Room, p.RoomProvider, p.RoomSource, p.roomConflict, now,
 			))
 			sb.WriteByte('\n')
 		}
 	}
 
 	return sb.String(), nil
-}
-
-// OnRoomChange registers a callback that fires whenever a tracked person's
-// room observation or its provenance changes. Observers are called outside
-// the tracker's lock so they may perform blocking I/O (e.g., MQTT publishes).
-// Must be called before the poller starts.
-func (t *PresenceTracker) OnRoomChange(fn RoomObserver) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	t.observers = append(t.observers, fn)
-}
-
-// UpdateRoom sets one provider-attributed room observation for a tracked
-// person. An exact duplicate is ignored. A provider or source-evidence change
-// is retained without resetting RoomSince when the room itself is unchanged.
-// When a person transitions to not_home, HandleStateChange clears room data
-// automatically; callers may also pass an empty room to clear it explicitly.
-//
-// Registered [RoomObserver] callbacks are invoked after the state
-// update, outside the lock, so they may perform blocking operations.
-func (t *PresenceTracker) UpdateRoom(entityID, room, provider, source string) {
-	var notify bool
-	if room == "" {
-		provider = ""
-		source = ""
-	}
-
-	t.mu.Lock()
-	p, ok := t.people[entityID]
-	if !ok {
-		t.mu.Unlock()
-		return
-	}
-
-	if p.Room == room && p.RoomProvider == provider && p.RoomSource == source {
-		t.mu.Unlock()
-		return
-	}
-	roomChanged := p.Room != room
-
-	t.logger.Debug("person room changed",
-		"entity_id", entityID,
-		"friendly_name", p.FriendlyName,
-		"old_room", p.Room,
-		"new_room", room,
-		"room_provider", provider,
-		"room_source", source,
-	)
-
-	p.Room = room
-	p.RoomProvider = provider
-	p.RoomSource = source
-	if room != "" && roomChanged {
-		p.RoomSince = time.Now()
-	} else if room == "" {
-		p.RoomSince = time.Time{}
-	}
-
-	notify = len(t.observers) > 0
-	// Copy observer slice reference under lock. The slice is append-only
-	// and only grows before the poller starts, so reading it after unlock
-	// is safe.
-	obs := t.observers
-	t.mu.Unlock()
-
-	if notify {
-		for _, fn := range obs {
-			fn(entityID, room, provider, source)
-		}
-	}
 }
 
 // SetDeviceMACs configures the MAC addresses associated with a tracked
@@ -367,17 +315,22 @@ func (t *PresenceTracker) SetDeviceMACs(entityID string, macs []string) {
 	p.DeviceMACs = macs
 }
 
-// PersonSnapshot is a read-only copy of one tracked person's live
-// state, for consumers that join presence onto other views (#1450).
+// PersonSnapshot is a read-only copy of one tracked person's live state, for
+// consumers that join presence onto other views (#1450). Room is populated
+// only when every current observation agrees; RoomConflict distinguishes
+// disagreement from no room data. RoomObservations is a deterministic,
+// defensive copy of the evidence retained by the tracker.
 type PersonSnapshot struct {
-	EntityID     string
-	FriendlyName string
-	State        string
-	Since        time.Time
-	Room         string
-	RoomSince    time.Time
-	RoomProvider string
-	RoomSource   string
+	EntityID         string            `json:"entity_id"`
+	FriendlyName     string            `json:"friendly_name"`
+	State            string            `json:"state"`
+	Since            time.Time         `json:"since"`
+	Room             string            `json:"room,omitempty"`
+	RoomSince        time.Time         `json:"room_since,omitempty"`
+	RoomProvider     string            `json:"room_provider,omitempty"`
+	RoomSource       string            `json:"room_source,omitempty"`
+	RoomConflict     bool              `json:"room_conflict,omitempty"`
+	RoomObservations []RoomObservation `json:"room_observations,omitempty"`
 }
 
 // Snapshot returns the current state of one tracked person entity.
@@ -390,14 +343,16 @@ func (t *PresenceTracker) Snapshot(entityID string) (PersonSnapshot, bool) {
 		return PersonSnapshot{}, false
 	}
 	return PersonSnapshot{
-		EntityID:     p.EntityID,
-		FriendlyName: p.FriendlyName,
-		State:        p.State,
-		Since:        p.Since,
-		Room:         p.Room,
-		RoomSince:    p.RoomSince,
-		RoomProvider: p.RoomProvider,
-		RoomSource:   p.RoomSource,
+		EntityID:         p.EntityID,
+		FriendlyName:     p.FriendlyName,
+		State:            p.State,
+		Since:            p.Since,
+		Room:             p.Room,
+		RoomSince:        p.RoomSince,
+		RoomProvider:     p.RoomProvider,
+		RoomSource:       p.RoomSource,
+		RoomConflict:     p.roomConflict,
+		RoomObservations: sortedRoomObservations(p.roomObservations),
 	}, true
 }
 

--- a/internal/state/contacts/room_presence.go
+++ b/internal/state/contacts/room_presence.go
@@ -1,0 +1,306 @@
+package contacts
+
+import (
+	"sort"
+	"strings"
+	"time"
+)
+
+// RoomObservation is one provider-attributed claim about a tracked person's
+// current room. Provider identifies the integration family, Source identifies
+// the concrete device or sensor within that provider, and ObservedAt records
+// when that source produced the claim.
+type RoomObservation struct {
+	Room       string    `json:"room"`
+	Provider   string    `json:"provider"`
+	Source     string    `json:"source,omitempty"`
+	ObservedAt time.Time `json:"observed_at"`
+}
+
+type roomObservationKey struct {
+	provider string
+	source   string
+}
+
+type roomResolutionLog struct {
+	room             string
+	provider         string
+	source           string
+	conflict         bool
+	observationCount int
+}
+
+// OnRoomChange registers a callback that fires whenever one tracked room
+// observation changes or is withdrawn. A withdrawal carries an empty room but
+// retains provider and source so observers can clear only their own projection.
+// Observers are called outside the tracker's lock and should be registered
+// before room producers start.
+func (t *PresenceTracker) OnRoomChange(fn RoomObserver) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.observers = append(t.observers, fn)
+}
+
+// ObserveRoom records one provider/source-keyed room observation. Multiple
+// sources may coexist. Agreement resolves to one room; disagreement retains
+// every observation but clears the resolved room and marks a conflict.
+//
+// An empty room withdraws this exact provider/source observation. A zero
+// ObservedAt is replaced with the current time. Exact semantic refreshes update
+// freshness without notifying observers or resetting RoomSince.
+func (t *PresenceTracker) ObserveRoom(entityID string, observation RoomObservation) {
+	now := time.Now()
+	observation = normalizeRoomObservation(observation, now)
+	if observation.Room == "" {
+		t.WithdrawRoom(entityID, observation.Provider, observation.Source)
+		return
+	}
+
+	key := roomObservationKey{provider: observation.Provider, source: observation.Source}
+
+	t.mu.Lock()
+	p, ok := t.people[entityID]
+	if !ok {
+		t.mu.Unlock()
+		return
+	}
+	previous, existed := p.roomObservations[key]
+	p.roomObservations[key] = observation
+	resolvePersonRoom(p, now)
+	friendlyName := p.FriendlyName
+	resolution := roomResolutionForLog(p)
+	observers := append([]RoomObserver(nil), t.observers...)
+	t.mu.Unlock()
+
+	if existed && normalizedRoomName(previous.Room) == normalizedRoomName(observation.Room) {
+		return
+	}
+	t.logRoomObservation("observed", entityID, friendlyName, observation, resolution)
+	t.notifyRoomObservers(observers, entityID, observation.Room, observation.Provider, observation.Source)
+}
+
+// WithdrawRoom removes one exact provider/source room observation. Other
+// providers and sources remain available to the resolver. Missing observations
+// and untracked entities are no-ops.
+func (t *PresenceTracker) WithdrawRoom(entityID, provider, source string) {
+	provider, source = normalizeRoomObservationIdentity(provider, source)
+	key := roomObservationKey{provider: provider, source: source}
+
+	t.mu.Lock()
+	p, ok := t.people[entityID]
+	if !ok {
+		t.mu.Unlock()
+		return
+	}
+	observation, exists := p.roomObservations[key]
+	if !exists {
+		t.mu.Unlock()
+		return
+	}
+	delete(p.roomObservations, key)
+	resolvePersonRoom(p, time.Now())
+	friendlyName := p.FriendlyName
+	resolution := roomResolutionForLog(p)
+	observers := append([]RoomObserver(nil), t.observers...)
+	t.mu.Unlock()
+
+	t.logRoomObservation("withdrawn", entityID, friendlyName, observation, resolution)
+	t.notifyRoomObservers(observers, entityID, "", provider, source)
+}
+
+// UpdateRoom is the compatibility path for providers, such as the current
+// UniFi poller, that publish one current observation per person. A populated
+// update replaces every prior observation from that provider atomically. An
+// empty update with provider/source withdraws that exact observation; an empty
+// update without identity clears every observation for legacy callers.
+func (t *PresenceTracker) UpdateRoom(entityID, room, provider, source string) {
+	room = strings.TrimSpace(room)
+	provider, source = normalizeRoomObservationIdentity(provider, source)
+	if room == "" {
+		if provider != "" || source != "" {
+			t.WithdrawRoom(entityID, provider, source)
+			return
+		}
+		t.withdrawAllRooms(entityID)
+		return
+	}
+
+	now := time.Now()
+	observation := normalizeRoomObservation(RoomObservation{
+		Room:       room,
+		Provider:   provider,
+		Source:     source,
+		ObservedAt: now,
+	}, now)
+	key := roomObservationKey{provider: observation.Provider, source: observation.Source}
+
+	t.mu.Lock()
+	p, ok := t.people[entityID]
+	if !ok {
+		t.mu.Unlock()
+		return
+	}
+	previous, existed := p.roomObservations[key]
+	providerObservationCount := 0
+	for existingKey := range p.roomObservations {
+		if existingKey.provider != observation.Provider {
+			continue
+		}
+		providerObservationCount++
+		if existingKey != key {
+			delete(p.roomObservations, existingKey)
+		}
+	}
+	p.roomObservations[key] = observation
+	resolvePersonRoom(p, now)
+	friendlyName := p.FriendlyName
+	resolution := roomResolutionForLog(p)
+	observers := append([]RoomObserver(nil), t.observers...)
+	t.mu.Unlock()
+
+	if existed && providerObservationCount == 1 && normalizedRoomName(previous.Room) == normalizedRoomName(observation.Room) {
+		return
+	}
+	t.logRoomObservation("replaced", entityID, friendlyName, observation, resolution)
+	t.notifyRoomObservers(observers, entityID, observation.Room, observation.Provider, observation.Source)
+}
+
+func (t *PresenceTracker) withdrawAllRooms(entityID string) {
+	t.mu.Lock()
+	p, ok := t.people[entityID]
+	if !ok || len(p.roomObservations) == 0 {
+		t.mu.Unlock()
+		return
+	}
+	withdrawn := sortedRoomObservations(p.roomObservations)
+	clear(p.roomObservations)
+	resolvePersonRoom(p, time.Now())
+	friendlyName := p.FriendlyName
+	resolution := roomResolutionForLog(p)
+	observers := append([]RoomObserver(nil), t.observers...)
+	t.mu.Unlock()
+
+	t.logger.Debug("person room observations cleared",
+		"entity_id", entityID,
+		"friendly_name", friendlyName,
+		"withdrawn_observations", len(withdrawn),
+		"resolved_room", resolution.room,
+		"room_conflict", resolution.conflict,
+	)
+	for _, observation := range withdrawn {
+		t.notifyRoomObservers(observers, entityID, "", observation.Provider, observation.Source)
+	}
+}
+
+func (t *PresenceTracker) logRoomObservation(operation, entityID, friendlyName string, observation RoomObservation, resolution roomResolutionLog) {
+	t.logger.Debug("person room observation changed",
+		"operation", operation,
+		"entity_id", entityID,
+		"friendly_name", friendlyName,
+		"room", observation.Room,
+		"room_provider", observation.Provider,
+		"room_source", observation.Source,
+		"observed_at", observation.ObservedAt,
+		"resolved_room", resolution.room,
+		"resolved_room_provider", resolution.provider,
+		"resolved_room_source", resolution.source,
+		"room_conflict", resolution.conflict,
+		"room_observations", resolution.observationCount,
+	)
+}
+
+func roomResolutionForLog(person *Person) roomResolutionLog {
+	return roomResolutionLog{
+		room:             person.Room,
+		provider:         person.RoomProvider,
+		source:           person.RoomSource,
+		conflict:         person.roomConflict,
+		observationCount: len(person.roomObservations),
+	}
+}
+
+func (t *PresenceTracker) notifyRoomObservers(observers []RoomObserver, entityID, room, provider, source string) {
+	for _, fn := range observers {
+		fn(entityID, room, provider, source)
+	}
+}
+
+func normalizeRoomObservation(observation RoomObservation, now time.Time) RoomObservation {
+	observation.Room = strings.TrimSpace(observation.Room)
+	observation.Provider, observation.Source = normalizeRoomObservationIdentity(observation.Provider, observation.Source)
+	if observation.ObservedAt.IsZero() {
+		observation.ObservedAt = now
+	}
+	return observation
+}
+
+func normalizeRoomObservationIdentity(provider, source string) (string, string) {
+	return strings.ToLower(strings.TrimSpace(provider)), strings.TrimSpace(source)
+}
+
+func normalizedRoomName(room string) string {
+	return strings.ToLower(strings.TrimSpace(room))
+}
+
+func resolvePersonRoom(person *Person, now time.Time) {
+	observations := sortedRoomObservations(person.roomObservations)
+	if len(observations) == 0 {
+		clearResolvedRoom(person, false)
+		return
+	}
+
+	roomKey := normalizedRoomName(observations[0].Room)
+	for _, observation := range observations[1:] {
+		if normalizedRoomName(observation.Room) != roomKey {
+			clearResolvedRoom(person, true)
+			return
+		}
+	}
+
+	room := observations[0].Room
+	provider := observations[0].Provider
+	source := observations[0].Source
+	for _, observation := range observations[1:] {
+		if observation.Provider != provider {
+			provider = ""
+			source = ""
+			continue
+		}
+		if observation.Source != source {
+			source = ""
+		}
+	}
+
+	if normalizedRoomName(person.Room) != roomKey {
+		person.RoomSince = now
+	}
+	person.Room = room
+	person.RoomProvider = provider
+	person.RoomSource = source
+	person.roomConflict = false
+}
+
+func clearResolvedRoom(person *Person, conflict bool) {
+	person.Room = ""
+	person.RoomSince = time.Time{}
+	person.RoomProvider = ""
+	person.RoomSource = ""
+	person.roomConflict = conflict
+}
+
+func sortedRoomObservations(observations map[roomObservationKey]RoomObservation) []RoomObservation {
+	result := make([]RoomObservation, 0, len(observations))
+	for _, observation := range observations {
+		result = append(result, observation)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Provider != result[j].Provider {
+			return result[i].Provider < result[j].Provider
+		}
+		if result[i].Source != result[j].Source {
+			return result[i].Source < result[j].Source
+		}
+		return result[i].Room < result[j].Room
+	})
+	return result
+}

--- a/internal/state/contacts/room_presence_test.go
+++ b/internal/state/contacts/room_presence_test.go
@@ -1,0 +1,275 @@
+package contacts
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+)
+
+func TestPresenceTrackerObserveRoomConsensus(t *testing.T) {
+	tracker := NewPresenceTracker([]string{"person.alice"}, "UTC", nil)
+	phoneAt := time.Date(2026, 8, 30, 12, 0, 0, 0, time.UTC)
+	watchAt := phoneAt.Add(time.Second)
+
+	tracker.ObserveRoom("person.alice", RoomObservation{
+		Room:       "Office",
+		Provider:   " Bermuda ",
+		Source:     "device_tracker.phone_bermuda",
+		ObservedAt: phoneAt,
+	})
+	first, _ := tracker.Snapshot("person.alice")
+	if first.Room != "Office" || first.RoomProvider != "bermuda" || first.RoomSource != "device_tracker.phone_bermuda" {
+		t.Fatalf("single-source resolution = %+v", first)
+	}
+
+	tracker.ObserveRoom("person.alice", RoomObservation{
+		Room:       " office ",
+		Provider:   "bermuda",
+		Source:     "device_tracker.watch_bermuda",
+		ObservedAt: watchAt,
+	})
+	providerConsensus, _ := tracker.Snapshot("person.alice")
+	if providerConsensus.Room != "Office" || providerConsensus.RoomProvider != "bermuda" || providerConsensus.RoomSource != "" {
+		t.Fatalf("same-provider consensus = %+v", providerConsensus)
+	}
+	if providerConsensus.RoomConflict {
+		t.Fatal("agreeing sources reported a conflict")
+	}
+	if !providerConsensus.RoomSince.Equal(first.RoomSince) {
+		t.Errorf("agreeing source reset RoomSince: %v then %v", first.RoomSince, providerConsensus.RoomSince)
+	}
+
+	tracker.ObserveRoom("person.alice", RoomObservation{
+		Room:       "OFFICE",
+		Provider:   "unifi",
+		Source:     "ap-office",
+		ObservedAt: watchAt.Add(time.Second),
+	})
+	crossProviderConsensus, _ := tracker.Snapshot("person.alice")
+	if crossProviderConsensus.Room != "Office" || crossProviderConsensus.RoomProvider != "" || crossProviderConsensus.RoomSource != "" {
+		t.Fatalf("cross-provider consensus = %+v", crossProviderConsensus)
+	}
+	if crossProviderConsensus.RoomConflict {
+		t.Fatal("case-insensitive cross-provider agreement reported a conflict")
+	}
+	if len(crossProviderConsensus.RoomObservations) != 3 {
+		t.Fatalf("observations = %+v, want 3", crossProviderConsensus.RoomObservations)
+	}
+	if crossProviderConsensus.RoomObservations[0].Source != "device_tracker.phone_bermuda" ||
+		crossProviderConsensus.RoomObservations[1].Source != "device_tracker.watch_bermuda" ||
+		crossProviderConsensus.RoomObservations[2].Source != "ap-office" {
+		t.Errorf("observations not deterministically ordered: %+v", crossProviderConsensus.RoomObservations)
+	}
+}
+
+func TestPresenceTrackerRoomConflictAndRecovery(t *testing.T) {
+	tracker := NewPresenceTracker([]string{"person.alice"}, "UTC", nil)
+	tracker.HandleStateChange("person.alice", "", "home", "")
+	tracker.ObserveRoom("person.alice", RoomObservation{
+		Room: "office", Provider: "bermuda", Source: "device_tracker.phone_bermuda",
+	})
+	tracker.ObserveRoom("person.alice", RoomObservation{
+		Room: "kitchen", Provider: "unifi", Source: "ap-kitchen",
+	})
+
+	conflicted, _ := tracker.Snapshot("person.alice")
+	if !conflicted.RoomConflict {
+		t.Fatal("disagreeing observations did not report a conflict")
+	}
+	if conflicted.Room != "" || conflicted.RoomProvider != "" || conflicted.RoomSource != "" || !conflicted.RoomSince.IsZero() {
+		t.Errorf("conflict asserted a resolved room: %+v", conflicted)
+	}
+	if len(conflicted.RoomObservations) != 2 {
+		t.Fatalf("conflict discarded evidence: %+v", conflicted.RoomObservations)
+	}
+	rendered, err := tracker.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(rendered, `"room_conflict":true`) || strings.Contains(rendered, `"room":`) {
+		t.Fatalf("conflict context = %s, want conflict without resolved room", rendered)
+	}
+
+	tracker.WithdrawRoom("person.alice", "unifi", "ap-kitchen")
+	recovered, _ := tracker.Snapshot("person.alice")
+	if recovered.RoomConflict || recovered.Room != "office" || recovered.RoomProvider != "bermuda" || recovered.RoomSource != "device_tracker.phone_bermuda" {
+		t.Fatalf("resolution after withdrawal = %+v", recovered)
+	}
+	if recovered.RoomSince.IsZero() {
+		t.Fatal("recovered resolution did not establish RoomSince")
+	}
+}
+
+func TestPresenceTrackerWithdrawRoomPreservesOtherEvidence(t *testing.T) {
+	tracker := NewPresenceTracker([]string{"person.alice"}, "UTC", nil)
+	tracker.ObserveRoom("person.alice", RoomObservation{
+		Room: "office", Provider: "bermuda", Source: "device_tracker.phone_bermuda",
+	})
+	tracker.ObserveRoom("person.alice", RoomObservation{
+		Room: "office", Provider: "bermuda", Source: "device_tracker.watch_bermuda",
+	})
+	before, _ := tracker.Snapshot("person.alice")
+
+	tracker.WithdrawRoom("person.alice", " BERMUDA ", "device_tracker.watch_bermuda")
+	after, _ := tracker.Snapshot("person.alice")
+	if after.Room != "office" || after.RoomProvider != "bermuda" || after.RoomSource != "device_tracker.phone_bermuda" {
+		t.Fatalf("remaining observation did not resolve: %+v", after)
+	}
+	if len(after.RoomObservations) != 1 {
+		t.Fatalf("withdrawal removed unrelated evidence: %+v", after.RoomObservations)
+	}
+	if !after.RoomSince.Equal(before.RoomSince) {
+		t.Errorf("same resolved room reset RoomSince: %v then %v", before.RoomSince, after.RoomSince)
+	}
+}
+
+func TestPresenceTrackerObservationRefresh(t *testing.T) {
+	tracker := NewPresenceTracker([]string{"person.alice"}, "UTC", nil)
+	var notifications int
+	tracker.OnRoomChange(func(_, _, _, _ string) { notifications++ })
+	firstAt := time.Date(2026, 8, 30, 12, 0, 0, 0, time.UTC)
+	secondAt := firstAt.Add(10 * time.Second)
+	observation := RoomObservation{
+		Room: "office", Provider: "bermuda", Source: "device_tracker.phone_bermuda", ObservedAt: firstAt,
+	}
+	tracker.ObserveRoom("person.alice", observation)
+	first, _ := tracker.Snapshot("person.alice")
+
+	observation.Room = " OFFICE "
+	observation.ObservedAt = secondAt
+	tracker.ObserveRoom("person.alice", observation)
+	second, _ := tracker.Snapshot("person.alice")
+	if notifications != 1 {
+		t.Errorf("semantic refresh emitted %d notifications, want 1", notifications)
+	}
+	if !second.RoomObservations[0].ObservedAt.Equal(secondAt) {
+		t.Errorf("ObservedAt = %v, want %v", second.RoomObservations[0].ObservedAt, secondAt)
+	}
+	if !second.RoomSince.Equal(first.RoomSince) {
+		t.Errorf("semantic refresh reset RoomSince: %v then %v", first.RoomSince, second.RoomSince)
+	}
+}
+
+func TestFormatPersonPresenceConflictSuppressesResolvedRoom(t *testing.T) {
+	now := time.Date(2026, 8, 30, 12, 0, 0, 0, time.UTC)
+	rendered := FormatPersonPresence(
+		"person.alice", "Alice", "home", now.Add(-time.Hour),
+		"office", "unifi", "ap-office", true, now,
+	)
+	if !strings.Contains(rendered, `"room_conflict":true`) || strings.Contains(rendered, `"room":`) {
+		t.Fatalf("conflict context = %s, want conflict without resolved room", rendered)
+	}
+}
+
+func TestPresenceTrackerUpdateRoomReplacesProviderObservation(t *testing.T) {
+	tracker := NewPresenceTracker([]string{"person.alice"}, "UTC", nil)
+	tracker.UpdateRoom("person.alice", "office", "unifi", "ap-office-east")
+	first, _ := tracker.Snapshot("person.alice")
+
+	tracker.UpdateRoom("person.alice", "office", "unifi", "ap-office-west")
+	second, _ := tracker.Snapshot("person.alice")
+	if len(second.RoomObservations) != 1 || second.RoomObservations[0].Source != "ap-office-west" {
+		t.Fatalf("compatibility update retained stale provider evidence: %+v", second.RoomObservations)
+	}
+	if !second.RoomSince.Equal(first.RoomSince) {
+		t.Errorf("same-room provider replacement reset RoomSince: %v then %v", first.RoomSince, second.RoomSince)
+	}
+}
+
+func TestPresenceTrackerRoomObserverWithdrawalRetainsIdentity(t *testing.T) {
+	tracker := NewPresenceTracker([]string{"person.alice"}, "UTC", nil)
+	type notification struct {
+		room     string
+		provider string
+		source   string
+	}
+	var notifications []notification
+	tracker.OnRoomChange(func(_ string, room string, provider string, source string) {
+		notifications = append(notifications, notification{room: room, provider: provider, source: source})
+	})
+
+	tracker.ObserveRoom("person.alice", RoomObservation{
+		Room: "office", Provider: "unifi", Source: "ap-office",
+	})
+	tracker.WithdrawRoom("person.alice", "unifi", "ap-office")
+
+	if len(notifications) != 2 {
+		t.Fatalf("notifications = %+v, want observe + withdraw", notifications)
+	}
+	withdrawal := notifications[1]
+	if withdrawal.room != "" || withdrawal.provider != "unifi" || withdrawal.source != "ap-office" {
+		t.Errorf("withdrawal lost identity: %+v", withdrawal)
+	}
+}
+
+func TestPresenceTrackerLegacyClearWithdrawsEveryObservation(t *testing.T) {
+	tracker := NewPresenceTracker([]string{"person.alice"}, "UTC", nil)
+	tracker.ObserveRoom("person.alice", RoomObservation{
+		Room: "office", Provider: "bermuda", Source: "device_tracker.phone_bermuda",
+	})
+	tracker.ObserveRoom("person.alice", RoomObservation{
+		Room: "office", Provider: "unifi", Source: "ap-office",
+	})
+	var withdrawn []string
+	tracker.OnRoomChange(func(_ string, room string, provider string, source string) {
+		if room == "" {
+			withdrawn = append(withdrawn, provider+":"+source)
+		}
+	})
+
+	tracker.UpdateRoom("person.alice", "", "", "")
+	snapshot, _ := tracker.Snapshot("person.alice")
+	if snapshot.Room != "" || snapshot.RoomConflict || len(snapshot.RoomObservations) != 0 {
+		t.Errorf("legacy clear retained room state: %+v", snapshot)
+	}
+	if len(withdrawn) != 2 || withdrawn[0] != "bermuda:device_tracker.phone_bermuda" || withdrawn[1] != "unifi:ap-office" {
+		t.Errorf("withdrawals = %v", withdrawn)
+	}
+}
+
+func TestPresenceTrackerNotHomeWithdrawsEveryObservation(t *testing.T) {
+	tracker := NewPresenceTracker([]string{"person.alice"}, "UTC", nil)
+	tracker.HandleStateChange("person.alice", "", "home", "")
+	tracker.ObserveRoom("person.alice", RoomObservation{
+		Room: "office", Provider: "bermuda", Source: "device_tracker.phone_bermuda",
+	})
+	tracker.ObserveRoom("person.alice", RoomObservation{
+		Room: "office", Provider: "unifi", Source: "ap-office",
+	})
+	var withdrawn []string
+	tracker.OnRoomChange(func(_ string, room string, provider string, source string) {
+		if room == "" {
+			withdrawn = append(withdrawn, provider+":"+source)
+		}
+	})
+
+	tracker.HandleStateChange("person.alice", "home", "not_home", "")
+	snap, _ := tracker.Snapshot("person.alice")
+	if snap.Room != "" || snap.RoomConflict || len(snap.RoomObservations) != 0 {
+		t.Errorf("not_home retained room state: %+v", snap)
+	}
+	if len(withdrawn) != 2 || withdrawn[0] != "bermuda:device_tracker.phone_bermuda" || withdrawn[1] != "unifi:ap-office" {
+		t.Errorf("withdrawals = %v", withdrawn)
+	}
+	rendered, _ := tracker.TagContext(context.Background(), agentctx.ContextRequest{})
+	if rendered == "" {
+		t.Fatal("tracked person context unexpectedly empty")
+	}
+}
+
+func TestPresenceTrackerSnapshotCopiesObservations(t *testing.T) {
+	tracker := NewPresenceTracker([]string{"person.alice"}, "UTC", nil)
+	tracker.ObserveRoom("person.alice", RoomObservation{
+		Room: "office", Provider: "unifi", Source: "ap-office",
+	})
+
+	first, _ := tracker.Snapshot("person.alice")
+	first.RoomObservations[0].Room = "tampered"
+	second, _ := tracker.Snapshot("person.alice")
+	if second.RoomObservations[0].Room != "office" {
+		t.Errorf("snapshot mutation leaked into tracker: %+v", second.RoomObservations)
+	}
+}

--- a/internal/tools/counterparty_tools.go
+++ b/internal/tools/counterparty_tools.go
@@ -53,6 +53,7 @@ func (r *Registry) EnableCounterpartyTools(deps CounterpartyToolDeps) {
 			"contact record roots and ranked best-first: room-level presence while they are home, their " +
 			"freshest companion-device location when away, and zone-level person state as the floor. Each " +
 			"source carries its own provenance and freshness — nothing is blended into a single guess. " +
+			"When current room observations disagree, room_conflict is true and no room is asserted. " +
 			"Only the leading available device fix includes its location payload; every device entry " +
 			"carries account, client_id, and device_id, so fetch any other device's payload with " +
 			"companion_last_known_location. " +
@@ -124,9 +125,12 @@ type whereaboutsResult struct {
 	// BestSource names the leading usable entry of Sources and Basis says
 	// why it leads — precomputed so the model does not re-derive the
 	// ranking. It is omitted when every source is withdrawn provenance.
-	BestSource string              `json:"best_source,omitempty"`
-	Basis      string              `json:"basis,omitempty"`
-	Sources    []whereaboutsSource `json:"sources"`
+	BestSource string `json:"best_source,omitempty"`
+	Basis      string `json:"basis,omitempty"`
+	// RoomConflict is true when current room observations disagree. The tool
+	// deliberately omits a room source instead of guessing between them.
+	RoomConflict bool                `json:"room_conflict,omitempty"`
+	Sources      []whereaboutsSource `json:"sources"`
 }
 
 // whereaboutsRoomSource keeps provider attribution honest without allowing an
@@ -156,6 +160,7 @@ func handleContactWhereabouts(ctx context.Context, deps CounterpartyToolDeps, na
 	// report unavailable, and the basis must not claim "not home" on
 	// either of those.
 	home, presenceUnknown := false, true
+	roomConflict := false
 	hasHABinding := false
 
 	entity, hasEntity, err := deps.Contacts.HAPersonEntity(contact.ID)
@@ -169,11 +174,12 @@ func handleContactWhereabouts(ctx context.Context, deps CounterpartyToolDeps, na
 				state := strings.ToLower(strings.TrimSpace(snap.State))
 				home = state == "home"
 				presenceUnknown = state == "" || state == "unknown" || state == "unavailable"
+				roomConflict = home && snap.RoomConflict
 				zone := whereaboutsSource{Source: "ha_person_zone", State: snap.State}
 				if !snap.Since.IsZero() {
 					zone.Since = promptfmt.FormatDeltaOnly(snap.Since, now)
 				}
-				if home && snap.Room != "" {
+				if home && !roomConflict && snap.Room != "" {
 					room := whereaboutsSource{
 						Source:  whereaboutsRoomSource(snap.RoomProvider),
 						Room:    snap.Room,
@@ -260,9 +266,10 @@ func handleContactWhereabouts(ctx context.Context, deps CounterpartyToolDeps, na
 	}
 
 	result := whereaboutsResult{
-		Contact:   contact.FormattedName,
-		ContactID: contact.ID.String(),
-		TrustZone: contact.TrustZone,
+		Contact:      contact.FormattedName,
+		ContactID:    contact.ID.String(),
+		TrustZone:    contact.TrustZone,
+		RoomConflict: roomConflict,
 	}
 
 	// Only the leading available fix carries its payload: the result
@@ -307,7 +314,9 @@ func handleContactWhereabouts(ctx context.Context, deps CounterpartyToolDeps, na
 		result.Sources = append(result.Sources, presenceSources...)
 		result.Sources = append(result.Sources, available...)
 		result.Sources = append(result.Sources, withdrawn...)
-		if len(presenceSources) > 0 && presenceSources[0].Room != "" {
+		if roomConflict {
+			result.Basis = "home per person entity; current room observations conflict, so no room is asserted"
+		} else if len(presenceSources) > 0 && presenceSources[0].Room != "" {
 			result.Basis = "home per person entity; room-level presence leads as the most specific source while home"
 		} else {
 			result.Basis = "home per person entity; zone state leads because no room-level presence is available"

--- a/internal/tools/counterparty_tools_test.go
+++ b/internal/tools/counterparty_tools_test.go
@@ -120,6 +120,44 @@ func TestContactWhereaboutsHomeRanking(t *testing.T) {
 	}
 }
 
+func TestContactWhereaboutsReportsRoomConflictWithoutGuessing(t *testing.T) {
+	fx := newWhereaboutsFixture(t, "home", "", nil)
+	now := time.Now().UTC()
+	fx.deps.Presence = func(entity string) (contacts.PersonSnapshot, bool) {
+		if entity != "person.alice" {
+			return contacts.PersonSnapshot{}, false
+		}
+		return contacts.PersonSnapshot{
+			EntityID:     entity,
+			State:        "home",
+			Since:        now.Add(-2 * time.Hour),
+			Room:         "office",
+			RoomProvider: "bermuda",
+			RoomSource:   "device_tracker.phone_bermuda",
+			RoomConflict: true,
+			RoomObservations: []contacts.RoomObservation{
+				{Room: "office", Provider: "bermuda", Source: "device_tracker.phone_bermuda", ObservedAt: now.Add(-time.Minute)},
+				{Room: "kitchen", Provider: "unifi", Source: "ap-kitchen", ObservedAt: now.Add(-2 * time.Minute)},
+			},
+		}, true
+	}
+
+	out, err := handleContactWhereabouts(context.Background(), fx.deps, "Alice Operator", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := decodeWhereabouts(t, out)
+	if !res.RoomConflict {
+		t.Fatalf("result = %s, want room_conflict", out)
+	}
+	if len(res.Sources) != 1 || res.Sources[0].Source != "ha_person_zone" || res.Sources[0].Room != "" {
+		t.Fatalf("sources = %+v, want only the home zone floor", res.Sources)
+	}
+	if res.BestSource != "ha_person_zone" || !strings.Contains(res.Basis, "conflict") || !strings.Contains(res.Basis, "no room is asserted") {
+		t.Errorf("verdict = %q / %q", res.BestSource, res.Basis)
+	}
+}
+
 // TestContactWhereaboutsProductionPersonShapePreservesRoomProvider mirrors the
 // material parts of a production HA person backed by regular and Bermuda
 // device trackers. The aggregate person's active source must not overwrite the


### PR DESCRIPTION
## Summary

- retain room observations independently by provider and source
- resolve agreeing observations deterministically and expose room_conflict without guessing when they disagree
- preserve source identity through withdrawals while keeping the legacy UniFi MQTT projection scoped to UniFi evidence

## Why

A Home Assistant person can be backed by several device trackers, and the next Bermuda ingestion slice will add multiple room producers alongside the existing UniFi poller. The previous single room slot would make that last-writer-wins and could silently misattribute a room.

This PR establishes the shared observation and resolution boundary first. It intentionally does not ingest Bermuda attributes yet.

## User impact

Current single-source UniFi behavior remains compatible. When multiple sources are connected later, agreement resolves to one room; disagreement reports room_conflict and withholds a guessed room across ambient person context, counterparty channel context, and contact_whereabouts. Leaving home withdraws every retained observation with its provider/source identity, so the legacy UniFi AP sensor clears only from UniFi evidence.

## Test plan

- [x] just test
- [x] git diff --check
- [x] just ci
