### PR TITLE
feat: configure operator contact presence bindings

### DIFF
--- a/cmd/thane/init.go
+++ b/cmd/thane/init.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	_ "embed"
 	"errors"
 	"flag"
@@ -13,9 +14,12 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/nugget/thane-ai-agent/internal/model/talents"
+	platformconfig "github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/platform/identity"
 	"github.com/nugget/thane-ai-agent/internal/state/contacts"
+	"gopkg.in/yaml.v3"
 )
 
 //go:generate sh -c "cp ../../examples/config.example.yaml . && cp ../../examples/persona.example.md ."
@@ -68,14 +72,19 @@ type initOptions struct {
 }
 
 type operatorContactBootstrap struct {
-	contact     *contacts.Contact
-	store       *contacts.Store
-	dbPath      string
-	databaseNew bool
+	contact *contacts.Contact
+	store   *contacts.Store
+	created bool
 }
 
-func bootstrapOperatorContact(workspace, name string, logger *slog.Logger) (*operatorContactBootstrap, error) {
-	dbPath := filepath.Join(workspace, "db", "contacts.db")
+func bootstrapOperatorContact(dataDir string, id uuid.UUID, name string, logger *slog.Logger) (*operatorContactBootstrap, error) {
+	if id == uuid.Nil {
+		return nil, errors.New("operator contact ID is empty")
+	}
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create contact database directory: %w", err)
+	}
+	dbPath := filepath.Join(dataDir, "contacts.db")
 	_, statErr := os.Stat(dbPath)
 	databaseNew := errors.Is(statErr, os.ErrNotExist)
 	if statErr != nil && !databaseNew {
@@ -89,14 +98,40 @@ func bootstrapOperatorContact(workspace, name string, logger *slog.Logger) (*ope
 		}
 		return nil, fmt.Errorf("open contact database: %w", err)
 	}
+	existing, err := store.Get(id)
+	if err == nil {
+		return &operatorContactBootstrap{contact: existing, store: store}, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		store.Close() //nolint:errcheck // preserve the lookup error
+		if databaseNew {
+			return nil, errors.Join(fmt.Errorf("look up operator contact: %w", err), removeContactDatabaseFiles(dbPath))
+		}
+		return nil, fmt.Errorf("look up operator contact: %w", err)
+	}
+
+	active, err := store.ListAllLimit(1)
+	if err != nil {
+		store.Close() //nolint:errcheck // preserve the query error
+		if databaseNew {
+			return nil, errors.Join(fmt.Errorf("inspect contact database: %w", err), removeContactDatabaseFiles(dbPath))
+		}
+		return nil, fmt.Errorf("inspect contact database: %w", err)
+	}
+	if len(active) != 0 {
+		store.Close() //nolint:errcheck // no mutation occurred
+		return nil, fmt.Errorf("operator contact %s is missing from non-empty database %s", id, dbPath)
+	}
+
 	if name = strings.TrimSpace(name); name == "" {
 		name = "Operator"
 	}
-	contact, err := store.Upsert(&contacts.Contact{
+	contact, err := store.UpsertWithProperties(&contacts.Contact{
+		ID:            id,
 		FormattedName: name,
 		Kind:          "individual",
 		TrustZone:     contacts.ZoneAdmin,
-	})
+	}, nil)
 	if err != nil {
 		store.Close() //nolint:errcheck // preserve the contact creation error
 		if databaseNew {
@@ -105,10 +140,9 @@ func bootstrapOperatorContact(workspace, name string, logger *slog.Logger) (*ope
 		return nil, fmt.Errorf("create operator contact: %w", err)
 	}
 	return &operatorContactBootstrap{
-		contact:     contact,
-		store:       store,
-		dbPath:      dbPath,
-		databaseNew: databaseNew,
+		contact: contact,
+		store:   store,
+		created: true,
 	}, nil
 }
 
@@ -131,27 +165,35 @@ func (b *operatorContactBootstrap) close() error {
 	return err
 }
 
-// rollback removes only artifacts this bootstrap created. An existing
-// contact database is never discarded; its new stub is soft-deleted instead.
-func (b *operatorContactBootstrap) rollback() error {
-	if b == nil {
-		return nil
+type operatorBootstrapConfig struct {
+	DataDir  string `yaml:"data_dir"`
+	Identity struct {
+		OperatorContactID string `yaml:"operator_contact_id"`
+	} `yaml:"identity"`
+}
+
+// readOperatorBootstrapConfig reads only the two config values init needs to
+// seed or repair the initial contact. It deliberately does not load the full
+// runtime config: re-running init must remain possible while an operator is in
+// the middle of authoring unrelated settings.
+func readOperatorBootstrapConfig(path, workspace string) (uuid.UUID, string, bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return uuid.Nil, "", false, fmt.Errorf("read core config: %w", err)
 	}
-	var errs []error
-	if !b.databaseNew && b.store != nil && b.contact != nil {
-		if err := b.store.Delete(b.contact.ID); err != nil {
-			errs = append(errs, err)
-		}
+	var cfg operatorBootstrapConfig
+	if err := yaml.Unmarshal([]byte(os.ExpandEnv(string(data))), &cfg); err != nil {
+		return uuid.Nil, "", false, fmt.Errorf("parse core config: %w", err)
 	}
-	if err := b.close(); err != nil {
-		errs = append(errs, err)
+	rawID := strings.TrimSpace(cfg.Identity.OperatorContactID)
+	if rawID == "" {
+		return uuid.Nil, "", false, nil
 	}
-	if b.databaseNew {
-		if err := removeContactDatabaseFiles(b.dbPath); err != nil {
-			errs = append(errs, err)
-		}
+	id, err := uuid.Parse(rawID)
+	if err != nil || id == uuid.Nil || id.String() != rawID {
+		return uuid.Nil, "", false, fmt.Errorf("identity.operator_contact_id must be a canonical non-zero UUID, got %q", rawID)
 	}
-	return errors.Join(errs...)
+	return id, platformconfig.ResolveDataDir(workspace, cfg.DataDir), true, nil
 }
 
 // resolveOperatorSigner decides which key founds core, and explains the
@@ -243,39 +285,33 @@ func runInit(w io.Writer, dir string, opts initOptions) error {
 		return err
 	}
 
-	var contactBootstrap *operatorContactBootstrap
 	coreConfigPath := filepath.Join(absDir, "core", identity.CoreConfigFile)
+	operatorContactID := ""
 	if _, statErr := os.Stat(coreConfigPath); errors.Is(statErr, os.ErrNotExist) {
-		contactBootstrap, err = bootstrapOperatorContact(absDir, opts.OperatorName, slog.Default())
-		if err != nil {
-			return err
+		id, idErr := uuid.NewV7()
+		if idErr != nil {
+			return fmt.Errorf("generate operator contact ID: %w", idErr)
 		}
+		operatorContactID = id.String()
 	} else if statErr != nil {
 		return fmt.Errorf("stat core config: %w", statErr)
 	}
 
-	operatorContactID := ""
-	if contactBootstrap != nil {
-		operatorContactID = contactBootstrap.contact.ID.String()
-	}
 	result, err := identity.BootstrapCore(ctx, filepath.Join(absDir, "core"), filepath.Base(absDir), operator, operatorContactID, bundledTalents, slog.Default())
 	if err != nil {
-		if rollbackErr := contactBootstrap.rollback(); rollbackErr != nil {
-			return errors.Join(fmt.Errorf("bootstrap core identity: %w", err), fmt.Errorf("rollback operator contact: %w", rollbackErr))
-		}
 		return fmt.Errorf("bootstrap core identity: %w", err)
 	}
-	if contactBootstrap != nil && !result.Created {
-		if rollbackErr := contactBootstrap.rollback(); rollbackErr != nil {
-			return fmt.Errorf("core identity already existed after creating an operator contact; rollback failed: %w", rollbackErr)
-		}
-		return fmt.Errorf("core identity already existed after creating an operator contact")
+
+	configuredOperatorID, dataDir, operatorConfigured, err := readOperatorBootstrapConfig(coreConfigPath, absDir)
+	if err != nil {
+		return err
 	}
-	if contactBootstrap != nil {
-		if err := contactBootstrap.close(); err != nil {
-			return fmt.Errorf("close operator contact database: %w", err)
+	var contactBootstrap *operatorContactBootstrap
+	if operatorConfigured {
+		contactBootstrap, err = bootstrapOperatorContact(dataDir, configuredOperatorID, opts.OperatorName, slog.Default())
+		if err != nil {
+			return err
 		}
-		fmt.Fprintf(w, "  ✓ operator contact %q (%s)\n", contactBootstrap.contact.FormattedName, contactBootstrap.contact.ID)
 	}
 	if result.Created {
 		fmt.Fprintf(w, "  ✓ %s (core identity, signing %s)\n", result.CoreDir, result.SigningKeyFingerprint)
@@ -283,6 +319,16 @@ func runInit(w io.Writer, dir string, opts initOptions) error {
 		describeCorePosture(w, result, why)
 	} else {
 		fmt.Fprintf(w, "  · %s (core identity exists, skipping)\n", result.CoreDir)
+	}
+	if contactBootstrap != nil {
+		if err := contactBootstrap.close(); err != nil {
+			return fmt.Errorf("close operator contact database: %w", err)
+		}
+		if contactBootstrap.created {
+			fmt.Fprintf(w, "  ✓ operator contact %q (%s)\n", contactBootstrap.contact.FormattedName, contactBootstrap.contact.ID)
+		} else {
+			fmt.Fprintf(w, "  · operator contact %q (%s) (exists, skipping)\n", contactBootstrap.contact.FormattedName, contactBootstrap.contact.ID)
+		}
 	}
 
 	if err := bootstrapArchive(w, absDir); err != nil {

--- a/cmd/thane/init.go
+++ b/cmd/thane/init.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/nugget/thane-ai-agent/internal/model/talents"
 	"github.com/nugget/thane-ai-agent/internal/platform/identity"
+	"github.com/nugget/thane-ai-agent/internal/state/contacts"
 )
 
 //go:generate sh -c "cp ../../examples/config.example.yaml . && cp ../../examples/persona.example.md ."
@@ -58,9 +59,99 @@ type initOptions struct {
 	OperatorKey string
 	// OperatorPrincipal overrides the identity the key signs as.
 	OperatorPrincipal string
+	// OperatorName is the display name for the initial operator contact.
+	// Empty creates an explicit stub named "Operator".
+	OperatorName string
 	// SelfSigned skips the search entirely and founds core with the agent's
 	// own key, for an operator who has decided that is what they want.
 	SelfSigned bool
+}
+
+type operatorContactBootstrap struct {
+	contact     *contacts.Contact
+	store       *contacts.Store
+	dbPath      string
+	databaseNew bool
+}
+
+func bootstrapOperatorContact(workspace, name string, logger *slog.Logger) (*operatorContactBootstrap, error) {
+	dbPath := filepath.Join(workspace, "db", "contacts.db")
+	_, statErr := os.Stat(dbPath)
+	databaseNew := errors.Is(statErr, os.ErrNotExist)
+	if statErr != nil && !databaseNew {
+		return nil, fmt.Errorf("stat contact database: %w", statErr)
+	}
+
+	store, err := contacts.Open(dbPath, logger)
+	if err != nil {
+		if databaseNew {
+			return nil, errors.Join(fmt.Errorf("open contact database: %w", err), removeContactDatabaseFiles(dbPath))
+		}
+		return nil, fmt.Errorf("open contact database: %w", err)
+	}
+	if name = strings.TrimSpace(name); name == "" {
+		name = "Operator"
+	}
+	contact, err := store.Upsert(&contacts.Contact{
+		FormattedName: name,
+		Kind:          "individual",
+		TrustZone:     contacts.ZoneAdmin,
+	})
+	if err != nil {
+		store.Close() //nolint:errcheck // preserve the contact creation error
+		if databaseNew {
+			return nil, errors.Join(fmt.Errorf("create operator contact: %w", err), removeContactDatabaseFiles(dbPath))
+		}
+		return nil, fmt.Errorf("create operator contact: %w", err)
+	}
+	return &operatorContactBootstrap{
+		contact:     contact,
+		store:       store,
+		dbPath:      dbPath,
+		databaseNew: databaseNew,
+	}, nil
+}
+
+func removeContactDatabaseFiles(dbPath string) error {
+	var errs []error
+	for _, path := range []string{dbPath, dbPath + "-journal", dbPath + "-shm", dbPath + "-wal"} {
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			errs = append(errs, fmt.Errorf("remove %s: %w", path, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (b *operatorContactBootstrap) close() error {
+	if b == nil || b.store == nil {
+		return nil
+	}
+	err := b.store.Close()
+	b.store = nil
+	return err
+}
+
+// rollback removes only artifacts this bootstrap created. An existing
+// contact database is never discarded; its new stub is soft-deleted instead.
+func (b *operatorContactBootstrap) rollback() error {
+	if b == nil {
+		return nil
+	}
+	var errs []error
+	if !b.databaseNew && b.store != nil && b.contact != nil {
+		if err := b.store.Delete(b.contact.ID); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if err := b.close(); err != nil {
+		errs = append(errs, err)
+	}
+	if b.databaseNew {
+		if err := removeContactDatabaseFiles(b.dbPath); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // resolveOperatorSigner decides which key founds core, and explains the
@@ -151,9 +242,40 @@ func runInit(w io.Writer, dir string, opts initOptions) error {
 	if err != nil {
 		return err
 	}
-	result, err := identity.BootstrapCore(ctx, filepath.Join(absDir, "core"), filepath.Base(absDir), operator, bundledTalents, slog.Default())
+
+	var contactBootstrap *operatorContactBootstrap
+	coreConfigPath := filepath.Join(absDir, "core", identity.CoreConfigFile)
+	if _, statErr := os.Stat(coreConfigPath); errors.Is(statErr, os.ErrNotExist) {
+		contactBootstrap, err = bootstrapOperatorContact(absDir, opts.OperatorName, slog.Default())
+		if err != nil {
+			return err
+		}
+	} else if statErr != nil {
+		return fmt.Errorf("stat core config: %w", statErr)
+	}
+
+	operatorContactID := ""
+	if contactBootstrap != nil {
+		operatorContactID = contactBootstrap.contact.ID.String()
+	}
+	result, err := identity.BootstrapCore(ctx, filepath.Join(absDir, "core"), filepath.Base(absDir), operator, operatorContactID, bundledTalents, slog.Default())
 	if err != nil {
+		if rollbackErr := contactBootstrap.rollback(); rollbackErr != nil {
+			return errors.Join(fmt.Errorf("bootstrap core identity: %w", err), fmt.Errorf("rollback operator contact: %w", rollbackErr))
+		}
 		return fmt.Errorf("bootstrap core identity: %w", err)
+	}
+	if contactBootstrap != nil && !result.Created {
+		if rollbackErr := contactBootstrap.rollback(); rollbackErr != nil {
+			return fmt.Errorf("core identity already existed after creating an operator contact; rollback failed: %w", rollbackErr)
+		}
+		return fmt.Errorf("core identity already existed after creating an operator contact")
+	}
+	if contactBootstrap != nil {
+		if err := contactBootstrap.close(); err != nil {
+			return fmt.Errorf("close operator contact database: %w", err)
+		}
+		fmt.Fprintf(w, "  ✓ operator contact %q (%s)\n", contactBootstrap.contact.FormattedName, contactBootstrap.contact.ID)
 	}
 	if result.Created {
 		fmt.Fprintf(w, "  ✓ %s (core identity, signing %s)\n", result.CoreDir, result.SigningKeyFingerprint)
@@ -252,6 +374,8 @@ func runInitCommand(stdout, stderr io.Writer, args []string) error {
 		"private SSH key that founds core, making the instance answerable to its holder (default: from git's user.signingkey)")
 	fs.StringVar(&opts.OperatorPrincipal, "operator-principal", "",
 		"identity the operator key signs as (default: git's user.email)")
+	fs.StringVar(&opts.OperatorName, "operator-name", "",
+		"display name for the initial operator contact (default: Operator)")
 	fs.BoolVar(&opts.SelfSigned, "self-signed", false,
 		"found core with the instance's own agent key, without looking for an operator key")
 	if err := fs.Parse(args); err != nil {

--- a/cmd/thane/init_test.go
+++ b/cmd/thane/init_test.go
@@ -215,6 +215,53 @@ func TestRunInit_FreshDirectory(t *testing.T) {
 	}
 }
 
+func TestRunInit_RepairsMissingOperatorDatabaseFromCoreConfig(t *testing.T) {
+	requireGit(t)
+	dir := t.TempDir()
+	var buf bytes.Buffer
+	if err := runInit(&buf, dir, initOptions{SelfSigned: true, OperatorName: "Alice Example"}); err != nil {
+		t.Fatalf("first runInit: %v", err)
+	}
+
+	var generated struct {
+		Identity struct {
+			OperatorContactID string `yaml:"operator_contact_id"`
+		} `yaml:"identity"`
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "core", "config.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := yaml.Unmarshal(data, &generated); err != nil {
+		t.Fatal(err)
+	}
+	operatorID, err := uuid.Parse(generated.Identity.OperatorContactID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dbPath := filepath.Join(dir, "db", "contacts.db")
+	if err := removeContactDatabaseFiles(dbPath); err != nil {
+		t.Fatalf("remove initialized contact database: %v", err)
+	}
+
+	buf.Reset()
+	if err := runInit(&buf, dir, initOptions{SelfSigned: true}); err != nil {
+		t.Fatalf("repair runInit: %v", err)
+	}
+	store, err := contacts.Open(dbPath, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	operator, err := store.Get(operatorID)
+	if err != nil {
+		t.Fatalf("get repaired operator contact: %v", err)
+	}
+	if operator.FormattedName != "Operator" || operator.TrustZone != contacts.ZoneAdmin {
+		t.Fatalf("repaired operator contact = %+v", operator)
+	}
+}
+
 // TestRunInit_ArchiveBootstrapIdempotent verifies that re-running init
 // over an existing archive skeleton leaves every file untouched (same
 // mtime, same content) — the writeIfMissing path uses O_EXCL.

--- a/cmd/thane/init_test.go
+++ b/cmd/thane/init_test.go
@@ -8,6 +8,10 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+
+	"github.com/google/uuid"
+	"github.com/nugget/thane-ai-agent/internal/state/contacts"
+	"gopkg.in/yaml.v3"
 )
 
 // clearUmask sets the process umask to 0 so file permission assertions are
@@ -136,6 +140,45 @@ func TestRunInit_FreshDirectory(t *testing.T) {
 		if got := info.Mode().Perm(); got != 0o600 {
 			t.Errorf("%s permissions = %o, want 0600", rel, got)
 		}
+	}
+
+	var generated struct {
+		Identity struct {
+			OperatorContactID string `yaml:"operator_contact_id"`
+		} `yaml:"identity"`
+		Person struct {
+			ContactBindings map[string]string `yaml:"contact_bindings"`
+		} `yaml:"person"`
+	}
+	configData, err := os.ReadFile(filepath.Join(dir, "core", "config.yaml"))
+	if err != nil {
+		t.Fatalf("read generated config: %v", err)
+	}
+	if err := yaml.Unmarshal(configData, &generated); err != nil {
+		t.Fatalf("parse generated config: %v", err)
+	}
+	operatorID, err := uuid.Parse(generated.Identity.OperatorContactID)
+	if err != nil || operatorID == uuid.Nil {
+		t.Fatalf("generated operator_contact_id = %q, %v", generated.Identity.OperatorContactID, err)
+	}
+	if generated.Person.ContactBindings == nil || len(generated.Person.ContactBindings) != 0 {
+		t.Fatalf("generated person.contact_bindings = %#v, want explicit empty map", generated.Person.ContactBindings)
+	}
+
+	contactStore, err := contacts.Open(filepath.Join(dir, "db", "contacts.db"), nil)
+	if err != nil {
+		t.Fatalf("open initialized contacts database: %v", err)
+	}
+	t.Cleanup(func() { _ = contactStore.Close() })
+	operatorContact, err := contactStore.Get(operatorID)
+	if err != nil {
+		t.Fatalf("get initialized operator contact: %v", err)
+	}
+	if operatorContact.FormattedName != "Operator" || operatorContact.TrustZone != contacts.ZoneAdmin {
+		t.Fatalf("operator contact = %+v, want Operator in admin zone", operatorContact)
+	}
+	if !strings.Contains(out, operatorID.String()) {
+		t.Fatalf("init output should report operator contact UUID %s", operatorID)
 	}
 
 	// Archive skeleton (#937) — every fresh install gets the directory
@@ -377,6 +420,44 @@ func TestInitFlagErrorsGoToStderr(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "no-such-flag") {
 		t.Fatalf("stderr should carry the flag failure, got:\n%s", stderr.String())
+	}
+}
+
+func TestInitOperatorNameFlagNamesBootstrappedContact(t *testing.T) {
+	requireGit(t)
+	dir := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	if err := runInitCommand(&stdout, &stderr, []string{"-self-signed", "-operator-name", "Alice Example", dir}); err != nil {
+		t.Fatalf("runInitCommand: %v\nstderr:\n%s", err, stderr.String())
+	}
+
+	var generated struct {
+		Identity struct {
+			OperatorContactID string `yaml:"operator_contact_id"`
+		} `yaml:"identity"`
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "core", "config.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := yaml.Unmarshal(data, &generated); err != nil {
+		t.Fatal(err)
+	}
+	id, err := uuid.Parse(generated.Identity.OperatorContactID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := contacts.Open(filepath.Join(dir, "db", "contacts.db"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	operator, err := store.Get(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if operator.FormattedName != "Alice Example" {
+		t.Fatalf("operator contact name = %q, want Alice Example", operator.FormattedName)
 	}
 }
 

--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -161,17 +161,45 @@ value is rejected at config load; a UUID that matches no contact fails
 closed at render time — the devices degrade to account-only
 attribution and a warning names the unresolved binding.
 
-The second counterparty edge — binding a contact to its Home Assistant
+The second counterparty edge binds a contact to its Home Assistant
 person entity, through which zone state and separately resolved,
 provider-attributed room presence flow into that contact's channel
-context — is set on the contact card itself:
-add an `X-THANE-HA-PERSON` field (e.g. `person.alice`) via CardDAV,
-which is the operator-authenticated surface and the only one that
-honors the header. Model-facing vCard import ignores it, at most one
-active contact may claim a given person entity, and removing the field
-clears the binding. Presence flows only for entities the tracker
-watches: the same entity must also be listed under `person.track`, or
-the binding resolves but the presence join has nothing to report.
+context. Signed config is the preferred source of truth:
+
+```yaml
+identity:
+  operator_contact_id: 019c76e4-2ff1-7918-8d6f-6c2488f5098d
+
+person:
+  track:
+    - person.nugget
+  contact_bindings:
+    019c76e4-2ff1-7918-8d6f-6c2488f5098d: person.nugget
+```
+
+`identity.operator_contact_id` says which stable contact is the human
+operator; it does not infer that authority from presence. The legacy
+`identity.owner_contact_name` selector remains accepted for existing
+installations, but it is mutually exclusive with the UUID selector.
+When neither is configured, Thane falls back to the sole `admin`
+contact only when exactly one exists. New `thane init` workspaces create
+an `admin`-zone `Operator` contact stub, write its UUID into the signed
+config, and start with an explicit empty `person.contact_bindings` map.
+
+`person.contact_bindings` is an exact contact-UUID-to-person-entity map.
+Every referenced contact must exist at startup, every person entity must
+also appear under `person.track`, and a person may belong to only one
+active contact. When the key is present — even as `{}` — startup
+atomically reconciles the stored set to config. CardDAV still emits
+`X-THANE-HA-PERSON`, but treats it as a read-only projection and preserves
+it when clients omit unknown vCard fields. Removing a map entry clears
+that binding on the next restart.
+
+For backward compatibility, omitting `person.contact_bindings` entirely
+keeps the earlier CardDAV-managed behavior: an authenticated PUT may set
+or clear `X-THANE-HA-PERSON`. Model-facing vCard import never honors that
+field in either mode.
+
 The person tracker follows each person's Home Assistant `device_trackers`
 attribute and adds those linked entities to the system ingestion floor. A
 linked tracker contributes room presence only when its entity-registry

--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -195,7 +195,16 @@ atomically reconciles the stored set to config. CardDAV still emits
 `X-THANE-HA-PERSON`, but treats it as a read-only projection and preserves
 it when clients omit unknown vCard fields. An explicitly present value must
 match the projection; attempting to change or clear it is rejected. Removing
-a map entry clears that binding on the next restart.
+a map entry clears that binding on the next restart. A contact with a
+configured binding cannot be deleted through CardDAV until its map entry is
+removed and Thane restarts; unbound contacts remain deletable.
+
+Configs loaded through `-insecure-config` cannot declare these identity
+relationships. Thane ignores `person.contact_bindings`,
+`identity.operator_contact_id`, and the legacy
+`identity.owner_contact_name`: it does not reconcile stored bindings or grant
+operator authority from unsigned input, and CardDAV retains its legacy
+authenticated custody mode for bindings during recovery.
 
 For backward compatibility, omitting `person.contact_bindings` entirely
 keeps the earlier CardDAV-managed behavior: an authenticated PUT may set

--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -183,8 +183,9 @@ operator; it does not infer that authority from presence. The legacy
 installations, but it is mutually exclusive with the UUID selector.
 When neither is configured, Thane falls back to the sole `admin`
 contact only when exactly one exists. New `thane init` workspaces create
-an `admin`-zone `Operator` contact stub, write its UUID into the signed
-config, and start with an explicit empty `person.contact_bindings` map.
+a UUID in the signed config first, seed an `admin`-zone `Operator` contact
+stub with that exact ID, and start with an explicit empty
+`person.contact_bindings` map.
 
 `person.contact_bindings` is an exact contact-UUID-to-person-entity map.
 Every referenced contact must exist at startup, every person entity must
@@ -192,8 +193,9 @@ also appear under `person.track`, and a person may belong to only one
 active contact. When the key is present — even as `{}` — startup
 atomically reconciles the stored set to config. CardDAV still emits
 `X-THANE-HA-PERSON`, but treats it as a read-only projection and preserves
-it when clients omit unknown vCard fields. Removing a map entry clears
-that binding on the next restart.
+it when clients omit unknown vCard fields. An explicitly present value must
+match the projection; attempting to change or clear it is rejected. Removing
+a map entry clears that binding on the next restart.
 
 For backward compatibility, omitting `person.contact_bindings` entirely
 keeps the earlier CardDAV-managed behavior: an authenticated PUT may set
@@ -245,11 +247,14 @@ runtime-only tags from source defaults.
 ## Memory & Storage
 
 ```yaml
-data_dir: ~/Thane/data
+data_dir: ./db
 ```
 
-Where SQLite databases live (`thane.db`, `facts.db`). Defaults to
-`~/Thane/data`.
+Where SQLite databases live. Defaults to `./db`. For the normal signed config
+at `{workspace}/core/config.yaml`, relative paths resolve from the workspace,
+so the default is `{workspace}/db` regardless of the directory that launched
+Thane. Absolute paths remain unchanged; a config outside a workspace retains
+working-directory-relative behavior.
 
 ## Document Roots
 

--- a/docs/operating/getting-started.md
+++ b/docs/operating/getting-started.md
@@ -49,9 +49,10 @@ material, `core/config.yaml`, and the bundled talents under
 `core/talents/`. A reference `config.example.yaml` and
 `persona.example.md` are also written at the workspace root.
 
-Initialization also creates an `admin`-zone operator contact stub in
-`db/contacts.db` and records its stable UUID as
-`identity.operator_contact_id` in the signed config. Pass
+Initialization first generates a stable UUID into
+`identity.operator_contact_id` in the signed config, then seeds an
+`admin`-zone operator contact stub with that exact UUID in `db/contacts.db`.
+Pass
 `-operator-name "Your Name"` to `thane init` to name it immediately; the
 default display name is `Operator`. The generated config includes an explicit
 empty `person.contact_bindings` map, ready for UUID-to-Home-Assistant-person

--- a/docs/operating/getting-started.md
+++ b/docs/operating/getting-started.md
@@ -49,6 +49,14 @@ material, `core/config.yaml`, and the bundled talents under
 `core/talents/`. A reference `config.example.yaml` and
 `persona.example.md` are also written at the workspace root.
 
+Initialization also creates an `admin`-zone operator contact stub in
+`db/contacts.db` and records its stable UUID as
+`identity.operator_contact_id` in the signed config. Pass
+`-operator-name "Your Name"` to `thane init` to name it immediately; the
+default display name is `Operator`. The generated config includes an explicit
+empty `person.contact_bindings` map, ready for UUID-to-Home-Assistant-person
+bindings once `person.track` is configured.
+
 In normal operation the runtime reads `core/config.yaml` from the
 workspace and nothing else (`-insecure-config` exists as a recovery path
 for loading a file from outside the trust boundary, at the cost of a

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -44,8 +44,9 @@ Starts these listeners:
 
 Initialize a Thane workspace with bundled defaults. Creates the directory
 structure, the archive skeleton, and `db/contacts.db` with an initial
-`admin`-zone operator contact. Its stable UUID is written to
-`identity.operator_contact_id` in `core/config.yaml`, and the new config
+`admin`-zone operator contact. Its stable UUID is generated into
+`identity.operator_contact_id` in `core/config.yaml` first, then used to seed
+the contact database. The new config
 starts with an explicit empty `person.contact_bindings` map. The same signed
 core birth commit carries the generated identity material (signing key and
 channel CA), default policy, and bundled talents. Reference copies of the

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -42,21 +42,26 @@ Starts these listeners:
 
 ### `thane init [dir]`
 
-Initialize a Thane working directory with bundled defaults. Creates the
-directory structure (`db/`, `talents/`, `archive/`), writes a default
-`config.yaml` (0600 permissions, contains placeholders for secrets) and a
-default `persona.md`, deploys the embedded talent corpus, bootstraps the
-core identity (signing key, channel CA) and the archive skeleton
-(orientation READMEs + the `interactions/` schema stub). Existing files
-are never overwritten — re-runs report `(exists, skipping)` per file, so
-it's safe to run against an established workspace to fill in anything
-missing.
+Initialize a Thane workspace with bundled defaults. Creates the directory
+structure, the archive skeleton, and `db/contacts.db` with an initial
+`admin`-zone operator contact. Its stable UUID is written to
+`identity.operator_contact_id` in `core/config.yaml`, and the new config
+starts with an explicit empty `person.contact_bindings` map. The same signed
+core birth commit carries the generated identity material (signing key and
+channel CA), default policy, and bundled talents. Reference copies of the
+example config and persona are written at the workspace root. Existing files
+are never overwritten — re-runs report `(exists, skipping)` per file.
 
 `dir` defaults to the current directory.
 
 ```bash
 thane init ~/Thane
+thane init -operator-name "Alice Example" ~/Thane
 ```
+
+`-operator-name` controls the initial contact's display name and defaults to
+`Operator`. It does not affect the cryptographic operator principal selected
+by `-operator-key` / `-operator-principal`.
 
 ### `thane validate`
 
@@ -265,4 +270,3 @@ it is diagnosed.
 
 `-config` was the previous name and is now rejected with a message
 pointing at `-workspace` for the ordinary case.
-

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -256,6 +256,10 @@ to act on the world as though someone had:
 - **Service loops do not start automatically.** Unattended work needs a
   verified instance; an operator can still launch a specific loop
   deliberately.
+- **Contact identity configuration is ignored.** Unsigned
+  `person.contact_bindings`, `identity.operator_contact_id`, and legacy
+  `identity.owner_contact_name` values cannot rewrite persisted bindings or
+  select who receives operator authority.
 - **`/health` reports `status: degraded` with `trust: unverified`**, so a
   supervisor cannot mistake a recovery session for a healthy instance
   left running indefinitely.

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -277,9 +277,9 @@ being reimplemented in each loop prompt.
 
 | Tool | Description |
 |------|-------------|
-| `contact_owner` | Return the runtime owner identity. Protected tag. |
+| `contact_owner` | Return the runtime operator contact. Protected tag; name retained for compatibility. |
 
-Owner channel activity recency is reported with delta fields such as
+Operator channel activity recency is reported with delta fields such as
 `last_active_delta`.
 
 ## `files` — workspace filesystem access

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -979,7 +979,8 @@ compaction:
 #   as an empty map, signed configuration is the exact source of truth:
 #   startup atomically replaces the stored bindings and CardDAV exposes
 #   X-THANE-HA-PERSON as read-only. When absent, legacy CardDAV-managed
-#   bindings remain enabled.
+#   bindings remain enabled. Unverified configs cannot own or reconcile
+#   bindings; this key is ignored in recovery mode.
 #   contact_bindings:
 #     0d1f8a6e-4c2b-4b7e-9f00-3a7d0e2c9b41: person.alice
 #   Devices maps tracked person entity IDs to their wireless device
@@ -1130,13 +1131,14 @@ compaction:
 #   OperatorContactID is the stable UUID of the primary human operator's
 #   contact record. It is preferred over the legacy name-based selector
 #   because contact display names can change. The referenced active
-#   contact must exist at startup.
+#   contact must exist at startup. Ignored when the config is unverified.
 #   operator_contact_id: 0d1f8a6e-4c2b-4b7e-9f00-3a7d0e2c9b41
 #   OwnerContactName is the formatted name of the primary human
 #   operator's contact record. This legacy selector remains for
 #   compatibility; prefer OperatorContactID. The two selectors are
 #   mutually exclusive. When neither is set, contact_owner falls back
-#   to the sole admin contact if exactly one exists.
+#   to the sole admin contact if exactly one exists. Ignored when the
+#   config is unverified.
 #   owner_contact_name: ""
 #
 # (optional) Attachments configures content-addressed attachment storage.

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -696,7 +696,9 @@ shell_exec:
 # DataDir is the root directory for SQLite databases and other
 # opaque runtime state (memory, facts, scheduler, checkpoints).
 # Keep this separate from human-authored and model-authored
-# document roots. Default: "./db".
+# document roots. Relative paths are resolved from the workspace;
+# without a workspace they remain relative to the working directory.
+# Default: "./db".
 data_dir: ./db
 #
 # (optional) Archive configures session archive behavior.

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -972,6 +972,14 @@ compaction:
 #   track:
 #     - person.alice
 #     - person.bob
+#   ContactBindings maps stable contact UUIDs to tracked Home
+#   Assistant person entity IDs. When this key is present, including
+#   as an empty map, signed configuration is the exact source of truth:
+#   startup atomically replaces the stored bindings and CardDAV exposes
+#   X-THANE-HA-PERSON as read-only. When absent, legacy CardDAV-managed
+#   bindings remain enabled.
+#   contact_bindings:
+#     0d1f8a6e-4c2b-4b7e-9f00-3a7d0e2c9b41: person.alice
 #   Devices maps tracked person entity IDs to their wireless device
 #   MAC addresses. Used by the UniFi poller to determine which person
 #   a wireless client belongs to for room-level presence.
@@ -1111,18 +1119,23 @@ compaction:
 #       default_from: Thane <thane@example.com>
 #       sent_folder: ""
 #
-# (optional) Identity configures the agent's own contact identity for vCard
+# (optional) Identity configures contact identities for the agent and human operator.
 # identity:
 #   ContactName is the formatted name of the agent's own contact
 #   record. When set, contact_export_vcf name="self" resolves to this
 #   contact.
 #   contact_name: Thane
+#   OperatorContactID is the stable UUID of the primary human operator's
+#   contact record. It is preferred over the legacy name-based selector
+#   because contact display names can change. The referenced active
+#   contact must exist at startup.
+#   operator_contact_id: 0d1f8a6e-4c2b-4b7e-9f00-3a7d0e2c9b41
 #   OwnerContactName is the formatted name of the primary human
-#   owner/operator contact record. When set, the contact_owner tool
-#   resolves directly to this contact instead of guessing from trust
-#   zones. When empty, contact_owner falls back to the sole admin
-#   contact if exactly one exists.
-#   owner_contact_name: Operator Name
+#   operator's contact record. This legacy selector remains for
+#   compatibility; prefer OperatorContactID. The two selectors are
+#   mutually exclusive. When neither is set, contact_owner falls back
+#   to the sole admin contact if exactly one exists.
+#   owner_contact_name: ""
 #
 # (optional) Attachments configures content-addressed attachment storage.
 # attachments:

--- a/internal/app/adapters.go
+++ b/internal/app/adapters.go
@@ -148,20 +148,21 @@ func (r *contactPhoneResolver) ResolvePhone(phone string) (string, string, bool)
 // contactChannelBindingResolver resolves a channel/address pair to a
 // typed conversation binding with contact identity when available.
 type contactChannelBindingResolver struct {
-	store            *contacts.Store
-	ownerContactName string
+	store                  *contacts.Store
+	operatorContactID      uuid.UUID
+	legacyOwnerContactName string
 
-	mu                 sync.Mutex
-	ownerContactID     uuid.UUID
-	ownerContactCached bool
+	mu                      sync.Mutex
+	legacyOperatorContactID uuid.UUID
+	legacyOperatorCached    bool
 }
 
 // ResolveChannelBinding returns a typed binding for the given
 // channel/address pair. It always returns a channel-scoped binding when
 // the inputs are non-empty, even if no contact match is found.
 func (r *contactChannelBindingResolver) ResolveChannelBinding(channel, address string) *memory.ChannelBinding {
-	ownerConfigured := strings.TrimSpace(r.ownerContactName) != ""
-	return resolveChannelBinding(r.store, channel, address, ownerConfigured, r.cachedOwnerContactID())
+	operatorConfigured := r.operatorContactID != uuid.Nil || strings.TrimSpace(r.legacyOwnerContactName) != ""
+	return resolveChannelBinding(r.store, channel, address, operatorConfigured, r.resolvedOperatorContactID())
 }
 
 // contactNameLookup resolves contact names to rich context profiles for
@@ -569,23 +570,32 @@ func resolveChannelBinding(store *contacts.Store, channel, address string, owner
 	return binding.Normalize()
 }
 
-func (r *contactChannelBindingResolver) cachedOwnerContactID() uuid.UUID {
-	if r == nil || r.store == nil || strings.TrimSpace(r.ownerContactName) == "" {
+func (r *contactChannelBindingResolver) resolvedOperatorContactID() uuid.UUID {
+	if r == nil {
+		return uuid.Nil
+	}
+	if r.operatorContactID != uuid.Nil {
+		return r.operatorContactID
+	}
+	if r.store == nil {
+		return uuid.Nil
+	}
+	if strings.TrimSpace(r.legacyOwnerContactName) == "" {
 		return uuid.Nil
 	}
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if r.ownerContactCached {
-		return r.ownerContactID
+	if r.legacyOperatorCached {
+		return r.legacyOperatorContactID
 	}
 
-	owner, err := r.store.ResolveContact(r.ownerContactName)
-	if err == nil && owner != nil {
-		r.ownerContactID = owner.ID
+	operator, err := r.store.ResolveContact(r.legacyOwnerContactName)
+	if err == nil && operator != nil {
+		r.legacyOperatorContactID = operator.ID
 	}
-	r.ownerContactCached = true
-	return r.ownerContactID
+	r.legacyOperatorCached = true
+	return r.legacyOperatorContactID
 }
 
 func isOwnerContact(store *contacts.Store, contact *contacts.Contact, ownerConfigured bool, ownerContactID uuid.UUID) bool {

--- a/internal/app/adapters_test.go
+++ b/internal/app/adapters_test.go
@@ -286,7 +286,7 @@ func TestDetachedLoopCompletionDispatcherRequiresConversationID(t *testing.T) {
 	}
 }
 
-func TestContactChannelBindingResolverCachesConfiguredOwnerContact(t *testing.T) {
+func TestContactChannelBindingResolverCachesLegacyConfiguredContactName(t *testing.T) {
 	db, err := database.Open(t.TempDir() + "/contacts.db")
 	if err != nil {
 		t.Fatalf("database.Open: %v", err)
@@ -313,19 +313,27 @@ func TestContactChannelBindingResolverCachesConfiguredOwnerContact(t *testing.T)
 	}
 
 	resolver := &contactChannelBindingResolver{
-		store:            store,
-		ownerContactName: "Aimee",
+		store:                  store,
+		legacyOwnerContactName: "Aimee",
 	}
 
-	first := resolver.cachedOwnerContactID()
+	first := resolver.resolvedOperatorContactID()
 	if first == uuid.Nil {
-		t.Fatal("cachedOwnerContactID() returned zero UUID")
+		t.Fatal("resolvedOperatorContactID() returned zero UUID")
 	}
 
-	resolver.ownerContactName = "Nobody"
-	second := resolver.cachedOwnerContactID()
+	resolver.legacyOwnerContactName = "Nobody"
+	second := resolver.resolvedOperatorContactID()
 	if second != first {
-		t.Fatalf("cachedOwnerContactID() after rename = %v, want cached %v", second, first)
+		t.Fatalf("resolvedOperatorContactID() after rename = %v, want cached %v", second, first)
+	}
+}
+
+func TestContactChannelBindingResolverUsesConfiguredOperatorID(t *testing.T) {
+	configured := uuid.New()
+	resolver := &contactChannelBindingResolver{operatorContactID: configured}
+	if got := resolver.resolvedOperatorContactID(); got != configured {
+		t.Fatalf("resolvedOperatorContactID() = %v, want configured %v", got, configured)
 	}
 }
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -83,6 +83,10 @@ type App struct {
 	logger *slog.Logger
 	stdout io.Writer
 
+	// contactBindingsConfigOwned records the verified startup decision so
+	// CardDAV cannot reinterpret an ignored unverified config later.
+	contactBindingsConfigOwned bool
+
 	// LLM clients
 	llmClient             llm.Client
 	ollamaClients         map[string]*modelproviders.OllamaClient

--- a/internal/app/contact_identity_config_test.go
+++ b/internal/app/contact_identity_config_test.go
@@ -1,0 +1,93 @@
+package app
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/nugget/thane-ai-agent/internal/platform/config"
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
+	"github.com/nugget/thane-ai-agent/internal/state/contacts"
+)
+
+func newContactIdentityTestStore(t *testing.T) *contacts.Store {
+	t.Helper()
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store, err := contacts.NewStore(db, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
+func TestApplyContactIdentityConfigVerifiedAppliesAuthority(t *testing.T) {
+	store := newContactIdentityTestStore(t)
+	operator, err := store.Upsert(&contacts.Contact{FormattedName: "Operator", TrustZone: contacts.ZoneAdmin})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := config.Default()
+	cfg.Identity.OperatorContactID = operator.ID.String()
+	cfg.Person.ContactBindings = map[string]string{operator.ID.String(): "person.operator"}
+
+	resolved, err := applyContactIdentityConfig(cfg, store, slog.Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.operatorContactID != operator.ID || !resolved.configOwnsHAPersonBindings {
+		t.Fatalf("resolved config = %+v", resolved)
+	}
+	if entity, exists, err := store.HAPersonEntity(operator.ID); err != nil || !exists || entity != "person.operator" {
+		t.Fatalf("configured binding = %q, %v, %v", entity, exists, err)
+	}
+}
+
+func TestApplyContactIdentityConfigUnverifiedCannotChangeAuthority(t *testing.T) {
+	store := newContactIdentityTestStore(t)
+	persisted, err := store.Upsert(&contacts.Contact{FormattedName: "Persisted Operator", TrustZone: contacts.ZoneAdmin})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetHAPersonEntity(persisted.ID, "person.persisted"); err != nil {
+		t.Fatal(err)
+	}
+	selected, err := store.Upsert(&contacts.Contact{FormattedName: "Unsigned Selection"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := config.Default()
+	cfg.Identity.OperatorContactID = selected.ID.String()
+	cfg.Person.ContactBindings = map[string]string{selected.ID.String(): "person.unsigned"}
+	cfg.MarkUnverified()
+
+	resolved, err := applyContactIdentityConfig(cfg, store, slog.Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.operatorContactID != uuid.Nil || resolved.legacyOwnerContactName != "" || resolved.configOwnsHAPersonBindings {
+		t.Fatalf("unverified config resolved authority: %+v", resolved)
+	}
+	if entity, exists, err := store.HAPersonEntity(persisted.ID); err != nil || !exists || entity != "person.persisted" {
+		t.Fatalf("persisted binding changed = %q, %v, %v", entity, exists, err)
+	}
+	if entity, exists, err := store.HAPersonEntity(selected.ID); err != nil || !exists || entity != "" {
+		t.Fatalf("unsigned binding applied = %q, %v, %v", entity, exists, err)
+	}
+
+	legacy := config.Default()
+	legacy.Identity.OwnerContactName = selected.FormattedName
+	legacy.MarkUnverified()
+	resolved, err = applyContactIdentityConfig(legacy, store, slog.Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.legacyOwnerContactName != "" {
+		t.Fatalf("unverified legacy owner selector applied: %+v", resolved)
+	}
+}

--- a/internal/app/new_channels.go
+++ b/internal/app/new_channels.go
@@ -48,6 +48,58 @@ func toMCPToolOverrides(cfg map[string]config.MCPToolConfig) map[string]mcp.Tool
 	return out
 }
 
+type contactIdentityConfig struct {
+	operatorContactID          uuid.UUID
+	legacyOwnerContactName     string
+	configOwnsHAPersonBindings bool
+}
+
+// applyContactIdentityConfig is the signed-config custody boundary for
+// persistent contact-to-person edges and operator selection. Recovery configs
+// remain useful, but cannot rewrite those edges or choose who receives
+// operator authority because their provenance is deliberately unverified.
+func applyContactIdentityConfig(cfg *config.Config, store *contacts.Store, logger *slog.Logger) (contactIdentityConfig, error) {
+	var resolved contactIdentityConfig
+	if cfg.Unverified() {
+		if cfg.Person.ContactBindings != nil || cfg.Identity.OperatorContactID != "" || cfg.Identity.OwnerContactName != "" {
+			logger.Warn("ignoring contact identity configuration: config is unverified",
+				"person_contact_bindings", cfg.Person.ContactBindings != nil,
+				"operator_contact_id", cfg.Identity.OperatorContactID != "",
+				"legacy_owner_contact_name", cfg.Identity.OwnerContactName != "")
+		}
+		return resolved, nil
+	}
+
+	resolved.configOwnsHAPersonBindings = cfg.Person.ContactBindings != nil
+	if resolved.configOwnsHAPersonBindings {
+		bindings := make(map[uuid.UUID]string, len(cfg.Person.ContactBindings))
+		for rawID, entity := range cfg.Person.ContactBindings {
+			id, err := uuid.Parse(rawID)
+			if err != nil {
+				return contactIdentityConfig{}, fmt.Errorf("parse configured contact binding %q: %w", rawID, err)
+			}
+			bindings[id] = entity
+		}
+		if err := store.ReplaceHAPersonBindings(bindings); err != nil {
+			return contactIdentityConfig{}, fmt.Errorf("apply person.contact_bindings: %w", err)
+		}
+		logger.Info("configured contact-to-person bindings applied", "count", len(bindings))
+	}
+
+	if cfg.Identity.OperatorContactID != "" {
+		operatorContactID, err := uuid.Parse(cfg.Identity.OperatorContactID)
+		if err != nil {
+			return contactIdentityConfig{}, fmt.Errorf("parse identity.operator_contact_id: %w", err)
+		}
+		if _, err := store.Get(operatorContactID); err != nil {
+			return contactIdentityConfig{}, fmt.Errorf("resolve identity.operator_contact_id %s: %w", operatorContactID, err)
+		}
+		resolved.operatorContactID = operatorContactID
+	}
+	resolved.legacyOwnerContactName = cfg.Identity.OwnerContactName
+	return resolved, nil
+}
+
 // initChannels wires tools and external channels into the agent loop.
 // Sections include fact store, contact directory, notifications, email,
 // forge, working memory, fact extraction, provenance,
@@ -82,31 +134,13 @@ func (a *App) initChannels(s *newState) error {
 	a.onCloseErr("contacts", contactStore.Close)
 	a.contactStore = contactStore
 
-	if a.cfg.Person.ContactBindings != nil {
-		bindings := make(map[uuid.UUID]string, len(a.cfg.Person.ContactBindings))
-		for rawID, entity := range a.cfg.Person.ContactBindings {
-			id, parseErr := uuid.Parse(rawID)
-			if parseErr != nil {
-				return fmt.Errorf("parse configured contact binding %q: %w", rawID, parseErr)
-			}
-			bindings[id] = entity
-		}
-		if err := contactStore.ReplaceHAPersonBindings(bindings); err != nil {
-			return fmt.Errorf("apply person.contact_bindings: %w", err)
-		}
-		a.logger.Info("configured contact-to-person bindings applied", "count", len(bindings))
+	contactIdentity, err := applyContactIdentityConfig(a.cfg, contactStore, a.logger)
+	if err != nil {
+		return err
 	}
-
-	var operatorContactID uuid.UUID
-	if a.cfg.Identity.OperatorContactID != "" {
-		operatorContactID, err = uuid.Parse(a.cfg.Identity.OperatorContactID)
-		if err != nil {
-			return fmt.Errorf("parse identity.operator_contact_id: %w", err)
-		}
-		if _, err := contactStore.Get(operatorContactID); err != nil {
-			return fmt.Errorf("resolve identity.operator_contact_id %s: %w", operatorContactID, err)
-		}
-	}
+	a.contactBindingsConfigOwned = contactIdentity.configOwnsHAPersonBindings
+	operatorContactID := contactIdentity.operatorContactID
+	legacyOwnerContactName := contactIdentity.legacyOwnerContactName
 
 	// Wire summarizer → contact interaction tracking now that the
 	// contact store is available. Register the callback before Start()
@@ -127,8 +161,8 @@ func (a *App) initChannels(s *newState) error {
 	if operatorContactID != uuid.Nil {
 		contactTools.ConfigureOperatorContactID(operatorContactID)
 	}
-	if a.cfg.Identity.OwnerContactName != "" {
-		contactTools.SetOwnerContactName(a.cfg.Identity.OwnerContactName)
+	if legacyOwnerContactName != "" {
+		contactTools.SetOwnerContactName(legacyOwnerContactName)
 	}
 	ownerActivity := (&ownerChannelActivityAdapter{
 		loops: &channelLoopAdapter{registry: a.loopRegistry},
@@ -796,7 +830,7 @@ func (a *App) initChannels(s *newState) error {
 				Resolver: &contactChannelBindingResolver{
 					store:                  contactStore,
 					operatorContactID:      operatorContactID,
-					legacyOwnerContactName: a.cfg.Identity.OwnerContactName,
+					legacyOwnerContactName: legacyOwnerContactName,
 				},
 				BindConversation: a.mem.BindConversationChannel,
 				Attachments: sigcli.AttachmentConfig{

--- a/internal/app/new_channels.go
+++ b/internal/app/new_channels.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/nugget/thane-ai-agent/internal/channels/email"
 	sigcli "github.com/nugget/thane-ai-agent/internal/channels/messaging/signal"
 	"github.com/nugget/thane-ai-agent/internal/channels/notifications"
@@ -74,16 +75,38 @@ func (a *App) initChannels(s *newState) error {
 	// --- Contact directory ---
 	// Structured storage for people and organizations. Separate database
 	// from facts to keep concerns isolated.
-	contactDB, err := database.Open(a.cfg.DataDir + "/contacts.db")
-	if err != nil {
-		return fmt.Errorf("open contacts database: %w", err)
-	}
-	a.onCloseErr("contacts", contactDB.Close)
-	contactStore, err := contacts.NewStore(contactDB, a.logger)
+	contactStore, err := contacts.Open(a.cfg.DataDir+"/contacts.db", a.logger)
 	if err != nil {
 		return fmt.Errorf("open contact store: %w", err)
 	}
+	a.onCloseErr("contacts", contactStore.Close)
 	a.contactStore = contactStore
+
+	if a.cfg.Person.ContactBindings != nil {
+		bindings := make(map[uuid.UUID]string, len(a.cfg.Person.ContactBindings))
+		for rawID, entity := range a.cfg.Person.ContactBindings {
+			id, parseErr := uuid.Parse(rawID)
+			if parseErr != nil {
+				return fmt.Errorf("parse configured contact binding %q: %w", rawID, parseErr)
+			}
+			bindings[id] = entity
+		}
+		if err := contactStore.ReplaceHAPersonBindings(bindings); err != nil {
+			return fmt.Errorf("apply person.contact_bindings: %w", err)
+		}
+		a.logger.Info("configured contact-to-person bindings applied", "count", len(bindings))
+	}
+
+	var operatorContactID uuid.UUID
+	if a.cfg.Identity.OperatorContactID != "" {
+		operatorContactID, err = uuid.Parse(a.cfg.Identity.OperatorContactID)
+		if err != nil {
+			return fmt.Errorf("parse identity.operator_contact_id: %w", err)
+		}
+		if _, err := contactStore.Get(operatorContactID); err != nil {
+			return fmt.Errorf("resolve identity.operator_contact_id %s: %w", operatorContactID, err)
+		}
+	}
 
 	// Wire summarizer → contact interaction tracking now that the
 	// contact store is available. Register the callback before Start()
@@ -100,6 +123,9 @@ func (a *App) initChannels(s *newState) error {
 	contactTools := contacts.NewTools(contactStore)
 	if a.cfg.Identity.ContactName != "" {
 		contactTools.SetSelfContactName(a.cfg.Identity.ContactName)
+	}
+	if operatorContactID != uuid.Nil {
+		contactTools.ConfigureOperatorContactID(operatorContactID)
 	}
 	if a.cfg.Identity.OwnerContactName != "" {
 		contactTools.SetOwnerContactName(a.cfg.Identity.OwnerContactName)
@@ -768,8 +794,9 @@ func (a *App) initChannels(s *newState) error {
 				HandleTimeout: a.cfg.Signal.HandleTimeout,
 				Routing:       a.cfg.Signal.Routing,
 				Resolver: &contactChannelBindingResolver{
-					store:            contactStore,
-					ownerContactName: a.cfg.Identity.OwnerContactName,
+					store:                  contactStore,
+					operatorContactID:      operatorContactID,
+					legacyOwnerContactName: a.cfg.Identity.OwnerContactName,
 				},
 				BindConversation: a.mem.BindConversationChannel,
 				Attachments: sigcli.AttachmentConfig{

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -471,7 +471,7 @@ func (a *App) initServers(s *newState) error {
 	// Optional: exposes the contacts store as a CardDAV address book so
 	// native contact apps (macOS Contacts.app, iOS, Thunderbird) can sync.
 	if cfg.CardDAV.Configured() {
-		carddavBackend := cdav.NewBackend(a.contactStore, cfg.Person.ContactBindings != nil, logger)
+		carddavBackend := cdav.NewBackend(a.contactStore, a.contactBindingsConfigOwned, logger)
 		a.carddavServer = cdav.NewServer(
 			cfg.CardDAV.Listen,
 			cfg.CardDAV.Username,

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -471,7 +471,7 @@ func (a *App) initServers(s *newState) error {
 	// Optional: exposes the contacts store as a CardDAV address book so
 	// native contact apps (macOS Contacts.app, iOS, Thunderbird) can sync.
 	if cfg.CardDAV.Configured() {
-		carddavBackend := cdav.NewBackend(a.contactStore, logger)
+		carddavBackend := cdav.NewBackend(a.contactStore, cfg.Person.ContactBindings != nil, logger)
 		a.carddavServer = cdav.NewServer(
 			cfg.CardDAV.Listen,
 			cfg.CardDAV.Username,

--- a/internal/model/toolcatalog/catalog_tags.go
+++ b/internal/model/toolcatalog/catalog_tags.go
@@ -149,7 +149,7 @@ var builtinTagSpecs = map[string]BuiltinTagSpec{
 		Protected:   true,
 	},
 	"owner": {
-		Description: "Trusted owner/operator context set by runtime identity. When present, treat it as true; it can unlock owner-specific guidance and tools.",
+		Description: "Trusted operator context set by runtime identity. When present, treat it as true; it can unlock operator-specific guidance and tools.",
 		Protected:   true,
 		Parents:     []string{"interactive", "people"},
 	},

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -305,7 +305,9 @@ type Config struct {
 	// DataDir is the root directory for SQLite databases and other
 	// opaque runtime state (memory, facts, scheduler, checkpoints).
 	// Keep this separate from human-authored and model-authored
-	// document roots. Default: "./db".
+	// document roots. Relative paths are resolved from the workspace;
+	// without a workspace they remain relative to the working directory.
+	// Default: "./db".
 	DataDir string `yaml:"data_dir"`
 
 	// TalentsDir is the directory holding the talent markdown that extends
@@ -2896,9 +2898,7 @@ func (c *Config) applyDefaults() {
 	if c.Listen.Port == 0 {
 		c.Listen.Port = 8080
 	}
-	if c.DataDir == "" {
-		c.DataDir = "./db"
-	}
+	c.DataDir = ResolveDataDir(c.Workspace.Path, c.DataDir)
 	if c.TalentsDir == "" {
 		// Derived, never authored: talents live inside core so they carry the
 		// same signed history and the same cleanliness rule as the prompts
@@ -3123,6 +3123,22 @@ func (c *Config) applyDefaults() {
 			c.Models.Available[i].Provider = "ollama"
 		}
 	}
+}
+
+// ResolveDataDir applies the data directory default and anchors a relative
+// path to workspace. Config loaded from core always has a derived workspace,
+// so its opaque runtime state follows the instance instead of the process's
+// current working directory. Callers without a workspace retain the historical
+// working-directory-relative behavior.
+func ResolveDataDir(workspace, dataDir string) string {
+	dataDir = strings.TrimSpace(dataDir)
+	if dataDir == "" {
+		dataDir = "./db"
+	}
+	if filepath.IsAbs(dataDir) || strings.TrimSpace(workspace) == "" {
+		return dataDir
+	}
+	return filepath.Join(workspace, dataDir)
 }
 
 // Validate checks that the configuration is internally consistent after

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -351,7 +351,7 @@ type Config struct {
 	CapabilityTags map[string]CapabilityTagConfig `yaml:"capability_tags"`
 
 	// ChannelTags maps source channels to broad optional capability tags.
-	// Use this for coarse source defaults, not runtime facts such as owner
+	// Use this for coarse source defaults, not runtime facts such as operator
 	// identity or current message-channel affordances. Runtime-only tags
 	// such as owner and message_channel are skipped here; they must be
 	// asserted by trusted current-run evidence. This is additive to
@@ -389,8 +389,7 @@ type Config struct {
 	// email server subprocess.
 	Email email.Config `yaml:"email"`
 
-	// Identity configures the agent's own contact identity for vCard
-	// export and self-referencing operations.
+	// Identity configures contact identities for the agent and human operator.
 	Identity IdentityConfig `yaml:"identity"`
 
 	// Attachments configures content-addressed attachment storage.
@@ -876,21 +875,28 @@ func (c CompanionConfig) TokenIndex() map[string]string {
 	return idx
 }
 
-// IdentityConfig configures the agent's own contact identity. The
-// ContactName must match a contact record in the directory to enable
-// self-referencing operations like vCard export.
+// IdentityConfig configures the agent's own contact identity and the primary
+// human operator's stable contact reference. ContactName must match a contact
+// record in the directory to enable self-referencing operations like vCard
+// export.
 type IdentityConfig struct {
 	// ContactName is the formatted name of the agent's own contact
 	// record. When set, contact_export_vcf name="self" resolves to this
 	// contact.
 	ContactName string `yaml:"contact_name"`
 
+	// OperatorContactID is the stable UUID of the primary human operator's
+	// contact record. It is preferred over the legacy name-based selector
+	// because contact display names can change. The referenced active
+	// contact must exist at startup.
+	OperatorContactID string `yaml:"operator_contact_id"`
+
 	// OwnerContactName is the formatted name of the primary human
-	// owner/operator contact record. When set, the contact_owner tool
-	// resolves directly to this contact instead of guessing from trust
-	// zones. When empty, contact_owner falls back to the sole admin
-	// contact if exactly one exists.
-	OwnerContactName string `yaml:"owner_contact_name"`
+	// operator's contact record. This legacy selector remains for
+	// compatibility; prefer OperatorContactID. The two selectors are
+	// mutually exclusive. When neither is set, contact_owner falls back
+	// to the sole admin contact if exactly one exists.
+	OwnerContactName string `yaml:"owner_contact_name,omitempty"`
 }
 
 // AttachmentsConfig configures content-addressed attachment storage.
@@ -1942,6 +1948,14 @@ type PersonConfig struct {
 	// (e.g., ["person.nugget", "person.dan"]). Each entry must begin
 	// with "person.". An empty list disables person tracking.
 	Track []string `yaml:"track"`
+
+	// ContactBindings maps stable contact UUIDs to tracked Home
+	// Assistant person entity IDs. When this key is present, including
+	// as an empty map, signed configuration is the exact source of truth:
+	// startup atomically replaces the stored bindings and CardDAV exposes
+	// X-THANE-HA-PERSON as read-only. When absent, legacy CardDAV-managed
+	// bindings remain enabled.
+	ContactBindings map[string]string `yaml:"contact_bindings"`
 
 	// Devices maps tracked person entity IDs to their wireless device
 	// MAC addresses. Used by the UniFi poller to determine which person
@@ -3143,6 +3157,15 @@ func (c *Config) Validate() error {
 			}
 		}
 	}
+	if c.Identity.OperatorContactID != "" {
+		operatorID, err := uuid.Parse(c.Identity.OperatorContactID)
+		if err != nil || operatorID == uuid.Nil || operatorID.String() != c.Identity.OperatorContactID {
+			return fmt.Errorf("identity.operator_contact_id %q must be a canonical non-nil UUID", c.Identity.OperatorContactID)
+		}
+		if strings.TrimSpace(c.Identity.OwnerContactName) != "" {
+			return fmt.Errorf("identity.operator_contact_id and legacy identity.owner_contact_name are mutually exclusive")
+		}
+	}
 	// Validate logging — both new and deprecated fields.
 	if c.Logging.Level != "" {
 		if _, err := ParseLogLevel(c.Logging.Level); err != nil {
@@ -3257,6 +3280,29 @@ func (c *Config) Validate() error {
 	for _, id := range c.Person.Track {
 		tracked[id] = true
 	}
+	contactIDs := make([]string, 0, len(c.Person.ContactBindings))
+	for contactID := range c.Person.ContactBindings {
+		contactIDs = append(contactIDs, contactID)
+	}
+	sort.Strings(contactIDs)
+	claimedPeople := make(map[string]string, len(contactIDs))
+	for _, contactID := range contactIDs {
+		parsed, err := uuid.Parse(contactID)
+		if err != nil || parsed == uuid.Nil || parsed.String() != contactID {
+			return fmt.Errorf("person.contact_bindings key %q must be a canonical non-nil contact UUID", contactID)
+		}
+		entityID := c.Person.ContactBindings[contactID]
+		if !validHAPersonEntityID(entityID) {
+			return fmt.Errorf("person.contact_bindings[%s] %q must match person.<object_id> (lowercase letters, digits, underscores)", contactID, entityID)
+		}
+		if !tracked[entityID] {
+			return fmt.Errorf("person.contact_bindings[%s] references untracked entity %q", contactID, entityID)
+		}
+		if holder, exists := claimedPeople[entityID]; exists {
+			return fmt.Errorf("person.contact_bindings assigns %q to both %s and %s", entityID, holder, contactID)
+		}
+		claimedPeople[entityID] = contactID
+	}
 	for entityID := range c.Person.Devices {
 		if !tracked[entityID] {
 			return fmt.Errorf("person.devices references untracked entity %q", entityID)
@@ -3349,6 +3395,19 @@ func (c *Config) Validate() error {
 		return err
 	}
 	return nil
+}
+
+func validHAPersonEntityID(entityID string) bool {
+	const prefix = "person."
+	if !strings.HasPrefix(entityID, prefix) || len(entityID) == len(prefix) {
+		return false
+	}
+	for _, r := range entityID[len(prefix):] {
+		if (r < 'a' || r > 'z') && (r < '0' || r > '9') && r != '_' {
+			return false
+		}
+	}
+	return true
 }
 
 func (c *Config) validateModels() error {

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -890,14 +890,15 @@ type IdentityConfig struct {
 	// OperatorContactID is the stable UUID of the primary human operator's
 	// contact record. It is preferred over the legacy name-based selector
 	// because contact display names can change. The referenced active
-	// contact must exist at startup.
+	// contact must exist at startup. Ignored when the config is unverified.
 	OperatorContactID string `yaml:"operator_contact_id"`
 
 	// OwnerContactName is the formatted name of the primary human
 	// operator's contact record. This legacy selector remains for
 	// compatibility; prefer OperatorContactID. The two selectors are
 	// mutually exclusive. When neither is set, contact_owner falls back
-	// to the sole admin contact if exactly one exists.
+	// to the sole admin contact if exactly one exists. Ignored when the
+	// config is unverified.
 	OwnerContactName string `yaml:"owner_contact_name,omitempty"`
 }
 
@@ -1956,7 +1957,8 @@ type PersonConfig struct {
 	// as an empty map, signed configuration is the exact source of truth:
 	// startup atomically replaces the stored bindings and CardDAV exposes
 	// X-THANE-HA-PERSON as read-only. When absent, legacy CardDAV-managed
-	// bindings remain enabled.
+	// bindings remain enabled. Unverified configs cannot own or reconcile
+	// bindings; this key is ignored in recovery mode.
 	ContactBindings map[string]string `yaml:"contact_bindings"`
 
 	// Devices maps tracked person entity IDs to their wireless device

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -148,6 +148,58 @@ func TestLoad_ExpandsEnvVars(t *testing.T) {
 	}
 }
 
+func TestLoad_ResolvesDataDirFromDerivedWorkspace(t *testing.T) {
+	absDataDir := t.TempDir()
+	tests := []struct {
+		name    string
+		config  string
+		wantDir func(string) string
+	}{
+		{
+			name:   "default",
+			config: "listen:\n  port: 8080\n",
+			wantDir: func(workspace string) string {
+				return filepath.Join(workspace, "db")
+			},
+		},
+		{
+			name:   "explicit relative",
+			config: "data_dir: state/sqlite\n",
+			wantDir: func(workspace string) string {
+				return filepath.Join(workspace, "state", "sqlite")
+			},
+		},
+		{
+			name:   "absolute remains absolute",
+			config: "data_dir: " + absDataDir + "\n",
+			wantDir: func(string) string {
+				return absDataDir
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workspace := t.TempDir()
+			coreDir := filepath.Join(workspace, "core")
+			if err := os.MkdirAll(coreDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(coreDir, "config.yaml")
+			if err := os.WriteFile(path, []byte(tt.config), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			cfg, err := Load(path)
+			if err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if want := tt.wantDir(workspace); cfg.DataDir != want {
+				t.Fatalf("DataDir = %q, want %q", cfg.DataDir, want)
+			}
+		})
+	}
+}
+
 func TestLoad_InlineSecrets(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 func TestFindConfig_Explicit(t *testing.T) {
@@ -180,6 +182,32 @@ companion:
 	}
 	if got := cfg.Companion.TokenIndex()["secret"]; got != "nugget" {
 		t.Fatalf("token index = %q, want nugget", got)
+	}
+}
+
+func TestLoad_PersonContactBindingsPresenceControlsAuthority(t *testing.T) {
+	tests := []struct {
+		name        string
+		yaml        string
+		wantPresent bool
+	}{
+		{name: "absent keeps legacy authority", yaml: "person:\n  track: []\n"},
+		{name: "explicit empty map selects config authority", yaml: "person:\n  track: []\n  contact_bindings: {}\n", wantPresent: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.yaml")
+			if err := os.WriteFile(path, []byte(tt.yaml), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := Load(path)
+			if err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if got := cfg.Person.ContactBindings != nil; got != tt.wantPresent {
+				t.Fatalf("ContactBindings present = %v, want %v", got, tt.wantPresent)
+			}
+		})
 	}
 }
 
@@ -873,6 +901,116 @@ func TestValidate_LoggingInvalidFormat(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "logging.format") {
 		t.Errorf("error %q should mention logging.format", err)
+	}
+}
+
+func TestValidate_OperatorContactID(t *testing.T) {
+	const contactID = "019c76e4-2ff1-7918-8d6f-6c2488f5098d"
+	tests := []struct {
+		name      string
+		configure func(*Config)
+		wantError string
+	}{
+		{
+			name: "canonical uuid",
+			configure: func(cfg *Config) {
+				cfg.Identity.OperatorContactID = contactID
+			},
+		},
+		{
+			name: "malformed uuid",
+			configure: func(cfg *Config) {
+				cfg.Identity.OperatorContactID = "not-a-uuid"
+			},
+			wantError: "identity.operator_contact_id",
+		},
+		{
+			name: "nil uuid",
+			configure: func(cfg *Config) {
+				cfg.Identity.OperatorContactID = uuid.Nil.String()
+			},
+			wantError: "non-nil UUID",
+		},
+		{
+			name: "legacy name conflicts",
+			configure: func(cfg *Config) {
+				cfg.Identity.OperatorContactID = contactID
+				cfg.Identity.OwnerContactName = "Operator Name"
+			},
+			wantError: "mutually exclusive",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Default()
+			tt.configure(cfg)
+			err := cfg.Validate()
+			if tt.wantError == "" {
+				if err != nil {
+					t.Fatalf("Validate() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("Validate() error = %v, want substring %q", err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestValidate_PersonContactBindings(t *testing.T) {
+	const (
+		aliceID = "019c76e4-2ff1-7918-8d6f-6c2488f5098d"
+		bobID   = "0d1f8a6e-4c2b-4b7e-9f00-3a7d0e2c9b41"
+	)
+	tests := []struct {
+		name      string
+		bindings  map[string]string
+		wantError string
+	}{
+		{
+			name:     "tracked unique bindings",
+			bindings: map[string]string{aliceID: "person.alice", bobID: "person.bob"},
+		},
+		{
+			name:      "malformed contact uuid",
+			bindings:  map[string]string{"alice": "person.alice"},
+			wantError: "canonical non-nil contact UUID",
+		},
+		{
+			name:      "malformed person entity",
+			bindings:  map[string]string{aliceID: "person.Alice"},
+			wantError: "must match person.<object_id>",
+		},
+		{
+			name:      "untracked person entity",
+			bindings:  map[string]string{aliceID: "person.carol"},
+			wantError: "untracked entity",
+		},
+		{
+			name:      "duplicate person claim",
+			bindings:  map[string]string{aliceID: "person.alice", bobID: "person.alice"},
+			wantError: "assigns \"person.alice\" to both",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Default()
+			cfg.Person.Track = []string{"person.alice", "person.bob"}
+			cfg.Person.ContactBindings = tt.bindings
+			err := cfg.Validate()
+			if tt.wantError == "" {
+				if err != nil {
+					t.Fatalf("Validate() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("Validate() error = %v, want substring %q", err, tt.wantError)
+			}
+		})
 	}
 }
 

--- a/internal/platform/config/example.go
+++ b/internal/platform/config/example.go
@@ -232,6 +232,9 @@ func ExampleConfig() *Config {
 
 		Person: PersonConfig{
 			Track: []string{"person.alice", "person.bob"},
+			ContactBindings: map[string]string{
+				"0d1f8a6e-4c2b-4b7e-9f00-3a7d0e2c9b41": "person.alice",
+			},
 			Devices: map[string][]DeviceMapping{
 				"person.alice": {
 					{MAC: "AA:BB:CC:DD:EE:FF"},
@@ -273,8 +276,8 @@ func ExampleConfig() *Config {
 		},
 
 		Identity: IdentityConfig{
-			ContactName:      "Thane",
-			OwnerContactName: "Operator Name",
+			ContactName:       "Thane",
+			OperatorContactID: "0d1f8a6e-4c2b-4b7e-9f00-3a7d0e2c9b41",
 		},
 
 		Attachments: AttachmentsConfig{

--- a/internal/platform/identity/bootstrap.go
+++ b/internal/platform/identity/bootstrap.go
@@ -82,12 +82,16 @@ func operatorPrincipal(operator *OperatorSigner) string {
 // Private key material is written under core/ with 0600 permissions and
 // ignored by git. Public key material, the channel CA certificate, and
 // core/config.yaml are committed together as the signed birth commit.
+// operatorContactID, when non-empty, is written as the stable runtime
+// operator identity. New cores also declare an explicit empty
+// person.contact_bindings map so signed config owns that relationship from
+// birth rather than inheriting the legacy CardDAV mutation path.
 // birthFiles are additional repo-relative files to include in the birth
 // commit. The talent set travels this way: talents steer every turn, so an
 // instance whose behaviour definitions are covered by the same operator
 // signature that founds it is attested from its first moment rather than from
 // whenever someone remembers to commit them.
-func BootstrapCore(ctx context.Context, coreDir, instanceName string, operator *OperatorSigner, birthFiles map[string]string, logger *slog.Logger) (*BootstrapResult, error) {
+func BootstrapCore(ctx context.Context, coreDir, instanceName string, operator *OperatorSigner, operatorContactID string, birthFiles map[string]string, logger *slog.Logger) (*BootstrapResult, error) {
 	absCoreDir, err := filepath.Abs(coreDir)
 	if err != nil {
 		return nil, fmt.Errorf("resolve core dir: %w", err)
@@ -161,7 +165,7 @@ func BootstrapCore(ctx context.Context, coreDir, instanceName string, operator *
 	if err != nil {
 		return nil, err
 	}
-	policy, err := renderCoreConfig(instanceName, now, signing, channelCA, operator)
+	policy, err := renderCoreConfig(instanceName, now, signing, channelCA, operator, operatorContactID)
 	if err != nil {
 		return nil, err
 	}
@@ -282,6 +286,7 @@ type coreConfig struct {
 	Version     int                       `yaml:"version"`
 	GeneratedAt string                    `yaml:"generated_at"`
 	Identity    identityPolicy            `yaml:"identity"`
+	Person      personPolicy              `yaml:"person"`
 	Trust       trustPolicy               `yaml:"trust"`
 	Delegation  delegationPolicy          `yaml:"delegation"`
 	Channels    channelPolicy             `yaml:"channels"`
@@ -289,9 +294,14 @@ type coreConfig struct {
 }
 
 type identityPolicy struct {
-	InstanceName string         `yaml:"instance_name"`
-	SigningKey   signingKeyRef  `yaml:"signing_key"`
-	ChannelCA    certificateRef `yaml:"channel_ca"`
+	InstanceName      string         `yaml:"instance_name"`
+	OperatorContactID string         `yaml:"operator_contact_id,omitempty"`
+	SigningKey        signingKeyRef  `yaml:"signing_key"`
+	ChannelCA         certificateRef `yaml:"channel_ca"`
+}
+
+type personPolicy struct {
+	ContactBindings map[string]string `yaml:"contact_bindings"`
 }
 
 type signingKeyRef struct {
@@ -359,13 +369,14 @@ func coreSeedDeclaration(signing *SigningKeyPair, operator *OperatorSigner) core
 	}}}
 }
 
-func renderCoreConfig(instanceName string, generatedAt time.Time, signing *SigningKeyPair, ca *CertificateAuthority, operator *OperatorSigner) ([]byte, error) {
+func renderCoreConfig(instanceName string, generatedAt time.Time, signing *SigningKeyPair, ca *CertificateAuthority, operator *OperatorSigner, operatorContactID string) ([]byte, error) {
 	cfg := coreConfig{
 		Roots:       map[string]coreRootPolicy{"core": coreSeedDeclaration(signing, operator)},
 		Version:     1,
 		GeneratedAt: generatedAt.Format(time.RFC3339),
 		Identity: identityPolicy{
-			InstanceName: instanceName,
+			InstanceName:      instanceName,
+			OperatorContactID: strings.TrimSpace(operatorContactID),
 			SigningKey: signingKeyRef{
 				PublicKeyPath: SigningPublicKeyFile,
 				Fingerprint:   signing.Fingerprint,
@@ -377,6 +388,7 @@ func renderCoreConfig(instanceName string, generatedAt time.Time, signing *Signi
 				NotAfter:    ca.NotAfter.Format(time.RFC3339),
 			},
 		},
+		Person: personPolicy{ContactBindings: map[string]string{}},
 		Trust: trustPolicy{
 			TrustedPeerCAs: []string{},
 			Revocations:    []string{},

--- a/internal/platform/identity/bootstrap_test.go
+++ b/internal/platform/identity/bootstrap_test.go
@@ -30,8 +30,9 @@ func TestBootstrapCoreCreatesSignedBirthCommit(t *testing.T) {
 	requireGit(t)
 	clearUmask(t)
 
+	const operatorContactID = "019c76e4-2ff1-7918-8d6f-6c2488f5098d"
 	coreDir := filepath.Join(t.TempDir(), "core")
-	result, err := BootstrapCore(t.Context(), coreDir, "pocket", nil, nil, nil)
+	result, err := BootstrapCore(t.Context(), coreDir, "pocket", nil, operatorContactID, nil, nil)
 	if err != nil {
 		t.Fatalf("BootstrapCore: %v", err)
 	}
@@ -79,6 +80,12 @@ func TestBootstrapCoreCreatesSignedBirthCommit(t *testing.T) {
 	}
 	if cfg.Identity.InstanceName != "pocket" {
 		t.Fatalf("instance_name = %q, want pocket", cfg.Identity.InstanceName)
+	}
+	if cfg.Identity.OperatorContactID != operatorContactID {
+		t.Fatalf("operator_contact_id = %q, want %q", cfg.Identity.OperatorContactID, operatorContactID)
+	}
+	if cfg.Person.ContactBindings == nil || len(cfg.Person.ContactBindings) != 0 {
+		t.Fatalf("person.contact_bindings = %#v, want explicit empty map", cfg.Person.ContactBindings)
 	}
 	if cfg.Identity.SigningKey.Fingerprint != result.SigningKeyFingerprint {
 		t.Fatalf("signing fingerprint = %q, want %q", cfg.Identity.SigningKey.Fingerprint, result.SigningKeyFingerprint)
@@ -141,7 +148,7 @@ func TestBootstrapCorePostureFieldsAgree(t *testing.T) {
 					PrivateKeyPath: keyPath,
 				}
 			}
-			result, err := BootstrapCore(t.Context(), filepath.Join(t.TempDir(), "core"), "pocket", operator, nil, nil)
+			result, err := BootstrapCore(t.Context(), filepath.Join(t.TempDir(), "core"), "pocket", operator, "", nil, nil)
 			if err != nil {
 				t.Fatalf("BootstrapCore: %v", err)
 			}
@@ -162,10 +169,10 @@ func TestBootstrapCoreSkipsCompleteIdentity(t *testing.T) {
 	requireGit(t)
 
 	coreDir := filepath.Join(t.TempDir(), "core")
-	if _, err := BootstrapCore(t.Context(), coreDir, "pocket", nil, nil, nil); err != nil {
+	if _, err := BootstrapCore(t.Context(), coreDir, "pocket", nil, "", nil, nil); err != nil {
 		t.Fatalf("first BootstrapCore: %v", err)
 	}
-	result, err := BootstrapCore(t.Context(), coreDir, "pocket", nil, nil, nil)
+	result, err := BootstrapCore(t.Context(), coreDir, "pocket", nil, "", nil, nil)
 	if err != nil {
 		t.Fatalf("second BootstrapCore: %v", err)
 	}
@@ -186,7 +193,7 @@ func TestBootstrapCoreRejectsPartialIdentity(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := BootstrapCore(t.Context(), coreDir, "pocket", nil, nil, nil); err == nil {
+	if _, err := BootstrapCore(t.Context(), coreDir, "pocket", nil, "", nil, nil); err == nil {
 		t.Fatal("BootstrapCore partial identity returned nil, want error")
 	}
 }
@@ -197,7 +204,7 @@ func TestBootstrapCoreRollsBackFailedBirthCommit(t *testing.T) {
 	coreDir := filepath.Join(t.TempDir(), "core")
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
-	if _, err := BootstrapCore(ctx, coreDir, "pocket", nil, nil, nil); err == nil {
+	if _, err := BootstrapCore(ctx, coreDir, "pocket", nil, "", nil, nil); err == nil {
 		t.Fatal("BootstrapCore with canceled context returned nil, want error")
 	}
 
@@ -216,7 +223,7 @@ func TestBootstrapCoreRollsBackFailedBirthCommit(t *testing.T) {
 		}
 	}
 
-	if _, err := BootstrapCore(t.Context(), coreDir, "pocket", nil, nil, nil); err != nil {
+	if _, err := BootstrapCore(t.Context(), coreDir, "pocket", nil, "", nil, nil); err != nil {
 		t.Fatalf("BootstrapCore after rollback: %v", err)
 	}
 }

--- a/internal/platform/identity/evidence_test.go
+++ b/internal/platform/identity/evidence_test.go
@@ -184,7 +184,7 @@ func evidenceCore(t *testing.T, operatorAnchored bool) (string, []provenance.Tru
 			PrivateKeyPath: keyPath,
 		}
 	}
-	if _, err := BootstrapCore(t.Context(), coreDir, "pocket", operator, nil, nil); err != nil {
+	if _, err := BootstrapCore(t.Context(), coreDir, "pocket", operator, "", nil, nil); err != nil {
 		t.Fatalf("BootstrapCore: %v", err)
 	}
 	if operator != nil {

--- a/internal/platform/identity/operator_test.go
+++ b/internal/platform/identity/operator_test.go
@@ -99,7 +99,7 @@ func TestBootstrapCoreAnchorsToAnOperatorKey(t *testing.T) {
 	}
 
 	coreDir := filepath.Join(t.TempDir(), "core")
-	result, err := BootstrapCore(t.Context(), coreDir, "pocket", operator, nil, nil)
+	result, err := BootstrapCore(t.Context(), coreDir, "pocket", operator, "", nil, nil)
 	if err != nil {
 		t.Fatalf("BootstrapCore: %v", err)
 	}
@@ -137,7 +137,7 @@ func TestBootstrapCoreAnchorsToAnOperatorKey(t *testing.T) {
 func TestBootstrapCoreSelfSignedIsAdmissible(t *testing.T) {
 	t.Parallel()
 	coreDir := filepath.Join(t.TempDir(), "core")
-	result, err := BootstrapCore(t.Context(), coreDir, "pocket", nil, nil, nil)
+	result, err := BootstrapCore(t.Context(), coreDir, "pocket", nil, "", nil, nil)
 	if err != nil {
 		t.Fatalf("BootstrapCore: %v", err)
 	}

--- a/internal/server/carddav/backend.go
+++ b/internal/server/carddav/backend.go
@@ -17,14 +17,20 @@ import (
 // Backend implements the [carddav.Backend] interface using the
 // contacts store.  It exposes a single read-write address book.
 type Backend struct {
-	store  *contacts.Store
-	logger *slog.Logger
+	store                      *contacts.Store
+	configOwnsHAPersonBindings bool
+	logger                     *slog.Logger
 }
 
 // NewBackend creates a CardDAV backend backed by the given contact
-// store.
-func NewBackend(store *contacts.Store, logger *slog.Logger) *Backend {
-	return &Backend{store: store, logger: logger}
+// store. When configOwnsHAPersonBindings is true, CardDAV emits the
+// configured X-THANE-HA-PERSON value but cannot mutate it.
+func NewBackend(store *contacts.Store, configOwnsHAPersonBindings bool, logger *slog.Logger) *Backend {
+	return &Backend{
+		store:                      store,
+		configOwnsHAPersonBindings: configOwnsHAPersonBindings,
+		logger:                     logger,
+	}
 }
 
 // CurrentUserPrincipal returns the principal URL for the authenticated
@@ -169,15 +175,35 @@ func (b *Backend) PutAddressObject(_ context.Context, path string, card vcard.Ca
 	contact, props := contacts.CardToContact(card)
 	contact.ID = id
 
-	// X-THANE-HA-PERSON is honored here and only here: CardDAV is the
-	// operator-authenticated surface, so the card is the operator's
-	// custody path for the counterparty binding (#1450). The shared
-	// codec ignores the header, which keeps model-facing vCard import
-	// blind to it. Absent or empty clears the binding, and the binding
-	// commits atomically with the contact and its properties — a
-	// rejected binding (malformed, or a claim another contact holds)
-	// fails the whole PUT with nothing applied.
-	upserted, err := b.store.UpsertWithPropertiesAndHAPerson(contact, props, card.Value("X-THANE-HA-PERSON"))
+	var upserted *contacts.Contact
+	if b.configOwnsHAPersonBindings {
+		currentEntity := ""
+		if exists {
+			var bindingExists bool
+			currentEntity, bindingExists, err = b.store.HAPersonEntity(id)
+			if err != nil {
+				return nil, fmt.Errorf("read configured ha person binding: %w", err)
+			}
+			if !bindingExists {
+				return nil, fmt.Errorf("read configured ha person binding: contact %s disappeared", id)
+			}
+		}
+		incomingEntity := strings.TrimSpace(card.Value("X-THANE-HA-PERSON"))
+		if incomingEntity != "" && incomingEntity != currentEntity {
+			return nil, fmt.Errorf("X-THANE-HA-PERSON is owned by signed person.contact_bindings; edit config and restart Thane")
+		}
+		// Header-less PUTs are normal for clients that discard unknown
+		// vCard extensions. Preserve the configured projection instead of
+		// treating absence as a request to clear it.
+		upserted, err = b.store.UpsertWithProperties(contact, props)
+	} else {
+		// Legacy custody: when person.contact_bindings is absent, CardDAV
+		// remains the operator-authenticated mutation surface. The shared
+		// codec ignores the header, keeping model-facing imports blind to
+		// it. Absent or empty clears the binding, and a rejected claim fails
+		// the whole PUT atomically with the contact update.
+		upserted, err = b.store.UpsertWithPropertiesAndHAPerson(contact, props, card.Value("X-THANE-HA-PERSON"))
+	}
 	if err != nil {
 		return nil, fmt.Errorf("upsert contact: %w", err)
 	}

--- a/internal/server/carddav/backend.go
+++ b/internal/server/carddav/backend.go
@@ -188,8 +188,12 @@ func (b *Backend) PutAddressObject(_ context.Context, path string, card vcard.Ca
 				return nil, fmt.Errorf("read configured ha person binding: contact %s disappeared", id)
 			}
 		}
-		incomingEntity := strings.TrimSpace(card.Value("X-THANE-HA-PERSON"))
-		if incomingEntity != "" && incomingEntity != currentEntity {
+		incomingField := card.Get("X-THANE-HA-PERSON")
+		incomingEntity := ""
+		if incomingField != nil {
+			incomingEntity = strings.TrimSpace(incomingField.Value)
+		}
+		if incomingField != nil && incomingEntity != currentEntity {
 			return nil, fmt.Errorf("X-THANE-HA-PERSON is owned by signed person.contact_bindings; edit config and restart Thane")
 		}
 		// Header-less PUTs are normal for clients that discard unknown

--- a/internal/server/carddav/backend.go
+++ b/internal/server/carddav/backend.go
@@ -24,7 +24,8 @@ type Backend struct {
 
 // NewBackend creates a CardDAV backend backed by the given contact
 // store. When configOwnsHAPersonBindings is true, CardDAV emits the
-// configured X-THANE-HA-PERSON value but cannot mutate it.
+// configured X-THANE-HA-PERSON value but cannot mutate it or delete
+// its bound contact.
 func NewBackend(store *contacts.Store, configOwnsHAPersonBindings bool, logger *slog.Logger) *Backend {
 	return &Backend{
 		store:                      store,
@@ -225,6 +226,15 @@ func (b *Backend) DeleteAddressObject(_ context.Context, path string) error {
 	id, err := contactIDFromPath(path)
 	if err != nil {
 		return err
+	}
+	if b.configOwnsHAPersonBindings {
+		entity, exists, err := b.store.HAPersonEntity(id)
+		if err != nil {
+			return fmt.Errorf("read configured ha person binding: %w", err)
+		}
+		if exists && entity != "" {
+			return fmt.Errorf("contact %s is bound by signed person.contact_bindings; edit config and restart Thane before deleting it", id)
+		}
 	}
 	return b.store.Delete(id)
 }

--- a/internal/server/carddav/backend_test.go
+++ b/internal/server/carddav/backend_test.go
@@ -536,12 +536,22 @@ func TestConfiguredHAPersonBindingIsReadOnlyInCardDAV(t *testing.T) {
 		t.Fatalf("round-trip of configured value: %v", err)
 	}
 
+	clear := newTestCard("Rejected Clear", operator.ID)
+	clear.SetValue("X-THANE-HA-PERSON", "  ")
+	if _, err := b.PutAddressObject(ctx, objectPath(operator.ID), clear, nil); err == nil || !strings.Contains(err.Error(), "person.contact_bindings") {
+		t.Fatalf("explicit clear of configured binding error = %v, want config guidance", err)
+	}
+	unchanged, err := b.store.Get(operator.ID)
+	if err != nil || unchanged.FormattedName != "Still Operator" {
+		t.Fatalf("rejected clear changed contact = %+v, %v", unchanged, err)
+	}
+
 	changed := newTestCard("Rejected Rename", operator.ID)
 	changed.SetValue("X-THANE-HA-PERSON", "person.somebody_else")
 	if _, err := b.PutAddressObject(ctx, objectPath(operator.ID), changed, nil); err == nil || !strings.Contains(err.Error(), "person.contact_bindings") {
 		t.Fatalf("changed configured binding error = %v, want config guidance", err)
 	}
-	unchanged, err := b.store.Get(operator.ID)
+	unchanged, err = b.store.Get(operator.ID)
 	if err != nil || unchanged.FormattedName != "Still Operator" {
 		t.Fatalf("rejected PUT changed contact = %+v, %v", unchanged, err)
 	}

--- a/internal/server/carddav/backend_test.go
+++ b/internal/server/carddav/backend_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/emersion/go-vcard"
@@ -16,6 +17,10 @@ import (
 )
 
 func newTestBackend(t *testing.T) *Backend {
+	return newTestBackendWithConfigBindings(t, false)
+}
+
+func newTestBackendWithConfigBindings(t *testing.T, configOwnsHAPersonBindings bool) *Backend {
 	t.Helper()
 	tmp, err := os.CreateTemp("", "thane-carddav-test-*.db")
 	if err != nil {
@@ -35,7 +40,7 @@ func newTestBackend(t *testing.T) *Backend {
 		t.Fatal(err)
 	}
 
-	return NewBackend(store, slog.Default())
+	return NewBackend(store, configOwnsHAPersonBindings, slog.Default())
 }
 
 func TestBackend_ListAddressBooks(t *testing.T) {
@@ -485,5 +490,74 @@ func TestHAPersonBindingPutIsAtomic(t *testing.T) {
 	// Atomicity: the rival contact must not exist at all.
 	if _, err := b.store.GetWithProperties(rivalID); err == nil {
 		t.Fatal("rejected PUT still created the contact — binding write is not atomic with the upsert")
+	}
+}
+
+func TestConfiguredHAPersonBindingIsReadOnlyInCardDAV(t *testing.T) {
+	b := newTestBackendWithConfigBindings(t, true)
+	ctx := context.Background()
+
+	operator, err := b.store.Upsert(&contacts.Contact{FormattedName: "Operator"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := b.store.ReplaceHAPersonBindings(map[uuid.UUID]string{
+		operator.ID: "person.operator",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := b.GetAddressObject(ctx, objectPath(operator.ID), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if entity := got.Card.Value("X-THANE-HA-PERSON"); entity != "person.operator" {
+		t.Fatalf("GET binding = %q, want person.operator", entity)
+	}
+
+	// Clients commonly discard unknown X- fields. A header-less update
+	// must preserve the configured binding while applying ordinary data.
+	headerless := newTestCard("Renamed Operator", operator.ID)
+	if _, err := b.PutAddressObject(ctx, objectPath(operator.ID), headerless, nil); err != nil {
+		t.Fatalf("header-less PUT: %v", err)
+	}
+	entity, ok, err := b.store.HAPersonEntity(operator.ID)
+	if err != nil || !ok || entity != "person.operator" {
+		t.Fatalf("binding after header-less PUT = %q, %v, %v", entity, ok, err)
+	}
+	updated, err := b.store.Get(operator.ID)
+	if err != nil || updated.FormattedName != "Renamed Operator" {
+		t.Fatalf("ordinary contact update = %+v, %v", updated, err)
+	}
+
+	equal := newTestCard("Still Operator", operator.ID)
+	equal.SetValue("X-THANE-HA-PERSON", "person.operator")
+	if _, err := b.PutAddressObject(ctx, objectPath(operator.ID), equal, nil); err != nil {
+		t.Fatalf("round-trip of configured value: %v", err)
+	}
+
+	changed := newTestCard("Rejected Rename", operator.ID)
+	changed.SetValue("X-THANE-HA-PERSON", "person.somebody_else")
+	if _, err := b.PutAddressObject(ctx, objectPath(operator.ID), changed, nil); err == nil || !strings.Contains(err.Error(), "person.contact_bindings") {
+		t.Fatalf("changed configured binding error = %v, want config guidance", err)
+	}
+	unchanged, err := b.store.Get(operator.ID)
+	if err != nil || unchanged.FormattedName != "Still Operator" {
+		t.Fatalf("rejected PUT changed contact = %+v, %v", unchanged, err)
+	}
+
+	newID := uuid.New()
+	claim := newTestCard("New Claim", newID)
+	claim.SetValue("X-THANE-HA-PERSON", "person.new_claim")
+	if _, err := b.PutAddressObject(ctx, objectPath(newID), claim, nil); err == nil {
+		t.Fatal("CardDAV created a binding while config owns the set")
+	}
+	if _, err := b.store.Get(newID); err == nil {
+		t.Fatal("rejected configured-binding PUT still created the contact")
+	}
+
+	headerlessID := uuid.New()
+	if _, err := b.PutAddressObject(ctx, objectPath(headerlessID), newTestCard("Ordinary Contact", headerlessID), nil); err != nil {
+		t.Fatalf("header-less new contact should remain writable: %v", err)
 	}
 }

--- a/internal/server/carddav/backend_test.go
+++ b/internal/server/carddav/backend_test.go
@@ -565,9 +565,21 @@ func TestConfiguredHAPersonBindingIsReadOnlyInCardDAV(t *testing.T) {
 	if _, err := b.store.Get(newID); err == nil {
 		t.Fatal("rejected configured-binding PUT still created the contact")
 	}
+	if err := b.DeleteAddressObject(ctx, objectPath(operator.ID)); err == nil || !strings.Contains(err.Error(), "person.contact_bindings") {
+		t.Fatalf("delete configured-bound contact error = %v, want config guidance", err)
+	}
+	if entity, exists, err := b.store.HAPersonEntity(operator.ID); err != nil || !exists || entity != "person.operator" {
+		t.Fatalf("binding after rejected DELETE = %q, %v, %v", entity, exists, err)
+	}
 
 	headerlessID := uuid.New()
 	if _, err := b.PutAddressObject(ctx, objectPath(headerlessID), newTestCard("Ordinary Contact", headerlessID), nil); err != nil {
 		t.Fatalf("header-less new contact should remain writable: %v", err)
+	}
+	if err := b.DeleteAddressObject(ctx, objectPath(headerlessID)); err != nil {
+		t.Fatalf("delete unbound contact: %v", err)
+	}
+	if _, err := b.store.Get(headerlessID); err == nil {
+		t.Fatal("unbound contact still exists after DELETE")
 	}
 }

--- a/internal/state/contacts/counterparty.go
+++ b/internal/state/contacts/counterparty.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -24,6 +26,115 @@ var haPersonEntityRE = regexp.MustCompile(`^person\.[a-z0-9_]+$`)
 // or operator-initiated code.
 func (s *Store) SetHAPersonEntity(id uuid.UUID, entity string) error {
 	return applyHAPersonEntity(s.db, id, entity)
+}
+
+// ReplaceHAPersonBindings atomically makes bindings the exact set of
+// active contact to Home Assistant person edges. Existing bindings not in
+// the map are cleared. Every referenced contact must exist and every person
+// entity must be valid and unique; otherwise the transaction rolls back
+// without changing any binding.
+//
+// This is the signed-configuration reconciliation boundary. Model-facing
+// contact tools must not call it.
+func (s *Store) ReplaceHAPersonBindings(bindings map[uuid.UUID]string) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin replacing ha person bindings: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // best-effort on defer
+
+	ids := make([]uuid.UUID, 0, len(bindings))
+	for id := range bindings {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i].String() < ids[j].String() })
+
+	desired := make(map[string]string, len(bindings))
+	claimed := make(map[string]uuid.UUID, len(bindings))
+	for _, id := range ids {
+		rawEntity := bindings[id]
+		entity := strings.TrimSpace(rawEntity)
+		if !haPersonEntityRE.MatchString(entity) {
+			return fmt.Errorf("ha person entity for %s must match person.<object_id> (lowercase letters, digits, underscores), got %q", id, rawEntity)
+		}
+		if holder, exists := claimed[entity]; exists {
+			return fmt.Errorf("ha person entity %q is assigned to both %s and %s", entity, holder, id)
+		}
+		claimed[entity] = id
+		desired[id.String()] = entity
+	}
+
+	current := make(map[string]string)
+	rows, err := tx.Query(`SELECT id, COALESCE(ha_person_entity, '') FROM contacts WHERE deleted_at IS NULL`)
+	if err != nil {
+		return fmt.Errorf("list contacts while replacing ha person bindings: %w", err)
+	}
+	for rows.Next() {
+		var id, entity string
+		if err := rows.Scan(&id, &entity); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan contact while replacing ha person bindings: %w", err)
+		}
+		current[id] = entity
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close contacts while replacing ha person bindings: %w", err)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("list contacts while replacing ha person bindings: %w", err)
+	}
+
+	for _, id := range ids {
+		if _, exists := current[id.String()]; !exists {
+			return fmt.Errorf("replace ha person bindings: contact %s not found", id)
+		}
+	}
+
+	changed := make([]string, 0)
+	for id, currentEntity := range current {
+		if currentEntity != desired[id] {
+			changed = append(changed, id)
+		}
+	}
+	if len(changed) == 0 {
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit unchanged ha person bindings: %w", err)
+		}
+		return nil
+	}
+	sort.Strings(changed)
+
+	// Clear changed rows first so swapping two existing person claims is
+	// legal under the unique index. One timestamp across the transaction
+	// gives CardDAV a stable ETag/CTag change without churning unchanged
+	// contacts on every restart.
+	now := time.Now().UTC().Format(time.RFC3339)
+	for _, id := range changed {
+		if _, err := tx.Exec(
+			`UPDATE contacts SET ha_person_entity = NULL, rev = ?, updated_at = ? WHERE id = ? AND deleted_at IS NULL`,
+			now, now, id,
+		); err != nil {
+			return fmt.Errorf("clear ha person binding for %s: %w", id, err)
+		}
+	}
+	for _, id := range changed {
+		entity := desired[id]
+		if entity == "" {
+			continue
+		}
+		parsed, err := uuid.Parse(id)
+		if err != nil {
+			return fmt.Errorf("parse contact id %q while replacing ha person bindings: %w", id, err)
+		}
+		if err := applyHAPersonEntity(tx, parsed, entity); err != nil {
+			return err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit replacing ha person bindings: %w", err)
+	}
+	return nil
 }
 
 // sqlRunner is the subset of database/sql shared by *sql.DB and

--- a/internal/state/contacts/counterparty_test.go
+++ b/internal/state/contacts/counterparty_test.go
@@ -109,3 +109,106 @@ func TestHAPersonEntityUniqueness(t *testing.T) {
 		t.Fatalf("rebind after clear: %v", err)
 	}
 }
+
+func TestReplaceHAPersonBindingsExact(t *testing.T) {
+	store := newCounterpartyTestStore(t)
+	alice, err := store.Upsert(&Contact{FormattedName: "Alice Operator"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	bob, err := store.Upsert(&Contact{FormattedName: "Bob Guest"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	carol, err := store.Upsert(&Contact{FormattedName: "Carol Guest"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetHAPersonEntity(alice.ID, "person.legacy_alice"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetHAPersonEntity(bob.ID, "person.legacy_bob"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.ReplaceHAPersonBindings(map[uuid.UUID]string{
+		alice.ID: "person.alice",
+		carol.ID: "person.carol",
+	}); err != nil {
+		t.Fatalf("ReplaceHAPersonBindings: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		id   uuid.UUID
+		want string
+	}{
+		{name: "replaced", id: alice.ID, want: "person.alice"},
+		{name: "removed", id: bob.ID, want: ""},
+		{name: "added", id: carol.ID, want: "person.carol"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok, err := store.HAPersonEntity(tc.id)
+			if err != nil || !ok || got != tc.want {
+				t.Fatalf("HAPersonEntity(%s) = %q, %v, %v; want %q, true, nil", tc.id, got, ok, err, tc.want)
+			}
+		})
+	}
+
+	if err := store.ReplaceHAPersonBindings(map[uuid.UUID]string{
+		alice.ID: "person.carol",
+		carol.ID: "person.alice",
+	}); err != nil {
+		t.Fatalf("swap existing unique claims: %v", err)
+	}
+	if got, _, _ := store.HAPersonEntity(alice.ID); got != "person.carol" {
+		t.Fatalf("alice binding after swap = %q, want person.carol", got)
+	}
+	if got, _, _ := store.HAPersonEntity(carol.ID); got != "person.alice" {
+		t.Fatalf("carol binding after swap = %q, want person.alice", got)
+	}
+
+	if err := store.ReplaceHAPersonBindings(map[uuid.UUID]string{}); err != nil {
+		t.Fatalf("clear all bindings: %v", err)
+	}
+	for _, id := range []uuid.UUID{alice.ID, bob.ID, carol.ID} {
+		if got, _, err := store.HAPersonEntity(id); err != nil || got != "" {
+			t.Fatalf("binding after exact empty replacement for %s = %q, %v", id, got, err)
+		}
+	}
+}
+
+func TestReplaceHAPersonBindingsRollback(t *testing.T) {
+	store := newCounterpartyTestStore(t)
+	alice, err := store.Upsert(&Contact{FormattedName: "Alice Operator"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetHAPersonEntity(alice.ID, "person.alice"); err != nil {
+		t.Fatal(err)
+	}
+
+	err = store.ReplaceHAPersonBindings(map[uuid.UUID]string{
+		alice.ID:   "person.changed",
+		uuid.New(): "person.missing",
+	})
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("missing contact error = %v, want not found", err)
+	}
+	got, ok, err := store.HAPersonEntity(alice.ID)
+	if err != nil || !ok || got != "person.alice" {
+		t.Fatalf("binding after rollback = %q, %v, %v; want person.alice, true, nil", got, ok, err)
+	}
+
+	err = store.ReplaceHAPersonBindings(map[uuid.UUID]string{
+		alice.ID:   "person.same",
+		uuid.New(): "person.same",
+	})
+	if err == nil || !strings.Contains(err.Error(), "assigned to both") {
+		t.Fatalf("duplicate person error = %v, want duplicate assignment", err)
+	}
+	got, _, _ = store.HAPersonEntity(alice.ID)
+	if got != "person.alice" {
+		t.Fatalf("binding after duplicate rollback = %q, want person.alice", got)
+	}
+}

--- a/internal/state/contacts/store.go
+++ b/internal/state/contacts/store.go
@@ -118,6 +118,31 @@ type Store struct {
 	logger     *slog.Logger
 }
 
+// Open creates a contact store at path and owns the resulting database
+// connection. Call [Store.Close] when the store is no longer needed.
+func Open(path string, logger *slog.Logger) (*Store, error) {
+	db, err := database.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	store, err := NewStore(db, logger)
+	if err != nil {
+		db.Close() //nolint:errcheck // preserve the initialization error
+		return nil, err
+	}
+	return store, nil
+}
+
+// Close closes the database connection owned by a store created with
+// [Open]. Callers that use [NewStore] may continue to close their database
+// directly.
+func (s *Store) Close() error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	return s.db.Close()
+}
+
 // NewStore creates a contact store backed by db. The caller owns db's
 // lifecycle; NewStore applies the schema and sets up the optional
 // FTS5 index.

--- a/internal/state/contacts/tools.go
+++ b/internal/state/contacts/tools.go
@@ -40,11 +40,12 @@ const ownerActivitySummaryLimit = 8
 
 // Tools provides contact-related tools for the agent.
 type Tools struct {
-	store            *Store
-	embeddings       EmbeddingClient
-	selfContactName  string
-	ownerContactName string
-	ownerActivity    func() []OwnerChannelActivity
+	store             *Store
+	embeddings        EmbeddingClient
+	selfContactName   string
+	operatorContactID uuid.UUID
+	ownerContactName  string
+	ownerActivity     func() []OwnerChannelActivity
 }
 
 // NewTools creates contact tools using the given store.
@@ -63,8 +64,14 @@ func (t *Tools) SetSelfContactName(name string) {
 	t.selfContactName = name
 }
 
+// ConfigureOperatorContactID sets the stable contact UUID used to resolve the
+// primary human operator.
+func (t *Tools) ConfigureOperatorContactID(id uuid.UUID) {
+	t.operatorContactID = id
+}
+
 // SetOwnerContactName sets the contact name used to resolve the
-// primary human owner/operator contact.
+// primary human operator contact for legacy configurations.
 func (t *Tools) SetOwnerContactName(name string) {
 	t.ownerContactName = name
 }
@@ -75,8 +82,8 @@ func (t *Tools) SetOwnerActivitySource(src func() []OwnerChannelActivity) {
 	t.ownerActivity = src
 }
 
-// OwnerContact returns the configured owner contact, or falls back to
-// the sole admin contact when no explicit owner contact name is set.
+// OwnerContact returns the configured operator contact, or falls back to
+// the sole admin contact when no explicit operator identity is set.
 func (t *Tools) OwnerContact(_ string) (string, error) {
 	c, err := t.resolveOwnerContact()
 	if err != nil {
@@ -92,18 +99,29 @@ func (t *Tools) OwnerContact(_ string) (string, error) {
 }
 
 func (t *Tools) resolveOwnerContact() (*Contact, error) {
+	if t.operatorContactID != uuid.Nil {
+		full, err := t.store.GetWithProperties(t.operatorContactID)
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("configured operator contact %s not found", t.operatorContactID)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("get configured operator contact details: %w", err)
+		}
+		return full, nil
+	}
+
 	name := strings.TrimSpace(t.ownerContactName)
 	if name != "" {
 		c, err := t.store.ResolveContact(name)
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, fmt.Errorf("configured owner contact %q not found", name)
+			return nil, fmt.Errorf("configured legacy operator contact name %q not found", name)
 		}
 		if err != nil {
-			return nil, fmt.Errorf("resolve configured owner contact: %w", err)
+			return nil, fmt.Errorf("resolve configured legacy operator contact name: %w", err)
 		}
 		full, err := t.store.GetWithProperties(c.ID)
 		if err != nil {
-			return nil, fmt.Errorf("get configured owner contact details: %w", err)
+			return nil, fmt.Errorf("get configured operator contact details: %w", err)
 		}
 		return full, nil
 	}
@@ -114,11 +132,11 @@ func (t *Tools) resolveOwnerContact() (*Contact, error) {
 	}
 	switch len(admins) {
 	case 0:
-		return nil, fmt.Errorf("owner contact not configured: set identity.owner_contact_name or mark exactly one admin contact")
+		return nil, fmt.Errorf("operator contact not configured: set identity.operator_contact_id or mark exactly one admin contact")
 	case 1:
 		full, err := t.store.GetWithProperties(admins[0].ID)
 		if err != nil {
-			return nil, fmt.Errorf("get owner contact details: %w", err)
+			return nil, fmt.Errorf("get operator contact details: %w", err)
 		}
 		return full, nil
 	default:
@@ -127,7 +145,7 @@ func (t *Tools) resolveOwnerContact() (*Contact, error) {
 			names = append(names, admin.FormattedName)
 		}
 		sort.Strings(names)
-		return nil, fmt.Errorf("owner contact is ambiguous: multiple admin contacts found (%s); set identity.owner_contact_name", strings.Join(names, ", "))
+		return nil, fmt.Errorf("operator contact is ambiguous: multiple admin contacts found (%s); set identity.operator_contact_id", strings.Join(names, ", "))
 	}
 }
 

--- a/internal/state/contacts/tools_test.go
+++ b/internal/state/contacts/tools_test.go
@@ -917,6 +917,31 @@ func TestOwnerContact_ConfiguredName(t *testing.T) {
 	}
 }
 
+func TestOwnerContact_ConfiguredOperatorID(t *testing.T) {
+	tools := newTestTools(t)
+	if _, err := tools.SaveContact(`{"name":"Original Name","kind":"individual","facts":{"email":"operator@example.com"}}`); err != nil {
+		t.Fatal(err)
+	}
+	operator, err := tools.store.FindByName("Original Name")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tools.ConfigureOperatorContactID(operator.ID)
+
+	operator.FormattedName = "Renamed Operator"
+	if _, err := tools.store.Upsert(operator); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := tools.OwnerContact(`{}`)
+	if err != nil {
+		t.Fatalf("OwnerContact() error = %v", err)
+	}
+	if !strings.Contains(result, "**Renamed Operator**") {
+		t.Fatalf("OwnerContact() = %q, want UUID-selected renamed contact", result)
+	}
+}
+
 func TestOwnerContact_FallsBackToSoleAdmin(t *testing.T) {
 	tools := newTestTools(t)
 
@@ -996,7 +1021,7 @@ func TestOwnerContact_AmbiguousAdminRequiresConfig(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected ambiguity error when multiple admin contacts exist")
 	}
-	if !strings.Contains(err.Error(), "identity.owner_contact_name") {
+	if !strings.Contains(err.Error(), "identity.operator_contact_id") {
 		t.Fatalf("error = %v, want owner contact config hint", err)
 	}
 }

--- a/internal/tools/contact_tools.go
+++ b/internal/tools/contact_tools.go
@@ -133,7 +133,7 @@ func (r *Registry) registerContactTools() {
 
 	r.Register(&Tool{
 		Name:        "contact_owner",
-		Description: "Return the primary owner/operator contact record with rich details and contact properties, plus a structured summary of currently active owner-scoped channels. Uses identity.owner_contact_name when configured; otherwise falls back to the sole admin contact if exactly one exists.",
+		Description: "Return the primary operator contact record with rich details and contact properties, plus a structured summary of currently active operator-scoped channels. Uses identity.operator_contact_id when configured; otherwise supports the legacy name selector and finally the sole admin contact if exactly one exists.",
 		Parameters: map[string]any{
 			"type":       "object",
 			"properties": map[string]any{},

--- a/internal/tools/counterparty_tools.go
+++ b/internal/tools/counterparty_tools.go
@@ -262,7 +262,7 @@ func handleContactWhereabouts(ctx context.Context, deps CounterpartyToolDeps, na
 	// gets a valid empty result whose basis says exactly which binding
 	// produced nothing — bound-but-silent is not misconfigured.
 	if !hasHABinding && len(boundAccounts) == 0 {
-		return "", fmt.Errorf("contact %q has no HA person binding and no bound companion devices — there is no whereabouts source to consult; the operator binds a person entity via the X-THANE-HA-PERSON contact field and companion accounts via companion.providers.<account>.contact", contact.FormattedName)
+		return "", fmt.Errorf("contact %q has no HA person binding and no bound companion devices — there is no whereabouts source to consult; the operator binds the contact UUID to a tracked person entity via signed person.contact_bindings and companion accounts via companion.providers.<account>.contact", contact.FormattedName)
 	}
 
 	result := whereaboutsResult{

--- a/talents/contacts.md
+++ b/talents/contacts.md
@@ -26,7 +26,7 @@ often reaches for one when the right answer is another:
 | You want to store / find... | Surface |
 |---|---|
 | "Frank prefers Signal" / "Alice is Engineering Lead at X" / "Bob's home address" | `contacts` (`contact_save` with `facts` or `note`) — this leaf |
-| "Who is the owner of this host" | `contacts` (`contact_owner`) — this leaf |
+| "Who operates this host" | `contacts` (`contact_owner`) — this leaf |
 | "Sump pump runs Tuesdays" / "Garage door takes 23s to close" — stable, compact, *non-person* facts | `memory` (`remember_fact`) — see [`memory.md`](memory.md) |
 | "The VLAN renumber plan landed on 2026-04-22" / a project decision / design rationale | `documents` (`kb:`, `core:`) or workspace files — NOT memory, NOT contacts |
 | "What did Frank and I last discuss" | `archive_text` scoped to the conversation — the words live there, not in the contact record |
@@ -74,10 +74,11 @@ document-shaped, it isn't a memory fact either — push to documents.
   tombstone. Lookup before forgetting; the cost of removing the wrong
   record is real.
 
-- **The owner is a contact too.** The host's primary user lives in the
-  same table as everyone else, marked by `identity.owner_contact_name`
-  config or (fallback) by being the sole `admin`-zone contact. Treat
-  `contact_owner` as authoritative for "who is this host's user"
+- **The operator is a contact too.** The host's primary operator lives in
+  the same table as everyone else, marked by the stable
+  `identity.operator_contact_id` config, the legacy name selector, or
+  (fallback) by being the sole `admin`-zone contact. Treat
+  `contact_owner` as authoritative for "who operates this host"
   rather than guessing from message senders or workspace metadata.
 
 ## Cross-references
@@ -176,21 +177,22 @@ anchor — useful for "show me everyone" or "show me all orgs":
 `kind` is `individual` / `group` / `org` / `location`. Without `kind`,
 all types appear. Use `limit` to bound the result size.
 
-## You need the host's owner
+## You need the host's operator
 
 `contact_owner` returns the primary operator's record with rich
-detail plus a structured summary of currently active owner-scoped
+detail plus a structured summary of currently active operator-scoped
 channels:
 
 ```json
 {}
 ```
 
-No arguments needed. Uses `identity.owner_contact_name` from config
-when set; otherwise falls back to the sole `admin`-zone contact if
-exactly one exists. Right tool when the model needs to assert "this is
-the user I'm talking to" or "what channels does the owner have active
-right now."
+No arguments needed. Uses `identity.operator_contact_id` from config
+when set, accepts the legacy name selector for existing installs, and
+otherwise falls back to the sole `admin`-zone contact if exactly one
+exists. Right tool when the model needs to assert "this is the operator
+I'm talking to" or "what channels does the operator have active right
+now."
 
 ## Cross-references
 


### PR DESCRIPTION
## Summary

- add stable `identity.operator_contact_id` selection for the human operator contact
- add exact signed `person.contact_bindings` mappings from contact UUIDs to tracked Home Assistant `person.*` entities
- atomically reconcile configured mappings at startup and expose them as read-only CardDAV projections
- ignore contact identity mappings and operator selectors from unverified recovery config
- make `thane init` generate the operator UUID into signed config first, then seed an admin-zone stub with that exact ID
- resolve relative `data_dir` values from the derived instance workspace so runtime state does not depend on the launch directory

## Why

The current operator identity is selected by mutable display name, while contact-to-HA-person bindings require a CardDAV `X-THANE-HA-PERSON` edit. Both relationships are operator-custodied identity edges and should be easy to declare in signed config without allowing HA presence to confer operator authority.

The signed config should also be authoritative for the initial operator UUID. A workspace-relative data directory keeps the config and runtime pointed at the same contact database even when `thane serve` starts from another directory. Config loaded through `-insecure-config` cannot be allowed to rewrite these persisted identity edges or select who receives operator privileges.

## User impact

Existing installs remain compatible: `identity.owner_contact_name` and CardDAV-managed HA-person bindings continue to work when the new keys are absent. Operators can migrate to stable UUID configuration; once `person.contact_bindings` is present, even as `{}`, verified config becomes the exact source of truth. CardDAV cannot change or explicitly clear those links, and configured-bound contacts cannot be deleted until their map entry is removed and Thane restarts. Headerless updates and deletion of unbound contacts continue to work.

Under `-insecure-config`, `person.contact_bindings`, `identity.operator_contact_id`, and legacy `identity.owner_contact_name` are ignored. Stored bindings remain unchanged and unsigned input cannot confer operator authority.

New workspaces start with a durable operator UUID in signed config, a contact stub seeded from that UUID, and config-owned binding posture from birth. Relative `data_dir` values in normal core configs now resolve from the workspace; absolute paths are unchanged.

For production, the intended configuration is:

```yaml
identity:
  operator_contact_id: 019c76e4-2ff1-7918-8d6f-6c2488f5098d

person:
  track:
    - person.nugget
  contact_bindings:
    019c76e4-2ff1-7918-8d6f-6c2488f5098d: person.nugget
```

The legacy `identity.owner_contact_name` entry must be removed when `operator_contact_id` is added.

## Test plan

- [x] `just test`
- [x] `just lint`
- [x] `just architecture-check`
- [x] `just ci`
- [x] init tests verify config-first exact operator IDs, default/custom stubs, and missing-database recovery
- [x] config tests verify UUID/entity validation, absent-versus-empty authority, and workspace-relative data paths
- [x] app tests verify unverified config cannot reconcile bindings or select UUID/legacy operator authority
- [x] store tests verify exact replacement, swaps, clearing, and rollback
- [x] CardDAV tests verify read-only projection, headerless preservation, explicit mutation rejection, and bound-delete protection

Refs #1450