### PR TITLE
feat(contacts): ingest linked Bermuda room presence

### DIFF
--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -172,14 +172,15 @@ active contact may claim a given person entity, and removing the field
 clears the binding. Presence flows only for entities the tracker
 watches: the same entity must also be listed under `person.track`, or
 the binding resolves but the presence join has nothing to report.
-The person binding itself does not infer a room from Home Assistant
-device-tracker attributes. Today room observations come from the
-configured UniFi poller, and model-facing output identifies `unifi` as
-the provider plus the AP name as source evidence. The presence tracker
-retains room observations by provider and source: observations that agree
-resolve to one room, while disagreement reports `room_conflict` and withholds
-a guessed room. This is the ingestion boundary future room providers join
-rather than a last-writer-wins slot.
+The person tracker follows each person's Home Assistant `device_trackers`
+attribute and adds those linked entities to the system ingestion floor. A
+linked tracker contributes room presence only when its entity-registry
+platform is `bermuda`, its state is `home`, and its `area` attribute is a
+non-empty string. The tracker entity ID remains the stable observation identity;
+the human-readable `scanner` attribute is surfaced as source evidence. The
+configured UniFi poller remains a second room provider and uses the AP name as
+its evidence. Observations that agree resolve to one room, while disagreement
+reports `room_conflict` and withholds a guessed room.
 Use `companion:`. A top-level `platform:` section is rejected at config
 load with an actionable error and must be renamed to `companion:` (the
 field shape is unchanged).

--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -177,9 +177,10 @@ attribute and adds those linked entities to the system ingestion floor. A
 linked tracker contributes room presence only when its entity-registry
 platform is `bermuda`, its state is `home`, and its `area` attribute is a
 non-empty string. The tracker entity ID remains the stable observation identity;
-the human-readable `scanner` attribute is surfaced as source evidence. The
-configured UniFi poller remains a second room provider and uses the AP name as
-its evidence. Observations that agree resolve to one room, while disagreement
+a non-empty human-readable `scanner` attribute is surfaced as source evidence,
+while missing scanner evidence stays empty rather than exposing the tracker ID.
+The configured UniFi poller remains a second room provider and uses the AP name
+as its evidence. Observations that agree resolve to one room, while disagreement
 reports `room_conflict` and withholds a guessed room.
 Use `companion:`. A top-level `platform:` section is rejected at config
 load with an actionable error and must be renamed to `companion:` (the

--- a/docs/operating/homeassistant.md
+++ b/docs/operating/homeassistant.md
@@ -67,10 +67,12 @@ the workhorse for most HA interactions.
 Persistent connection for real-time `state_changed` events. The event feed
 is gated client-side by the subscription registry: ingest-mode entity
 subscriptions (ids or globs like `binary_sensor.*door*`, added via
-`add_entity_subscription` from any owner) plus the system-seeded person
-floor from `person.track` decide what is captured. This is the same
-mechanism used by the HA frontend and mobile apps — the official,
-first-class event bus.
+`add_entity_subscription` from any owner) plus the system-seeded presence
+floor decide what is captured. That floor contains `person.track` and the
+device trackers linked from each person's HA `device_trackers` attribute,
+allowing attribute-only Bermuda room changes through without ingesting the
+whole `device_tracker.*` domain. This is the same mechanism used by the HA
+frontend and mobile apps — the official, first-class event bus.
 
 WebSocket events can trigger agent wakes, enabling proactive behavior without
 polling.

--- a/internal/app/new_awareness.go
+++ b/internal/app/new_awareness.go
@@ -313,6 +313,19 @@ func (a *App) initAwareness(s *newState) error {
 	if len(cfg.Person.Track) > 0 {
 		s.personTracker = contacts.NewPresenceTracker(cfg.Person.Track, cfg.Timezone, logger)
 		s.personTracker.OnIngestEntitiesChange(seedPresenceIngestFloor)
+		s.personTracker.OnLinkedTrackersChange(func(entityIDs []string) {
+			if a.ha == nil || len(entityIDs) == 0 {
+				return
+			}
+			linked := append([]string(nil), entityIDs...)
+			go func() {
+				refreshCtx, refreshCancel := context.WithTimeout(s.ctx, 10*time.Second)
+				defer refreshCancel()
+				if err := s.personTracker.RefreshLinkedTrackers(refreshCtx, a.ha, linked); err != nil {
+					logger.Warn("newly linked HA presence tracker refresh incomplete", "error", err)
+				}
+			}()
+		})
 		a.loop.RegisterAlwaysContextProvider(s.personTracker)
 
 		// Configure device MAC addresses from config.

--- a/internal/app/new_awareness.go
+++ b/internal/app/new_awareness.go
@@ -115,25 +115,30 @@ func (a *App) initAwareness(s *newState) error {
 	// into prompts.
 	watchlistStore := a.watchlistStore
 
-	// Person-entity ingestion floor: the tracked person entities are
-	// system-owned ingest subscriptions, re-seeded from person.track on
-	// every boot so config edits win. Expressing the floor as registry
-	// rows (instead of a hardcoded append onto the ingestion filter)
-	// makes list_entity_subscriptions tell the whole truth about what
-	// is being watched and ingested (#1209).
-	if watchlistStore != nil {
-		floor := make([]looppkg.EntitySubscription, 0, len(cfg.Person.Track))
-		for _, entityID := range cfg.Person.Track {
+	// Presence ingestion floor: tracked person entities and the device trackers
+	// they link in HA are system-owned ingest subscriptions. The callback is
+	// reused when a person attribute-only update changes that linked set, so the
+	// registry and client-side WebSocket filter move together.
+	seedPresenceIngestFloor := func(entityIDs []string) {
+		if watchlistStore == nil {
+			return
+		}
+		floor := make([]looppkg.EntitySubscription, 0, len(entityIDs))
+		for _, entityID := range entityIDs {
 			floor = append(floor, looppkg.EntitySubscription{
 				EntityID: entityID,
 				Mode:     looppkg.SubscriptionModeIngest,
 			})
 		}
 		if err := watchlistStore.ReplaceOwner(awareness.OwnerSystem, floor); err != nil {
-			// The degraded ingest-filter fallback below still feeds the
-			// person tracker directly, so a failed seed loses registry
-			// visibility, not presence tracking.
-			logger.Warn("failed to seed the person-entity ingestion floor", "error", err)
+			// The degraded ingest-filter fallback below still feeds these
+			// entities directly, so a failed seed loses registry visibility,
+			// not presence tracking.
+			logger.Warn("failed to seed the presence ingestion floor", "error", err)
+			return
+		}
+		if a.ingestFilterRebuild != nil {
+			a.ingestFilterRebuild()
 		}
 	}
 
@@ -307,6 +312,7 @@ func (a *App) initAwareness(s *newState) error {
 	// so a redundant call from OnReady is harmless.
 	if len(cfg.Person.Track) > 0 {
 		s.personTracker = contacts.NewPresenceTracker(cfg.Person.Track, cfg.Timezone, logger)
+		s.personTracker.OnIngestEntitiesChange(seedPresenceIngestFloor)
 		a.loop.RegisterAlwaysContextProvider(s.personTracker)
 
 		// Configure device MAC addresses from config.
@@ -327,6 +333,10 @@ func (a *App) initAwareness(s *newState) error {
 			}
 			initCancel()
 		}
+	} else {
+		// Config is the source of truth; clear system rows left by a prior
+		// configuration that tracked people.
+		seedPresenceIngestFloor(nil)
 	}
 
 	// --- UniFi room presence ---
@@ -442,7 +452,7 @@ func (a *App) initAwareness(s *newState) error {
 	// from every owner, rebuilt on every registry mutation — no HA
 	// re-subscription needed, the WS feed is a firehose gated
 	// client-side. The person floor arrives through the registry too
-	// (system-owned rows seeded above), not a hardcoded append.
+	// (system-owned rows maintained above), not a hardcoded append.
 	if a.haWS != nil {
 		buildIngestFilter := func() (*homeassistant.EntityFilter, error) {
 			globs, err := watchlistStore.IngestGlobs(time.Now())
@@ -460,10 +470,10 @@ func (a *App) initAwareness(s *newState) error {
 		if err != nil {
 			// A failed registry read at boot degrades to the person
 			// floor — the tracker must not go deaf — and says so.
-			logger.Warn("ingest registry read failed at startup; ingesting the person-entity floor only", "error", err)
+			logger.Warn("ingest registry read failed at startup; ingesting the presence floor only", "error", err)
 			var personGlobs []string
 			if s.personTracker != nil {
-				personGlobs = s.personTracker.EntityIDs()
+				personGlobs = s.personTracker.IngestEntityIDs()
 			}
 			if len(personGlobs) == 0 {
 				filter = homeassistant.NewEntityFilterMatchNone(logger)
@@ -473,13 +483,10 @@ func (a *App) initAwareness(s *newState) error {
 		}
 		limiter := homeassistant.NewEntityRateLimiter(cfg.HomeAssistant.IngestRateLimitPerMinute)
 
-		// Compose handler: the state window, person tracker, and
-		// subscription wake feeder all see every state change that
-		// passes the filter and rate limiter.
+		// Compose the compact transition taps. The person tracker registers a
+		// complete-state tap below because Bermuda and linked-tracker updates
+		// depend on attributes and HA timestamps that this compact surface omits.
 		taps := []homeassistant.StateWatchHandler{stateWindowProvider.HandleStateChange}
-		if s.personTracker != nil {
-			taps = append(taps, s.personTracker.HandleStateChange)
-		}
 		if a.subWakeFeeder != nil {
 			taps = append(taps, a.subWakeFeeder.HandleStateChange)
 		}
@@ -494,6 +501,9 @@ func (a *App) initAwareness(s *newState) error {
 		}
 
 		watcher := homeassistant.NewStateWatcher(a.haWS.Events(), filter, limiter, handler, logger)
+		if s.personTracker != nil {
+			watcher.AddStateChangeHandler(s.personTracker.HandleHAStateChange)
+		}
 		a.haStateWatcher = watcher
 		a.ingestFilterRebuild = func() {
 			rebuilt, err := buildIngestFilter()

--- a/internal/integrations/homeassistant/statewatch.go
+++ b/internal/integrations/homeassistant/statewatch.go
@@ -17,6 +17,12 @@ import (
 // integration's original class). Empty when the entity has none.
 type StateWatchHandler func(entityID, oldState, newState, deviceClass string)
 
+// StateChangeHandler receives the complete Home Assistant state-change
+// payload after the event passes the ingestion filter and rate limiter.
+// NewState is guaranteed non-nil. Handlers must treat the state objects and
+// their attribute maps as read-only.
+type StateChangeHandler func(change StateChangedData)
+
 // EntityFilter selects which entity IDs to process using glob patterns.
 // An empty filter matches all entities.
 type EntityFilter struct {
@@ -153,6 +159,8 @@ type StateWatcher struct {
 	filter   *EntityFilter
 	limiter  *EntityRateLimiter
 	handler  StateWatchHandler
+	changeMu sync.RWMutex
+	changes  []StateChangeHandler
 	logger   *slog.Logger
 }
 
@@ -189,6 +197,18 @@ func NewStateWatcher(events <-chan Event, filter *EntityFilter, limiter *EntityR
 		handler: handler,
 		logger:  logger,
 	}
+}
+
+// AddStateChangeHandler registers a complete-state handler. Complete-state
+// handlers complement the compact legacy handler passed to [NewStateWatcher]
+// and are intended for consumers that need attributes or HA timestamps.
+func (w *StateWatcher) AddStateChangeHandler(handler StateChangeHandler) {
+	if handler == nil {
+		return
+	}
+	w.changeMu.Lock()
+	w.changes = append(w.changes, handler)
+	w.changeMu.Unlock()
 }
 
 // cleanupInterval is how often the rate limiter's stale counters are
@@ -288,6 +308,14 @@ func (w *StateWatcher) handleEvent(ev Event) bool {
 		deviceClass = dc
 	}
 
-	w.handler(data.EntityID, oldState, data.NewState.State, deviceClass)
+	if w.handler != nil {
+		w.handler(data.EntityID, oldState, data.NewState.State, deviceClass)
+	}
+	w.changeMu.RLock()
+	changes := w.changes
+	w.changeMu.RUnlock()
+	for _, handler := range changes {
+		handler(data)
+	}
 	return true
 }

--- a/internal/integrations/homeassistant/statewatch_test.go
+++ b/internal/integrations/homeassistant/statewatch_test.go
@@ -282,6 +282,49 @@ func TestHandleEvent_ReturnValue(t *testing.T) {
 	}
 }
 
+func TestStateWatcherCompleteHandlerReceivesAttributeOnlyChange(t *testing.T) {
+	updatedAt := time.Date(2026, 8, 30, 23, 38, 29, 0, time.UTC)
+	var (
+		compactCalls int
+		got          StateChangedData
+	)
+	watcher := NewStateWatcher(nil, NewEntityFilter([]string{"device_tracker.watch"}, nil), nil,
+		func(_, oldState, newState, _ string) {
+			compactCalls++
+			if oldState != "home" || newState != "home" {
+				t.Errorf("compact states = %q -> %q", oldState, newState)
+			}
+		}, nil)
+	watcher.AddStateChangeHandler(func(change StateChangedData) { got = change })
+
+	data := StateChangedData{
+		EntityID: "device_tracker.watch",
+		OldState: &State{EntityID: "device_tracker.watch", State: "home"},
+		NewState: &State{
+			EntityID:    "device_tracker.watch",
+			State:       "home",
+			LastUpdated: updatedAt,
+			Attributes: map[string]any{
+				"area":    "Office",
+				"scanner": "Desk Presence",
+			},
+		},
+	}
+	raw, err := json.Marshal(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !watcher.HandleEvent(Event{Type: "state_changed", Data: raw}) {
+		t.Fatal("attribute-only event was not dispatched")
+	}
+	if compactCalls != 1 {
+		t.Fatalf("compact handler calls = %d, want 1", compactCalls)
+	}
+	if got.NewState == nil || got.NewState.Attributes["area"] != "Office" || !got.NewState.LastUpdated.Equal(updatedAt) {
+		t.Fatalf("complete change = %+v", got)
+	}
+}
+
 // makeStateEvent creates a state_changed Event for testing.
 func makeStateEvent(t *testing.T, entityID, oldState, newState string) Event {
 	t.Helper()

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -1932,10 +1932,11 @@ func (c MQTTConfig) Configured() bool {
 	return c.Broker != "" && c.DeviceName != ""
 }
 
-// PersonConfig configures household member presence tracking. When
-// Track contains entity IDs, the person tracker maintains in-memory
-// state from Home Assistant and injects a presence summary into the
-// agent's system prompt on every wake.
+// PersonConfig configures household member presence tracking. When Track
+// contains entity IDs, the person tracker maintains in-memory state from Home
+// Assistant, follows each person's linked device trackers for supported room
+// providers, and injects a presence summary into the agent's system prompt on
+// every wake.
 type PersonConfig struct {
 	// Track is a list of Home Assistant person entity IDs to monitor
 	// (e.g., ["person.nugget", "person.dan"]). Each entry must begin

--- a/internal/state/awareness/watchlist_provider.go
+++ b/internal/state/awareness/watchlist_provider.go
@@ -89,7 +89,7 @@ func (p *WatchlistProvider) TagContext(ctx context.Context, req agentctx.Context
 	// the root container and every context is de facto core's context.
 	// Loop-owned rows are rendered by [LoopSubscriptionProvider] after
 	// walking the ancestor chain, and system-owned rows (the
-	// person-entity ingestion floor) never render — they are
+	// presence ingestion floor) never render — they are
 	// ingest-mode by construction.
 	rows, err := p.store.ListOwner(looppkg.CoreLoopName)
 	if err != nil {

--- a/internal/state/awareness/watchlist_store.go
+++ b/internal/state/awareness/watchlist_store.go
@@ -13,11 +13,11 @@ import (
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 )
 
-// OwnerSystem is the reserved owner for rows the runtime seeds and
-// maintains itself — today the person-entity ingestion floor, re-seeded
-// from config at every boot. System rows are visible in
+// OwnerSystem is the reserved owner for rows the runtime seeds and maintains
+// itself — today the presence ingestion floor: configured person entities plus
+// their HA-linked device trackers. System rows are visible in
 // list_entity_subscriptions like any other row but refuse tool-driven
-// mutation; the configuration is their source of truth.
+// mutation; person.track and live HA linkage are their sources of truth.
 const OwnerSystem = "system"
 
 // OwnerCore is the owner of the always-visible tier: core is the root

--- a/internal/state/awareness/watchlist_tool_provider.go
+++ b/internal/state/awareness/watchlist_tool_provider.go
@@ -99,7 +99,7 @@ func retiredTagsError(param string) error {
 func (w *WatchlistTools) Tools() []*tools.Tool {
 	ownerParam := map[string]any{
 		"type":        "string",
-		"description": "Who owns the subscription. Omit (or pass \"core\") for an always-visible subscription: it lands on core — the root container whose context every turn shares — and appears everywhere. Pass a loop definition name to subscribe that loop instead: the entry lands on its spec's subscriptions and follows the loop's lifecycle. From inside a loop's own turn, prefer watch_entity (no name needed). The reserved owner \"system\" is read-only (runtime-seeded rows such as the person-presence ingestion floor, configured via person.track).",
+		"description": "Who owns the subscription. Omit (or pass \"core\") for an always-visible subscription: it lands on core — the root container whose context every turn shares — and appears everywhere. Pass a loop definition name to subscribe that loop instead: the entry lands on its spec's subscriptions and follows the loop's lifecycle. From inside a loop's own turn, prefer watch_entity (no name needed). The reserved owner \"system\" is read-only (the runtime-seeded presence ingestion floor: person.track plus HA-linked device trackers).",
 	}
 	return []*tools.Tool{
 		{
@@ -176,7 +176,7 @@ func (w *WatchlistTools) Tools() []*tools.Tool {
 		},
 		{
 			Name: "list_entity_subscriptions",
-			Description: "List the entity-subscription registry: every subscription with its owner — always-visible rows (owner \"\"), loop-owned rows compiled from loop specs, and system-seeded rows such as the person-presence ingestion floor. " +
+			Description: "List the entity-subscription registry: every subscription with its owner — always-visible rows (owner \"\"), loop-owned rows compiled from loop specs, and the system-seeded presence ingestion floor (person.track plus HA-linked device trackers). " +
 				"When Home Assistant is connected, each glob or area/label/floor subscription carries an expansion object with its current member count and a sample, so a subscription that currently matches nothing is visible at a glance. " +
 				"Inherited effective sets for a running loop (own + container ancestors') are surfaced by loop_definition_get on that loop's name.",
 			Parameters: map[string]any{
@@ -227,7 +227,7 @@ func (w *WatchlistTools) handleAddEntitySubscription(ctx context.Context, args m
 
 	owner := strings.TrimSpace(stringArg(args, "owner"))
 	if owner == OwnerSystem {
-		return "", fmt.Errorf("owner %q is reserved for runtime-seeded rows (the person-presence ingestion floor, configured via person.track) and cannot be written by tools; omit owner for an always-visible subscription or name a loop", OwnerSystem)
+		return "", fmt.Errorf("owner %q is reserved for the runtime-seeded presence ingestion floor (person.track plus HA-linked device trackers) and cannot be written by tools; omit owner for an always-visible subscription or name a loop", OwnerSystem)
 	}
 	// The anonymous always-visible tier collapsed into core (#1208):
 	// omitted owner means core, and core routes store-direct — it has
@@ -603,7 +603,7 @@ func (w *WatchlistTools) handleRemoveEntitySubscription(ctx context.Context, arg
 	}
 	switch {
 	case owner == OwnerSystem:
-		return "", fmt.Errorf("system-owned rows are seeded from configuration (person.track) and re-appear at the next startup; change the configuration instead of removing them here")
+		return "", fmt.Errorf("system-owned rows are seeded from person.track and live HA device-tracker linkage; change the person configuration or HA linkage instead of removing them here")
 	case owner != OwnerCore:
 		// The mutator persists the spec, and the app's persist hook
 		// re-mirrors the registry and rebuilds the ingestion filter —

--- a/internal/state/contacts/ha_presence.go
+++ b/internal/state/contacts/ha_presence.go
@@ -1,0 +1,491 @@
+package contacts
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+)
+
+// BermudaRoomProvider is the stable provider name used for room observations
+// sourced from Home Assistant's Bermuda integration.
+const BermudaRoomProvider = "bermuda"
+
+const maxLinkedDeviceTrackersPerPerson = 64
+
+var entityRegistryRetryDelays = [...]time.Duration{
+	100 * time.Millisecond,
+	250 * time.Millisecond,
+	500 * time.Millisecond,
+	1 * time.Second,
+	2 * time.Second,
+	4 * time.Second,
+}
+
+// StateGetter abstracts the Home Assistant state and entity-registry reads the
+// presence tracker needs. The registry platform is the authority for deciding
+// whether a linked device tracker may contribute Bermuda room evidence.
+type StateGetter interface {
+	GetState(ctx context.Context, entityID string) (*homeassistant.State, error)
+	GetEntityRegistry(ctx context.Context) ([]homeassistant.EntityRegistryEntry, error)
+}
+
+type presenceFetchResult struct {
+	entityID string
+	state    *homeassistant.State
+	err      error
+}
+
+type roomWithdrawal struct {
+	entityID    string
+	observation RoomObservation
+}
+
+// OnIngestEntitiesChange registers the callback that mirrors the presence
+// tracker's person entities and HA-linked device trackers into the ingestion
+// registry. Registration immediately publishes the current set. The callback
+// is invoked outside the tracker's lock.
+func (t *PresenceTracker) OnIngestEntitiesChange(callback func([]string)) {
+	t.mu.Lock()
+	t.ingestObserver = callback
+	entityIDs := t.ingestEntityIDsLocked()
+	t.mu.Unlock()
+	if callback != nil {
+		callback(entityIDs)
+	}
+}
+
+// IngestEntityIDs returns the tracked person entities followed by the
+// deduplicated HA device trackers currently linked from those people.
+func (t *PresenceTracker) IngestEntityIDs() []string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.ingestEntityIDsLocked()
+}
+
+// Initialize refreshes tracked people, their linked HA device trackers, and
+// registry-verified Bermuda room observations. Person-state failures leave the
+// affected person unchanged; registry or tracker failures retain previously
+// known room evidence and are returned as a partial initialization error.
+// Network I/O never holds the tracker lock.
+func (t *PresenceTracker) Initialize(ctx context.Context, ha StateGetter) error {
+	personResults := fetchPresenceStates(ctx, ha, t.EntityIDs())
+	var firstErr error
+	linked := make(map[string]bool)
+	for _, entityID := range t.linkedTrackerEntityIDs() {
+		linked[entityID] = true
+	}
+	for _, result := range personResults {
+		if result.err != nil {
+			t.logger.Warn("failed to fetch person state", "entity_id", result.entityID, "error", result.err)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("fetch %s: %w", result.entityID, result.err)
+			}
+			continue
+		}
+		trackers, err := linkedDeviceTrackerIDs(result.state.Attributes)
+		if err != nil {
+			t.logger.Warn("person device tracker links are malformed; retaining previous links",
+				"entity_id", result.entityID, "error", err)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("parse %s device trackers: %w", result.entityID, err)
+			}
+			continue
+		}
+		for _, entityID := range trackers {
+			linked[entityID] = true
+		}
+	}
+
+	if len(linked) > 0 {
+		entries, err := getEntityRegistryWithRetry(ctx, ha, entityRegistryRetryDelays[:])
+		if err != nil {
+			t.logger.Warn("failed to identify linked HA device tracker platforms; retaining previous provider map", "error", err)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("fetch HA entity registry for room providers: %w", err)
+			}
+		} else {
+			platforms := make(map[string]string, len(entries))
+			for _, entry := range entries {
+				platforms[entry.EntityID] = strings.ToLower(strings.TrimSpace(entry.Platform))
+			}
+			t.replaceTrackerPlatforms(platforms)
+		}
+	}
+
+	for _, result := range personResults {
+		if result.err == nil {
+			t.applyPersonState(result.entityID, result.state, true)
+		}
+	}
+	t.pruneInvalidBermudaObservations()
+
+	bermudaIDs := t.linkedTrackersForPlatform(BermudaRoomProvider)
+	for _, result := range fetchPresenceStates(ctx, ha, bermudaIDs) {
+		if result.err != nil {
+			t.logger.Warn("failed to fetch linked Bermuda tracker state", "entity_id", result.entityID, "error", result.err)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("fetch %s: %w", result.entityID, result.err)
+			}
+			continue
+		}
+		t.applyBermudaState(result.entityID, result.state)
+	}
+
+	return firstErr
+}
+
+func getEntityRegistryWithRetry(ctx context.Context, ha StateGetter, delays []time.Duration) ([]homeassistant.EntityRegistryEntry, error) {
+	for attempt := 0; ; attempt++ {
+		entries, err := ha.GetEntityRegistry(ctx)
+		if err == nil {
+			return entries, nil
+		}
+		if attempt >= len(delays) {
+			return nil, err
+		}
+		delay := delays[attempt]
+		if delay <= 0 {
+			continue
+		}
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+// HandleHAStateChange consumes the complete, filtered Home Assistant event.
+// Person attribute-only updates refresh linked tracker ownership; linked
+// registry-verified Bermuda trackers update or withdraw room observations.
+func (t *PresenceTracker) HandleHAStateChange(change homeassistant.StateChangedData) {
+	if change.NewState == nil {
+		return
+	}
+	entityID := strings.TrimSpace(change.EntityID)
+	if entityID == "" {
+		entityID = strings.TrimSpace(change.NewState.EntityID)
+	}
+	if entityID == "" {
+		return
+	}
+
+	t.mu.RLock()
+	_, isPerson := t.people[entityID]
+	t.mu.RUnlock()
+	if isPerson {
+		t.applyPersonState(entityID, change.NewState, true)
+		return
+	}
+	t.applyBermudaState(entityID, change.NewState)
+}
+
+// HandleStateChange retains the compact compatibility surface used by direct
+// callers and tests. Full HA watcher wiring uses [HandleHAStateChange] so
+// attribute-only updates and source timestamps are preserved.
+func (t *PresenceTracker) HandleStateChange(entityID, _, newState, _ string) {
+	t.applyPersonState(entityID, &homeassistant.State{
+		EntityID:    entityID,
+		State:       newState,
+		LastChanged: time.Now(),
+	}, false)
+}
+
+func fetchPresenceStates(ctx context.Context, ha StateGetter, entityIDs []string) []presenceFetchResult {
+	results := make([]presenceFetchResult, 0, len(entityIDs))
+	for _, entityID := range entityIDs {
+		state, err := ha.GetState(ctx, entityID)
+		if err == nil && state == nil {
+			err = fmt.Errorf("empty state response")
+		}
+		results = append(results, presenceFetchResult{entityID: entityID, state: state, err: err})
+	}
+	return results
+}
+
+func (t *PresenceTracker) applyPersonState(entityID string, state *homeassistant.State, updateLinks bool) {
+	if state == nil {
+		return
+	}
+	var linked []string
+	if updateLinks {
+		var err error
+		linked, err = linkedDeviceTrackerIDs(state.Attributes)
+		if err != nil {
+			t.logger.Warn("person device tracker links are malformed; retaining previous links",
+				"entity_id", entityID, "error", err)
+			updateLinks = false
+		}
+	}
+
+	t.mu.Lock()
+	person, ok := t.people[entityID]
+	if !ok {
+		t.mu.Unlock()
+		return
+	}
+	oldState := person.State
+	stateChanged := oldState != state.State
+	person.State = state.State
+	if stateChanged {
+		person.Since = state.LastChanged
+		if person.Since.IsZero() {
+			person.Since = time.Now()
+		}
+	}
+	if name, ok := state.Attributes["friendly_name"].(string); ok && strings.TrimSpace(name) != "" {
+		person.FriendlyName = strings.TrimSpace(name)
+	}
+	friendlyName := person.FriendlyName
+
+	ingestChanged := false
+	if updateLinks && !slices.Equal(t.linkedByPerson[entityID], linked) {
+		t.linkedByPerson[entityID] = linked
+		t.rebuildTrackerOwnersLocked()
+		ingestChanged = true
+	}
+
+	var withdrawn []RoomObservation
+	if strings.EqualFold(state.State, "not_home") {
+		withdrawn = sortedRoomObservations(person.roomObservations)
+		clear(person.roomObservations)
+		clearResolvedRoom(person, false)
+	} else {
+		withdrawn = t.prunePersonBermudaObservationsLocked(entityID, person)
+	}
+	observers := append([]RoomObserver(nil), t.observers...)
+	ingestObserver := t.ingestObserver
+	var ingestEntityIDs []string
+	if ingestChanged {
+		ingestEntityIDs = t.ingestEntityIDsLocked()
+	}
+	t.mu.Unlock()
+
+	if stateChanged {
+		t.logger.Debug("person state changed",
+			"entity_id", entityID,
+			"friendly_name", friendlyName,
+			"old_state", oldState,
+			"new_state", state.State,
+		)
+	}
+	for _, observation := range withdrawn {
+		t.notifyRoomObservers(observers, entityID, "", observation.Provider, observation.Source)
+	}
+	if ingestChanged && ingestObserver != nil {
+		ingestObserver(ingestEntityIDs)
+	}
+}
+
+func (t *PresenceTracker) applyBermudaState(entityID string, state *homeassistant.State) {
+	if state == nil {
+		return
+	}
+	t.mu.RLock()
+	platform := t.trackerPlatform[entityID]
+	owners := append([]string(nil), t.ownersByTracker[entityID]...)
+	t.mu.RUnlock()
+	if platform != BermudaRoomProvider || len(owners) == 0 {
+		return
+	}
+
+	room, roomOK := stringAttribute(state.Attributes, "area")
+	via, viaOK := stringAttribute(state.Attributes, "scanner")
+	if !roomOK {
+		t.logger.Warn("Bermuda tracker area has an unexpected type; withdrawing room observation",
+			"entity_id", entityID,
+		)
+		room = ""
+	}
+	if !viaOK {
+		t.logger.Warn("Bermuda tracker scanner has an unexpected type; retaining room without scanner evidence",
+			"entity_id", entityID,
+		)
+		via = ""
+	}
+	room = strings.TrimSpace(room)
+	if !strings.EqualFold(state.State, "home") {
+		room = ""
+	}
+	observedAt := state.LastUpdated
+	if observedAt.IsZero() {
+		observedAt = time.Now()
+	}
+	for _, owner := range owners {
+		if room == "" {
+			t.WithdrawRoom(owner, BermudaRoomProvider, entityID)
+			continue
+		}
+		t.ObserveRoom(owner, RoomObservation{
+			Room:       room,
+			Provider:   BermudaRoomProvider,
+			Source:     entityID,
+			Via:        via,
+			ObservedAt: observedAt,
+		})
+	}
+}
+
+func (t *PresenceTracker) replaceTrackerPlatforms(platforms map[string]string) {
+	t.mu.Lock()
+	t.trackerPlatform = platforms
+	t.mu.Unlock()
+}
+
+func (t *PresenceTracker) linkedTrackersForPlatform(platform string) []string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	var result []string
+	for entityID := range t.ownersByTracker {
+		if t.trackerPlatform[entityID] == platform {
+			result = append(result, entityID)
+		}
+	}
+	sort.Strings(result)
+	return result
+}
+
+func (t *PresenceTracker) linkedTrackerEntityIDs() []string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	result := make([]string, 0, len(t.ownersByTracker))
+	for entityID := range t.ownersByTracker {
+		result = append(result, entityID)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func (t *PresenceTracker) rebuildTrackerOwnersLocked() {
+	owners := make(map[string][]string)
+	seenPeople := make(map[string]bool, len(t.order))
+	for _, personID := range t.order {
+		if seenPeople[personID] {
+			continue
+		}
+		seenPeople[personID] = true
+		for _, trackerID := range t.linkedByPerson[personID] {
+			owners[trackerID] = append(owners[trackerID], personID)
+		}
+	}
+	t.ownersByTracker = owners
+}
+
+func (t *PresenceTracker) ingestEntityIDsLocked() []string {
+	result := make([]string, 0, len(t.order)+len(t.ownersByTracker))
+	seen := make(map[string]bool, cap(result))
+	for _, entityID := range t.order {
+		if !seen[entityID] {
+			result = append(result, entityID)
+			seen[entityID] = true
+		}
+	}
+	linked := make([]string, 0, len(t.ownersByTracker))
+	for entityID := range t.ownersByTracker {
+		if !seen[entityID] {
+			linked = append(linked, entityID)
+		}
+	}
+	sort.Strings(linked)
+	return append(result, linked...)
+}
+
+func (t *PresenceTracker) pruneInvalidBermudaObservations() {
+	t.mu.Lock()
+	var withdrawn []roomWithdrawal
+	seen := make(map[string]bool, len(t.order))
+	for _, entityID := range t.order {
+		if seen[entityID] {
+			continue
+		}
+		seen[entityID] = true
+		person := t.people[entityID]
+		for _, observation := range t.prunePersonBermudaObservationsLocked(entityID, person) {
+			withdrawn = append(withdrawn, roomWithdrawal{entityID: entityID, observation: observation})
+		}
+	}
+	observers := append([]RoomObserver(nil), t.observers...)
+	t.mu.Unlock()
+	for _, withdrawal := range withdrawn {
+		t.notifyRoomObservers(observers, withdrawal.entityID, "", withdrawal.observation.Provider, withdrawal.observation.Source)
+	}
+}
+
+func (t *PresenceTracker) prunePersonBermudaObservationsLocked(entityID string, person *Person) []RoomObservation {
+	linked := make(map[string]bool, len(t.linkedByPerson[entityID]))
+	for _, trackerID := range t.linkedByPerson[entityID] {
+		linked[trackerID] = true
+	}
+	var withdrawn []RoomObservation
+	for key, observation := range person.roomObservations {
+		if key.provider != BermudaRoomProvider {
+			continue
+		}
+		if linked[key.source] && t.trackerPlatform[key.source] == BermudaRoomProvider {
+			continue
+		}
+		withdrawn = append(withdrawn, observation)
+		delete(person.roomObservations, key)
+	}
+	if len(withdrawn) > 0 {
+		sort.Slice(withdrawn, func(i, j int) bool {
+			return withdrawn[i].Source < withdrawn[j].Source
+		})
+		resolvePersonRoom(person, time.Now())
+	}
+	return withdrawn
+}
+
+func linkedDeviceTrackerIDs(attributes map[string]any) ([]string, error) {
+	raw, ok := attributes["device_trackers"]
+	if !ok || raw == nil {
+		return nil, nil
+	}
+	var values []any
+	switch typed := raw.(type) {
+	case []any:
+		values = typed
+	case []string:
+		values = make([]any, len(typed))
+		for i := range typed {
+			values[i] = typed[i]
+		}
+	default:
+		return nil, fmt.Errorf("device_trackers is %T, want an array", raw)
+	}
+	if len(values) > maxLinkedDeviceTrackersPerPerson {
+		return nil, fmt.Errorf("device_trackers has %d entries, limit is %d", len(values), maxLinkedDeviceTrackersPerPerson)
+	}
+	seen := make(map[string]bool, len(values))
+	result := make([]string, 0, len(values))
+	for i, value := range values {
+		entityID, ok := value.(string)
+		if !ok {
+			return nil, fmt.Errorf("device_trackers[%d] is %T, want a string", i, value)
+		}
+		entityID = strings.TrimSpace(entityID)
+		if !strings.HasPrefix(entityID, "device_tracker.") || seen[entityID] {
+			continue
+		}
+		seen[entityID] = true
+		result = append(result, entityID)
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
+func stringAttribute(attributes map[string]any, key string) (string, bool) {
+	value, ok := attributes[key]
+	if !ok || value == nil {
+		return "", true
+	}
+	text, ok := value.(string)
+	return strings.TrimSpace(text), ok
+}

--- a/internal/state/contacts/ha_presence.go
+++ b/internal/state/contacts/ha_presence.go
@@ -26,12 +26,14 @@ var entityRegistryRetryDelays = [...]time.Duration{
 	4 * time.Second,
 }
 
-// StateGetter abstracts the Home Assistant state and entity-registry reads the
-// presence tracker needs. The registry platform is the authority for deciding
-// whether a linked device tracker may contribute Bermuda room evidence.
+// StateGetter abstracts the Home Assistant state and entity-registry operations
+// the presence tracker needs. The registry platform is the authority for
+// deciding whether a linked device tracker may contribute Bermuda room
+// evidence; invalidation ensures a just-created linked entity is discoverable.
 type StateGetter interface {
 	GetState(ctx context.Context, entityID string) (*homeassistant.State, error)
 	GetEntityRegistry(ctx context.Context) ([]homeassistant.EntityRegistryEntry, error)
+	InvalidateRegistryCache()
 }
 
 type presenceFetchResult struct {
@@ -45,28 +47,6 @@ type roomWithdrawal struct {
 	observation RoomObservation
 }
 
-// OnIngestEntitiesChange registers the callback that mirrors the presence
-// tracker's person entities and HA-linked device trackers into the ingestion
-// registry. Registration immediately publishes the current set. The callback
-// is invoked outside the tracker's lock.
-func (t *PresenceTracker) OnIngestEntitiesChange(callback func([]string)) {
-	t.mu.Lock()
-	t.ingestObserver = callback
-	entityIDs := t.ingestEntityIDsLocked()
-	t.mu.Unlock()
-	if callback != nil {
-		callback(entityIDs)
-	}
-}
-
-// IngestEntityIDs returns the tracked person entities followed by the
-// deduplicated HA device trackers currently linked from those people.
-func (t *PresenceTracker) IngestEntityIDs() []string {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-	return t.ingestEntityIDsLocked()
-}
-
 // Initialize refreshes tracked people, their linked HA device trackers, and
 // registry-verified Bermuda room observations. Person-state failures leave the
 // affected person unchanged; registry or tracker failures retain previously
@@ -75,10 +55,6 @@ func (t *PresenceTracker) IngestEntityIDs() []string {
 func (t *PresenceTracker) Initialize(ctx context.Context, ha StateGetter) error {
 	personResults := fetchPresenceStates(ctx, ha, t.EntityIDs())
 	var firstErr error
-	linked := make(map[string]bool)
-	for _, entityID := range t.linkedTrackerEntityIDs() {
-		linked[entityID] = true
-	}
 	for _, result := range personResults {
 		if result.err != nil {
 			t.logger.Warn("failed to fetch person state", "entity_id", result.entityID, "error", result.err)
@@ -87,21 +63,17 @@ func (t *PresenceTracker) Initialize(ctx context.Context, ha StateGetter) error 
 			}
 			continue
 		}
-		trackers, err := linkedDeviceTrackerIDs(result.state.Attributes)
-		if err != nil {
-			t.logger.Warn("person device tracker links are malformed; retaining previous links",
-				"entity_id", result.entityID, "error", err)
+		if _, err := linkedDeviceTrackerIDs(result.state.Attributes); err != nil {
 			if firstErr == nil {
 				firstErr = fmt.Errorf("parse %s device trackers: %w", result.entityID, err)
 			}
-			continue
 		}
-		for _, entityID := range trackers {
-			linked[entityID] = true
-		}
+		// Apply immediately: registry discovery may retry for several seconds,
+		// while the live WebSocket watcher remains active on reconnects.
+		t.applyPersonState(result.entityID, result.state, true)
 	}
 
-	if len(linked) > 0 {
+	if len(t.linkedTrackerEntityIDs()) > 0 {
 		entries, err := getEntityRegistryWithRetry(ctx, ha, entityRegistryRetryDelays[:])
 		if err != nil {
 			t.logger.Warn("failed to identify linked HA device tracker platforms; retaining previous provider map", "error", err)
@@ -117,11 +89,6 @@ func (t *PresenceTracker) Initialize(ctx context.Context, ha StateGetter) error 
 		}
 	}
 
-	for _, result := range personResults {
-		if result.err == nil {
-			t.applyPersonState(result.entityID, result.state, true)
-		}
-	}
 	t.pruneInvalidBermudaObservations()
 
 	bermudaIDs := t.linkedTrackersForPlatform(BermudaRoomProvider)
@@ -181,7 +148,15 @@ func (t *PresenceTracker) HandleHAStateChange(change homeassistant.StateChangedD
 	_, isPerson := t.people[entityID]
 	t.mu.RUnlock()
 	if isPerson {
-		t.applyPersonState(entityID, change.NewState, true)
+		newlyLinked := t.applyPersonState(entityID, change.NewState, true)
+		if len(newlyLinked) > 0 {
+			t.mu.RLock()
+			observer := t.linkedObserver
+			t.mu.RUnlock()
+			if observer != nil {
+				observer(newlyLinked)
+			}
+		}
 		return
 	}
 	t.applyBermudaState(entityID, change.NewState)
@@ -210,10 +185,11 @@ func fetchPresenceStates(ctx context.Context, ha StateGetter, entityIDs []string
 	return results
 }
 
-func (t *PresenceTracker) applyPersonState(entityID string, state *homeassistant.State, updateLinks bool) {
+func (t *PresenceTracker) applyPersonState(entityID string, state *homeassistant.State, updateLinks bool) []string {
 	if state == nil {
-		return
+		return nil
 	}
+	updatedAt := stateUpdatedAt(state)
 	var linked []string
 	if updateLinks {
 		var err error
@@ -229,15 +205,26 @@ func (t *PresenceTracker) applyPersonState(entityID string, state *homeassistant
 	person, ok := t.people[entityID]
 	if !ok {
 		t.mu.Unlock()
-		return
+		return nil
 	}
+	if !person.lastUpdated.IsZero() && updatedAt.Before(person.lastUpdated) {
+		currentUpdatedAt := person.lastUpdated
+		t.mu.Unlock()
+		t.logger.Debug("ignored stale person state",
+			"entity_id", entityID,
+			"updated_at", updatedAt,
+			"current_updated_at", currentUpdatedAt,
+		)
+		return nil
+	}
+	person.lastUpdated = updatedAt
 	oldState := person.State
 	stateChanged := oldState != state.State
 	person.State = state.State
 	if stateChanged {
 		person.Since = state.LastChanged
 		if person.Since.IsZero() {
-			person.Since = time.Now()
+			person.Since = updatedAt
 		}
 	}
 	if name, ok := state.Attributes["friendly_name"].(string); ok && strings.TrimSpace(name) != "" {
@@ -246,7 +233,9 @@ func (t *PresenceTracker) applyPersonState(entityID string, state *homeassistant
 	friendlyName := person.FriendlyName
 
 	ingestChanged := false
+	var newlyLinked []string
 	if updateLinks && !slices.Equal(t.linkedByPerson[entityID], linked) {
+		newlyLinked = addedEntityIDs(t.linkedByPerson[entityID], linked)
 		t.linkedByPerson[entityID] = linked
 		t.rebuildTrackerOwnersLocked()
 		ingestChanged = true
@@ -282,19 +271,32 @@ func (t *PresenceTracker) applyPersonState(entityID string, state *homeassistant
 	if ingestChanged && ingestObserver != nil {
 		ingestObserver(ingestEntityIDs)
 	}
+	return newlyLinked
 }
 
 func (t *PresenceTracker) applyBermudaState(entityID string, state *homeassistant.State) {
 	if state == nil {
 		return
 	}
-	t.mu.RLock()
+	observedAt := stateUpdatedAt(state)
+	t.mu.Lock()
 	platform := t.trackerPlatform[entityID]
 	owners := append([]string(nil), t.ownersByTracker[entityID]...)
-	t.mu.RUnlock()
 	if platform != BermudaRoomProvider || len(owners) == 0 {
+		t.mu.Unlock()
 		return
 	}
+	if current := t.trackerUpdated[entityID]; !current.IsZero() && observedAt.Before(current) {
+		t.mu.Unlock()
+		t.logger.Debug("ignored stale Bermuda tracker state",
+			"entity_id", entityID,
+			"updated_at", observedAt,
+			"current_updated_at", current,
+		)
+		return
+	}
+	t.trackerUpdated[entityID] = observedAt
+	t.mu.Unlock()
 
 	room, roomOK := stringAttribute(state.Attributes, "area")
 	via, viaOK := stringAttribute(state.Attributes, "scanner")
@@ -314,87 +316,19 @@ func (t *PresenceTracker) applyBermudaState(entityID string, state *homeassistan
 	if !strings.EqualFold(state.State, "home") {
 		room = ""
 	}
-	observedAt := state.LastUpdated
-	if observedAt.IsZero() {
-		observedAt = time.Now()
-	}
 	for _, owner := range owners {
 		if room == "" {
-			t.WithdrawRoom(owner, BermudaRoomProvider, entityID)
+			t.withdrawRoomAt(owner, BermudaRoomProvider, entityID, observedAt)
 			continue
 		}
-		t.ObserveRoom(owner, RoomObservation{
+		t.observeRoom(owner, RoomObservation{
 			Room:       room,
 			Provider:   BermudaRoomProvider,
 			Source:     entityID,
 			Via:        via,
 			ObservedAt: observedAt,
-		})
+		}, true)
 	}
-}
-
-func (t *PresenceTracker) replaceTrackerPlatforms(platforms map[string]string) {
-	t.mu.Lock()
-	t.trackerPlatform = platforms
-	t.mu.Unlock()
-}
-
-func (t *PresenceTracker) linkedTrackersForPlatform(platform string) []string {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-	var result []string
-	for entityID := range t.ownersByTracker {
-		if t.trackerPlatform[entityID] == platform {
-			result = append(result, entityID)
-		}
-	}
-	sort.Strings(result)
-	return result
-}
-
-func (t *PresenceTracker) linkedTrackerEntityIDs() []string {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-	result := make([]string, 0, len(t.ownersByTracker))
-	for entityID := range t.ownersByTracker {
-		result = append(result, entityID)
-	}
-	sort.Strings(result)
-	return result
-}
-
-func (t *PresenceTracker) rebuildTrackerOwnersLocked() {
-	owners := make(map[string][]string)
-	seenPeople := make(map[string]bool, len(t.order))
-	for _, personID := range t.order {
-		if seenPeople[personID] {
-			continue
-		}
-		seenPeople[personID] = true
-		for _, trackerID := range t.linkedByPerson[personID] {
-			owners[trackerID] = append(owners[trackerID], personID)
-		}
-	}
-	t.ownersByTracker = owners
-}
-
-func (t *PresenceTracker) ingestEntityIDsLocked() []string {
-	result := make([]string, 0, len(t.order)+len(t.ownersByTracker))
-	seen := make(map[string]bool, cap(result))
-	for _, entityID := range t.order {
-		if !seen[entityID] {
-			result = append(result, entityID)
-			seen[entityID] = true
-		}
-	}
-	linked := make([]string, 0, len(t.ownersByTracker))
-	for entityID := range t.ownersByTracker {
-		if !seen[entityID] {
-			linked = append(linked, entityID)
-		}
-	}
-	sort.Strings(linked)
-	return append(result, linked...)
 }
 
 func (t *PresenceTracker) pruneInvalidBermudaObservations() {
@@ -488,4 +422,14 @@ func stringAttribute(attributes map[string]any, key string) (string, bool) {
 	}
 	text, ok := value.(string)
 	return strings.TrimSpace(text), ok
+}
+
+func stateUpdatedAt(state *homeassistant.State) time.Time {
+	if !state.LastUpdated.IsZero() {
+		return state.LastUpdated
+	}
+	if !state.LastChanged.IsZero() {
+		return state.LastChanged
+	}
+	return time.Now()
 }

--- a/internal/state/contacts/ha_presence_links.go
+++ b/internal/state/contacts/ha_presence_links.go
@@ -1,0 +1,170 @@
+package contacts
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// OnIngestEntitiesChange registers the callback that mirrors the presence
+// tracker's person entities and HA-linked device trackers into the ingestion
+// registry. Registration immediately publishes the current set. The callback
+// is invoked outside the tracker's lock.
+func (t *PresenceTracker) OnIngestEntitiesChange(callback func([]string)) {
+	t.mu.Lock()
+	t.ingestObserver = callback
+	entityIDs := t.ingestEntityIDsLocked()
+	t.mu.Unlock()
+	if callback != nil {
+		callback(entityIDs)
+	}
+}
+
+// OnLinkedTrackersChange registers the callback used to hydrate newly linked
+// device trackers after their ingestion filter has expanded. Unlike
+// [PresenceTracker.OnIngestEntitiesChange], registration does not publish an
+// initial value; initialization already hydrates the complete linked set. The
+// callback is invoked outside the tracker's lock.
+func (t *PresenceTracker) OnLinkedTrackersChange(callback func([]string)) {
+	t.mu.Lock()
+	t.linkedObserver = callback
+	t.mu.Unlock()
+}
+
+// IngestEntityIDs returns the tracked person entities followed by the
+// deduplicated HA device trackers currently linked from those people.
+func (t *PresenceTracker) IngestEntityIDs() []string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.ingestEntityIDsLocked()
+}
+
+// RefreshLinkedTrackers refreshes the provider registry and current states for
+// an explicitly newly linked set. It closes the event-ordering gap where a
+// stable tracker changed before the ingestion filter expanded and would not
+// otherwise emit another state change.
+func (t *PresenceTracker) RefreshLinkedTrackers(ctx context.Context, ha StateGetter, entityIDs []string) error {
+	if len(entityIDs) == 0 {
+		return nil
+	}
+	ha.InvalidateRegistryCache()
+	entries, err := getEntityRegistryWithRetry(ctx, ha, entityRegistryRetryDelays[:])
+	if err != nil {
+		return fmt.Errorf("refresh HA entity registry for newly linked room providers: %w", err)
+	}
+	platforms := make(map[string]string, len(entries))
+	for _, entry := range entries {
+		platforms[entry.EntityID] = strings.ToLower(strings.TrimSpace(entry.Platform))
+	}
+	t.replaceTrackerPlatforms(platforms)
+	t.pruneInvalidBermudaObservations()
+
+	var firstErr error
+	for _, result := range fetchPresenceStates(ctx, ha, t.filterLinkedTrackersForPlatform(entityIDs, BermudaRoomProvider)) {
+		if result.err != nil {
+			t.logger.Warn("failed to fetch newly linked Bermuda tracker state", "entity_id", result.entityID, "error", result.err)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("fetch %s: %w", result.entityID, result.err)
+			}
+			continue
+		}
+		t.applyBermudaState(result.entityID, result.state)
+	}
+	return firstErr
+}
+
+func (t *PresenceTracker) replaceTrackerPlatforms(platforms map[string]string) {
+	t.mu.Lock()
+	t.trackerPlatform = platforms
+	t.mu.Unlock()
+}
+
+func (t *PresenceTracker) linkedTrackersForPlatform(platform string) []string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	var result []string
+	for entityID := range t.ownersByTracker {
+		if t.trackerPlatform[entityID] == platform {
+			result = append(result, entityID)
+		}
+	}
+	sort.Strings(result)
+	return result
+}
+
+func (t *PresenceTracker) filterLinkedTrackersForPlatform(entityIDs []string, platform string) []string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	seen := make(map[string]bool, len(entityIDs))
+	result := make([]string, 0, len(entityIDs))
+	for _, entityID := range entityIDs {
+		entityID = strings.TrimSpace(entityID)
+		if entityID == "" || seen[entityID] || len(t.ownersByTracker[entityID]) == 0 || t.trackerPlatform[entityID] != platform {
+			continue
+		}
+		seen[entityID] = true
+		result = append(result, entityID)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func (t *PresenceTracker) linkedTrackerEntityIDs() []string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	result := make([]string, 0, len(t.ownersByTracker))
+	for entityID := range t.ownersByTracker {
+		result = append(result, entityID)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func (t *PresenceTracker) rebuildTrackerOwnersLocked() {
+	owners := make(map[string][]string)
+	seenPeople := make(map[string]bool, len(t.order))
+	for _, personID := range t.order {
+		if seenPeople[personID] {
+			continue
+		}
+		seenPeople[personID] = true
+		for _, trackerID := range t.linkedByPerson[personID] {
+			owners[trackerID] = append(owners[trackerID], personID)
+		}
+	}
+	t.ownersByTracker = owners
+}
+
+func (t *PresenceTracker) ingestEntityIDsLocked() []string {
+	result := make([]string, 0, len(t.order)+len(t.ownersByTracker))
+	seen := make(map[string]bool, cap(result))
+	for _, entityID := range t.order {
+		if !seen[entityID] {
+			result = append(result, entityID)
+			seen[entityID] = true
+		}
+	}
+	linked := make([]string, 0, len(t.ownersByTracker))
+	for entityID := range t.ownersByTracker {
+		if !seen[entityID] {
+			linked = append(linked, entityID)
+		}
+	}
+	sort.Strings(linked)
+	return append(result, linked...)
+}
+
+func addedEntityIDs(previous, current []string) []string {
+	seen := make(map[string]bool, len(previous))
+	for _, entityID := range previous {
+		seen[entityID] = true
+	}
+	var added []string
+	for _, entityID := range current {
+		if !seen[entityID] {
+			added = append(added, entityID)
+		}
+	}
+	return added
+}

--- a/internal/state/contacts/ha_presence_test.go
+++ b/internal/state/contacts/ha_presence_test.go
@@ -1,0 +1,256 @@
+package contacts
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+)
+
+type registryPresenceGetter struct {
+	states   map[string]*homeassistant.State
+	registry []homeassistant.EntityRegistryEntry
+	gets     []string
+}
+
+type retryRegistryGetter struct {
+	calls int
+}
+
+func (g *retryRegistryGetter) GetState(context.Context, string) (*homeassistant.State, error) {
+	return nil, fmt.Errorf("not used")
+}
+
+func (g *retryRegistryGetter) GetEntityRegistry(context.Context) ([]homeassistant.EntityRegistryEntry, error) {
+	g.calls++
+	if g.calls == 1 {
+		return nil, fmt.Errorf("websocket not connected")
+	}
+	return []homeassistant.EntityRegistryEntry{{EntityID: "device_tracker.phone", Platform: "bermuda"}}, nil
+}
+
+func (g *registryPresenceGetter) GetState(_ context.Context, entityID string) (*homeassistant.State, error) {
+	g.gets = append(g.gets, entityID)
+	state, ok := g.states[entityID]
+	if !ok {
+		return nil, fmt.Errorf("state %q not found", entityID)
+	}
+	return state, nil
+}
+
+func (g *registryPresenceGetter) GetEntityRegistry(context.Context) ([]homeassistant.EntityRegistryEntry, error) {
+	return g.registry, nil
+}
+
+func TestPresenceTrackerInitializesProductionBermudaShape(t *testing.T) {
+	personChanged := time.Date(2026, 8, 29, 18, 32, 38, 0, time.UTC)
+	phoneUpdated := time.Date(2026, 8, 30, 23, 3, 19, 0, time.UTC)
+	watchUpdated := time.Date(2026, 8, 30, 23, 38, 29, 0, time.UTC)
+	const (
+		personID = "person.alice"
+		gpsID    = "device_tracker.alice_phone"
+		phoneID  = "device_tracker.alice_phone_bermuda_tracker"
+		watchID  = "device_tracker.alice_watch_bermuda_tracker"
+	)
+	getter := &registryPresenceGetter{
+		states: map[string]*homeassistant.State{
+			personID: {
+				EntityID:    personID,
+				State:       "home",
+				LastChanged: personChanged,
+				Attributes: map[string]any{
+					"friendly_name":   "Alice",
+					"source":          watchID,
+					"device_trackers": []any{gpsID, phoneID, watchID},
+				},
+			},
+			phoneID: bermudaTrackerState(phoneID, "home", "Office", "Desk Presence", phoneUpdated),
+			watchID: bermudaTrackerState(watchID, "home", "Office", "Desk Presence", watchUpdated),
+		},
+		registry: []homeassistant.EntityRegistryEntry{
+			{EntityID: gpsID, Platform: "mobile_app"},
+			{EntityID: phoneID, Platform: "bermuda"},
+			{EntityID: watchID, Platform: "bermuda"},
+		},
+	}
+	tracker := NewPresenceTracker([]string{personID}, "UTC", nil)
+	var ingestSets [][]string
+	tracker.OnIngestEntitiesChange(func(entityIDs []string) {
+		ingestSets = append(ingestSets, append([]string(nil), entityIDs...))
+	})
+
+	if err := tracker.Initialize(context.Background(), getter); err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(getter.gets, []string{personID, phoneID, watchID}) {
+		t.Fatalf("GetState calls = %v, want person plus registry-verified Bermuda trackers", getter.gets)
+	}
+	wantIngest := []string{personID, gpsID, phoneID, watchID}
+	if !slices.Equal(tracker.IngestEntityIDs(), wantIngest) {
+		t.Fatalf("ingest entities = %v, want %v", tracker.IngestEntityIDs(), wantIngest)
+	}
+	if len(ingestSets) != 2 || !slices.Equal(ingestSets[0], []string{personID}) || !slices.Equal(ingestSets[1], wantIngest) {
+		t.Fatalf("ingest callbacks = %v", ingestSets)
+	}
+
+	snapshot, ok := tracker.Snapshot(personID)
+	if !ok {
+		t.Fatal("person snapshot missing")
+	}
+	if snapshot.State != "home" || !snapshot.Since.Equal(personChanged) {
+		t.Errorf("person state = %+v", snapshot)
+	}
+	if snapshot.Room != "Office" || snapshot.RoomProvider != BermudaRoomProvider || snapshot.RoomSource != "Desk Presence" || snapshot.RoomConflict {
+		t.Fatalf("resolved Bermuda room = %+v", snapshot)
+	}
+	if len(snapshot.RoomObservations) != 2 {
+		t.Fatalf("room observations = %+v", snapshot.RoomObservations)
+	}
+	if snapshot.RoomObservations[0].Source != phoneID || snapshot.RoomObservations[0].Via != "Desk Presence" || !snapshot.RoomObservations[0].ObservedAt.Equal(phoneUpdated) {
+		t.Errorf("phone observation = %+v", snapshot.RoomObservations[0])
+	}
+	if snapshot.RoomObservations[1].Source != watchID || !snapshot.RoomObservations[1].ObservedAt.Equal(watchUpdated) {
+		t.Errorf("watch observation = %+v", snapshot.RoomObservations[1])
+	}
+}
+
+func TestPresenceTrackerHandlesAttributeOnlyBermudaUpdatesAndUnlink(t *testing.T) {
+	const (
+		personID = "person.alice"
+		phoneID  = "device_tracker.alice_phone_bermuda_tracker"
+		watchID  = "device_tracker.alice_watch_bermuda_tracker"
+	)
+	getter := &registryPresenceGetter{
+		states: map[string]*homeassistant.State{
+			personID: {
+				EntityID: personID, State: "home", LastChanged: time.Now().Add(-time.Hour),
+				Attributes: map[string]any{"device_trackers": []any{phoneID, watchID}},
+			},
+			phoneID: bermudaTrackerState(phoneID, "home", "Office", "Desk Presence", time.Now().Add(-time.Minute)),
+			watchID: bermudaTrackerState(watchID, "home", "Office", "Desk Presence", time.Now().Add(-time.Minute)),
+		},
+		registry: []homeassistant.EntityRegistryEntry{
+			{EntityID: phoneID, Platform: "bermuda"},
+			{EntityID: watchID, Platform: "bermuda"},
+		},
+	}
+	tracker := NewPresenceTracker([]string{personID}, "UTC", nil)
+	if err := tracker.Initialize(context.Background(), getter); err != nil {
+		t.Fatal(err)
+	}
+
+	watchUpdated := time.Date(2026, 8, 30, 23, 45, 0, 0, time.UTC)
+	tracker.HandleHAStateChange(homeassistant.StateChangedData{
+		EntityID: watchID,
+		OldState: bermudaTrackerState(watchID, "home", "Office", "Desk Presence", watchUpdated.Add(-time.Minute)),
+		NewState: bermudaTrackerState(watchID, "home", "Kitchen", "Kitchen Proxy", watchUpdated),
+	})
+	conflicted, _ := tracker.Snapshot(personID)
+	if !conflicted.RoomConflict || conflicted.Room != "" {
+		t.Fatalf("attribute-only disagreement = %+v", conflicted)
+	}
+
+	phoneUpdated := watchUpdated.Add(time.Second)
+	tracker.HandleHAStateChange(homeassistant.StateChangedData{
+		EntityID: phoneID,
+		OldState: bermudaTrackerState(phoneID, "home", "Office", "Desk Presence", phoneUpdated.Add(-time.Minute)),
+		NewState: bermudaTrackerState(phoneID, "home", "Kitchen", "Kitchen Proxy", phoneUpdated),
+	})
+	resolved, _ := tracker.Snapshot(personID)
+	if resolved.RoomConflict || resolved.Room != "Kitchen" || resolved.RoomProvider != BermudaRoomProvider || resolved.RoomSource != "Kitchen Proxy" {
+		t.Fatalf("attribute-only consensus = %+v", resolved)
+	}
+
+	tracker.HandleHAStateChange(homeassistant.StateChangedData{
+		EntityID: personID,
+		OldState: &homeassistant.State{EntityID: personID, State: "home"},
+		NewState: &homeassistant.State{
+			EntityID: personID,
+			State:    "home",
+			Attributes: map[string]any{
+				"device_trackers": []any{phoneID},
+			},
+		},
+	})
+	unlinked, _ := tracker.Snapshot(personID)
+	if len(unlinked.RoomObservations) != 1 || unlinked.RoomObservations[0].Source != phoneID || unlinked.Room != "Kitchen" {
+		t.Fatalf("unlink retained stale watch evidence: %+v", unlinked)
+	}
+	if !slices.Equal(tracker.IngestEntityIDs(), []string{personID, phoneID}) {
+		t.Fatalf("ingest entities after unlink = %v", tracker.IngestEntityIDs())
+	}
+
+	tracker.HandleHAStateChange(homeassistant.StateChangedData{
+		EntityID: phoneID,
+		OldState: bermudaTrackerState(phoneID, "home", "Kitchen", "Kitchen Proxy", phoneUpdated),
+		NewState: bermudaTrackerState(phoneID, "not_home", "", "", phoneUpdated.Add(time.Second)),
+	})
+	withdrawn, _ := tracker.Snapshot(personID)
+	if withdrawn.Room != "" || len(withdrawn.RoomObservations) != 0 || withdrawn.RoomConflict {
+		t.Fatalf("not_home tracker retained room evidence: %+v", withdrawn)
+	}
+}
+
+func TestLinkedDeviceTrackerIDs(t *testing.T) {
+	tooMany := make([]any, maxLinkedDeviceTrackersPerPerson+1)
+	for i := range tooMany {
+		tooMany[i] = fmt.Sprintf("device_tracker.tracker_%d", i)
+	}
+	tests := []struct {
+		name    string
+		attrs   map[string]any
+		want    []string
+		wantErr bool
+	}{
+		{name: "missing", attrs: nil},
+		{
+			name: "sorted deduplicated trackers only",
+			attrs: map[string]any{"device_trackers": []any{
+				"device_tracker.watch", "sensor.not_a_tracker", " device_tracker.phone ", "device_tracker.watch",
+			}},
+			want: []string{"device_tracker.phone", "device_tracker.watch"},
+		},
+		{name: "wrong container", attrs: map[string]any{"device_trackers": "device_tracker.phone"}, wantErr: true},
+		{name: "non-string member", attrs: map[string]any{"device_trackers": []any{42}}, wantErr: true},
+		{name: "bounded", attrs: map[string]any{"device_trackers": tooMany}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := linkedDeviceTrackerIDs(tt.attrs)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("trackers = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetEntityRegistryWithRetryAllowsWebSocketStartup(t *testing.T) {
+	getter := &retryRegistryGetter{}
+	entries, err := getEntityRegistryWithRetry(context.Background(), getter, []time.Duration{0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if getter.calls != 2 || len(entries) != 1 || entries[0].Platform != "bermuda" {
+		t.Fatalf("calls = %d, entries = %+v", getter.calls, entries)
+	}
+}
+
+func bermudaTrackerState(entityID, state, area, scanner string, updatedAt time.Time) *homeassistant.State {
+	return &homeassistant.State{
+		EntityID:    entityID,
+		State:       state,
+		LastChanged: updatedAt,
+		LastUpdated: updatedAt,
+		Attributes: map[string]any{
+			"area":        area,
+			"scanner":     scanner,
+			"source_type": "bluetooth_le",
+		},
+	}
+}

--- a/internal/state/contacts/ha_presence_test.go
+++ b/internal/state/contacts/ha_presence_test.go
@@ -11,9 +11,10 @@ import (
 )
 
 type registryPresenceGetter struct {
-	states   map[string]*homeassistant.State
-	registry []homeassistant.EntityRegistryEntry
-	gets     []string
+	states        map[string]*homeassistant.State
+	registry      []homeassistant.EntityRegistryEntry
+	gets          []string
+	invalidations int
 }
 
 type retryRegistryGetter struct {
@@ -32,6 +33,8 @@ func (g *retryRegistryGetter) GetEntityRegistry(context.Context) ([]homeassistan
 	return []homeassistant.EntityRegistryEntry{{EntityID: "device_tracker.phone", Platform: "bermuda"}}, nil
 }
 
+func (g *retryRegistryGetter) InvalidateRegistryCache() {}
+
 func (g *registryPresenceGetter) GetState(_ context.Context, entityID string) (*homeassistant.State, error) {
 	g.gets = append(g.gets, entityID)
 	state, ok := g.states[entityID]
@@ -43,6 +46,10 @@ func (g *registryPresenceGetter) GetState(_ context.Context, entityID string) (*
 
 func (g *registryPresenceGetter) GetEntityRegistry(context.Context) ([]homeassistant.EntityRegistryEntry, error) {
 	return g.registry, nil
+}
+
+func (g *registryPresenceGetter) InvalidateRegistryCache() {
+	g.invalidations++
 }
 
 func TestPresenceTrackerInitializesProductionBermudaShape(t *testing.T) {
@@ -123,14 +130,15 @@ func TestPresenceTrackerHandlesAttributeOnlyBermudaUpdatesAndUnlink(t *testing.T
 		phoneID  = "device_tracker.alice_phone_bermuda_tracker"
 		watchID  = "device_tracker.alice_watch_bermuda_tracker"
 	)
+	initialUpdated := time.Date(2026, 8, 30, 23, 40, 0, 0, time.UTC)
 	getter := &registryPresenceGetter{
 		states: map[string]*homeassistant.State{
 			personID: {
 				EntityID: personID, State: "home", LastChanged: time.Now().Add(-time.Hour),
 				Attributes: map[string]any{"device_trackers": []any{phoneID, watchID}},
 			},
-			phoneID: bermudaTrackerState(phoneID, "home", "Office", "Desk Presence", time.Now().Add(-time.Minute)),
-			watchID: bermudaTrackerState(watchID, "home", "Office", "Desk Presence", time.Now().Add(-time.Minute)),
+			phoneID: bermudaTrackerState(phoneID, "home", "Office", "Desk Presence", initialUpdated),
+			watchID: bermudaTrackerState(watchID, "home", "Office", "Desk Presence", initialUpdated),
 		},
 		registry: []homeassistant.EntityRegistryEntry{
 			{EntityID: phoneID, Platform: "bermuda"},
@@ -194,6 +202,157 @@ func TestPresenceTrackerHandlesAttributeOnlyBermudaUpdatesAndUnlink(t *testing.T
 	}
 }
 
+func TestPresenceTrackerRejectsStalePersonState(t *testing.T) {
+	const (
+		personID = "person.alice"
+		phoneID  = "device_tracker.alice_phone_bermuda_tracker"
+	)
+	initialAt := time.Date(2026, 8, 30, 23, 0, 0, 0, time.UTC)
+	getter := &registryPresenceGetter{
+		states: map[string]*homeassistant.State{
+			personID: personHAState(personID, "home", []any{phoneID}, initialAt),
+			phoneID:  bermudaTrackerState(phoneID, "home", "Office", "Desk Presence", initialAt),
+		},
+		registry: []homeassistant.EntityRegistryEntry{{EntityID: phoneID, Platform: "bermuda"}},
+	}
+	tracker := NewPresenceTracker([]string{personID}, "UTC", nil)
+	if err := tracker.Initialize(context.Background(), getter); err != nil {
+		t.Fatal(err)
+	}
+
+	newerAt := initialAt.Add(2 * time.Minute)
+	tracker.HandleHAStateChange(homeassistant.StateChangedData{
+		EntityID: personID,
+		NewState: personHAState(personID, "not_home", []any{phoneID}, newerAt),
+	})
+	tracker.HandleHAStateChange(homeassistant.StateChangedData{
+		EntityID: personID,
+		NewState: personHAState(personID, "home", []any{phoneID}, initialAt.Add(time.Minute)),
+	})
+
+	snapshot, _ := tracker.Snapshot(personID)
+	if snapshot.State != "not_home" || !snapshot.Since.Equal(newerAt) || len(snapshot.RoomObservations) != 0 {
+		t.Fatalf("stale person state overwrote newer away state: %+v", snapshot)
+	}
+}
+
+func TestPresenceTrackerRejectsStaleBermudaState(t *testing.T) {
+	const (
+		personID = "person.alice"
+		phoneID  = "device_tracker.alice_phone_bermuda_tracker"
+	)
+	initialAt := time.Date(2026, 8, 30, 23, 0, 0, 0, time.UTC)
+	getter := &registryPresenceGetter{
+		states: map[string]*homeassistant.State{
+			personID: personHAState(personID, "home", []any{phoneID}, initialAt),
+			phoneID:  bermudaTrackerState(phoneID, "home", "Office", "Desk Presence", initialAt),
+		},
+		registry: []homeassistant.EntityRegistryEntry{{EntityID: phoneID, Platform: "bermuda"}},
+	}
+	tracker := NewPresenceTracker([]string{personID}, "UTC", nil)
+	if err := tracker.Initialize(context.Background(), getter); err != nil {
+		t.Fatal(err)
+	}
+
+	newerAt := initialAt.Add(3 * time.Minute)
+	tracker.HandleHAStateChange(homeassistant.StateChangedData{
+		EntityID: phoneID,
+		NewState: bermudaTrackerState(phoneID, "home", "Kitchen", "Kitchen Proxy", newerAt),
+	})
+	tracker.HandleHAStateChange(homeassistant.StateChangedData{
+		EntityID: phoneID,
+		NewState: bermudaTrackerState(phoneID, "home", "Office", "Desk Presence", initialAt.Add(2*time.Minute)),
+	})
+	tracker.HandleHAStateChange(homeassistant.StateChangedData{
+		EntityID: phoneID,
+		NewState: bermudaTrackerState(phoneID, "not_home", "", "", initialAt.Add(time.Minute)),
+	})
+
+	snapshot, _ := tracker.Snapshot(personID)
+	if snapshot.Room != "Kitchen" || snapshot.RoomSource != "Kitchen Proxy" || len(snapshot.RoomObservations) != 1 || !snapshot.RoomObservations[0].ObservedAt.Equal(newerAt) {
+		t.Fatalf("stale Bermuda state overwrote newer room: %+v", snapshot)
+	}
+}
+
+func TestPresenceTrackerDoesNotAccumulateBermudaRoomWhileAway(t *testing.T) {
+	const (
+		personID = "person.alice"
+		phoneID  = "device_tracker.alice_phone_bermuda_tracker"
+	)
+	initialAt := time.Date(2026, 8, 30, 23, 0, 0, 0, time.UTC)
+	getter := &registryPresenceGetter{
+		states: map[string]*homeassistant.State{
+			personID: personHAState(personID, "home", []any{phoneID}, initialAt),
+			phoneID:  bermudaTrackerState(phoneID, "home", "Office", "Desk Presence", initialAt),
+		},
+		registry: []homeassistant.EntityRegistryEntry{{EntityID: phoneID, Platform: "bermuda"}},
+	}
+	tracker := NewPresenceTracker([]string{personID}, "UTC", nil)
+	if err := tracker.Initialize(context.Background(), getter); err != nil {
+		t.Fatal(err)
+	}
+
+	tracker.HandleHAStateChange(homeassistant.StateChangedData{
+		EntityID: personID,
+		NewState: personHAState(personID, "not_home", []any{phoneID}, initialAt.Add(time.Minute)),
+	})
+	tracker.HandleHAStateChange(homeassistant.StateChangedData{
+		EntityID: phoneID,
+		NewState: bermudaTrackerState(phoneID, "home", "Kitchen", "Kitchen Proxy", initialAt.Add(2*time.Minute)),
+	})
+	tracker.HandleHAStateChange(homeassistant.StateChangedData{
+		EntityID: personID,
+		NewState: personHAState(personID, "home", []any{phoneID}, initialAt.Add(3*time.Minute)),
+	})
+
+	snapshot, _ := tracker.Snapshot(personID)
+	if snapshot.State != "home" || snapshot.Room != "" || len(snapshot.RoomObservations) != 0 {
+		t.Fatalf("away-time Bermuda claim resurfaced on return: %+v", snapshot)
+	}
+}
+
+func TestPresenceTrackerRefreshesNewlyLinkedBermudaTracker(t *testing.T) {
+	const (
+		personID = "person.alice"
+		phoneID  = "device_tracker.alice_phone_bermuda_tracker"
+	)
+	initialAt := time.Date(2026, 8, 30, 23, 0, 0, 0, time.UTC)
+	getter := &registryPresenceGetter{
+		states: map[string]*homeassistant.State{
+			personID: personHAState(personID, "home", nil, initialAt),
+			phoneID:  bermudaTrackerState(phoneID, "home", "Office", "Desk Presence", initialAt.Add(time.Minute)),
+		},
+		registry: []homeassistant.EntityRegistryEntry{{EntityID: phoneID, Platform: "bermuda"}},
+	}
+	tracker := NewPresenceTracker([]string{personID}, "UTC", nil)
+	if err := tracker.Initialize(context.Background(), getter); err != nil {
+		t.Fatal(err)
+	}
+	var (
+		refreshed  []string
+		refreshErr error
+	)
+	tracker.OnLinkedTrackersChange(func(entityIDs []string) {
+		refreshed = append([]string(nil), entityIDs...)
+		refreshErr = tracker.RefreshLinkedTrackers(context.Background(), getter, entityIDs)
+	})
+
+	tracker.HandleHAStateChange(homeassistant.StateChangedData{
+		EntityID: personID,
+		NewState: personHAState(personID, "home", []any{phoneID}, initialAt.Add(2*time.Minute)),
+	})
+	if refreshErr != nil {
+		t.Fatal(refreshErr)
+	}
+	if !slices.Equal(refreshed, []string{phoneID}) || getter.invalidations != 1 {
+		t.Fatalf("linked refresh = %v, invalidations = %d", refreshed, getter.invalidations)
+	}
+	snapshot, _ := tracker.Snapshot(personID)
+	if snapshot.Room != "Office" || snapshot.RoomSource != "Desk Presence" || len(snapshot.RoomObservations) != 1 {
+		t.Fatalf("newly linked tracker was not hydrated: %+v", snapshot)
+	}
+}
+
 func TestLinkedDeviceTrackerIDs(t *testing.T) {
 	tooMany := make([]any, maxLinkedDeviceTrackersPerPerson+1)
 	for i := range tooMany {
@@ -252,5 +411,15 @@ func bermudaTrackerState(entityID, state, area, scanner string, updatedAt time.T
 			"scanner":     scanner,
 			"source_type": "bluetooth_le",
 		},
+	}
+}
+
+func personHAState(entityID, state string, trackers []any, updatedAt time.Time) *homeassistant.State {
+	return &homeassistant.State{
+		EntityID:    entityID,
+		State:       state,
+		LastChanged: updatedAt,
+		LastUpdated: updatedAt,
+		Attributes:  map[string]any{"device_trackers": trackers},
 	}
 }

--- a/internal/state/contacts/presence.go
+++ b/internal/state/contacts/presence.go
@@ -10,7 +10,6 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
 	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 )
@@ -65,8 +64,8 @@ func FormatPersonPresence(
 
 // Person represents the current presence state of a tracked household
 // member. State is typically "home", "not_home", or a zone name like
-// "zone.work". Room fields are populated by an external poller (e.g.,
-// UniFi AP associations) when available.
+// "zone.work". Room fields resolve provider-attributed observations such as
+// UniFi AP associations and linked Bermuda device trackers.
 type Person struct {
 	EntityID     string
 	FriendlyName string
@@ -76,17 +75,10 @@ type Person struct {
 	Room         string    // resolved room when current observations agree
 	RoomSince    time.Time // when the current resolved room began
 	RoomProvider string    // shared provider, empty for cross-provider consensus
-	RoomSource   string    // sole source, empty when multiple sources agree
+	RoomSource   string    // shared provider evidence, empty when evidence differs
 
 	roomObservations map[roomObservationKey]RoomObservation
 	roomConflict     bool
-}
-
-// StateGetter abstracts the Home Assistant REST client for fetching
-// entity state. Using an interface keeps the tracker testable without
-// a real HA instance.
-type StateGetter interface {
-	GetState(ctx context.Context, entityID string) (*homeassistant.State, error)
 }
 
 // RoomObserver is called when a tracked person's room observation changes.
@@ -105,9 +97,15 @@ type PresenceTracker struct {
 	people    map[string]*Person // entity_id → Person
 	order     []string           // insertion order for deterministic output
 	observers []RoomObserver     // called on room changes
-	mu        sync.RWMutex
-	loc       *time.Location
-	logger    *slog.Logger
+
+	linkedByPerson  map[string][]string
+	ownersByTracker map[string][]string
+	trackerPlatform map[string]string
+	ingestObserver  func([]string)
+
+	mu     sync.RWMutex
+	loc    *time.Location
+	logger *slog.Logger
 }
 
 // NewPresenceTracker creates a person tracker for the given entity IDs. All
@@ -141,124 +139,19 @@ func NewPresenceTracker(entityIDs []string, timezone string, logger *slog.Logger
 	}
 
 	return &PresenceTracker{
-		people: people,
-		order:  order,
-		loc:    loc,
-		logger: logger,
+		people:          people,
+		order:           order,
+		linkedByPerson:  make(map[string][]string),
+		ownersByTracker: make(map[string][]string),
+		trackerPlatform: make(map[string]string),
+		loc:             loc,
+		logger:          logger,
 	}
 }
 
 // TagContextBucket places current person presence in live state.
 func (t *PresenceTracker) TagContextBucket() agentctx.ContextBucket {
 	return agentctx.ContextBucketLiveState
-}
-
-// Initialize fetches the current state of all tracked entities from the
-// Home Assistant REST API. Entities that fail to load are logged and
-// left in "Unknown" state. This method is idempotent and safe to call
-// from a connwatch OnReady callback on every reconnection.
-//
-// Network I/O is performed without holding the lock so that GetContext
-// and HandleStateChange are not blocked during initialization.
-func (t *PresenceTracker) Initialize(ctx context.Context, ha StateGetter) error {
-	// Read entity order without the lock — order is immutable after
-	// construction, so this is safe.
-	ids := t.EntityIDs()
-
-	// Fetch all states outside the lock to avoid blocking readers
-	// during network I/O.
-	type fetchResult struct {
-		id    string
-		state *homeassistant.State
-		err   error
-	}
-	results := make([]fetchResult, 0, len(ids))
-	for _, id := range ids {
-		state, err := ha.GetState(ctx, id)
-		results = append(results, fetchResult{id: id, state: state, err: err})
-	}
-
-	// Apply fetched results under the lock.
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	var firstErr error
-	for _, r := range results {
-		if r.err != nil {
-			t.logger.Warn("failed to fetch person state",
-				"entity_id", r.id,
-				"error", r.err,
-			)
-			if firstErr == nil {
-				firstErr = fmt.Errorf("fetch %s: %w", r.id, r.err)
-			}
-			continue
-		}
-
-		p := t.people[r.id]
-		p.State = r.state.State
-		p.Since = r.state.LastChanged
-
-		if name, ok := r.state.Attributes["friendly_name"].(string); ok && name != "" {
-			p.FriendlyName = name
-		}
-
-		t.logger.Debug("person state initialized",
-			"entity_id", r.id,
-			"friendly_name", p.FriendlyName,
-			"state", p.State,
-			"since", p.Since,
-		)
-	}
-
-	return firstErr
-}
-
-// HandleStateChange updates the tracked person's state when a
-// state_changed event is received. It matches the
-// homeassistant.StateWatchHandler function signature; the old-state and
-// device_class arguments are unused. Untracked entities and no-change
-// events are silently ignored. Room data is cleared when a person
-// transitions to "not_home".
-func (t *PresenceTracker) HandleStateChange(entityID, _, newState, _ string) {
-	t.mu.Lock()
-
-	p, ok := t.people[entityID]
-	if !ok {
-		t.mu.Unlock()
-		return
-	}
-
-	if p.State == newState {
-		t.mu.Unlock()
-		return
-	}
-
-	t.logger.Debug("person state changed",
-		"entity_id", entityID,
-		"friendly_name", p.FriendlyName,
-		"old_state", p.State,
-		"new_state", newState,
-	)
-
-	p.State = newState
-	p.Since = time.Now()
-
-	var withdrawn []RoomObservation
-	var observers []RoomObserver
-	// Withdraw every room observation when the person leaves home. Retaining
-	// provider/source identity lets observers clear only their own projection.
-	if strings.EqualFold(newState, "not_home") {
-		withdrawn = sortedRoomObservations(p.roomObservations)
-		clear(p.roomObservations)
-		clearResolvedRoom(p, false)
-		observers = append([]RoomObserver(nil), t.observers...)
-	}
-	t.mu.Unlock()
-
-	for _, observation := range withdrawn {
-		t.notifyRoomObservers(observers, entityID, "", observation.Provider, observation.Source)
-	}
 }
 
 // TagContext returns a formatted presence block for injection into the

--- a/internal/state/contacts/presence.go
+++ b/internal/state/contacts/presence.go
@@ -79,6 +79,9 @@ type Person struct {
 
 	roomObservations map[roomObservationKey]RoomObservation
 	roomConflict     bool
+	// lastUpdated prevents a reconnect snapshot fetched before a live HA event
+	// from overwriting that newer event after slower registry I/O completes.
+	lastUpdated time.Time
 }
 
 // RoomObserver is called when a tracked person's room observation changes.
@@ -101,7 +104,11 @@ type PresenceTracker struct {
 	linkedByPerson  map[string][]string
 	ownersByTracker map[string][]string
 	trackerPlatform map[string]string
-	ingestObserver  func([]string)
+	// trackerUpdated retains provider timestamps even after withdrawals so a
+	// delayed home event cannot resurrect an older room claim.
+	trackerUpdated map[string]time.Time
+	ingestObserver func([]string)
+	linkedObserver func([]string)
 
 	mu     sync.RWMutex
 	loc    *time.Location
@@ -144,6 +151,7 @@ func NewPresenceTracker(entityIDs []string, timezone string, logger *slog.Logger
 		linkedByPerson:  make(map[string][]string),
 		ownersByTracker: make(map[string][]string),
 		trackerPlatform: make(map[string]string),
+		trackerUpdated:  make(map[string]time.Time),
 		loc:             loc,
 		logger:          logger,
 	}

--- a/internal/state/contacts/presence_test.go
+++ b/internal/state/contacts/presence_test.go
@@ -28,6 +28,10 @@ func (m *mockStateGetter) GetState(_ context.Context, entityID string) (*homeass
 	return s, nil
 }
 
+func (m *mockStateGetter) GetEntityRegistry(context.Context) ([]homeassistant.EntityRegistryEntry, error) {
+	return nil, nil
+}
+
 func TestNewPresenceTracker(t *testing.T) {
 	tracker := NewPresenceTracker([]string{"person.alice", "person.bob"}, "America/Chicago", nil)
 

--- a/internal/state/contacts/presence_test.go
+++ b/internal/state/contacts/presence_test.go
@@ -32,6 +32,8 @@ func (m *mockStateGetter) GetEntityRegistry(context.Context) ([]homeassistant.En
 	return nil, nil
 }
 
+func (m *mockStateGetter) InvalidateRegistryCache() {}
+
 func TestNewPresenceTracker(t *testing.T) {
 	tracker := NewPresenceTracker([]string{"person.alice", "person.bob"}, "America/Chicago", nil)
 
@@ -766,7 +768,7 @@ func TestPresenceSnapshot(t *testing.T) {
 	if !ok {
 		t.Fatal("tracked entity not found")
 	}
-	if snap.Room != "office" || snap.RoomProvider != "bermuda" || snap.RoomSource != "device_tracker.alice_bermuda" {
+	if snap.Room != "office" || snap.RoomProvider != "bermuda" || snap.RoomSource != "" {
 		t.Errorf("snapshot = %+v", snap)
 	}
 	if _, ok := tracker.Snapshot("person.nobody"); ok {

--- a/internal/state/contacts/room_presence.go
+++ b/internal/state/contacts/room_presence.go
@@ -48,9 +48,17 @@ func (t *PresenceTracker) OnRoomChange(fn RoomObserver) {
 // every observation but clears the resolved room and marks a conflict.
 //
 // An empty room withdraws this exact provider/source observation. A zero
-// ObservedAt is replaced with the current time. Exact semantic refreshes update
+// ObservedAt is replaced with the current time. Observations older than the
+// retained provider/source claim are ignored. Exact semantic refreshes update
 // freshness without notifying observers or resetting RoomSince.
 func (t *PresenceTracker) ObserveRoom(entityID string, observation RoomObservation) {
+	t.observeRoom(entityID, observation, false)
+}
+
+// observeRoom records an observation and optionally requires the person to be
+// home at the same locked instant. Bermuda uses the guarded path so tracker
+// updates received while a person is away cannot become latent room claims.
+func (t *PresenceTracker) observeRoom(entityID string, observation RoomObservation, requireHome bool) {
 	now := time.Now()
 	observation = normalizeRoomObservation(observation, now)
 	if observation.Room == "" {
@@ -66,7 +74,24 @@ func (t *PresenceTracker) ObserveRoom(entityID string, observation RoomObservati
 		t.mu.Unlock()
 		return
 	}
+	if requireHome && !strings.EqualFold(p.State, "home") {
+		t.mu.Unlock()
+		return
+	}
 	previous, existed := p.roomObservations[key]
+	if existed && observation.ObservedAt.Before(previous.ObservedAt) {
+		friendlyName := p.FriendlyName
+		t.mu.Unlock()
+		t.logger.Debug("ignored stale person room observation",
+			"entity_id", entityID,
+			"friendly_name", friendlyName,
+			"room_provider", observation.Provider,
+			"room_source", observation.Source,
+			"observed_at", observation.ObservedAt,
+			"current_observed_at", previous.ObservedAt,
+		)
+		return
+	}
 	p.roomObservations[key] = observation
 	resolvePersonRoom(p, now)
 	friendlyName := p.FriendlyName
@@ -85,6 +110,13 @@ func (t *PresenceTracker) ObserveRoom(entityID string, observation RoomObservati
 // providers and sources remain available to the resolver. Missing observations
 // and untracked entities are no-ops.
 func (t *PresenceTracker) WithdrawRoom(entityID, provider, source string) {
+	t.withdrawRoomAt(entityID, provider, source, time.Time{})
+}
+
+// withdrawRoomAt withdraws an observation unless the provider timestamp is
+// older than the claim it would remove. A zero timestamp remains the explicit,
+// unconditional compatibility behavior of [PresenceTracker.WithdrawRoom].
+func (t *PresenceTracker) withdrawRoomAt(entityID, provider, source string, observedAt time.Time) {
 	provider, source = normalizeRoomObservationIdentity(provider, source)
 	key := roomObservationKey{provider: provider, source: source}
 
@@ -96,6 +128,10 @@ func (t *PresenceTracker) WithdrawRoom(entityID, provider, source string) {
 	}
 	observation, exists := p.roomObservations[key]
 	if !exists {
+		t.mu.Unlock()
+		return
+	}
+	if !observedAt.IsZero() && observedAt.Before(observation.ObservedAt) {
 		t.mu.Unlock()
 		return
 	}
@@ -287,6 +323,12 @@ func resolvePersonRoom(person *Person, now time.Time) {
 func roomObservationEvidence(observation RoomObservation) string {
 	if observation.Via != "" {
 		return observation.Via
+	}
+	// Bermuda's Source is a private device_tracker identity. Its optional Via
+	// is the only model-safe evidence. Other providers retain the compatibility
+	// fallback because sources such as UniFi AP names are operator-readable.
+	if observation.Provider == BermudaRoomProvider {
+		return ""
 	}
 	return observation.Source
 }

--- a/internal/state/contacts/room_presence.go
+++ b/internal/state/contacts/room_presence.go
@@ -7,13 +7,15 @@ import (
 )
 
 // RoomObservation is one provider-attributed claim about a tracked person's
-// current room. Provider identifies the integration family, Source identifies
-// the concrete device or sensor within that provider, and ObservedAt records
-// when that source produced the claim.
+// current room. Provider identifies the integration family, Source is the
+// stable device or sensor identity within that provider, Via is optional
+// human-readable evidence such as a scanner or access-point name, and
+// ObservedAt records when that source produced the claim.
 type RoomObservation struct {
 	Room       string    `json:"room"`
 	Provider   string    `json:"provider"`
 	Source     string    `json:"source,omitempty"`
+	Via        string    `json:"via,omitempty"`
 	ObservedAt time.Time `json:"observed_at"`
 }
 
@@ -72,7 +74,7 @@ func (t *PresenceTracker) ObserveRoom(entityID string, observation RoomObservati
 	observers := append([]RoomObserver(nil), t.observers...)
 	t.mu.Unlock()
 
-	if existed && normalizedRoomName(previous.Room) == normalizedRoomName(observation.Room) {
+	if existed && normalizedRoomName(previous.Room) == normalizedRoomName(observation.Room) && previous.Via == observation.Via {
 		return
 	}
 	t.logRoomObservation("observed", entityID, friendlyName, observation, resolution)
@@ -200,6 +202,7 @@ func (t *PresenceTracker) logRoomObservation(operation, entityID, friendlyName s
 		"room", observation.Room,
 		"room_provider", observation.Provider,
 		"room_source", observation.Source,
+		"room_via", observation.Via,
 		"observed_at", observation.ObservedAt,
 		"resolved_room", resolution.room,
 		"resolved_room_provider", resolution.provider,
@@ -228,6 +231,7 @@ func (t *PresenceTracker) notifyRoomObservers(observers []RoomObserver, entityID
 func normalizeRoomObservation(observation RoomObservation, now time.Time) RoomObservation {
 	observation.Room = strings.TrimSpace(observation.Room)
 	observation.Provider, observation.Source = normalizeRoomObservationIdentity(observation.Provider, observation.Source)
+	observation.Via = strings.TrimSpace(observation.Via)
 	if observation.ObservedAt.IsZero() {
 		observation.ObservedAt = now
 	}
@@ -259,14 +263,14 @@ func resolvePersonRoom(person *Person, now time.Time) {
 
 	room := observations[0].Room
 	provider := observations[0].Provider
-	source := observations[0].Source
+	source := roomObservationEvidence(observations[0])
 	for _, observation := range observations[1:] {
 		if observation.Provider != provider {
 			provider = ""
 			source = ""
 			continue
 		}
-		if observation.Source != source {
+		if roomObservationEvidence(observation) != source {
 			source = ""
 		}
 	}
@@ -278,6 +282,13 @@ func resolvePersonRoom(person *Person, now time.Time) {
 	person.RoomProvider = provider
 	person.RoomSource = source
 	person.roomConflict = false
+}
+
+func roomObservationEvidence(observation RoomObservation) string {
+	if observation.Via != "" {
+		return observation.Via
+	}
+	return observation.Source
 }
 
 func clearResolvedRoom(person *Person, conflict bool) {

--- a/internal/state/contacts/room_presence_test.go
+++ b/internal/state/contacts/room_presence_test.go
@@ -97,7 +97,7 @@ func TestPresenceTrackerRoomConflictAndRecovery(t *testing.T) {
 
 	tracker.WithdrawRoom("person.alice", "unifi", "ap-kitchen")
 	recovered, _ := tracker.Snapshot("person.alice")
-	if recovered.RoomConflict || recovered.Room != "office" || recovered.RoomProvider != "bermuda" || recovered.RoomSource != "device_tracker.phone_bermuda" {
+	if recovered.RoomConflict || recovered.Room != "office" || recovered.RoomProvider != "bermuda" || recovered.RoomSource != "" {
 		t.Fatalf("resolution after withdrawal = %+v", recovered)
 	}
 	if recovered.RoomSince.IsZero() {
@@ -117,7 +117,7 @@ func TestPresenceTrackerWithdrawRoomPreservesOtherEvidence(t *testing.T) {
 
 	tracker.WithdrawRoom("person.alice", " BERMUDA ", "device_tracker.watch_bermuda")
 	after, _ := tracker.Snapshot("person.alice")
-	if after.Room != "office" || after.RoomProvider != "bermuda" || after.RoomSource != "device_tracker.phone_bermuda" {
+	if after.Room != "office" || after.RoomProvider != "bermuda" || after.RoomSource != "" {
 		t.Fatalf("remaining observation did not resolve: %+v", after)
 	}
 	if len(after.RoomObservations) != 1 {
@@ -163,6 +163,36 @@ func TestPresenceTrackerObservationRefresh(t *testing.T) {
 	}
 	if withEvidence.RoomSource != "Desk Presence" || !withEvidence.RoomSince.Equal(first.RoomSince) {
 		t.Errorf("evidence refresh = %+v", withEvidence)
+	}
+}
+
+func TestRoomObservationEvidenceKeepsBermudaIdentityPrivate(t *testing.T) {
+	tests := []struct {
+		name        string
+		observation RoomObservation
+		want        string
+	}{
+		{
+			name:        "Bermuda without scanner",
+			observation: RoomObservation{Provider: BermudaRoomProvider, Source: "device_tracker.private_watch"},
+		},
+		{
+			name:        "Bermuda scanner",
+			observation: RoomObservation{Provider: BermudaRoomProvider, Source: "device_tracker.private_watch", Via: "Desk Presence"},
+			want:        "Desk Presence",
+		},
+		{
+			name:        "UniFi AP compatibility fallback",
+			observation: RoomObservation{Provider: "unifi", Source: "ap-office"},
+			want:        "ap-office",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := roomObservationEvidence(tt.observation); got != tt.want {
+				t.Errorf("evidence = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/state/contacts/room_presence_test.go
+++ b/internal/state/contacts/room_presence_test.go
@@ -18,10 +18,11 @@ func TestPresenceTrackerObserveRoomConsensus(t *testing.T) {
 		Room:       "Office",
 		Provider:   " Bermuda ",
 		Source:     "device_tracker.phone_bermuda",
+		Via:        "Desk Presence",
 		ObservedAt: phoneAt,
 	})
 	first, _ := tracker.Snapshot("person.alice")
-	if first.Room != "Office" || first.RoomProvider != "bermuda" || first.RoomSource != "device_tracker.phone_bermuda" {
+	if first.Room != "Office" || first.RoomProvider != "bermuda" || first.RoomSource != "Desk Presence" {
 		t.Fatalf("single-source resolution = %+v", first)
 	}
 
@@ -29,10 +30,11 @@ func TestPresenceTrackerObserveRoomConsensus(t *testing.T) {
 		Room:       " office ",
 		Provider:   "bermuda",
 		Source:     "device_tracker.watch_bermuda",
+		Via:        "Desk Presence",
 		ObservedAt: watchAt,
 	})
 	providerConsensus, _ := tracker.Snapshot("person.alice")
-	if providerConsensus.Room != "Office" || providerConsensus.RoomProvider != "bermuda" || providerConsensus.RoomSource != "" {
+	if providerConsensus.Room != "Office" || providerConsensus.RoomProvider != "bermuda" || providerConsensus.RoomSource != "Desk Presence" {
 		t.Fatalf("same-provider consensus = %+v", providerConsensus)
 	}
 	if providerConsensus.RoomConflict {
@@ -150,6 +152,17 @@ func TestPresenceTrackerObservationRefresh(t *testing.T) {
 	}
 	if !second.RoomSince.Equal(first.RoomSince) {
 		t.Errorf("semantic refresh reset RoomSince: %v then %v", first.RoomSince, second.RoomSince)
+	}
+
+	observation.Via = "Desk Presence"
+	observation.ObservedAt = secondAt.Add(time.Second)
+	tracker.ObserveRoom("person.alice", observation)
+	withEvidence, _ := tracker.Snapshot("person.alice")
+	if notifications != 2 {
+		t.Errorf("evidence change emitted %d notifications, want 2 total", notifications)
+	}
+	if withEvidence.RoomSource != "Desk Presence" || !withEvidence.RoomSince.Equal(first.RoomSince) {
+		t.Errorf("evidence refresh = %+v", withEvidence)
 	}
 }
 

--- a/internal/tools/counterparty_tools_test.go
+++ b/internal/tools/counterparty_tools_test.go
@@ -34,6 +34,8 @@ func (g staticWhereaboutsStateGetter) GetEntityRegistry(context.Context) ([]home
 	return nil, nil
 }
 
+func (g staticWhereaboutsStateGetter) InvalidateRegistryCache() {}
+
 type registryWhereaboutsStateGetter struct {
 	states   map[string]*homeassistant.State
 	registry []homeassistant.EntityRegistryEntry
@@ -50,6 +52,8 @@ func (g registryWhereaboutsStateGetter) GetState(_ context.Context, entityID str
 func (g registryWhereaboutsStateGetter) GetEntityRegistry(context.Context) ([]homeassistant.EntityRegistryEntry, error) {
 	return g.registry, nil
 }
+
+func (g registryWhereaboutsStateGetter) InvalidateRegistryCache() {}
 
 // newWhereaboutsFixture builds a contact ("Alice Operator") with an HA
 // person binding, one bound companion account carrying the given
@@ -276,6 +280,42 @@ func TestContactWhereaboutsProductionBermudaConsensusUsesScannerEvidence(t *test
 	}
 	if strings.Contains(out, phoneID) || strings.Contains(out, watchID) {
 		t.Fatalf("model-facing result leaked observation identity instead of scanner evidence: %s", out)
+	}
+}
+
+func TestContactWhereaboutsBermudaWithoutScannerKeepsTrackerPrivate(t *testing.T) {
+	now := time.Now().UTC()
+	const trackerID = "device_tracker.alice_private_watch_bermuda_tracker"
+	getter := registryWhereaboutsStateGetter{
+		states: map[string]*homeassistant.State{
+			"person.alice": {
+				EntityID: "person.alice", State: "home", LastChanged: now.Add(-2 * time.Hour), LastUpdated: now.Add(-2 * time.Hour),
+				Attributes: map[string]any{"device_trackers": []any{trackerID}},
+			},
+			trackerID: {
+				EntityID: trackerID, State: "home", LastUpdated: now.Add(-time.Minute),
+				Attributes: map[string]any{"area": "Office"},
+			},
+		},
+		registry: []homeassistant.EntityRegistryEntry{{EntityID: trackerID, Platform: "bermuda"}},
+	}
+	tracker := contacts.NewPresenceTracker([]string{"person.alice"}, "UTC", nil)
+	if err := tracker.Initialize(context.Background(), getter); err != nil {
+		t.Fatal(err)
+	}
+
+	fx := newWhereaboutsFixture(t, "home", "", nil)
+	fx.deps.Presence = tracker.Snapshot
+	out, err := handleContactWhereabouts(context.Background(), fx.deps, "Alice Operator", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := decodeWhereabouts(t, out)
+	if len(res.Sources) < 2 || res.Sources[0].Source != "bermuda_room" || res.Sources[0].Room != "Office" || res.Sources[0].RoomVia != "" {
+		t.Fatalf("Bermuda room without scanner = %+v", res.Sources)
+	}
+	if strings.Contains(out, trackerID) {
+		t.Fatalf("model-facing result leaked private tracker identity: %s", out)
 	}
 }
 

--- a/internal/tools/counterparty_tools_test.go
+++ b/internal/tools/counterparty_tools_test.go
@@ -30,6 +30,27 @@ func (g staticWhereaboutsStateGetter) GetState(_ context.Context, entityID strin
 	return state, nil
 }
 
+func (g staticWhereaboutsStateGetter) GetEntityRegistry(context.Context) ([]homeassistant.EntityRegistryEntry, error) {
+	return nil, nil
+}
+
+type registryWhereaboutsStateGetter struct {
+	states   map[string]*homeassistant.State
+	registry []homeassistant.EntityRegistryEntry
+}
+
+func (g registryWhereaboutsStateGetter) GetState(_ context.Context, entityID string) (*homeassistant.State, error) {
+	state, ok := g.states[entityID]
+	if !ok {
+		return nil, fmt.Errorf("state %q not found", entityID)
+	}
+	return state, nil
+}
+
+func (g registryWhereaboutsStateGetter) GetEntityRegistry(context.Context) ([]homeassistant.EntityRegistryEntry, error) {
+	return g.registry, nil
+}
+
 // newWhereaboutsFixture builds a contact ("Alice Operator") with an HA
 // person binding, one bound companion account carrying the given
 // observations, and a fake presence snapshot.
@@ -202,6 +223,59 @@ func TestContactWhereaboutsProductionPersonShapePreservesRoomProvider(t *testing
 	}
 	if strings.Contains(out, "bermuda_room") {
 		t.Fatalf("aggregate HA source fabricated Bermuda room provenance: %s", out)
+	}
+}
+
+func TestContactWhereaboutsProductionBermudaConsensusUsesScannerEvidence(t *testing.T) {
+	now := time.Now().UTC()
+	const (
+		phoneID = "device_tracker.alice_phone_bermuda_tracker"
+		watchID = "device_tracker.alice_watch_bermuda_tracker"
+	)
+	getter := registryWhereaboutsStateGetter{
+		states: map[string]*homeassistant.State{
+			"person.alice": {
+				EntityID: "person.alice", State: "home", LastChanged: now.Add(-2 * time.Hour),
+				Attributes: map[string]any{
+					"source":          watchID,
+					"device_trackers": []any{phoneID, watchID},
+				},
+			},
+			phoneID: {
+				EntityID: phoneID, State: "home", LastUpdated: now.Add(-2 * time.Minute),
+				Attributes: map[string]any{"area": "Office", "scanner": "Desk Presence"},
+			},
+			watchID: {
+				EntityID: watchID, State: "home", LastUpdated: now.Add(-time.Minute),
+				Attributes: map[string]any{"area": "Office", "scanner": "Desk Presence"},
+			},
+		},
+		registry: []homeassistant.EntityRegistryEntry{
+			{EntityID: phoneID, Platform: "bermuda"},
+			{EntityID: watchID, Platform: "bermuda"},
+		},
+	}
+	tracker := contacts.NewPresenceTracker([]string{"person.alice"}, "UTC", nil)
+	if err := tracker.Initialize(context.Background(), getter); err != nil {
+		t.Fatal(err)
+	}
+
+	fx := newWhereaboutsFixture(t, "home", "", nil)
+	fx.deps.Presence = tracker.Snapshot
+	out, err := handleContactWhereabouts(context.Background(), fx.deps, "Alice Operator", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := decodeWhereabouts(t, out)
+	if len(res.Sources) < 2 {
+		t.Fatalf("sources = %+v, want Bermuda room and person zone", res.Sources)
+	}
+	room := res.Sources[0]
+	if room.Source != "bermuda_room" || room.Room != "Office" || room.RoomVia != "Desk Presence" {
+		t.Fatalf("Bermuda room source = %+v", room)
+	}
+	if strings.Contains(out, phoneID) || strings.Contains(out, watchID) {
+		t.Fatalf("model-facing result leaked observation identity instead of scanner evidence: %s", out)
 	}
 }
 


### PR DESCRIPTION
## Summary

- discover the device trackers linked from configured HA people and mirror them into the explicit system ingestion floor
- verify Bermuda trackers through the HA entity registry and preserve attribute-only `area` and `scanner` updates
- keep tracker entity IDs as internal observation identities while exposing shared scanner evidence to the model and withdrawing exact stale claims

## Why

The audited production person entity links ordinary GPS trackers and two Bermuda trackers. The existing compact state-change surface discarded the room attributes, while subscribing to all of `device_tracker.*` would broaden ingestion unnecessarily. The active person source also switches between trackers and is not trustworthy room provenance.

## User impact

No configuration changes are required. Linked trackers are followed automatically, but only entity-registry-verified Bermuda trackers contribute room claims. Multiple agreeing Bermuda trackers resolve to their shared scanner evidence (for example, `Office` via `Desk Presence`); disagreement continues to report a conflict, UniFi remains an independent provider, and private tracker IDs do not reach model-facing whereabouts output.

## Test plan

- [x] `just ci`
- [x] `git diff --check`
- [x] production HA shape audit (read-only)
