### PR TITLE
One Go version to chase: 1.27 everywhere

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.27.0'
   # golangci-lint and vacuum are pinned in tools/go.mod and run via `go run`
   # (see the just recipes) — no install step here. lychee is a Rust tool and
   # has no go.mod home, so it stays a pinned download.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Thank you for your interest in contributing to Thane!
 
 ### Prerequisites
 
-- [Go](https://go.dev/) 1.25+
+- [Go](https://go.dev/) 1.27+
 - [just](https://just.systems/) (command runner)
 - [lychee](https://github.com/lycheeverse/lychee) — optional; only the
   markdown link check needs it. `just ci` skips link-check locally when

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-bookworm AS builder
+FROM golang:1.27-bookworm AS builder
 
 WORKDIR /build
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nugget/thane-ai-agent
 
-go 1.25.0
+go 1.27.0
 
 require (
 	github.com/eclipse/paho.golang v0.23.0

--- a/internal/app/taskexec_test.go
+++ b/internal/app/taskexec_test.go
@@ -427,7 +427,7 @@ func TestBuildScheduledTaskLoopProfile(t *testing.T) {
 				t.Fatalf("LocalOnly = %q, want %q", got.LocalOnly, tt.want.LocalOnly)
 			}
 			if got.QualityFloor != tt.want.QualityFloor {
-				t.Fatalf("QualityFloor = %q, want %q", got.QualityFloor, tt.want.QualityFloor)
+				t.Fatalf("QualityFloor = %d, want %d", got.QualityFloor, tt.want.QualityFloor)
 			}
 			if got.Mission != tt.want.Mission {
 				t.Fatalf("Mission = %q, want %q", got.Mission, tt.want.Mission)

--- a/internal/model/router/loopprofile_test.go
+++ b/internal/model/router/loopprofile_test.go
@@ -234,7 +234,7 @@ func TestLoopProfileJSONRoundTrip(t *testing.T) {
 		t.Errorf("Model = %q, want %q", restored.Model, original.Model)
 	}
 	if restored.QualityFloor != original.QualityFloor {
-		t.Errorf("QualityFloor = %q, want %q", restored.QualityFloor, original.QualityFloor)
+		t.Errorf("QualityFloor = %d, want %d", restored.QualityFloor, original.QualityFloor)
 	}
 	if restored.Mission != original.Mission {
 		t.Errorf("Mission = %q, want %q", restored.Mission, original.Mission)

--- a/internal/server/openapi/native.yaml
+++ b/internal/server/openapi/native.yaml
@@ -1550,7 +1550,7 @@ components:
         version: v0.9.2-596-gf92a9208
         git_commit: f92a9208
         git_branch: main
-        go_version: go1.26.1
+        go_version: go1.27.0
         uptime: 133h30m0s
 
     LogEntry:
@@ -1872,7 +1872,7 @@ components:
           version: v0.9.2-596-gf92a9208
           git_commit: f92a9208
           git_branch: main
-          go_version: go1.26.1
+          go_version: go1.27.0
           uptime: 133h30m0s
         health:
           home_assistant: { name: Home Assistant, ready: true, last_check: "2026-06-24T14:30:55Z" }
@@ -3407,7 +3407,7 @@ components:
           version: v0.9.2-596-gf92a9208
           git_commit: f92a9208
           git_branch: main
-          go_version: go1.26.1
+          go_version: go1.27.0
 
     SessionMessage:
       type: object

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/nugget/thane-ai-agent/tools
 
-go 1.26.0
+go 1.27.0
 
 tool (
 	github.com/daveshanley/vacuum


### PR DESCRIPTION
## The decree

The repo standardizes on Go 1.27, and any rough edge with older Go versions resolves in favor of 1.27. The gate work that pinned `GOTOOLCHAIN=go1.27.0` in the justfile and `GO_VERSION: '1.27.0'` in ci.yml did the heavy lifting; this PR sweeps up every remaining pin so the repo states one version, everywhere.

## What moves

The main module's `go` directive rises from 1.25.0 to 1.27.0, the tools module's from 1.26.0, and release.yml's `GO_VERSION` from '1.25' to '1.27.0'. Review then caught two pins the first sweep missed — the Dockerfile's builder image (`golang:1.25-bookworm` → `golang:1.27-bookworm`), which had kept an independent older toolchain on the container release path, and CONTRIBUTING.md's prerequisite (Go 1.25+ → 1.27+). The OpenAPI version-endpoint examples advertising `go1.26.1` ride along so documented output matches what a 1.27 build reports. The next toolchain bump now has exactly one version to chase.

## What the bump surfaced

Raising the language version sharpens govet's printf analysis, which flagged two latent test bugs on main: failure messages quoting the int field `QualityFloor` with `%q`, which would have rendered a failing value as rune-quoted noise (`'\x05'`) instead of a number. Both now use `%d` — the first concrete payout of resolving rough edges toward 1.27 rather than pinning around them.

## Test plan

- [x] `just ci` passes locally (architecture check, lint incl. sharpened govet, full race suite)
- [x] Repo-wide sweep (`grep -rn "1\.25\|1\.26"` over .mod/.yml/.yaml/.md/Dockerfile) shows no remaining Go version references below 1.27

🤖 Generated with [Claude Code](https://claude.com/claude-code)