### PR TITLE
feat: protect document writes with hidden revision receipts

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -216,12 +216,21 @@ Document tool results use model-facing time deltas such as
 absolute timestamps. Timestamp filter inputs still accept RFC3339 values
 or signed deltas like `-604800s`.
 
+On git-backed roots, `doc_read` returns a `revision` token. A loop that may
+race another loop or an operator should pass that token as
+`expected_revision` to `doc_write`, `doc_edit`, or `doc_journal_update`.
+The mutation then compares and commits atomically; if the document changed
+after the read, it returns a conflict without replacing the newer content.
+Use `expected_revision: absent` only when a deliberate new ref must have no
+prior file history. Successful mutations return the new `revision` for the
+next update when `expected_revision` was supplied.
+
 | Tool | Description |
 |------|-------------|
 | `doc_roots` | List configured document roots with policy, health, and counts. |
 | `doc_browse` | Walk a document root by folder. |
 | `doc_outline` | Emit the heading/section outline for a document. |
-| `doc_read` | Read a document by prefixed path. |
+| `doc_read` | Read a document by prefixed path, including its current revision token on a git-backed root. |
 | `doc_section` | Retrieve a named section from a document. |
 | `doc_search` | Full-text and tagged search across roots. |
 | `doc_links` | List inbound/outbound links for a document. |
@@ -229,14 +238,14 @@ or signed deltas like `-604800s`.
 | `doc_create` | Create a new document safely: corpus collision check + normalized placement + write in one call; declines with an analysis when a similar document exists. |
 | `doc_intake` | Analyze proposed knowledge against the existing corpus before writing it (the deliberate two-step form of `doc_create`). |
 | `doc_commit` | Commit an approved `doc_intake`/declined `doc_create` result through managed mutations. |
-| `doc_write` | Replace a document's content (creates at a fresh ref only when the destination is already deliberate — prefer `doc_create` for new documents). |
-| `doc_edit` | Targeted edit within a document. |
+| `doc_write` | Replace a document's content, with an optional revision precondition (creates at a fresh ref only when the destination is already deliberate — prefer `doc_create` for new documents). |
+| `doc_edit` | Targeted edit within a document, with an optional revision precondition. |
 | `doc_copy` | Copy a document to another location. |
 | `doc_move` | Move or rename a document. |
 | `doc_delete` | Delete a document. |
 | `doc_copy_section` | Copy one named section into another document. |
 | `doc_move_section` | Move one named section into another document. |
-| `doc_journal_update` | Append or update a journal-style entry. |
+| `doc_journal_update` | Append or update a journal-style entry, with an optional revision precondition. |
 
 Loop-declared document output tools are request-scoped and do not appear
 in the global catalog above. When a loop declares an output, Thane

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -216,21 +216,23 @@ Document tool results use model-facing time deltas such as
 absolute timestamps. Timestamp filter inputs still accept RFC3339 values
 or signed deltas like `-604800s`.
 
-On git-backed roots, `doc_read` returns a `revision` token. A loop that may
-race another loop or an operator should pass that token as
-`expected_revision` to `doc_write`, `doc_edit`, or `doc_journal_update`.
-The mutation then compares and commits atomically; if the document changed
-after the read, it returns a conflict without replacing the newer content.
-Use `expected_revision: absent` only when a deliberate new ref must have no
-prior file history. Successful mutations return the new `revision` for the
-next update when `expected_revision` was supplied.
+On writable git-backed roots, Thane retains a hidden read receipt for each
+loop/conversation and document ref. `doc_write`, `doc_edit`, and
+`doc_journal_update` use that receipt automatically; revision hashes are not
+part of their model-facing contract. If the document changed after the read,
+the mutation returns `applied: false` without replacing newer content and
+includes a bounded `changed_since_read` patch. The receipt then advances to the
+current document so a reconciled retry has the right comparison base. When a
+patch is unavailable or truncated, the result includes a bounded current
+excerpt instead. Replacing an existing whole body requires reading it first;
+structured edits can safely derive a fresh base as part of the operation.
 
 | Tool | Description |
 |------|-------------|
 | `doc_roots` | List configured document roots with policy, health, and counts. |
 | `doc_browse` | Walk a document root by folder. |
 | `doc_outline` | Emit the heading/section outline for a document. |
-| `doc_read` | Read a document by prefixed path, including its current revision token on a git-backed root. |
+| `doc_read` | Read a document by prefixed path; on writable git-backed roots, also retain a hidden comparison base for this loop/conversation. |
 | `doc_section` | Retrieve a named section from a document. |
 | `doc_search` | Full-text and tagged search across roots. |
 | `doc_links` | List inbound/outbound links for a document. |
@@ -238,14 +240,14 @@ next update when `expected_revision` was supplied.
 | `doc_create` | Create a new document safely: corpus collision check + normalized placement + write in one call; declines with an analysis when a similar document exists. |
 | `doc_intake` | Analyze proposed knowledge against the existing corpus before writing it (the deliberate two-step form of `doc_create`). |
 | `doc_commit` | Commit an approved `doc_intake`/declined `doc_create` result through managed mutations. |
-| `doc_write` | Replace a document's content, with an optional revision precondition (creates at a fresh ref only when the destination is already deliberate — prefer `doc_create` for new documents). |
-| `doc_edit` | Targeted edit within a document, with an optional revision precondition. |
+| `doc_write` | Replace a document's content with automatic stale-write protection (creates at a fresh ref only when the destination is already deliberate — prefer `doc_create` for new documents). |
+| `doc_edit` | Targeted edit within a document, with automatic stale-write protection. |
 | `doc_copy` | Copy a document to another location. |
 | `doc_move` | Move or rename a document. |
 | `doc_delete` | Delete a document. |
 | `doc_copy_section` | Copy one named section into another document. |
 | `doc_move_section` | Move one named section into another document. |
-| `doc_journal_update` | Append or update a journal-style entry, with an optional revision precondition. |
+| `doc_journal_update` | Append or update a journal-style entry, with automatic stale-write protection. |
 
 Loop-declared document output tools are request-scoped and do not appear
 in the global catalog above. When a loop declares an output, Thane

--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -322,6 +322,22 @@ cannot mutate roots with signed git provenance; those changes must go
 through managed document tools so root writers can preserve authoring
 policy, git history, and signatures.
 
+### Concurrent writers
+
+Git history makes a mistaken overwrite recoverable, but history alone does
+not stop a stale loop from replacing another writer's current work. Managed
+reads therefore expose the newest file revision on git-backed roots. When a
+loop reads, transforms, and writes a document that another loop or operator
+may also edit, it should return that token as `expected_revision` on
+`doc_write`, `doc_edit`, or `doc_journal_update`.
+
+The root writer compares the token and commits under the same lock. A stale
+token returns a revision conflict and leaves the worktree and HEAD unchanged;
+the caller can read the new version, reconcile its intended change, and retry.
+`expected_revision: absent` is the creation precondition for a deliberate ref
+that must have no prior file history. Omitting the field retains unconditional
+mutation behavior for compatibility and for roots with a single writer.
+
 Directory-walk surfaces (`file_list`, `file_tree`, `file_stat`,
 `file_search`, `file_grep`) intentionally do not consult the verifier.
 `file_list`, `file_tree`, `file_stat`, and `file_search` return only

--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -325,18 +325,27 @@ policy, git history, and signatures.
 ### Concurrent writers
 
 Git history makes a mistaken overwrite recoverable, but history alone does
-not stop a stale loop from replacing another writer's current work. Managed
-reads therefore expose the newest file revision on git-backed roots. When a
-loop reads, transforms, and writes a document that another loop or operator
-may also edit, it should return that token as `expected_revision` on
-`doc_write`, `doc_edit`, or `doc_journal_update`.
+not stop a stale loop from replacing another writer's current work. On writable
+git-backed roots, a managed read therefore records the current file revision as
+a hidden receipt keyed by loop/conversation and document ref. The model never
+passes hashes between tools. A later `doc_write`, `doc_edit`, or
+`doc_journal_update` supplies that receipt to the root writer internally.
+Read-only history roots do not create mutation receipts.
 
-The root writer compares the token and commits under the same lock. A stale
-token returns a revision conflict and leaves the worktree and HEAD unchanged;
-the caller can read the new version, reconcile its intended change, and retry.
-`expected_revision: absent` is the creation precondition for a deliberate ref
-that must have no prior file history. Omitting the field retains unconditional
-mutation behavior for compatibility and for roots with a single writer.
+The root writer compares and commits managed mutations under the same lock, and
+the Git ref update also verifies its expected parent. A stale receipt returns
+`applied: false`, leaves the worktree and HEAD unchanged, and provides a bounded
+base-to-current patch. The receipt advances to current HEAD so the caller can
+reconcile and retry without another hash-bearing parameter. A missing or
+oversized patch falls back to a bounded current excerpt. A scoped whole-body
+replacement of an existing document requires a prior managed read; structured
+edits and creates derive a safe current/absent base within the operation.
+
+This coordinates Thane's managed writers and rejects operator edits that are
+already dirty when the mutation begins. It is not a general filesystem lock:
+an editor that ignores this coordination can still save in the narrow window
+between the final worktree check and replacement. Git history remains the
+recovery boundary for that external race.
 
 Directory-walk surfaces (`file_list`, `file_tree`, `file_stat`,
 `file_search`, `file_grep`) intentionally do not consult the verifier.

--- a/internal/app/document_root_reviser.go
+++ b/internal/app/document_root_reviser.go
@@ -32,6 +32,14 @@ func (r *documentRootProvenanceReviser) Resolve(ctx context.Context, filename, s
 	return revisionRefFromProvenance(rev), nil
 }
 
+func (r *documentRootProvenanceReviser) Snapshot(ctx context.Context, filename string) (documents.RevisionContent, error) {
+	revision, content, err := r.reader.Snapshot(ctx, r.storeFilename(filename))
+	if err != nil {
+		return documents.RevisionContent{}, err
+	}
+	return documents.RevisionContent{Revision: revisionRefFromProvenance(revision), Content: content}, nil
+}
+
 func (r *documentRootProvenanceReviser) History(ctx context.Context, filename string, opts documents.RevisionQuery) (documents.RevisionListing, error) {
 	page, err := r.reader.Revisions(ctx, r.storeFilename(filename), provenance.RevisionOptions{
 		Limit:       opts.Limit,

--- a/internal/app/document_root_writer.go
+++ b/internal/app/document_root_writer.go
@@ -2,7 +2,9 @@ package app
 
 import (
 	"context"
+	"errors"
 
+	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
 	"github.com/nugget/thane-ai-agent/internal/state/documents"
 )
 
@@ -15,6 +17,13 @@ func (w *documentRootProvenanceWriter) WriteIfRevision(ctx context.Context, file
 	}
 	revision, err := store.WriteIfRevision(ctx, w.storeFilename(filename), content, w.withTurnProvenance(ctx, message), expectedRevision)
 	if err != nil {
+		var conflict *provenance.RevisionConflictError
+		if errors.As(err, &conflict) {
+			return "", &documents.RootRevisionConflictError{
+				Expected: conflict.Expected,
+				Actual:   conflict.Actual,
+			}
+		}
 		return "", err
 	}
 	return revision.Short, nil

--- a/internal/app/document_root_writer.go
+++ b/internal/app/document_root_writer.go
@@ -1,0 +1,21 @@
+package app
+
+import (
+	"context"
+
+	"github.com/nugget/thane-ai-agent/internal/state/documents"
+)
+
+var _ documents.RootWriter = (*documentRootProvenanceWriter)(nil)
+
+func (w *documentRootProvenanceWriter) WriteIfRevision(ctx context.Context, filename, content, message, expectedRevision string) (string, error) {
+	store, err := w.store()
+	if err != nil {
+		return "", err
+	}
+	revision, err := store.WriteIfRevision(ctx, w.storeFilename(filename), content, w.withTurnProvenance(ctx, message), expectedRevision)
+	if err != nil {
+		return "", err
+	}
+	return revision.Short, nil
+}

--- a/internal/platform/provenance/conditional_write.go
+++ b/internal/platform/provenance/conditional_write.go
@@ -3,8 +3,10 @@ package provenance
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -26,6 +28,11 @@ type RevisionConflictError struct {
 	Expected string
 	// Actual is the current token or a named state such as worktree_dirty.
 	Actual string
+}
+
+type conditionalBase struct {
+	current Revision
+	head    string
 }
 
 // Error implements error.
@@ -55,18 +62,11 @@ func (s *Store) WriteIfRevision(ctx context.Context, filename, content, message,
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	current, err := s.checkExpectedRevisionLocked(ctx, filename, expectedRevision)
+	base, err := s.checkExpectedRevisionLocked(ctx, filename, expectedRevision)
 	if err != nil {
 		return Revision{}, err
 	}
-	absPath := filepath.Join(s.path, filename)
-	if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
-		return Revision{}, fmt.Errorf("provenance: create directory for %s: %w", filename, err)
-	}
-	if err := os.WriteFile(absPath, []byte(content), 0o644); err != nil {
-		return Revision{}, fmt.Errorf("provenance: write %s: %w", filename, err)
-	}
-	commitHash, err := s.commitFile(ctx, filename, message)
+	commitHash, err := s.commitFileContentAtHead(ctx, filename, []byte(content), message, base.head)
 	if err != nil {
 		return Revision{}, fmt.Errorf("provenance: commit %s: %w", filename, err)
 	}
@@ -78,64 +78,71 @@ func (s *Store) WriteIfRevision(ctx context.Context, filename, content, message,
 		)
 		return Revision{Commit: commitHash, Short: shorten(commitHash)}, nil
 	}
-	return current, nil
+	return base.current, nil
 }
 
 // checkExpectedRevisionLocked compares one file's latest committed revision
 // while the caller holds s.mu. A dirty target is always a conflict: resolving
 // only committed history and then overwriting uncommitted operator bytes would
 // satisfy the hash comparison while violating its purpose.
-func (s *Store) checkExpectedRevisionLocked(ctx context.Context, filename, expectedRevision string) (Revision, error) {
-	dirty, err := s.fileDirty(ctx, filename)
+func (s *Store) checkExpectedRevisionLocked(ctx context.Context, filename, expectedRevision string) (conditionalBase, error) {
+	head, err := repositoryHead(ctx, s.path)
 	if err != nil {
-		return Revision{}, fmt.Errorf("provenance: inspect worktree state for %s: %w", filename, err)
+		return conditionalBase{}, fmt.Errorf("provenance: resolve repository head: %w", err)
+	}
+	dirty, err := s.fileDirtyAtHead(ctx, filename, head)
+	if err != nil {
+		return conditionalBase{}, fmt.Errorf("provenance: inspect worktree state for %s: %w", filename, err)
 	}
 	if dirty {
-		return Revision{}, &RevisionConflictError{Filename: filename, Expected: expectedRevision, Actual: "worktree_dirty"}
+		return conditionalBase{}, &RevisionConflictError{Filename: filename, Expected: expectedRevision, Actual: "worktree_dirty"}
 	}
 
-	current, hasCurrent, err := s.currentFileRevisionLocked(ctx, filename)
+	current, hasCurrent, err := s.currentFileRevisionAtHead(ctx, filename, head)
 	if err != nil {
-		return Revision{}, fmt.Errorf("provenance: resolve current revision for %s: %w", filename, err)
+		return conditionalBase{}, fmt.Errorf("provenance: resolve current revision for %s: %w", filename, err)
 	}
+	base := conditionalBase{current: current, head: head}
 	if strings.EqualFold(expectedRevision, RevisionAbsent) {
 		if hasCurrent {
-			return Revision{}, &RevisionConflictError{Filename: filename, Expected: RevisionAbsent, Actual: current.Short}
+			return conditionalBase{}, &RevisionConflictError{Filename: filename, Expected: RevisionAbsent, Actual: current.Short}
 		}
 		if _, statErr := os.Stat(filepath.Join(s.path, filename)); statErr == nil {
-			return Revision{}, &RevisionConflictError{Filename: filename, Expected: RevisionAbsent, Actual: "worktree_dirty"}
+			return conditionalBase{}, &RevisionConflictError{Filename: filename, Expected: RevisionAbsent, Actual: "worktree_dirty"}
 		} else if !os.IsNotExist(statErr) {
-			return Revision{}, fmt.Errorf("provenance: stat %s: %w", filename, statErr)
+			return conditionalBase{}, fmt.Errorf("provenance: stat %s: %w", filename, statErr)
 		}
-		return Revision{}, nil
+		return base, nil
 	}
 	if !hasCurrent {
-		return Revision{}, &RevisionConflictError{Filename: filename, Expected: expectedRevision, Actual: RevisionAbsent}
+		return conditionalBase{}, &RevisionConflictError{Filename: filename, Expected: expectedRevision, Actual: RevisionAbsent}
 	}
 
 	expected, err := resolveRevision(ctx, s.path, filename, expectedRevision)
 	if err != nil {
-		return Revision{}, fmt.Errorf("provenance: resolve expected revision %q for %s: %w", expectedRevision, filename, err)
+		return conditionalBase{}, fmt.Errorf("provenance: resolve expected revision %q for %s: %w", expectedRevision, filename, err)
 	}
 	if expected.Commit != current.Commit {
-		return Revision{}, &RevisionConflictError{Filename: filename, Expected: expected.Short, Actual: current.Short}
+		return conditionalBase{}, &RevisionConflictError{Filename: filename, Expected: expected.Short, Actual: current.Short}
 	}
-	return current, nil
+	return base, nil
 }
 
-// currentFileRevisionLocked distinguishes a missing file history from a git
-// failure. resolveRevision deliberately presents both as errors, which is
-// useful for readers but unsafe for RevisionAbsent: an unavailable repository
-// must never be mistaken for permission to create.
-func (s *Store) currentFileRevisionLocked(ctx context.Context, filename string) (Revision, bool, error) {
-	hasHead, err := repositoryHasHead(ctx, s.path)
+// currentFileRevisionAtHead distinguishes a path that exists in the captured
+// tree from one that merely has history. A deletion commit is therefore
+// RevisionAbsent until a later create restores the path.
+func (s *Store) currentFileRevisionAtHead(ctx context.Context, filename, head string) (Revision, bool, error) {
+	if head == "" {
+		return Revision{}, false, nil
+	}
+	exists, err := runGitText(ctx, s.path, "ls-tree", "-z", "--name-only", "--full-tree", head, "--", filename)
 	if err != nil {
 		return Revision{}, false, err
 	}
-	if !hasHead {
+	if exists == "" {
 		return Revision{}, false, nil
 	}
-	commit, err := runGitText(ctx, s.path, "rev-list", "-1", "--end-of-options", "HEAD", "--", filename)
+	commit, err := runGitText(ctx, s.path, "rev-list", "-1", "--end-of-options", head, "--", filename)
 	if err != nil {
 		return Revision{}, false, err
 	}
@@ -143,17 +150,201 @@ func (s *Store) currentFileRevisionLocked(ctx context.Context, filename string) 
 	if commit == "" {
 		return Revision{}, false, nil
 	}
-	revision, err := describeRevision(ctx, s.path, filename, commit, "HEAD")
+	revision, err := describeRevision(ctx, s.path, filename, commit, head)
 	if err != nil {
 		return Revision{}, false, err
 	}
 	return revision, true, nil
 }
 
-func (s *Store) fileDirty(ctx context.Context, filename string) (bool, error) {
-	var out bytes.Buffer
-	if err := s.git(ctx, nil, &out, "--literal-pathspecs", "status", "--porcelain=v1", "--", filename); err != nil {
-		return false, err
+func (s *Store) fileDirtyAtHead(ctx context.Context, filename, head string) (bool, error) {
+	if head == "" {
+		if _, err := os.Lstat(filepath.Join(s.path, filename)); err == nil {
+			return true, nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return false, err
+		}
+		return s.fileTracked(ctx, filename)
 	}
-	return strings.TrimSpace(out.String()) != "", nil
+	err := s.git(ctx, nil, nil, "--literal-pathspecs", "diff", "--quiet", head, "--", filename)
+	if err == nil {
+		return false, nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		return true, nil
+	}
+	return false, err
+}
+
+func repositoryHead(ctx context.Context, repoPath string) (string, error) {
+	hasHead, err := repositoryHasHead(ctx, repoPath)
+	if err != nil || !hasHead {
+		return "", err
+	}
+	head, err := runGitText(ctx, repoPath, "rev-parse", "--verify", "HEAD^{commit}")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(head), nil
+}
+
+// commitFileContentAtHead builds the candidate commit through an isolated
+// index, then advances HEAD only if it still names expectedHead. Neither the
+// shared index nor the visible document is changed before that guarded ref
+// update succeeds.
+func (s *Store) commitFileContentAtHead(ctx context.Context, filename string, content []byte, message, expectedHead string) (string, error) {
+	gitDirText, err := runGitText(ctx, s.path, "rev-parse", "--absolute-git-dir")
+	if err != nil {
+		return "", fmt.Errorf("locate git directory: %w", err)
+	}
+	gitDir := strings.TrimSpace(gitDirText)
+
+	prepared, err := prepareCommittedFile(gitDir, content, 0o644)
+	if err != nil {
+		return "", fmt.Errorf("prepare worktree file: %w", err)
+	}
+	defer prepared.remove()
+
+	indexFile, err := os.CreateTemp(gitDir, "thane-index-*.tmp")
+	if err != nil {
+		return "", fmt.Errorf("prepare isolated index: %w", err)
+	}
+	indexPath := indexFile.Name()
+	if closeErr := indexFile.Close(); closeErr != nil {
+		os.Remove(indexPath)
+		return "", fmt.Errorf("close isolated index: %w", closeErr)
+	}
+	if err := os.Remove(indexPath); err != nil {
+		return "", fmt.Errorf("initialize isolated index: %w", err)
+	}
+	defer os.Remove(indexPath)
+	indexEnv := []string{"GIT_INDEX_FILE=" + indexPath}
+
+	if expectedHead == "" {
+		if err := s.gitWithEnv(ctx, indexEnv, nil, nil, "read-tree", "--empty"); err != nil {
+			return "", fmt.Errorf("git read-tree --empty: %w", err)
+		}
+	} else if err := s.gitWithEnv(ctx, indexEnv, nil, nil, "read-tree", expectedHead); err != nil {
+		return "", fmt.Errorf("git read-tree: %w", err)
+	}
+
+	var blobBuf bytes.Buffer
+	if err := s.git(ctx, bytes.NewReader(content), &blobBuf, "hash-object", "-w", "--stdin"); err != nil {
+		return "", fmt.Errorf("git hash-object blob: %w", err)
+	}
+	blob := strings.TrimSpace(blobBuf.String())
+	if err := s.gitWithEnv(ctx, indexEnv, nil, nil,
+		"update-index", "--add", "--cacheinfo", "100644", blob, filename); err != nil {
+		return "", fmt.Errorf("git update-index: %w", err)
+	}
+
+	var treeBuf bytes.Buffer
+	if err := s.gitWithEnv(ctx, indexEnv, nil, &treeBuf, "write-tree"); err != nil {
+		return "", fmt.Errorf("git write-tree: %w", err)
+	}
+	tree := strings.TrimSpace(treeBuf.String())
+	if expectedHead != "" {
+		baseTree, err := runGitText(ctx, s.path, "rev-parse", expectedHead+"^{tree}")
+		if err != nil {
+			return "", fmt.Errorf("resolve parent tree: %w", err)
+		}
+		if tree == strings.TrimSpace(baseTree) {
+			s.logger.Debug("no changes to commit", "files", []string{filename})
+			return "", nil
+		}
+	}
+
+	commitHash, err := s.writeSignedCommitObject(ctx, tree, expectedHead, message)
+	if err != nil {
+		return "", err
+	}
+	expectedRef := expectedHead
+	if expectedRef == "" {
+		expectedRef = strings.Repeat("0", len(commitHash))
+	}
+	if err := s.git(ctx, nil, nil, "update-ref", "HEAD", commitHash, expectedRef); err != nil {
+		return "", fmt.Errorf("git update-ref: %w", err)
+	}
+
+	if err := prepared.install(filepath.Join(s.path, filename)); err != nil {
+		rollbackErr := s.rollbackHead(commitHash, expectedHead)
+		if rollbackErr == nil {
+			return "", fmt.Errorf("materialize worktree file after guarded commit (HEAD rolled back): %w", err)
+		}
+		return "", fmt.Errorf("materialize worktree file after commit %s: %w (HEAD rollback also failed: %v)", shorten(commitHash), err, rollbackErr)
+	}
+
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), gitTimeout)
+	defer cancel()
+	if err := s.git(cleanupCtx, nil, nil, "reset", "--mixed", commitHash, "--", filename); err != nil {
+		s.logger.Warn("conditional provenance commit succeeded but index cleanup failed",
+			"commit", shorten(commitHash),
+			"file", filename,
+			"error", err,
+		)
+	}
+	return commitHash, nil
+}
+
+func (s *Store) rollbackHead(commitHash, previousHead string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), gitTimeout)
+	defer cancel()
+	if previousHead == "" {
+		return s.git(ctx, nil, nil, "update-ref", "-d", "HEAD", commitHash)
+	}
+	return s.git(ctx, nil, nil, "update-ref", "HEAD", previousHead, commitHash)
+}
+
+type preparedCommittedFile struct {
+	path string
+}
+
+func prepareCommittedFile(gitDir string, content []byte, perm os.FileMode) (*preparedCommittedFile, error) {
+	tmp, err := os.CreateTemp(gitDir, "thane-worktree-*.tmp")
+	if err != nil {
+		return nil, err
+	}
+	prepared := &preparedCommittedFile{path: tmp.Name()}
+	if err := tmp.Chmod(perm); err != nil {
+		tmp.Close()
+		prepared.remove()
+		return nil, err
+	}
+	if _, err := tmp.Write(content); err != nil {
+		tmp.Close()
+		prepared.remove()
+		return nil, err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		prepared.remove()
+		return nil, err
+	}
+	if err := tmp.Close(); err != nil {
+		prepared.remove()
+		return nil, err
+	}
+	return prepared, nil
+}
+
+func (f *preparedCommittedFile) install(target string) error {
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return err
+	}
+	if err := os.Rename(f.path, target); err != nil {
+		return err
+	}
+	f.path = ""
+	if dir, err := os.Open(filepath.Dir(target)); err == nil {
+		_ = dir.Sync()
+		_ = dir.Close()
+	}
+	return nil
+}
+
+func (f *preparedCommittedFile) remove() {
+	if f != nil && f.path != "" {
+		_ = os.Remove(f.path)
+	}
 }

--- a/internal/platform/provenance/conditional_write.go
+++ b/internal/platform/provenance/conditional_write.go
@@ -28,15 +28,18 @@ type RevisionConflictError struct {
 	Actual string
 }
 
-// Error implements error with a retry-oriented message suitable for passing
-// through model-facing document tools.
+// Error implements error.
 func (e *RevisionConflictError) Error() string {
-	return fmt.Sprintf("revision conflict for %s: expected %s, current is %s; read the current document and retry against its revision", e.Filename, e.Expected, e.Actual)
+	return fmt.Sprintf("revision conflict for %s: expected %s, current is %s", e.Filename, e.Expected, e.Actual)
 }
 
 // WriteIfRevision writes and commits content only when filename is still at
-// expectedRevision. The comparison and commit share the store mutex, so a
-// concurrent managed write or remote fast-forward cannot land between them.
+// expectedRevision. The comparison and commit share the store mutex, and the
+// HEAD update itself compares the parent, so concurrent managed writes and git
+// ref updates cannot land between them. An already-dirty target is rejected.
+// Editors that ignore Thane's coordination can still race in the narrow window
+// between the final worktree check and replacement; callers must not interpret
+// this as a general filesystem lock for arbitrary external writers.
 // Use [RevisionAbsent] to require creation of a file with no current history.
 // The returned revision is the exact commit produced by this call (or the
 // existing current revision when the content was already identical).
@@ -52,7 +55,8 @@ func (s *Store) WriteIfRevision(ctx context.Context, filename, content, message,
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if err := s.checkExpectedRevisionLocked(ctx, filename, expectedRevision); err != nil {
+	current, err := s.checkExpectedRevisionLocked(ctx, filename, expectedRevision)
+	if err != nil {
 		return Revision{}, err
 	}
 	absPath := filepath.Join(s.path, filename)
@@ -62,67 +66,61 @@ func (s *Store) WriteIfRevision(ctx context.Context, filename, content, message,
 	if err := os.WriteFile(absPath, []byte(content), 0o644); err != nil {
 		return Revision{}, fmt.Errorf("provenance: write %s: %w", filename, err)
 	}
-	committed, err := s.commitFile(ctx, filename, message)
+	commitHash, err := s.commitFile(ctx, filename, message)
 	if err != nil {
 		return Revision{}, fmt.Errorf("provenance: commit %s: %w", filename, err)
 	}
-	if committed {
+	if commitHash != "" {
 		s.logger.Info("provenance file committed",
 			"file", filename,
 			"bytes", len(content),
 			"message", messageSubject(message),
 		)
+		return Revision{Commit: commitHash, Short: shorten(commitHash)}, nil
 	}
-	revision, found, err := s.currentFileRevisionLocked(ctx, filename)
-	if err != nil {
-		return Revision{}, fmt.Errorf("provenance: resolve committed revision for %s: %w", filename, err)
-	}
-	if !found {
-		return Revision{}, fmt.Errorf("provenance: committed file %s has no revision", filename)
-	}
-	return revision, nil
+	return current, nil
 }
 
 // checkExpectedRevisionLocked compares one file's latest committed revision
 // while the caller holds s.mu. A dirty target is always a conflict: resolving
 // only committed history and then overwriting uncommitted operator bytes would
 // satisfy the hash comparison while violating its purpose.
-func (s *Store) checkExpectedRevisionLocked(ctx context.Context, filename, expectedRevision string) error {
+func (s *Store) checkExpectedRevisionLocked(ctx context.Context, filename, expectedRevision string) (Revision, error) {
 	dirty, err := s.fileDirty(ctx, filename)
 	if err != nil {
-		return fmt.Errorf("provenance: inspect worktree state for %s: %w", filename, err)
+		return Revision{}, fmt.Errorf("provenance: inspect worktree state for %s: %w", filename, err)
 	}
 	if dirty {
-		return &RevisionConflictError{Filename: filename, Expected: expectedRevision, Actual: "worktree_dirty"}
+		return Revision{}, &RevisionConflictError{Filename: filename, Expected: expectedRevision, Actual: "worktree_dirty"}
 	}
 
 	current, hasCurrent, err := s.currentFileRevisionLocked(ctx, filename)
 	if err != nil {
-		return fmt.Errorf("provenance: resolve current revision for %s: %w", filename, err)
+		return Revision{}, fmt.Errorf("provenance: resolve current revision for %s: %w", filename, err)
 	}
 	if strings.EqualFold(expectedRevision, RevisionAbsent) {
 		if hasCurrent {
-			return &RevisionConflictError{Filename: filename, Expected: RevisionAbsent, Actual: current.Short}
+			return Revision{}, &RevisionConflictError{Filename: filename, Expected: RevisionAbsent, Actual: current.Short}
 		}
 		if _, statErr := os.Stat(filepath.Join(s.path, filename)); statErr == nil {
-			return &RevisionConflictError{Filename: filename, Expected: RevisionAbsent, Actual: "worktree_dirty"}
+			return Revision{}, &RevisionConflictError{Filename: filename, Expected: RevisionAbsent, Actual: "worktree_dirty"}
 		} else if !os.IsNotExist(statErr) {
-			return fmt.Errorf("provenance: stat %s: %w", filename, statErr)
+			return Revision{}, fmt.Errorf("provenance: stat %s: %w", filename, statErr)
 		}
-		return nil
+		return Revision{}, nil
 	}
 	if !hasCurrent {
-		return &RevisionConflictError{Filename: filename, Expected: expectedRevision, Actual: RevisionAbsent}
+		return Revision{}, &RevisionConflictError{Filename: filename, Expected: expectedRevision, Actual: RevisionAbsent}
 	}
 
 	expected, err := resolveRevision(ctx, s.path, filename, expectedRevision)
 	if err != nil {
-		return fmt.Errorf("provenance: resolve expected revision %q for %s: %w", expectedRevision, filename, err)
+		return Revision{}, fmt.Errorf("provenance: resolve expected revision %q for %s: %w", expectedRevision, filename, err)
 	}
 	if expected.Commit != current.Commit {
-		return &RevisionConflictError{Filename: filename, Expected: expected.Short, Actual: current.Short}
+		return Revision{}, &RevisionConflictError{Filename: filename, Expected: expected.Short, Actual: current.Short}
 	}
-	return nil
+	return current, nil
 }
 
 // currentFileRevisionLocked distinguishes a missing file history from a git

--- a/internal/platform/provenance/conditional_write.go
+++ b/internal/platform/provenance/conditional_write.go
@@ -1,0 +1,161 @@
+package provenance
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// RevisionAbsent is the expected-revision token for a conditional write that
+// must create a file rather than replace one. It is deliberately a word, not
+// an empty string: empty retains the existing unconditional-write contract.
+const RevisionAbsent = "absent"
+
+// RevisionConflictError reports that a conditional write was based on a
+// revision that is no longer current. Expected is the caller's token; Actual
+// is the newest commit touching the file, RevisionAbsent when the file has no
+// history, or "worktree_dirty" when uncommitted bytes make a comparison
+// unsafe.
+type RevisionConflictError struct {
+	// Filename is the repository-relative file whose precondition failed.
+	Filename string
+	// Expected is the revision token supplied by the caller.
+	Expected string
+	// Actual is the current token or a named state such as worktree_dirty.
+	Actual string
+}
+
+// Error implements error with a retry-oriented message suitable for passing
+// through model-facing document tools.
+func (e *RevisionConflictError) Error() string {
+	return fmt.Sprintf("revision conflict for %s: expected %s, current is %s; read the current document and retry against its revision", e.Filename, e.Expected, e.Actual)
+}
+
+// WriteIfRevision writes and commits content only when filename is still at
+// expectedRevision. The comparison and commit share the store mutex, so a
+// concurrent managed write or remote fast-forward cannot land between them.
+// Use [RevisionAbsent] to require creation of a file with no current history.
+// The returned revision is the exact commit produced by this call (or the
+// existing current revision when the content was already identical).
+func (s *Store) WriteIfRevision(ctx context.Context, filename, content, message, expectedRevision string) (Revision, error) {
+	if err := validateFilename(filename); err != nil {
+		return Revision{}, fmt.Errorf("provenance: %w", err)
+	}
+	expectedRevision = strings.TrimSpace(expectedRevision)
+	if expectedRevision == "" {
+		return Revision{}, fmt.Errorf("provenance: expected revision is required for conditional write")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := s.checkExpectedRevisionLocked(ctx, filename, expectedRevision); err != nil {
+		return Revision{}, err
+	}
+	absPath := filepath.Join(s.path, filename)
+	if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
+		return Revision{}, fmt.Errorf("provenance: create directory for %s: %w", filename, err)
+	}
+	if err := os.WriteFile(absPath, []byte(content), 0o644); err != nil {
+		return Revision{}, fmt.Errorf("provenance: write %s: %w", filename, err)
+	}
+	committed, err := s.commitFile(ctx, filename, message)
+	if err != nil {
+		return Revision{}, fmt.Errorf("provenance: commit %s: %w", filename, err)
+	}
+	if committed {
+		s.logger.Info("provenance file committed",
+			"file", filename,
+			"bytes", len(content),
+			"message", messageSubject(message),
+		)
+	}
+	revision, found, err := s.currentFileRevisionLocked(ctx, filename)
+	if err != nil {
+		return Revision{}, fmt.Errorf("provenance: resolve committed revision for %s: %w", filename, err)
+	}
+	if !found {
+		return Revision{}, fmt.Errorf("provenance: committed file %s has no revision", filename)
+	}
+	return revision, nil
+}
+
+// checkExpectedRevisionLocked compares one file's latest committed revision
+// while the caller holds s.mu. A dirty target is always a conflict: resolving
+// only committed history and then overwriting uncommitted operator bytes would
+// satisfy the hash comparison while violating its purpose.
+func (s *Store) checkExpectedRevisionLocked(ctx context.Context, filename, expectedRevision string) error {
+	dirty, err := s.fileDirty(ctx, filename)
+	if err != nil {
+		return fmt.Errorf("provenance: inspect worktree state for %s: %w", filename, err)
+	}
+	if dirty {
+		return &RevisionConflictError{Filename: filename, Expected: expectedRevision, Actual: "worktree_dirty"}
+	}
+
+	current, hasCurrent, err := s.currentFileRevisionLocked(ctx, filename)
+	if err != nil {
+		return fmt.Errorf("provenance: resolve current revision for %s: %w", filename, err)
+	}
+	if strings.EqualFold(expectedRevision, RevisionAbsent) {
+		if hasCurrent {
+			return &RevisionConflictError{Filename: filename, Expected: RevisionAbsent, Actual: current.Short}
+		}
+		if _, statErr := os.Stat(filepath.Join(s.path, filename)); statErr == nil {
+			return &RevisionConflictError{Filename: filename, Expected: RevisionAbsent, Actual: "worktree_dirty"}
+		} else if !os.IsNotExist(statErr) {
+			return fmt.Errorf("provenance: stat %s: %w", filename, statErr)
+		}
+		return nil
+	}
+	if !hasCurrent {
+		return &RevisionConflictError{Filename: filename, Expected: expectedRevision, Actual: RevisionAbsent}
+	}
+
+	expected, err := resolveRevision(ctx, s.path, filename, expectedRevision)
+	if err != nil {
+		return fmt.Errorf("provenance: resolve expected revision %q for %s: %w", expectedRevision, filename, err)
+	}
+	if expected.Commit != current.Commit {
+		return &RevisionConflictError{Filename: filename, Expected: expected.Short, Actual: current.Short}
+	}
+	return nil
+}
+
+// currentFileRevisionLocked distinguishes a missing file history from a git
+// failure. resolveRevision deliberately presents both as errors, which is
+// useful for readers but unsafe for RevisionAbsent: an unavailable repository
+// must never be mistaken for permission to create.
+func (s *Store) currentFileRevisionLocked(ctx context.Context, filename string) (Revision, bool, error) {
+	hasHead, err := repositoryHasHead(ctx, s.path)
+	if err != nil {
+		return Revision{}, false, err
+	}
+	if !hasHead {
+		return Revision{}, false, nil
+	}
+	commit, err := runGitText(ctx, s.path, "rev-list", "-1", "--end-of-options", "HEAD", "--", filename)
+	if err != nil {
+		return Revision{}, false, err
+	}
+	commit = strings.TrimSpace(commit)
+	if commit == "" {
+		return Revision{}, false, nil
+	}
+	revision, err := describeRevision(ctx, s.path, filename, commit, "HEAD")
+	if err != nil {
+		return Revision{}, false, err
+	}
+	return revision, true, nil
+}
+
+func (s *Store) fileDirty(ctx context.Context, filename string) (bool, error) {
+	var out bytes.Buffer
+	if err := s.git(ctx, nil, &out, "--literal-pathspecs", "status", "--porcelain=v1", "--", filename); err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(out.String()) != "", nil
+}

--- a/internal/platform/provenance/git.go
+++ b/internal/platform/provenance/git.go
@@ -165,7 +165,7 @@ func (s *Store) commitFile(ctx context.Context, filename, message string) (strin
 }
 
 func (s *Store) fileTracked(ctx context.Context, filename string) (bool, error) {
-	err := s.git(ctx, nil, nil, "ls-files", "--error-unmatch", "--", filename)
+	err := s.git(ctx, nil, nil, "--literal-pathspecs", "ls-files", "--error-unmatch", "--", filename)
 	if err == nil {
 		return true, nil
 	}
@@ -219,7 +219,43 @@ func (s *Store) commitFiles(ctx context.Context, filenames []string, message str
 		parent = strings.TrimSpace(parentBuf.String())
 	}
 
-	// Build the commit object.
+	commitHash, err := s.writeSignedCommitObject(ctx, tree, parent, message)
+	if err != nil {
+		return "", err
+	}
+
+	// Update HEAD only if it still names the parent used above. The Store mutex
+	// coordinates Thane writers; update-ref's old-value guard also catches a
+	// concurrent operator git operation or transport fast-forward.
+	expectedHead := parent
+	if expectedHead == "" {
+		expectedHead = strings.Repeat("0", len(commitHash))
+	}
+	if err := s.git(ctx, nil, nil,
+		"update-ref", "HEAD", commitHash, expectedHead); err != nil {
+		return "", fmt.Errorf("git update-ref: %w", err)
+	}
+
+	// Reset the index to match HEAD so subsequent operations see a
+	// clean index. HEAD already contains the mutation, so context cancellation
+	// or an index-cleanup failure must not turn that success into an apparent
+	// failure that a caller may retry.
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), gitTimeout)
+	defer cancel()
+	if err := s.git(cleanupCtx, nil, nil, "reset", "--mixed", "HEAD"); err != nil {
+		s.logger.Warn("provenance commit succeeded but index cleanup failed",
+			"commit", shorten(commitHash),
+			"files", filenames,
+			"error", err,
+		)
+	}
+
+	return commitHash, nil
+}
+
+// writeSignedCommitObject creates a signed commit object without moving a ref.
+// Callers choose and guard the parent when they publish the returned object.
+func (s *Store) writeSignedCommitObject(ctx context.Context, tree, parent, message string) (string, error) {
 	now := time.Now()
 	unixTime := now.Unix()
 	_, offset := now.Zone()
@@ -266,35 +302,7 @@ func (s *Store) commitFiles(ctx context.Context, filenames []string, message str
 		"hash-object", "-t", "commit", "-w", "--stdin"); err != nil {
 		return "", fmt.Errorf("git hash-object: %w", err)
 	}
-	commitHash := strings.TrimSpace(hashBuf.String())
-
-	// Update HEAD only if it still names the parent used above. The Store mutex
-	// coordinates Thane writers; update-ref's old-value guard also catches a
-	// concurrent operator git operation or transport fast-forward.
-	expectedHead := parent
-	if expectedHead == "" {
-		expectedHead = strings.Repeat("0", len(commitHash))
-	}
-	if err := s.git(ctx, nil, nil,
-		"update-ref", "HEAD", commitHash, expectedHead); err != nil {
-		return "", fmt.Errorf("git update-ref: %w", err)
-	}
-
-	// Reset the index to match HEAD so subsequent operations see a
-	// clean index. HEAD already contains the mutation, so context cancellation
-	// or an index-cleanup failure must not turn that success into an apparent
-	// failure that a caller may retry.
-	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), gitTimeout)
-	defer cancel()
-	if err := s.git(cleanupCtx, nil, nil, "reset", "--mixed", "HEAD"); err != nil {
-		s.logger.Warn("provenance commit succeeded but index cleanup failed",
-			"commit", shorten(commitHash),
-			"files", filenames,
-			"error", err,
-		)
-	}
-
-	return commitHash, nil
+	return strings.TrimSpace(hashBuf.String()), nil
 }
 
 // fileHistory reads git log for a file and returns structured metadata.

--- a/internal/platform/provenance/git.go
+++ b/internal/platform/provenance/git.go
@@ -75,11 +75,11 @@ func (s *Store) BootstrapBirthCommit(ctx context.Context) error {
 		return fmt.Errorf("stat .allowed_signers: %w", err)
 	}
 
-	committed, err := s.commitFiles(ctx, bootstrapFiles, "bootstrap document root")
+	commitHash, err := s.commitFiles(ctx, bootstrapFiles, "bootstrap document root")
 	if err != nil {
 		return fmt.Errorf("birth commit: %w", err)
 	}
-	if committed {
+	if commitHash != "" {
 		s.logger.Info("created document root birth commit",
 			"path", s.path,
 			"files", bootstrapFiles,
@@ -157,8 +157,10 @@ func (s *Store) ensureRepo() error {
 	return nil
 }
 
-// commitFile stages a file and creates a signed commit.
-func (s *Store) commitFile(ctx context.Context, filename, message string) (bool, error) {
+// commitFile stages a file and creates a signed commit. It returns the exact
+// commit hash, or an empty string when the file already has the requested
+// content.
+func (s *Store) commitFile(ctx context.Context, filename, message string) (string, error) {
 	return s.commitFiles(ctx, []string{filename}, message)
 }
 
@@ -175,16 +177,18 @@ func (s *Store) fileTracked(ctx context.Context, filename string) (bool, error) 
 }
 
 // commitFiles stages files and creates one signed commit containing all
-// staged changes. It reports whether a commit was created.
-func (s *Store) commitFiles(ctx context.Context, filenames []string, message string) (bool, error) {
+// staged changes. It returns the exact commit hash, or an empty string when no
+// commit was needed. Once HEAD advances, later index cleanup is best-effort so
+// callers never receive a failure for a mutation that was actually committed.
+func (s *Store) commitFiles(ctx context.Context, filenames []string, message string) (string, error) {
 	if len(filenames) == 0 {
-		return false, fmt.Errorf("no files to commit")
+		return "", fmt.Errorf("no files to commit")
 	}
 
 	// Stage additions, modifications, and removals for the pathspecs.
 	args := append([]string{"add", "-A", "--"}, filenames...)
 	if err := s.git(ctx, nil, nil, args...); err != nil {
-		return false, fmt.Errorf("git add: %w", err)
+		return "", fmt.Errorf("git add: %w", err)
 	}
 
 	// Check if there are staged changes — skip commit if nothing changed.
@@ -194,17 +198,17 @@ func (s *Store) commitFiles(ctx context.Context, filenames []string, message str
 	if diffErr == nil {
 		// Exit code 0 means no differences — nothing to commit.
 		s.logger.Debug("no changes to commit", "files", filenames)
-		return false, nil
+		return "", nil
 	}
 	var exitErr *exec.ExitError
 	if errors.As(diffErr, &exitErr) && exitErr.ExitCode() != 1 {
-		return false, fmt.Errorf("git diff --cached: %w", diffErr)
+		return "", fmt.Errorf("git diff --cached: %w", diffErr)
 	}
 
 	// Get the tree hash.
 	var treeBuf bytes.Buffer
 	if err := s.git(ctx, nil, &treeBuf, "write-tree"); err != nil {
-		return false, fmt.Errorf("git write-tree: %w", err)
+		return "", fmt.Errorf("git write-tree: %w", err)
 	}
 	tree := strings.TrimSpace(treeBuf.String())
 
@@ -242,7 +246,7 @@ func (s *Store) commitFiles(ctx context.Context, filenames []string, message str
 	commitForSigning := commitObj.String() + "\n" + message + "\n"
 	armoredSig, err := s.signer.Sign([]byte(commitForSigning))
 	if err != nil {
-		return false, fmt.Errorf("sign commit: %w", err)
+		return "", fmt.Errorf("sign commit: %w", err)
 	}
 
 	// Insert the gpgsig header between the last header line and the
@@ -260,23 +264,37 @@ func (s *Store) commitFiles(ctx context.Context, filenames []string, message str
 	commitBytes := []byte(commitObj.String())
 	if err := s.git(ctx, bytes.NewReader(commitBytes), &hashBuf,
 		"hash-object", "-t", "commit", "-w", "--stdin"); err != nil {
-		return false, fmt.Errorf("git hash-object: %w", err)
+		return "", fmt.Errorf("git hash-object: %w", err)
 	}
 	commitHash := strings.TrimSpace(hashBuf.String())
 
-	// Update HEAD to point to the new commit.
+	// Update HEAD only if it still names the parent used above. The Store mutex
+	// coordinates Thane writers; update-ref's old-value guard also catches a
+	// concurrent operator git operation or transport fast-forward.
+	expectedHead := parent
+	if expectedHead == "" {
+		expectedHead = strings.Repeat("0", len(commitHash))
+	}
 	if err := s.git(ctx, nil, nil,
-		"update-ref", "HEAD", commitHash); err != nil {
-		return false, fmt.Errorf("git update-ref: %w", err)
+		"update-ref", "HEAD", commitHash, expectedHead); err != nil {
+		return "", fmt.Errorf("git update-ref: %w", err)
 	}
 
 	// Reset the index to match HEAD so subsequent operations see a
-	// clean working tree.
-	if err := s.git(ctx, nil, nil, "reset", "--mixed", "HEAD"); err != nil {
-		return false, fmt.Errorf("git reset: %w", err)
+	// clean index. HEAD already contains the mutation, so context cancellation
+	// or an index-cleanup failure must not turn that success into an apparent
+	// failure that a caller may retry.
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), gitTimeout)
+	defer cancel()
+	if err := s.git(cleanupCtx, nil, nil, "reset", "--mixed", "HEAD"); err != nil {
+		s.logger.Warn("provenance commit succeeded but index cleanup failed",
+			"commit", shorten(commitHash),
+			"files", filenames,
+			"error", err,
+		)
 	}
 
-	return true, nil
+	return commitHash, nil
 }
 
 // fileHistory reads git log for a file and returns structured metadata.

--- a/internal/platform/provenance/provenance.go
+++ b/internal/platform/provenance/provenance.go
@@ -255,12 +255,12 @@ func (s *Store) Write(ctx context.Context, filename, content, message string) er
 		return fmt.Errorf("provenance: write %s: %w", filename, err)
 	}
 
-	committed, err := s.commitFile(ctx, filename, message)
+	commitHash, err := s.commitFile(ctx, filename, message)
 	if err != nil {
 		return fmt.Errorf("provenance: commit %s: %w", filename, err)
 	}
 
-	if committed {
+	if commitHash != "" {
 		s.logger.Info("provenance file committed",
 			"file", filename,
 			"bytes", len(content),
@@ -303,12 +303,12 @@ func (s *Store) WriteFiles(ctx context.Context, files map[string]string, message
 		}
 	}
 
-	committed, err := s.commitFiles(ctx, filenames, message)
+	commitHash, err := s.commitFiles(ctx, filenames, message)
 	if err != nil {
 		return fmt.Errorf("provenance: commit files: %w", err)
 	}
 
-	if committed {
+	if commitHash != "" {
 		s.logger.Info("provenance files committed",
 			"files", filenames,
 			"message", messageSubject(message),
@@ -342,11 +342,11 @@ func (s *Store) Delete(ctx context.Context, filename, message string) error {
 		return fmt.Errorf("provenance: delete %s: %w", filename, err)
 	}
 
-	committed, err := s.commitFile(ctx, filename, message)
+	commitHash, err := s.commitFile(ctx, filename, message)
 	if err != nil {
 		return fmt.Errorf("provenance: commit delete %s: %w", filename, err)
 	}
-	if committed {
+	if commitHash != "" {
 		s.logger.Info("provenance file deletion committed",
 			"file", filename,
 			"message", messageSubject(message),

--- a/internal/platform/provenance/provenance_test.go
+++ b/internal/platform/provenance/provenance_test.go
@@ -1,6 +1,7 @@
 package provenance
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	"crypto/rand"
 	"errors"
@@ -116,6 +117,92 @@ func TestStoreWriteIfRevision(t *testing.T) {
 	}
 	if got, readErr := s.Read("contact.md"); readErr != nil || got != "second" {
 		t.Fatalf("Read after stale update = %q, %v; want second", got, readErr)
+	}
+}
+
+func TestStoreWriteIfRevisionTreatsDeletedPathAsAbsent(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+
+	if err := s.Write(ctx, "contact.md", "first", "create"); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	first, err := s.ResolveRevision(ctx, "contact.md", "HEAD")
+	if err != nil {
+		t.Fatalf("ResolveRevision: %v", err)
+	}
+	if err := s.Delete(ctx, "contact.md", "delete"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	_, err = s.WriteIfRevision(ctx, "contact.md", "stale", "stale update", first.Short)
+	var conflict *RevisionConflictError
+	if !errors.As(err, &conflict) || conflict.Actual != RevisionAbsent {
+		t.Fatalf("write against deleted path error = %v, conflict=%#v; want absent conflict", err, conflict)
+	}
+
+	created, err := s.WriteIfRevision(ctx, "contact.md", "recreated", "recreate", RevisionAbsent)
+	if err != nil {
+		t.Fatalf("recreate with absent precondition: %v", err)
+	}
+	if created.Commit == "" {
+		t.Fatal("recreate returned an empty revision")
+	}
+	if got, readErr := s.Read("contact.md"); readErr != nil || got != "recreated" {
+		t.Fatalf("Read after recreate = %q, %v; want recreated", got, readErr)
+	}
+}
+
+func TestConditionalCommitRejectsCapturedHeadMoveWithoutChangingTarget(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+
+	if err := s.Write(ctx, "contact.md", "original", "create contact"); err != nil {
+		t.Fatalf("Write contact: %v", err)
+	}
+	revision, err := s.ResolveRevision(ctx, "contact.md", "HEAD")
+	if err != nil {
+		t.Fatalf("ResolveRevision: %v", err)
+	}
+	base, err := s.checkExpectedRevisionLocked(ctx, "contact.md", revision.Short)
+	if err != nil {
+		t.Fatalf("checkExpectedRevisionLocked: %v", err)
+	}
+
+	if err := s.Write(ctx, "other.md", "external head move", "advance head"); err != nil {
+		t.Fatalf("advance HEAD: %v", err)
+	}
+	headAfterMove, err := repositoryHead(ctx, s.path)
+	if err != nil {
+		t.Fatalf("repositoryHead after move: %v", err)
+	}
+	if headAfterMove == base.head {
+		t.Fatal("test setup did not advance HEAD")
+	}
+	var statusBefore bytes.Buffer
+	if err := s.git(ctx, nil, &statusBefore, "status", "--porcelain=v1"); err != nil {
+		t.Fatalf("git status before refusal: %v", err)
+	}
+
+	if _, err := s.commitFileContentAtHead(ctx, "contact.md", []byte("stale replacement"), "stale update", base.head); err == nil {
+		t.Fatal("conditional commit against moved HEAD succeeded; want guarded update-ref failure")
+	}
+	if got, readErr := s.Read("contact.md"); readErr != nil || got != "original" {
+		t.Fatalf("target after rejected commit = %q, %v; want original", got, readErr)
+	}
+	currentHead, err := repositoryHead(ctx, s.path)
+	if err != nil {
+		t.Fatalf("repositoryHead after refusal: %v", err)
+	}
+	if currentHead != headAfterMove {
+		t.Fatalf("HEAD after refusal = %s, want external head %s", currentHead, headAfterMove)
+	}
+	var status bytes.Buffer
+	if err := s.git(ctx, nil, &status, "status", "--porcelain=v1"); err != nil {
+		t.Fatalf("git status: %v", err)
+	}
+	if status.String() != statusBefore.String() {
+		t.Fatalf("worktree/index changed after refusal: before %q, after %q", statusBefore.String(), status.String())
 	}
 }
 

--- a/internal/platform/provenance/provenance_test.go
+++ b/internal/platform/provenance/provenance_test.go
@@ -3,6 +3,7 @@ package provenance
 import (
 	"crypto/ed25519"
 	"crypto/rand"
+	"errors"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -79,6 +80,146 @@ func TestStoreWriteRead(t *testing.T) {
 
 	if got != content {
 		t.Errorf("Read = %q, want %q", got, content)
+	}
+}
+
+func TestStoreWriteIfRevision(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+
+	if _, err := s.WriteIfRevision(ctx, "contact.md", "first", "create", RevisionAbsent); err != nil {
+		t.Fatalf("create with absent precondition: %v", err)
+	}
+	first, err := s.ResolveRevision(ctx, "contact.md", "HEAD")
+	if err != nil {
+		t.Fatalf("resolve first revision: %v", err)
+	}
+	second, err := s.WriteIfRevision(ctx, "contact.md", "second", "update", first.Short)
+	if err != nil {
+		t.Fatalf("update with current precondition: %v", err)
+	}
+	current, err := s.ResolveRevision(ctx, "contact.md", "HEAD")
+	if err != nil {
+		t.Fatalf("resolve current revision: %v", err)
+	}
+	if second.Commit != current.Commit {
+		t.Fatalf("returned revision = %s, current = %s; want exact committed revision", second.Commit, current.Commit)
+	}
+
+	_, err = s.WriteIfRevision(ctx, "contact.md", "stale", "stale-update", first.Short)
+	var conflict *RevisionConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("stale update error = %v, want RevisionConflictError", err)
+	}
+	if conflict.Expected != first.Short || conflict.Actual == "" || conflict.Actual == first.Short {
+		t.Fatalf("conflict = %#v, want stale expected and newer actual", conflict)
+	}
+	if got, readErr := s.Read("contact.md"); readErr != nil || got != "second" {
+		t.Fatalf("Read after stale update = %q, %v; want second", got, readErr)
+	}
+}
+
+func TestStoreSnapshotPairsCurrentContentAndRevision(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+	if err := s.Write(ctx, "contact.md", "current dossier", "create"); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	revision, content, err := s.Snapshot(ctx, "contact.md")
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	committed, err := s.Blob(ctx, revision.Commit, "contact.md")
+	if err != nil {
+		t.Fatalf("Blob at snapshot revision: %v", err)
+	}
+	if content != committed || content != "current dossier" {
+		t.Fatalf("snapshot content = %q, committed content = %q; want current dossier", content, committed)
+	}
+}
+
+func TestStoreSnapshotReturnsUntrackedContentWithoutRevision(t *testing.T) {
+	s := testStore(t)
+	if err := os.WriteFile(filepath.Join(s.path, "draft.md"), []byte("untracked draft"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	revision, content, err := s.Snapshot(t.Context(), "draft.md")
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if revision.Commit != "" || content != "untracked draft" {
+		t.Fatalf("snapshot = revision %q, content %q; want no revision and untracked draft", revision.Commit, content)
+	}
+}
+
+func TestStoreWriteIfRevisionAllowsOnlyOneConcurrentWriter(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+
+	if _, err := s.WriteIfRevision(ctx, "contact.md", "first", "create", RevisionAbsent); err != nil {
+		t.Fatalf("create with absent precondition: %v", err)
+	}
+	first, err := s.ResolveRevision(ctx, "contact.md", "HEAD")
+	if err != nil {
+		t.Fatalf("resolve first revision: %v", err)
+	}
+
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	for _, content := range []string{"writer-a", "writer-b"} {
+		content := content
+		go func() {
+			<-start
+			_, err := s.WriteIfRevision(ctx, "contact.md", content, "concurrent update", first.Short)
+			errs <- err
+		}()
+	}
+	close(start)
+
+	successes := 0
+	conflicts := 0
+	for range 2 {
+		err := <-errs
+		if err == nil {
+			successes++
+			continue
+		}
+		var conflict *RevisionConflictError
+		if errors.As(err, &conflict) {
+			conflicts++
+			continue
+		}
+		t.Fatalf("concurrent write error = %v, want nil or RevisionConflictError", err)
+	}
+	if successes != 1 || conflicts != 1 {
+		t.Fatalf("concurrent outcomes = %d successes, %d conflicts; want 1 and 1", successes, conflicts)
+	}
+}
+
+func TestStoreWriteIfRevisionRejectsDirtyTarget(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+	if err := s.Write(ctx, "contact.md", "committed", "create"); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	rev, err := s.ResolveRevision(ctx, "contact.md", "HEAD")
+	if err != nil {
+		t.Fatalf("ResolveRevision: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(s.path, "contact.md"), []byte("operator edit"), 0o644); err != nil {
+		t.Fatalf("WriteFile dirty target: %v", err)
+	}
+
+	_, err = s.WriteIfRevision(ctx, "contact.md", "model edit", "update", rev.Short)
+	var conflict *RevisionConflictError
+	if !errors.As(err, &conflict) || conflict.Actual != "worktree_dirty" {
+		t.Fatalf("dirty-target error = %v, conflict=%#v; want worktree_dirty conflict", err, conflict)
+	}
+	got, readErr := os.ReadFile(filepath.Join(s.path, "contact.md"))
+	if readErr != nil || string(got) != "operator edit" {
+		t.Fatalf("dirty target after refusal = %q, %v; want operator edit preserved", got, readErr)
 	}
 }
 

--- a/internal/platform/provenance/reader.go
+++ b/internal/platform/provenance/reader.go
@@ -18,6 +18,10 @@ import (
 // filename is always repo-relative; callers that map a repository onto a
 // subtree translate the prefix before calling.
 type Reader interface {
+	// Snapshot returns the current worktree bytes and newest commit touching
+	// filename under one backend lock. Revision is zero for untracked files.
+	Snapshot(ctx context.Context, filename string) (revision Revision, content string, err error)
+
 	// ResolveRevision maps a selector onto a concrete revision of filename.
 	// Accepted selectors: "" / "HEAD" / "latest" (newest commit touching the
 	// file), an RFC3339 timestamp (newest commit at or before it), or a

--- a/internal/platform/provenance/snapshot.go
+++ b/internal/platform/provenance/snapshot.go
@@ -1,0 +1,68 @@
+package provenance
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Snapshot returns the current worktree content paired with its latest file
+// revision while holding the store's write lock.
+func (s *Store) Snapshot(ctx context.Context, filename string) (Revision, string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return readSnapshot(ctx, s.path, filename)
+}
+
+// Snapshot returns the current worktree content paired with its latest file
+// revision while holding the verifier's read lock.
+func (v *Verifier) Snapshot(ctx context.Context, filename string) (Revision, string, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return readSnapshot(ctx, v.path, filename)
+}
+
+func readSnapshot(ctx context.Context, repoPath, filename string) (Revision, string, error) {
+	if err := validateReaderFilename(filename); err != nil {
+		return Revision{}, "", fmt.Errorf("read snapshot: %w", err)
+	}
+	content, err := os.ReadFile(filepath.Join(repoPath, filename))
+	if err != nil {
+		return Revision{}, "", fmt.Errorf("read snapshot of %s: %w", filename, err)
+	}
+	hasHead, err := repositoryHasHead(ctx, repoPath)
+	if err != nil {
+		return Revision{}, "", err
+	}
+	if !hasHead {
+		return Revision{}, string(content), nil
+	}
+	commit, err := runGitText(ctx, repoPath, "rev-list", "-1", "--end-of-options", "HEAD", "--", filename)
+	if err != nil {
+		return Revision{}, "", fmt.Errorf("resolve snapshot revision: %w", err)
+	}
+	commit = strings.TrimSpace(commit)
+	if commit == "" {
+		return Revision{}, string(content), nil
+	}
+	revision, err := describeRevision(ctx, repoPath, filename, commit, "HEAD")
+	if err != nil {
+		return Revision{}, "", err
+	}
+	return revision, string(content), nil
+}
+
+func repositoryHasHead(ctx context.Context, repoPath string) (bool, error) {
+	if _, err := runGitText(ctx, repoPath, "rev-parse", "--verify", "--quiet", "HEAD^{commit}"); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}

--- a/internal/state/documents/activity_test.go
+++ b/internal/state/documents/activity_test.go
@@ -19,6 +19,10 @@ type recordingReviser struct {
 	diffBases map[string]string
 }
 
+func (r *recordingReviser) Snapshot(context.Context, string) (RevisionContent, error) {
+	return RevisionContent{}, nil
+}
+
 func (r *recordingReviser) Resolve(context.Context, string, string) (RevisionRef, error) {
 	return RevisionRef{}, nil
 }

--- a/internal/state/documents/model_tool_mutation_results.go
+++ b/internal/state/documents/model_tool_mutation_results.go
@@ -4,6 +4,7 @@ import "time"
 
 type modelMutationResult struct {
 	Action        string   `json:"action"`
+	Applied       bool     `json:"applied"`
 	Ref           string   `json:"ref"`
 	Root          string   `json:"root"`
 	Path          string   `json:"path"`
@@ -18,7 +19,6 @@ type modelMutationResult struct {
 	SizeBytes     int64    `json:"size_bytes"`
 	Section       string   `json:"section,omitempty"`
 	Window        string   `json:"window,omitempty"`
-	Revision      string   `json:"revision,omitempty"`
 }
 
 type modelDeleteResult struct {
@@ -110,6 +110,7 @@ func toModelMutationResult(result *MutationResult, now time.Time) *modelMutation
 	}
 	return &modelMutationResult{
 		Action:        result.Action,
+		Applied:       true,
 		Ref:           result.Ref,
 		Root:          result.Root,
 		Path:          result.Path,
@@ -124,7 +125,6 @@ func toModelMutationResult(result *MutationResult, now time.Time) *modelMutation
 		SizeBytes:     result.SizeBytes,
 		Section:       result.Section,
 		Window:        result.Window,
-		Revision:      result.Revision,
 	}
 }
 

--- a/internal/state/documents/model_tool_mutation_results.go
+++ b/internal/state/documents/model_tool_mutation_results.go
@@ -18,6 +18,7 @@ type modelMutationResult struct {
 	SizeBytes     int64    `json:"size_bytes"`
 	Section       string   `json:"section,omitempty"`
 	Window        string   `json:"window,omitempty"`
+	Revision      string   `json:"revision,omitempty"`
 }
 
 type modelDeleteResult struct {
@@ -123,6 +124,7 @@ func toModelMutationResult(result *MutationResult, now time.Time) *modelMutation
 		SizeBytes:     result.SizeBytes,
 		Section:       result.Section,
 		Window:        result.Window,
+		Revision:      result.Revision,
 	}
 }
 

--- a/internal/state/documents/model_tool_results.go
+++ b/internal/state/documents/model_tool_results.go
@@ -93,6 +93,7 @@ type modelDocumentRecord struct {
 	ModifiedDelta string              `json:"modified_delta,omitempty"`
 	WordCount     int                 `json:"word_count"`
 	SizeBytes     int64               `json:"size_bytes"`
+	Revision      string              `json:"revision,omitempty"`
 }
 
 type modelBacklink struct {
@@ -236,6 +237,7 @@ func toModelDocumentRecord(record *DocumentRecord, now time.Time) *modelDocument
 		ModifiedDelta: modelDelta(record.ModifiedAt, now),
 		WordCount:     record.WordCount,
 		SizeBytes:     record.SizeBytes,
+		Revision:      record.Revision,
 	}
 }
 

--- a/internal/state/documents/model_tool_results.go
+++ b/internal/state/documents/model_tool_results.go
@@ -93,7 +93,6 @@ type modelDocumentRecord struct {
 	ModifiedDelta string              `json:"modified_delta,omitempty"`
 	WordCount     int                 `json:"word_count"`
 	SizeBytes     int64               `json:"size_bytes"`
-	Revision      string              `json:"revision,omitempty"`
 }
 
 type modelBacklink struct {
@@ -237,7 +236,6 @@ func toModelDocumentRecord(record *DocumentRecord, now time.Time) *modelDocument
 		ModifiedDelta: modelDelta(record.ModifiedAt, now),
 		WordCount:     record.WordCount,
 		SizeBytes:     record.SizeBytes,
-		Revision:      record.Revision,
 	}
 }
 

--- a/internal/state/documents/mutate.go
+++ b/internal/state/documents/mutate.go
@@ -25,56 +25,56 @@ type DocumentRecord struct {
 	ModifiedAt  string              `json:"modified_at"`
 	WordCount   int                 `json:"word_count"`
 	SizeBytes   int64               `json:"size_bytes"`
-	// Revision is the newest commit touching this document on a
-	// revision-backed root. Pass it as expected_revision on a later
-	// mutation to reject stale read-modify-write cycles.
-	Revision string `json:"revision,omitempty"`
+	// Revision is internal coordination state for a revision-backed root.
+	// Model-facing adapters retain it as a hidden read receipt.
+	Revision string `json:"-"`
 }
 
 // WriteArgs creates or replaces a whole managed document.
 type WriteArgs struct {
-	Ref          string              `json:"ref"`
-	Title        string              `json:"title,omitempty"`
-	Description  string              `json:"description,omitempty"`
-	Tags         []string            `json:"tags,omitempty"`
-	Frontmatter  map[string][]string `json:"frontmatter,omitempty"`
-	Body         *string             `json:"body,omitempty"`
-	JournalEntry string              `json:"journal_entry,omitempty"`
-	// ExpectedRevision rejects a stale mutation on a revision-backed root.
-	ExpectedRevision string `json:"expected_revision,omitempty"`
+	Ref              string              `json:"ref"`
+	Title            string              `json:"title,omitempty"`
+	Description      string              `json:"description,omitempty"`
+	Tags             []string            `json:"tags,omitempty"`
+	Frontmatter      map[string][]string `json:"frontmatter,omitempty"`
+	Body             *string             `json:"body,omitempty"`
+	JournalEntry     string              `json:"journal_entry,omitempty"`
+	ExpectedRevision string              `json:"-"`
+	ReceiptScope     string              `json:"-"`
+	RequirePriorRead bool                `json:"-"`
 }
 
 // EditArgs updates part of a managed document without leaving the
 // semantic document abstraction.
 type EditArgs struct {
-	Ref         string              `json:"ref"`
-	Mode        string              `json:"mode"`
-	Body        string              `json:"body,omitempty"`
-	Section     string              `json:"section,omitempty"`
-	Heading     string              `json:"heading,omitempty"`
-	Level       int                 `json:"level,omitempty"`
-	Title       string              `json:"title,omitempty"`
-	Description string              `json:"description,omitempty"`
-	Tags        []string            `json:"tags,omitempty"`
-	Frontmatter map[string][]string `json:"frontmatter,omitempty"`
-	// ExpectedRevision rejects a stale mutation on a revision-backed root.
-	ExpectedRevision string `json:"expected_revision,omitempty"`
+	Ref              string              `json:"ref"`
+	Mode             string              `json:"mode"`
+	Body             string              `json:"body,omitempty"`
+	Section          string              `json:"section,omitempty"`
+	Heading          string              `json:"heading,omitempty"`
+	Level            int                 `json:"level,omitempty"`
+	Title            string              `json:"title,omitempty"`
+	Description      string              `json:"description,omitempty"`
+	Tags             []string            `json:"tags,omitempty"`
+	Frontmatter      map[string][]string `json:"frontmatter,omitempty"`
+	ExpectedRevision string              `json:"-"`
+	ReceiptScope     string              `json:"-"`
 }
 
 // JournalUpdateArgs appends a timestamped note into a rolling window
 // journal document while keeping window headings and timestamps stable.
 type JournalUpdateArgs struct {
-	Ref          string              `json:"ref"`
-	Entry        string              `json:"entry"`
-	Window       string              `json:"window,omitempty"`
-	MaxWindows   int                 `json:"max_windows,omitempty"`
-	HeadingLevel int                 `json:"heading_level,omitempty"`
-	Title        string              `json:"title,omitempty"`
-	Description  string              `json:"description,omitempty"`
-	Tags         []string            `json:"tags,omitempty"`
-	Frontmatter  map[string][]string `json:"frontmatter,omitempty"`
-	// ExpectedRevision rejects a stale mutation on a revision-backed root.
-	ExpectedRevision string `json:"expected_revision,omitempty"`
+	Ref              string              `json:"ref"`
+	Entry            string              `json:"entry"`
+	Window           string              `json:"window,omitempty"`
+	MaxWindows       int                 `json:"max_windows,omitempty"`
+	HeadingLevel     int                 `json:"heading_level,omitempty"`
+	Title            string              `json:"title,omitempty"`
+	Description      string              `json:"description,omitempty"`
+	Tags             []string            `json:"tags,omitempty"`
+	Frontmatter      map[string][]string `json:"frontmatter,omitempty"`
+	ExpectedRevision string              `json:"-"`
+	ReceiptScope     string              `json:"-"`
 }
 
 // MutationResult summarizes one managed document write/edit.
@@ -94,8 +94,20 @@ type MutationResult struct {
 	SizeBytes   int64    `json:"size_bytes"`
 	Section     string   `json:"section,omitempty"`
 	Window      string   `json:"window,omitempty"`
-	// Revision is the exact revision produced by a conditional mutation.
-	Revision string `json:"revision,omitempty"`
+	// Revision advances the hidden read receipt after a successful mutation.
+	Revision string `json:"-"`
+}
+
+// PriorReadRequiredError prevents a scoped whole-document replacement from
+// overwriting an existing revision-backed document the caller has not read.
+type PriorReadRequiredError struct {
+	// Ref is the semantic document ref that must be read first.
+	Ref string `json:"-"`
+}
+
+// Error implements error.
+func (e *PriorReadRequiredError) Error() string {
+	return fmt.Sprintf("read %s before replacing its whole body", e.Ref)
 }
 
 // IsNotFound reports whether err means the document does not exist, as
@@ -200,11 +212,14 @@ func (s *Store) Write(ctx context.Context, args WriteArgs) (*MutationResult, err
 	var existingRecord *DocumentRecord
 	if _, err := os.Stat(absPath); err == nil {
 		existed = true
-		record, _, _, readErr := s.readDocumentFile(absPath, root, relPath)
+		record, _, _, readErr := s.readCurrentDocumentParts(ctx, absPath, root, relPath)
 		if readErr != nil {
 			return nil, readErr
 		}
 		existingRecord = record
+	}
+	if existed && args.RequirePriorRead && args.ExpectedRevision == "" && args.Body != nil && s.rootWriter(root) != nil && s.rootReviser(root) != nil {
+		return nil, &PriorReadRequiredError{Ref: args.Ref}
 	}
 
 	// A new document with no body at all is almost never intent — it is
@@ -235,7 +250,8 @@ func (s *Store) Write(ctx context.Context, args WriteArgs) (*MutationResult, err
 	meta := mergeDocumentFrontmatter(existingRecord, args.Title, args.Description, args.Tags, args.Frontmatter, now)
 	raw := renderDocument(meta, body)
 
-	revision, err := s.writeDocumentFileAtRevision(ctx, root, relPath, raw, args.ExpectedRevision)
+	expectedRevision := s.automaticExpectedRevision(root, existed, existingRecord, args.ExpectedRevision)
+	revision, err := s.writeDocumentFileAtRevision(ctx, root, relPath, raw, expectedRevision)
 	if err != nil {
 		return nil, err
 	}
@@ -261,7 +277,7 @@ func (s *Store) Edit(ctx context.Context, args EditArgs) (*MutationResult, error
 		return nil, err
 	}
 
-	record, rawFrontmatter, body, err := s.readDocumentFile(absPath, root, relPath)
+	record, rawFrontmatter, body, err := s.readCurrentDocumentParts(ctx, absPath, root, relPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, fmt.Errorf("document not found: %s", args.Ref)
@@ -306,7 +322,8 @@ func (s *Store) Edit(ctx context.Context, args EditArgs) (*MutationResult, error
 		raw = touchDocumentFrontmatter(raw, record, time.Now())
 	}
 	rendered := renderDocumentFromParts(raw, editedBody)
-	revision, err := s.writeDocumentFileAtRevision(ctx, root, relPath, rendered, args.ExpectedRevision)
+	expectedRevision := s.automaticExpectedRevision(root, true, record, args.ExpectedRevision)
+	revision, err := s.writeDocumentFileAtRevision(ctx, root, relPath, rendered, expectedRevision)
 	if err != nil {
 		return nil, err
 	}
@@ -338,7 +355,7 @@ func (s *Store) JournalUpdate(ctx context.Context, args JournalUpdateArgs) (*Mut
 	var body string
 	if _, err := os.Stat(absPath); err == nil {
 		existed = true
-		record, rawFrontmatter, body, err = s.readDocumentFile(absPath, root, relPath)
+		record, rawFrontmatter, body, err = s.readCurrentDocumentParts(ctx, absPath, root, relPath)
 		if err != nil {
 			return nil, err
 		}
@@ -381,7 +398,8 @@ func (s *Store) JournalUpdate(ctx context.Context, args JournalUpdateArgs) (*Mut
 		meta := mergeDocumentFrontmatter(record, args.Title, args.Description, args.Tags, args.Frontmatter, now)
 		rendered = renderDocument(meta, updatedBody)
 	}
-	revision, err := s.writeDocumentFileAtRevision(ctx, root, relPath, rendered, args.ExpectedRevision)
+	expectedRevision := s.automaticExpectedRevision(root, existed, record, args.ExpectedRevision)
+	revision, err := s.writeDocumentFileAtRevision(ctx, root, relPath, rendered, expectedRevision)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/state/documents/mutate.go
+++ b/internal/state/documents/mutate.go
@@ -25,6 +25,10 @@ type DocumentRecord struct {
 	ModifiedAt  string              `json:"modified_at"`
 	WordCount   int                 `json:"word_count"`
 	SizeBytes   int64               `json:"size_bytes"`
+	// Revision is the newest commit touching this document on a
+	// revision-backed root. Pass it as expected_revision on a later
+	// mutation to reject stale read-modify-write cycles.
+	Revision string `json:"revision,omitempty"`
 }
 
 // WriteArgs creates or replaces a whole managed document.
@@ -36,6 +40,8 @@ type WriteArgs struct {
 	Frontmatter  map[string][]string `json:"frontmatter,omitempty"`
 	Body         *string             `json:"body,omitempty"`
 	JournalEntry string              `json:"journal_entry,omitempty"`
+	// ExpectedRevision rejects a stale mutation on a revision-backed root.
+	ExpectedRevision string `json:"expected_revision,omitempty"`
 }
 
 // EditArgs updates part of a managed document without leaving the
@@ -51,6 +57,8 @@ type EditArgs struct {
 	Description string              `json:"description,omitempty"`
 	Tags        []string            `json:"tags,omitempty"`
 	Frontmatter map[string][]string `json:"frontmatter,omitempty"`
+	// ExpectedRevision rejects a stale mutation on a revision-backed root.
+	ExpectedRevision string `json:"expected_revision,omitempty"`
 }
 
 // JournalUpdateArgs appends a timestamped note into a rolling window
@@ -65,6 +73,8 @@ type JournalUpdateArgs struct {
 	Description  string              `json:"description,omitempty"`
 	Tags         []string            `json:"tags,omitempty"`
 	Frontmatter  map[string][]string `json:"frontmatter,omitempty"`
+	// ExpectedRevision rejects a stale mutation on a revision-backed root.
+	ExpectedRevision string `json:"expected_revision,omitempty"`
 }
 
 // MutationResult summarizes one managed document write/edit.
@@ -84,6 +94,8 @@ type MutationResult struct {
 	SizeBytes   int64    `json:"size_bytes"`
 	Section     string   `json:"section,omitempty"`
 	Window      string   `json:"window,omitempty"`
+	// Revision is the exact revision produced by a conditional mutation.
+	Revision string `json:"revision,omitempty"`
 }
 
 // IsNotFound reports whether err means the document does not exist, as
@@ -130,7 +142,7 @@ func (s *Store) Read(ctx context.Context, ref string) (*DocumentRecord, error) {
 	if err := s.verifyDocumentForConsumer(ctx, root, relPath, "doc_read"); err != nil {
 		return nil, err
 	}
-	record, _, _, err := s.readDocumentFile(absPath, root, relPath)
+	record, err := s.readCurrentDocument(ctx, absPath, root, relPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, fmt.Errorf("document not found: %s", ref)
@@ -223,13 +235,15 @@ func (s *Store) Write(ctx context.Context, args WriteArgs) (*MutationResult, err
 	meta := mergeDocumentFrontmatter(existingRecord, args.Title, args.Description, args.Tags, args.Frontmatter, now)
 	raw := renderDocument(meta, body)
 
-	if err := s.writeDocumentFile(ctx, root, relPath, raw); err != nil {
-		return nil, err
-	}
-	record, _, _, err := s.readDocumentFile(absPath, root, relPath)
+	revision, err := s.writeDocumentFileAtRevision(ctx, root, relPath, raw, args.ExpectedRevision)
 	if err != nil {
 		return nil, err
 	}
+	record, _, _, err := documentRecordFromBytes(root, relPath, []byte(raw), time.Now())
+	if err != nil {
+		return nil, err
+	}
+	s.attachMutationRevision(ctx, record, revision)
 	return mutationResultFromRecord("doc_write", record, existed, sectionName, ""), nil
 }
 
@@ -292,13 +306,15 @@ func (s *Store) Edit(ctx context.Context, args EditArgs) (*MutationResult, error
 		raw = touchDocumentFrontmatter(raw, record, time.Now())
 	}
 	rendered := renderDocumentFromParts(raw, editedBody)
-	if err := s.writeDocumentFile(ctx, root, relPath, rendered); err != nil {
-		return nil, err
-	}
-	record, _, _, err = s.readDocumentFile(absPath, root, relPath)
+	revision, err := s.writeDocumentFileAtRevision(ctx, root, relPath, rendered, args.ExpectedRevision)
 	if err != nil {
 		return nil, err
 	}
+	record, _, _, err = documentRecordFromBytes(root, relPath, []byte(rendered), time.Now())
+	if err != nil {
+		return nil, err
+	}
+	s.attachMutationRevision(ctx, record, revision)
 	return mutationResultFromRecord("doc_edit", record, true, sectionName, ""), nil
 }
 
@@ -365,13 +381,15 @@ func (s *Store) JournalUpdate(ctx context.Context, args JournalUpdateArgs) (*Mut
 		meta := mergeDocumentFrontmatter(record, args.Title, args.Description, args.Tags, args.Frontmatter, now)
 		rendered = renderDocument(meta, updatedBody)
 	}
-	if err := s.writeDocumentFile(ctx, root, relPath, rendered); err != nil {
-		return nil, err
-	}
-	record, _, _, err = s.readDocumentFile(absPath, root, relPath)
+	revision, err := s.writeDocumentFileAtRevision(ctx, root, relPath, rendered, args.ExpectedRevision)
 	if err != nil {
 		return nil, err
 	}
+	record, _, _, err = documentRecordFromBytes(root, relPath, []byte(rendered), time.Now())
+	if err != nil {
+		return nil, err
+	}
+	s.attachMutationRevision(ctx, record, revision)
 	return mutationResultFromRecord("doc_journal_update", record, existed, windowHeading, windowKind), nil
 }
 
@@ -418,9 +436,20 @@ func (s *Store) readDocumentFile(absPath, root, relPath string) (*DocumentRecord
 	if err != nil {
 		return nil, "", "", err
 	}
+	return readDocumentRecordBytes(absPath, root, relPath, rawBytes)
+}
+
+func readDocumentRecordBytes(absPath, root, relPath string, rawBytes []byte) (*DocumentRecord, string, string, error) {
 	info, err := os.Stat(absPath)
 	if err != nil {
 		return nil, "", "", err
+	}
+	return documentRecordFromBytes(root, relPath, rawBytes, info.ModTime())
+}
+
+func documentRecordFromBytes(root, relPath string, rawBytes []byte, modifiedAt time.Time) (*DocumentRecord, string, string, error) {
+	if int64(len(rawBytes)) > maxReadableDocumentBytes {
+		return nil, "", "", fmt.Errorf("document %q exceeds the maximum readable size of %d bytes; it is likely runaway or corrupt and must be truncated or removed before Thane can read it", filepath.Base(relPath), maxReadableDocumentBytes)
 	}
 	raw := string(rawBytes)
 	rawFrontmatter, body, hasFrontmatter := splitFrontmatterBlock(raw)
@@ -439,9 +468,9 @@ func (s *Store) readDocumentFile(absPath, root, relPath string) (*DocumentRecord
 		Frontmatter: cloneFrontmatter(doc.Frontmatter),
 		Body:        strippedBody,
 		Outline:     append([]Section(nil), doc.Sections...),
-		ModifiedAt:  info.ModTime().UTC().Format(time.RFC3339Nano),
+		ModifiedAt:  modifiedAt.UTC().Format(time.RFC3339Nano),
 		WordCount:   doc.WordCount,
-		SizeBytes:   info.Size(),
+		SizeBytes:   int64(len(rawBytes)),
 	}, rawFrontmatter, body, nil
 }
 
@@ -523,6 +552,7 @@ func mutationResultFromRecord(action string, record *DocumentRecord, existed boo
 		SizeBytes:   record.SizeBytes,
 		Section:     section,
 		Window:      window,
+		Revision:    record.Revision,
 	}
 }
 

--- a/internal/state/documents/mutate_policy.go
+++ b/internal/state/documents/mutate_policy.go
@@ -12,45 +12,68 @@ import (
 )
 
 func (s *Store) writeDocumentFile(ctx context.Context, root, relPath, raw string) error {
+	_, err := s.writeDocumentFileAtRevision(ctx, root, relPath, raw, "")
+	return err
+}
+
+// writeDocumentFileAtRevision applies an optional compare-and-write
+// precondition. Empty preserves the unconditional mutation contract used by
+// existing callers; a non-empty revision requires a writer that can compare
+// and commit atomically.
+func (s *Store) writeDocumentFileAtRevision(ctx context.Context, root, relPath, raw, expectedRevision string) (string, error) {
 	absPath, err := s.resolveDocumentWritePath(root, relPath)
 	if err != nil {
-		return err
+		return "", err
 	}
 	if err := s.ensureRootAuthoringAllowed(root); err != nil {
-		return err
+		return "", err
 	}
 	if writer := s.rootWriter(root); writer != nil {
-		if err := writer.Write(ctx, relPath, raw, documentWriteMessage("doc_write", root, relPath, raw)); err != nil {
-			return fmt.Errorf("write document through root policy: %w", err)
+		message := documentWriteMessage("doc_write", root, relPath, raw)
+		expectedRevision = strings.TrimSpace(expectedRevision)
+		if expectedRevision != "" {
+			revision, err := writer.WriteIfRevision(ctx, relPath, raw, message, expectedRevision)
+			if err != nil {
+				return "", fmt.Errorf("write %s with expected_revision %q: %w", makeRef(root, relPath), expectedRevision, err)
+			}
+			if err := s.refreshDocumentWrite(ctx, root, relPath); err != nil {
+				return "", err
+			}
+			return revision, nil
+		} else if err := writer.Write(ctx, relPath, raw, message); err != nil {
+			return "", fmt.Errorf("write document through root policy: %w", err)
 		}
 		if err := s.refreshDocumentWrite(ctx, root, relPath); err != nil {
-			return err
+			return "", err
 		}
-		return nil
+		return "", nil
+	}
+	if strings.TrimSpace(expectedRevision) != "" {
+		return "", fmt.Errorf("expected_revision requires a revision-backed document root; root %q writes directly to the filesystem", root)
 	}
 	if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
-		return fmt.Errorf("create document directories: %w", err)
+		return "", fmt.Errorf("create document directories: %w", err)
 	}
 	tmp, err := os.CreateTemp(filepath.Dir(absPath), ".thane-doc-*")
 	if err != nil {
-		return fmt.Errorf("create temp document: %w", err)
+		return "", fmt.Errorf("create temp document: %w", err)
 	}
 	tmpPath := tmp.Name()
 	defer os.Remove(tmpPath)
 	if _, err := tmp.WriteString(raw); err != nil {
 		_ = tmp.Close()
-		return fmt.Errorf("write temp document: %w", err)
+		return "", fmt.Errorf("write temp document: %w", err)
 	}
 	if err := tmp.Close(); err != nil {
-		return fmt.Errorf("close temp document: %w", err)
+		return "", fmt.Errorf("close temp document: %w", err)
 	}
 	if err := os.Rename(tmpPath, absPath); err != nil {
-		return fmt.Errorf("replace document: %w", err)
+		return "", fmt.Errorf("replace document: %w", err)
 	}
 	if err := s.refreshDocumentWrite(ctx, root, relPath); err != nil {
-		return err
+		return "", err
 	}
-	return nil
+	return "", nil
 }
 
 func (s *Store) refreshDocumentWrite(ctx context.Context, root, relPath string) error {

--- a/internal/state/documents/mutate_policy.go
+++ b/internal/state/documents/mutate_policy.go
@@ -34,7 +34,7 @@ func (s *Store) writeDocumentFileAtRevision(ctx context.Context, root, relPath, 
 		if expectedRevision != "" {
 			revision, err := writer.WriteIfRevision(ctx, relPath, raw, message, expectedRevision)
 			if err != nil {
-				return "", fmt.Errorf("write %s with expected_revision %q: %w", makeRef(root, relPath), expectedRevision, err)
+				return "", fmt.Errorf("write %s with revision precondition: %w", makeRef(root, relPath), err)
 			}
 			if err := s.refreshDocumentWrite(ctx, root, relPath); err != nil {
 				return "", err
@@ -49,7 +49,7 @@ func (s *Store) writeDocumentFileAtRevision(ctx context.Context, root, relPath, 
 		return "", nil
 	}
 	if strings.TrimSpace(expectedRevision) != "" {
-		return "", fmt.Errorf("expected_revision requires a revision-backed document root; root %q writes directly to the filesystem", root)
+		return "", fmt.Errorf("revision preconditions require a revision-backed document root; root %q writes directly to the filesystem", root)
 	}
 	if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
 		return "", fmt.Errorf("create document directories: %w", err)

--- a/internal/state/documents/mutation_revision_test.go
+++ b/internal/state/documents/mutation_revision_test.go
@@ -14,10 +14,11 @@ import (
 )
 
 type revisionMutationBackend struct {
-	root     string
-	revision string
-	next     int
-	contents map[string]string
+	root        string
+	revision    string
+	next        int
+	contents    map[string]string
+	snapshotErr error
 }
 
 func (b *revisionMutationBackend) Write(_ context.Context, filename, content, _ string) error {
@@ -71,6 +72,9 @@ func (b *revisionMutationBackend) Content(context.Context, string, string) (Revi
 }
 
 func (b *revisionMutationBackend) Snapshot(_ context.Context, filename string) (RevisionContent, error) {
+	if b.snapshotErr != nil {
+		return RevisionContent{}, b.snapshotErr
+	}
 	content, err := os.ReadFile(filepath.Join(b.root, filename))
 	if err != nil {
 		return RevisionContent{}, err
@@ -202,6 +206,66 @@ func TestHiddenRevisionReceiptReturnsConflictDiffAndAdvances(t *testing.T) {
 	var retried modelMutationResult
 	if err := json.Unmarshal([]byte(retryJSON), &retried); err != nil {
 		t.Fatalf("unmarshal retry result: %v", err)
+	}
+	if !retried.Applied {
+		t.Fatalf("retry applied = false, want true: %s", retryJSON)
+	}
+}
+
+func TestHiddenRevisionReceiptAdvancesFromConflictWhenSnapshotFails(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	backend := &revisionMutationBackend{root: root, contents: make(map[string]string)}
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	store, err := NewStoreWithOptions(db, map[string]string{"contacts": root}, nil, StoreOptions{
+		RootWriters:  map[string]RootWriter{"contacts": backend},
+		RootRevisers: map[string]RootReviser{"contacts": backend},
+	})
+	if err != nil {
+		t.Fatalf("NewStoreWithOptions: %v", err)
+	}
+	tools := NewTools(store)
+	ctx := t.Context()
+	const scope = "loop:archivist-contacts"
+
+	if _, err := tools.Write(ctx, WriteArgs{Ref: "contacts:person.md", Body: stringPtr("First fact."), ReceiptScope: scope}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := tools.Read(ctx, RefArgs{Ref: "contacts:person.md", ReceiptScope: scope}); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if err := backend.Write(ctx, "person.md", "Second fact.", "operator update"); err != nil {
+		t.Fatalf("external update: %v", err)
+	}
+	backend.snapshotErr = fmt.Errorf("snapshot unavailable")
+
+	conflict := store.describeMutationConflict(ctx, "edit", "contacts:person.md", "rev-1", &RootRevisionConflictError{
+		Expected: "rev-1",
+		Actual:   backend.revision,
+	})
+	if conflict.receiptRevision != backend.revision || !strings.Contains(conflict.message, "could not load") || !strings.Contains(conflict.message, "comparison base has advanced") {
+		t.Fatalf("conflict = %#v, want honest snapshot failure with advanced base", conflict)
+	}
+	tools.rememberRevisionReceipt(scope, "contacts:person.md", conflict.receiptRevision)
+
+	backend.snapshotErr = nil
+	retryJSON, err := tools.Edit(ctx, EditArgs{
+		Ref:          "contacts:person.md",
+		Mode:         "append_body",
+		Body:         "Reconciled fact.",
+		ReceiptScope: scope,
+	})
+	if err != nil {
+		t.Fatalf("retry edit: %v", err)
+	}
+	var retried modelMutationResult
+	if err := json.Unmarshal([]byte(retryJSON), &retried); err != nil {
+		t.Fatalf("unmarshal retry: %v", err)
 	}
 	if !retried.Applied {
 		t.Fatalf("retry applied = false, want true: %s", retryJSON)

--- a/internal/state/documents/mutation_revision_test.go
+++ b/internal/state/documents/mutation_revision_test.go
@@ -1,0 +1,167 @@
+package documents
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
+)
+
+type revisionMutationBackend struct {
+	root     string
+	revision string
+	next     int
+}
+
+func (b *revisionMutationBackend) Write(_ context.Context, filename, content, _ string) error {
+	return b.write(filename, content)
+}
+
+func (b *revisionMutationBackend) WriteIfRevision(_ context.Context, filename, content, _ string, expectedRevision string) (string, error) {
+	actual := b.revision
+	if actual == "" {
+		actual = "absent"
+	}
+	if expectedRevision != actual {
+		return "", fmt.Errorf("revision conflict: expected %s, current is %s", expectedRevision, actual)
+	}
+	if err := b.write(filename, content); err != nil {
+		return "", err
+	}
+	return b.revision, nil
+}
+
+func (b *revisionMutationBackend) Delete(_ context.Context, filename, _ string) error {
+	return os.Remove(filepath.Join(b.root, filename))
+}
+
+func (b *revisionMutationBackend) Resolve(_ context.Context, _ string, _ string) (RevisionRef, error) {
+	if b.revision == "" {
+		return RevisionRef{}, fmt.Errorf("no revision")
+	}
+	return RevisionRef{Commit: b.revision, Short: b.revision}, nil
+}
+
+func (b *revisionMutationBackend) History(context.Context, string, RevisionQuery) (RevisionListing, error) {
+	return RevisionListing{}, nil
+}
+
+func (b *revisionMutationBackend) Diff(context.Context, string, string, string, string) (RevisionDiff, error) {
+	return RevisionDiff{}, nil
+}
+
+func (b *revisionMutationBackend) Content(context.Context, string, string) (RevisionContent, error) {
+	return RevisionContent{}, nil
+}
+
+func (b *revisionMutationBackend) Snapshot(_ context.Context, filename string) (RevisionContent, error) {
+	content, err := os.ReadFile(filepath.Join(b.root, filename))
+	if err != nil {
+		return RevisionContent{}, err
+	}
+	return RevisionContent{
+		Revision: RevisionRef{Commit: b.revision, Short: b.revision},
+		Content:  string(content),
+	}, nil
+}
+
+func (b *revisionMutationBackend) write(filename, content string) error {
+	path := filepath.Join(b.root, filename)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		return err
+	}
+	b.next++
+	b.revision = fmt.Sprintf("rev-%d", b.next)
+	return nil
+}
+
+func TestRevisionCheckedMutationRoundTripAndConflict(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	backend := &revisionMutationBackend{root: root}
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	store, err := NewStoreWithOptions(db, map[string]string{"contacts": root}, nil, StoreOptions{
+		RootWriters:  map[string]RootWriter{"contacts": backend},
+		RootRevisers: map[string]RootReviser{"contacts": backend},
+	})
+	if err != nil {
+		t.Fatalf("NewStoreWithOptions: %v", err)
+	}
+	tools := NewTools(store)
+	ctx := t.Context()
+
+	createdJSON, err := tools.Write(ctx, WriteArgs{
+		Ref:              "contacts:person.md",
+		Body:             stringPtr("First fact."),
+		ExpectedRevision: "absent",
+	})
+	if err != nil {
+		t.Fatalf("Write with absent revision: %v", err)
+	}
+	var created modelMutationResult
+	if err := json.Unmarshal([]byte(createdJSON), &created); err != nil {
+		t.Fatalf("unmarshal create result: %v", err)
+	}
+	if created.Revision != "rev-1" {
+		t.Fatalf("create revision = %q, want rev-1", created.Revision)
+	}
+
+	readJSON, err := tools.Read(ctx, RefArgs{Ref: "contacts:person.md"})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	var read modelDocumentRecord
+	if err := json.Unmarshal([]byte(readJSON), &read); err != nil {
+		t.Fatalf("unmarshal read result: %v", err)
+	}
+	if read.Revision != created.Revision {
+		t.Fatalf("read revision = %q, want %q", read.Revision, created.Revision)
+	}
+
+	updatedJSON, err := tools.Edit(ctx, EditArgs{
+		Ref:              "contacts:person.md",
+		Mode:             "append_body",
+		Body:             "Second fact.",
+		ExpectedRevision: created.Revision,
+	})
+	if err != nil {
+		t.Fatalf("Edit with current revision: %v", err)
+	}
+	var updated modelMutationResult
+	if err := json.Unmarshal([]byte(updatedJSON), &updated); err != nil {
+		t.Fatalf("unmarshal edit result: %v", err)
+	}
+	if updated.Revision != "rev-2" {
+		t.Fatalf("updated revision = %q, want rev-2", updated.Revision)
+	}
+
+	_, err = tools.Edit(ctx, EditArgs{
+		Ref:              "contacts:person.md",
+		Mode:             "append_body",
+		Body:             "Stale fact.",
+		ExpectedRevision: created.Revision,
+	})
+	if err == nil || !strings.Contains(err.Error(), "revision conflict") {
+		t.Fatalf("stale Edit error = %v, want revision conflict", err)
+	}
+	record, err := store.Read(ctx, "contacts:person.md")
+	if err != nil {
+		t.Fatalf("Read after stale edit: %v", err)
+	}
+	if !strings.Contains(record.Body, "Second fact.") || strings.Contains(record.Body, "Stale fact.") {
+		t.Fatalf("body after stale edit = %q, want second fact without stale fact", record.Body)
+	}
+}

--- a/internal/state/documents/mutation_revision_test.go
+++ b/internal/state/documents/mutation_revision_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 )
@@ -16,6 +17,7 @@ type revisionMutationBackend struct {
 	root     string
 	revision string
 	next     int
+	contents map[string]string
 }
 
 func (b *revisionMutationBackend) Write(_ context.Context, filename, content, _ string) error {
@@ -28,7 +30,7 @@ func (b *revisionMutationBackend) WriteIfRevision(_ context.Context, filename, c
 		actual = "absent"
 	}
 	if expectedRevision != actual {
-		return "", fmt.Errorf("revision conflict: expected %s, current is %s", expectedRevision, actual)
+		return "", &RootRevisionConflictError{Expected: expectedRevision, Actual: actual}
 	}
 	if err := b.write(filename, content); err != nil {
 		return "", err
@@ -51,8 +53,17 @@ func (b *revisionMutationBackend) History(context.Context, string, RevisionQuery
 	return RevisionListing{}, nil
 }
 
-func (b *revisionMutationBackend) Diff(context.Context, string, string, string, string) (RevisionDiff, error) {
-	return RevisionDiff{}, nil
+func (b *revisionMutationBackend) Diff(_ context.Context, _ string, from, to, _ string) (RevisionDiff, error) {
+	before, beforeOK := b.contents[from]
+	after, afterOK := b.contents[to]
+	if !beforeOK || !afterOK {
+		return RevisionDiff{}, fmt.Errorf("unknown diff endpoint")
+	}
+	return RevisionDiff{
+		Added:   1,
+		Removed: 1,
+		Body:    fmt.Sprintf("--- a/person.md\n+++ b/person.md\n-%s\n+%s\n", before, after),
+	}, nil
 }
 
 func (b *revisionMutationBackend) Content(context.Context, string, string) (RevisionContent, error) {
@@ -80,14 +91,18 @@ func (b *revisionMutationBackend) write(filename, content string) error {
 	}
 	b.next++
 	b.revision = fmt.Sprintf("rev-%d", b.next)
+	if b.contents == nil {
+		b.contents = make(map[string]string)
+	}
+	b.contents[b.revision] = content
 	return nil
 }
 
-func TestRevisionCheckedMutationRoundTripAndConflict(t *testing.T) {
+func TestHiddenRevisionReceiptReturnsConflictDiffAndAdvances(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
-	backend := &revisionMutationBackend{root: root}
+	backend := &revisionMutationBackend{root: root, contents: make(map[string]string)}
 	db, err := database.OpenMemory()
 	if err != nil {
 		t.Fatalf("OpenMemory: %v", err)
@@ -104,9 +119,9 @@ func TestRevisionCheckedMutationRoundTripAndConflict(t *testing.T) {
 	ctx := t.Context()
 
 	createdJSON, err := tools.Write(ctx, WriteArgs{
-		Ref:              "contacts:person.md",
-		Body:             stringPtr("First fact."),
-		ExpectedRevision: "absent",
+		Ref:          "contacts:person.md",
+		Body:         stringPtr("First fact."),
+		ReceiptScope: "loop:archivist-contacts",
 	})
 	if err != nil {
 		t.Fatalf("Write with absent revision: %v", err)
@@ -115,47 +130,57 @@ func TestRevisionCheckedMutationRoundTripAndConflict(t *testing.T) {
 	if err := json.Unmarshal([]byte(createdJSON), &created); err != nil {
 		t.Fatalf("unmarshal create result: %v", err)
 	}
-	if created.Revision != "rev-1" {
-		t.Fatalf("create revision = %q, want rev-1", created.Revision)
+	if !created.Applied {
+		t.Fatalf("create applied = false, want true: %s", createdJSON)
+	}
+	if strings.Contains(createdJSON, "revision") {
+		t.Fatalf("create exposed revision machinery: %s", createdJSON)
 	}
 
-	readJSON, err := tools.Read(ctx, RefArgs{Ref: "contacts:person.md"})
+	readJSON, err := tools.Read(ctx, RefArgs{Ref: "contacts:person.md", ReceiptScope: "loop:archivist-contacts"})
 	if err != nil {
 		t.Fatalf("Read: %v", err)
 	}
-	var read modelDocumentRecord
-	if err := json.Unmarshal([]byte(readJSON), &read); err != nil {
-		t.Fatalf("unmarshal read result: %v", err)
+	if strings.Contains(readJSON, "revision") {
+		t.Fatalf("read exposed revision machinery: %s", readJSON)
 	}
-	if read.Revision != created.Revision {
-		t.Fatalf("read revision = %q, want %q", read.Revision, created.Revision)
-	}
-
-	updatedJSON, err := tools.Edit(ctx, EditArgs{
-		Ref:              "contacts:person.md",
-		Mode:             "append_body",
-		Body:             "Second fact.",
-		ExpectedRevision: created.Revision,
+	blindJSON, err := tools.Write(ctx, WriteArgs{
+		Ref:          "contacts:person.md",
+		Body:         stringPtr("Blind replacement."),
+		ReceiptScope: "loop:different-writer",
 	})
 	if err != nil {
-		t.Fatalf("Edit with current revision: %v", err)
+		t.Fatalf("blind replacement: %v", err)
 	}
-	var updated modelMutationResult
-	if err := json.Unmarshal([]byte(updatedJSON), &updated); err != nil {
-		t.Fatalf("unmarshal edit result: %v", err)
+	var blind modelMutationConflict
+	if err := json.Unmarshal([]byte(blindJSON), &blind); err != nil {
+		t.Fatalf("unmarshal blind replacement: %v", err)
 	}
-	if updated.Revision != "rev-2" {
-		t.Fatalf("updated revision = %q, want rev-2", updated.Revision)
+	if blind.Applied || !strings.Contains(blind.Message, "Read contacts:person.md first") {
+		t.Fatalf("blind replacement = %#v, want read-first refusal", blind)
 	}
 
-	_, err = tools.Edit(ctx, EditArgs{
-		Ref:              "contacts:person.md",
-		Mode:             "append_body",
-		Body:             "Stale fact.",
-		ExpectedRevision: created.Revision,
+	if err := backend.Write(ctx, "person.md", "Second fact.", "operator update"); err != nil {
+		t.Fatalf("external update: %v", err)
+	}
+	conflictJSON, err := tools.Edit(ctx, EditArgs{
+		Ref:          "contacts:person.md",
+		Mode:         "append_body",
+		Body:         "Stale fact.",
+		ReceiptScope: "loop:archivist-contacts",
 	})
-	if err == nil || !strings.Contains(err.Error(), "revision conflict") {
-		t.Fatalf("stale Edit error = %v, want revision conflict", err)
+	if err != nil {
+		t.Fatalf("stale Edit: %v", err)
+	}
+	var conflict modelMutationConflict
+	if err := json.Unmarshal([]byte(conflictJSON), &conflict); err != nil {
+		t.Fatalf("unmarshal conflict result: %v", err)
+	}
+	if conflict.Applied || !strings.Contains(conflict.ChangedSinceRead, "Second fact.") {
+		t.Fatalf("conflict = %#v, want unapplied result with intervening diff", conflict)
+	}
+	if strings.Contains(conflictJSON, "rev-1") || strings.Contains(conflictJSON, "rev-2") {
+		t.Fatalf("conflict exposed hidden revision tokens: %s", conflictJSON)
 	}
 	record, err := store.Read(ctx, "contacts:person.md")
 	if err != nil {
@@ -163,5 +188,30 @@ func TestRevisionCheckedMutationRoundTripAndConflict(t *testing.T) {
 	}
 	if !strings.Contains(record.Body, "Second fact.") || strings.Contains(record.Body, "Stale fact.") {
 		t.Fatalf("body after stale edit = %q, want second fact without stale fact", record.Body)
+	}
+
+	retryJSON, err := tools.Edit(ctx, EditArgs{
+		Ref:          "contacts:person.md",
+		Mode:         "append_body",
+		Body:         "Reconciled fact.",
+		ReceiptScope: "loop:archivist-contacts",
+	})
+	if err != nil {
+		t.Fatalf("retry Edit: %v", err)
+	}
+	var retried modelMutationResult
+	if err := json.Unmarshal([]byte(retryJSON), &retried); err != nil {
+		t.Fatalf("unmarshal retry result: %v", err)
+	}
+	if !retried.Applied {
+		t.Fatalf("retry applied = false, want true: %s", retryJSON)
+	}
+}
+
+func TestTruncateRevisionConflictTextPreservesUTF8(t *testing.T) {
+	t.Parallel()
+	got, truncated := truncateRevisionConflictText("one 🧭 two", 6)
+	if !truncated || !strings.HasPrefix(got, "one") || !strings.Contains(got, "…") || !utf8.ValidString(got) {
+		t.Fatalf("truncateRevisionConflictText = %q, %v; want valid truncated UTF-8", got, truncated)
 	}
 }

--- a/internal/state/documents/policy.go
+++ b/internal/state/documents/policy.go
@@ -189,6 +189,22 @@ type RootWriter interface {
 	Delete(ctx context.Context, filename, message string) error
 }
 
+// RootRevisionConflictError reports a failed conditional root write without
+// coupling the documents package to the backing revision system. Expected and
+// Actual are internal coordination tokens; model-facing tools translate this
+// into a bounded narrative conflict instead of exposing them.
+type RootRevisionConflictError struct {
+	// Expected is the hidden revision receipt used by the attempted write.
+	Expected string `json:"-"`
+	// Actual is the current revision or a named worktree state.
+	Actual string `json:"-"`
+}
+
+// Error implements error.
+func (e *RootRevisionConflictError) Error() string {
+	return "document changed since the caller's read"
+}
+
 // RootVerifier verifies that a git-backed root or file is clean and
 // trusted before policy-sensitive consumers load it.
 type RootVerifier interface {

--- a/internal/state/documents/policy.go
+++ b/internal/state/documents/policy.go
@@ -183,6 +183,9 @@ type SignatureVerification struct {
 // the model.
 type RootWriter interface {
 	Write(ctx context.Context, filename, content, message string) error
+	// WriteIfRevision compares, commits, and returns the exact new revision
+	// atomically. expectedRevision may be the reserved creation token absent.
+	WriteIfRevision(ctx context.Context, filename, content, message, expectedRevision string) (revision string, err error)
 	Delete(ctx context.Context, filename, message string) error
 }
 

--- a/internal/state/documents/policy_test.go
+++ b/internal/state/documents/policy_test.go
@@ -53,6 +53,10 @@ func (w *recordingRootWriter) Write(_ context.Context, filename, content, messag
 	return os.WriteFile(path, []byte(content), 0o644)
 }
 
+func (w *recordingRootWriter) WriteIfRevision(ctx context.Context, filename, content, message, _ string) (string, error) {
+	return "", w.Write(ctx, filename, content, message)
+}
+
 func (w *recordingRootWriter) Delete(_ context.Context, filename, message string) error {
 	w.deletes = append(w.deletes, filename+"|"+message)
 	return os.Remove(filepath.Join(w.root, filename))

--- a/internal/state/documents/revision.go
+++ b/internal/state/documents/revision.go
@@ -5,6 +5,67 @@ import (
 	"time"
 )
 
+// attachCurrentRevision adds the round-trippable revision token when the
+// document's root exposes history. Revision lookup is supplementary to a
+// successful read or write: failing it must not turn an already-committed
+// mutation into an apparent failure that a caller may retry.
+func (s *Store) attachCurrentRevision(ctx context.Context, record *DocumentRecord) {
+	if s == nil || record == nil {
+		return
+	}
+	reviser := s.rootReviser(record.Root)
+	if reviser == nil {
+		return
+	}
+	rev, err := reviser.Resolve(ctx, record.Path, "HEAD")
+	if err != nil {
+		s.logger.Debug("document revision unavailable", "ref", record.Ref, "error", err)
+		return
+	}
+	record.Revision = rev.Short
+}
+
+func (s *Store) attachMutationRevision(ctx context.Context, record *DocumentRecord, revision string) {
+	if record == nil {
+		return
+	}
+	if revision != "" {
+		record.Revision = revision
+		return
+	}
+	if s.rootWriter(record.Root) != nil {
+		return
+	}
+	s.attachCurrentRevision(ctx, record)
+}
+
+func (s *Store) readCurrentDocument(ctx context.Context, absPath, root, relPath string) (*DocumentRecord, error) {
+	reviser := s.rootReviser(root)
+	if reviser != nil {
+		snapshot, err := reviser.Snapshot(ctx, relPath)
+		if err != nil {
+			return nil, err
+		}
+		record, _, _, err := readDocumentRecordBytes(absPath, root, relPath, []byte(snapshot.Content))
+		if err != nil {
+			return nil, err
+		}
+		record.Revision = snapshot.Revision.Short
+		return record, nil
+	}
+	record, _, _, err := s.readDocumentFile(absPath, root, relPath)
+	if err != nil {
+		return nil, err
+	}
+	// A conditional writer without atomic read snapshots must not advertise a
+	// token that may describe newer bytes than this read. The production git
+	// adapter supports snapshots; this guard keeps alternate adapters safe.
+	if s.rootWriter(root) == nil {
+		s.attachCurrentRevision(ctx, record)
+	}
+	return record, nil
+}
+
 // RootReviser exposes read-only revision history, diff, and point-in-time
 // recall for a git-backed document root. It is the documents-layer,
 // verifier-neutral counterpart to [RootWriter] and [RootVerifier]: the app
@@ -16,6 +77,8 @@ import (
 // Selectors are resolved forms — "HEAD"/"latest", an RFC3339 timestamp, or a
 // commit hash. Relative deltas are normalized to timestamps by the caller.
 type RootReviser interface {
+	// Snapshot returns current content and its revision under one backend lock.
+	Snapshot(ctx context.Context, filename string) (RevisionContent, error)
 	// Resolve maps a selector onto a concrete revision of the file.
 	Resolve(ctx context.Context, filename, selector string) (RevisionRef, error)
 	// History returns a newest-first page of the file's revisions.

--- a/internal/state/documents/revision.go
+++ b/internal/state/documents/revision.go
@@ -40,22 +40,30 @@ func (s *Store) attachMutationRevision(ctx context.Context, record *DocumentReco
 }
 
 func (s *Store) readCurrentDocument(ctx context.Context, absPath, root, relPath string) (*DocumentRecord, error) {
+	record, _, _, err := s.readCurrentDocumentParts(ctx, absPath, root, relPath)
+	return record, err
+}
+
+// readCurrentDocumentParts pairs the bytes used for a structured mutation
+// with their backing revision. The parsed record, raw frontmatter, and body
+// therefore all share the token used by the later conditional write.
+func (s *Store) readCurrentDocumentParts(ctx context.Context, absPath, root, relPath string) (*DocumentRecord, string, string, error) {
 	reviser := s.rootReviser(root)
 	if reviser != nil {
 		snapshot, err := reviser.Snapshot(ctx, relPath)
 		if err != nil {
-			return nil, err
+			return nil, "", "", err
 		}
-		record, _, _, err := readDocumentRecordBytes(absPath, root, relPath, []byte(snapshot.Content))
+		record, rawFrontmatter, body, err := readDocumentRecordBytes(absPath, root, relPath, []byte(snapshot.Content))
 		if err != nil {
-			return nil, err
+			return nil, "", "", err
 		}
 		record.Revision = snapshot.Revision.Short
-		return record, nil
+		return record, rawFrontmatter, body, nil
 	}
-	record, _, _, err := s.readDocumentFile(absPath, root, relPath)
+	record, rawFrontmatter, body, err := s.readDocumentFile(absPath, root, relPath)
 	if err != nil {
-		return nil, err
+		return nil, "", "", err
 	}
 	// A conditional writer without atomic read snapshots must not advertise a
 	// token that may describe newer bytes than this read. The production git
@@ -63,7 +71,7 @@ func (s *Store) readCurrentDocument(ctx context.Context, absPath, root, relPath 
 	if s.rootWriter(root) == nil {
 		s.attachCurrentRevision(ctx, record)
 	}
-	return record, nil
+	return record, rawFrontmatter, body, nil
 }
 
 // RootReviser exposes read-only revision history, diff, and point-in-time

--- a/internal/state/documents/revision_receipts.go
+++ b/internal/state/documents/revision_receipts.go
@@ -1,0 +1,264 @@
+package documents
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+const (
+	revisionAbsent          = "absent"
+	maxRevisionReceipts     = 2048
+	revisionReceiptTTL      = 24 * time.Hour
+	maxConflictDiffBytes    = 10 * 1024
+	maxConflictExcerptBytes = 4 * 1024
+)
+
+type revisionReceipt struct {
+	revision string
+	readAt   time.Time
+}
+
+type mutationConflict struct {
+	action           string
+	ref              string
+	message          string
+	changedSinceRead string
+	linesAdded       int
+	linesRemoved     int
+	diffTruncated    bool
+	currentExcerpt   string
+	currentTruncated bool
+	receiptRevision  string
+}
+
+type modelMutationConflict struct {
+	Action           string `json:"action"`
+	Applied          bool   `json:"applied"`
+	Ref              string `json:"ref"`
+	Message          string `json:"message"`
+	ChangedSinceRead string `json:"changed_since_read,omitempty"`
+	LinesAdded       int    `json:"lines_added,omitempty"`
+	LinesRemoved     int    `json:"lines_removed,omitempty"`
+	DiffTruncated    bool   `json:"diff_truncated,omitempty"`
+	CurrentExcerpt   string `json:"current_excerpt,omitempty"`
+	CurrentTruncated bool   `json:"current_excerpt_truncated,omitempty"`
+}
+
+func (s *Store) automaticExpectedRevision(root string, existed bool, record *DocumentRecord, expected string) string {
+	if expected = strings.TrimSpace(expected); expected != "" {
+		return expected
+	}
+	if s.rootWriter(root) == nil || s.rootReviser(root) == nil {
+		return ""
+	}
+	if !existed {
+		return revisionAbsent
+	}
+	if record != nil && strings.TrimSpace(record.Revision) != "" {
+		return record.Revision
+	}
+	// The path exists but has no committed file revision. Treating it as an
+	// unconditional update would overwrite an operator's untracked file; the
+	// conditional writer maps this creation precondition to a dirty conflict.
+	return revisionAbsent
+}
+
+func (t *Tools) rememberDocumentReceipt(scope string, doc *DocumentRecord) {
+	if t == nil || t.store == nil || doc == nil || t.store.rootWriter(doc.Root) == nil {
+		return
+	}
+	t.rememberRevisionReceipt(scope, doc.Ref, doc.Revision)
+}
+
+func (t *Tools) rememberRevisionReceipt(scope, ref, revision string) {
+	scope = strings.TrimSpace(scope)
+	ref = strings.TrimSpace(ref)
+	revision = strings.TrimSpace(revision)
+	if t == nil || scope == "" || ref == "" || revision == "" {
+		return
+	}
+	now := time.Now()
+	t.receiptMu.Lock()
+	defer t.receiptMu.Unlock()
+	if t.receipts == nil {
+		t.receipts = make(map[string]revisionReceipt)
+	}
+	for key, receipt := range t.receipts {
+		if now.Sub(receipt.readAt) > revisionReceiptTTL {
+			delete(t.receipts, key)
+		}
+	}
+	if len(t.receipts) >= maxRevisionReceipts {
+		oldestKey := ""
+		var oldest time.Time
+		for key, receipt := range t.receipts {
+			if oldestKey == "" || receipt.readAt.Before(oldest) {
+				oldestKey = key
+				oldest = receipt.readAt
+			}
+		}
+		delete(t.receipts, oldestKey)
+	}
+	t.receipts[revisionReceiptKey(scope, ref)] = revisionReceipt{revision: revision, readAt: now}
+}
+
+func (t *Tools) revisionReceipt(scope, ref string) (string, bool) {
+	scope = strings.TrimSpace(scope)
+	ref = strings.TrimSpace(ref)
+	if t == nil || scope == "" || ref == "" {
+		return "", false
+	}
+	now := time.Now()
+	key := revisionReceiptKey(scope, ref)
+	t.receiptMu.Lock()
+	defer t.receiptMu.Unlock()
+	receipt, ok := t.receipts[key]
+	if !ok {
+		return "", false
+	}
+	if now.Sub(receipt.readAt) > revisionReceiptTTL {
+		delete(t.receipts, key)
+		return "", false
+	}
+	return receipt.revision, true
+}
+
+func revisionReceiptKey(scope, ref string) string {
+	return scope + "\x00" + ref
+}
+
+func (t *Tools) prepareWriteReceipt(args *WriteArgs) {
+	if args == nil || strings.TrimSpace(args.ExpectedRevision) != "" {
+		return
+	}
+	revision, ok := t.revisionReceipt(args.ReceiptScope, args.Ref)
+	if ok {
+		args.ExpectedRevision = revision
+		return
+	}
+	args.RequirePriorRead = strings.TrimSpace(args.ReceiptScope) != "" && args.Body != nil
+}
+
+func (t *Tools) prepareEditReceipt(args *EditArgs) {
+	if args == nil || strings.TrimSpace(args.ExpectedRevision) != "" {
+		return
+	}
+	if revision, ok := t.revisionReceipt(args.ReceiptScope, args.Ref); ok {
+		args.ExpectedRevision = revision
+	}
+}
+
+func (t *Tools) prepareJournalReceipt(args *JournalUpdateArgs) {
+	if args == nil || strings.TrimSpace(args.ExpectedRevision) != "" {
+		return
+	}
+	if revision, ok := t.revisionReceipt(args.ReceiptScope, args.Ref); ok {
+		args.ExpectedRevision = revision
+	}
+}
+
+func (t *Tools) marshalMutationResult(ctx context.Context, action, ref, scope, expected string, result *MutationResult, err error) (string, error) {
+	if err == nil {
+		if result != nil {
+			t.rememberRevisionReceipt(scope, ref, result.Revision)
+		}
+		return marshalToolResult(toModelMutationResult(result, nowUTC()))
+	}
+
+	var readRequired *PriorReadRequiredError
+	if errors.As(err, &readRequired) {
+		return marshalToolResult(&modelMutationConflict{
+			Action:  action,
+			Applied: false,
+			Ref:     ref,
+			Message: fmt.Sprintf("No change was made. Read %s first so Thane can protect the whole-document replacement against intervening edits, then retry without any revision parameter.", ref),
+		})
+	}
+
+	var revisionConflict *RootRevisionConflictError
+	if !errors.As(err, &revisionConflict) {
+		return "", err
+	}
+	if strings.TrimSpace(expected) == "" {
+		expected = revisionConflict.Expected
+	}
+	conflict := t.store.describeMutationConflict(ctx, action, ref, expected, revisionConflict)
+	t.rememberRevisionReceipt(scope, ref, conflict.receiptRevision)
+	return marshalToolResult(&modelMutationConflict{
+		Action:           conflict.action,
+		Applied:          false,
+		Ref:              conflict.ref,
+		Message:          conflict.message,
+		ChangedSinceRead: conflict.changedSinceRead,
+		LinesAdded:       conflict.linesAdded,
+		LinesRemoved:     conflict.linesRemoved,
+		DiffTruncated:    conflict.diffTruncated,
+		CurrentExcerpt:   conflict.currentExcerpt,
+		CurrentTruncated: conflict.currentTruncated,
+	})
+}
+
+func (s *Store) describeMutationConflict(ctx context.Context, action, ref, expected string, conflict *RootRevisionConflictError) mutationConflict {
+	result := mutationConflict{
+		action: action,
+		ref:    ref,
+		message: "No change was made because this document changed after this loop last read it. " +
+			"Review the intervening change, reconcile it with the intended update, and retry; Thane will compare the retry with the current document automatically.",
+	}
+	root, relPath, err := parseRef(ref)
+	if err != nil {
+		return result
+	}
+	reviser := s.rootReviser(root)
+	if reviser == nil {
+		return result
+	}
+	snapshot, snapshotErr := reviser.Snapshot(ctx, relPath)
+	if snapshotErr != nil {
+		if conflict != nil && conflict.Actual == revisionAbsent {
+			result.message = "No change was made because this document was deleted after this loop last read it. Reconcile that deletion with the intended update, then retry."
+			result.receiptRevision = revisionAbsent
+		}
+		return result
+	}
+	result.receiptRevision = snapshot.Revision.Short
+	if result.receiptRevision == "" && conflict != nil && conflict.Actual == revisionAbsent {
+		result.receiptRevision = revisionAbsent
+	}
+
+	actual := ""
+	if conflict != nil {
+		actual = strings.TrimSpace(conflict.Actual)
+	}
+	if actual == "worktree_dirty" {
+		result.message = "No change was made because the document has uncommitted operator edits. The current worktree excerpt is included; preserve or commit those edits before retrying."
+	}
+
+	expected = strings.TrimSpace(expected)
+	if expected != "" && expected != revisionAbsent && actual != revisionAbsent && actual != "worktree_dirty" && snapshot.Revision.Commit != "" {
+		if diff, diffErr := reviser.Diff(ctx, relPath, expected, snapshot.Revision.Commit, "patch"); diffErr == nil {
+			result.linesAdded = diff.Added
+			result.linesRemoved = diff.Removed
+			result.changedSinceRead, result.diffTruncated = truncateRevisionConflictText(diff.Body, maxConflictDiffBytes)
+		}
+	}
+	if result.changedSinceRead == "" || result.diffTruncated || actual == "worktree_dirty" {
+		result.currentExcerpt, result.currentTruncated = truncateRevisionConflictText(snapshot.Content, maxConflictExcerptBytes)
+	}
+	return result
+}
+
+func truncateRevisionConflictText(value string, maxBytes int) (string, bool) {
+	if maxBytes <= 0 || len(value) <= maxBytes {
+		return value, false
+	}
+	cut := maxBytes
+	for cut > 0 && !utf8.RuneStart(value[cut]) {
+		cut--
+	}
+	return strings.TrimSpace(value[:cut]) + "\n…", true
+}

--- a/internal/state/documents/revision_receipts.go
+++ b/internal/state/documents/revision_receipts.go
@@ -219,9 +219,19 @@ func (s *Store) describeMutationConflict(ctx context.Context, action, ref, expec
 	}
 	snapshot, snapshotErr := reviser.Snapshot(ctx, relPath)
 	if snapshotErr != nil {
-		if conflict != nil && conflict.Actual == revisionAbsent {
+		actual := ""
+		if conflict != nil {
+			actual = strings.TrimSpace(conflict.Actual)
+		}
+		switch actual {
+		case revisionAbsent:
 			result.message = "No change was made because this document was deleted after this loop last read it. Reconcile that deletion with the intended update, then retry."
 			result.receiptRevision = revisionAbsent
+		case "", "worktree_dirty":
+			result.message = "No change was made because the document changed, but Thane could not load its current content. Read the document again before retrying so the intended update can be reconciled safely."
+		default:
+			result.message = "No change was made because the document changed. Thane could not load its current content to show the intervening diff, so read the document again before retrying; the comparison base has advanced to the observed revision."
+			result.receiptRevision = actual
 		}
 		return result
 	}

--- a/internal/state/documents/revision_tools_test.go
+++ b/internal/state/documents/revision_tools_test.go
@@ -16,6 +16,10 @@ type stubReviser struct {
 	content RevisionContent
 }
 
+func (s stubReviser) Snapshot(context.Context, string) (RevisionContent, error) {
+	return s.content, nil
+}
+
 func (s stubReviser) Resolve(context.Context, string, string) (RevisionRef, error) {
 	return s.content.Revision, nil
 }

--- a/internal/state/documents/tools.go
+++ b/internal/state/documents/tools.go
@@ -24,14 +24,20 @@ const (
 
 // Tools exposes model-facing document navigation tools.
 type Tools struct {
-	store    *Store
-	intakeMu sync.Mutex
-	intakes  map[string]intakeEntry
+	store     *Store
+	intakeMu  sync.Mutex
+	intakes   map[string]intakeEntry
+	receiptMu sync.Mutex
+	receipts  map[string]revisionReceipt
 }
 
 // NewTools creates a document tool surface.
 func NewTools(store *Store) *Tools {
-	return &Tools{store: store, intakes: make(map[string]intakeEntry)}
+	return &Tools{
+		store:    store,
+		intakes:  make(map[string]intakeEntry),
+		receipts: make(map[string]revisionReceipt),
+	}
 }
 
 type intakeEntry struct {
@@ -62,7 +68,8 @@ type SearchArgs struct {
 
 // RefArgs identifies one managed document by canonical semantic ref.
 type RefArgs struct {
-	Ref string `json:"ref"`
+	Ref          string `json:"ref"`
+	ReceiptScope string `json:"-"`
 }
 
 // SectionArgs selects one document section by ref and optional heading.
@@ -111,6 +118,7 @@ func (t *Tools) ReadWithResultBudget(ctx context.Context, args RefArgs, resultBu
 	if err != nil {
 		return "", err
 	}
+	t.rememberDocumentReceipt(args.ReceiptScope, doc)
 	return marshalToolResultBudget(toModelDocumentRecord(doc, nowUTC()), resultBudget)
 }
 
@@ -123,13 +131,24 @@ func (t *Tools) ReadWithResultBudget(ctx context.Context, args RefArgs, resultBu
 // that does know do the work, instead of this one growing a second
 // understanding of what a document's sections mean.
 func (t *Tools) Record(ctx context.Context, ref string) (*DocumentRecord, error) {
+	return t.RecordWithReceipt(ctx, RefArgs{Ref: ref})
+}
+
+// RecordWithReceipt returns one document as stored and retains its hidden
+// revision receipt for the supplied caller scope.
+func (t *Tools) RecordWithReceipt(ctx context.Context, args RefArgs) (*DocumentRecord, error) {
 	if t == nil || t.store == nil {
 		return nil, fmt.Errorf("document index not configured")
 	}
-	if strings.TrimSpace(ref) == "" {
+	if strings.TrimSpace(args.Ref) == "" {
 		return nil, fmt.Errorf("ref is required")
 	}
-	return t.store.Read(ctx, ref)
+	doc, err := t.store.Read(ctx, args.Ref)
+	if err != nil {
+		return nil, err
+	}
+	t.rememberDocumentReceipt(args.ReceiptScope, doc)
+	return doc, nil
 }
 
 // Roots returns summaries of the indexed document roots.
@@ -279,11 +298,9 @@ func (t *Tools) Write(ctx context.Context, args WriteArgs) (string, error) {
 	if args.Ref == "" {
 		return "", fmt.Errorf("ref is required")
 	}
+	t.prepareWriteReceipt(&args)
 	result, err := t.store.Write(ctx, args)
-	if err != nil {
-		return "", err
-	}
-	return marshalToolResult(toModelMutationResult(result, nowUTC()))
+	return t.marshalMutationResult(ctx, "doc_write", args.Ref, args.ReceiptScope, args.ExpectedRevision, result, err)
 }
 
 // Edit applies one structured edit to a managed document.
@@ -294,11 +311,9 @@ func (t *Tools) Edit(ctx context.Context, args EditArgs) (string, error) {
 	if args.Ref == "" {
 		return "", fmt.Errorf("ref is required")
 	}
+	t.prepareEditReceipt(&args)
 	result, err := t.store.Edit(ctx, args)
-	if err != nil {
-		return "", err
-	}
-	return marshalToolResult(toModelMutationResult(result, nowUTC()))
+	return t.marshalMutationResult(ctx, "doc_edit", args.Ref, args.ReceiptScope, args.ExpectedRevision, result, err)
 }
 
 // JournalUpdate appends one journal-window entry to a managed document.
@@ -309,11 +324,9 @@ func (t *Tools) JournalUpdate(ctx context.Context, args JournalUpdateArgs) (stri
 	if args.Ref == "" {
 		return "", fmt.Errorf("ref is required")
 	}
+	t.prepareJournalReceipt(&args)
 	result, err := t.store.JournalUpdate(ctx, args)
-	if err != nil {
-		return "", err
-	}
-	return marshalToolResult(toModelMutationResult(result, nowUTC()))
+	return t.marshalMutationResult(ctx, "doc_journal_update", args.Ref, args.ReceiptScope, args.ExpectedRevision, result, err)
 }
 
 // Delete removes one managed document.

--- a/internal/tools/context_test.go
+++ b/internal/tools/context_test.go
@@ -320,3 +320,29 @@ func TestSuppressAlwaysContext(t *testing.T) {
 		}
 	})
 }
+
+func TestDocumentRevisionScope(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ctx  context.Context
+		want string
+	}{
+		{name: "none", ctx: context.Background(), want: ""},
+		{name: "conversation", ctx: WithConversationID(context.Background(), "conv-1"), want: "conversation:conv-1"},
+		{name: "loop and conversation", ctx: WithConversationID(WithLoopID(context.Background(), "loop-1"), "conv-1"), want: "loop:loop-1/conversation:conv-1"},
+		{name: "loop", ctx: WithLoopID(context.Background(), "loop-1"), want: "loop:loop-1"},
+		{name: "session fallback", ctx: WithSessionID(context.Background(), "session-1"), want: "session:session-1"},
+		{name: "request fallback", ctx: WithRequestID(context.Background(), "request-1"), want: "request:request-1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := documentRevisionScope(tt.ctx); got != tt.want {
+				t.Fatalf("documentRevisionScope() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/tools/document_mutation_tools.go
+++ b/internal/tools/document_mutation_tools.go
@@ -15,8 +15,8 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 
 	r.Register(&Tool{
 		Name:                 "doc_write",
-		Description:          "Write (replace) a managed markdown document by semantic ref like `kb:article.md`. This tool owns frontmatter integrity for title, description, tags, created, and updated timestamps, and it can append a stamped entry to a standard `Journal` section so the model can think in documents instead of filesystem paths. For brand-new documents prefer doc_create, which collision-checks the corpus and normalizes placement first — doc_write creating a fresh ref is for destinations that are already deliberate. On a revision-backed root, pass the revision returned by doc_read as expected_revision (or `absent` for a deliberate create) when another loop or operator may edit the same document; a stale write fails instead of silently replacing newer work.",
-		ContentResolveExempt: []string{"ref", "title", "description", "tags", "frontmatter", "expected_revision"},
+		Description:          "Write (replace) a managed markdown document by semantic ref like `kb:article.md`. This tool owns frontmatter integrity for title, description, tags, created, and updated timestamps, and it can append a stamped entry to a standard `Journal` section so the model can think in documents instead of filesystem paths. For brand-new documents prefer doc_create, which collision-checks the corpus and normalizes placement first — doc_write creating a fresh ref is for destinations that are already deliberate. On revision-backed roots Thane automatically protects a document you read from intervening edits; if it changed, no write occurs and the result includes the bounded intervening diff. Read an existing document before replacing its whole body.",
+		ContentResolveExempt: []string{"ref", "title", "description", "tags", "frontmatter"},
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -50,10 +50,6 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 					"type":        "string",
 					"description": "Optional timestamped note to append under the managed `Journal` section while writing the current document state.",
 				},
-				"expected_revision": map[string]any{
-					"type":        "string",
-					"description": "Optional compare-and-write token for revision-backed roots: use the revision returned by doc_read, or `absent` to require that a new ref does not already exist. A stale token returns the current revision and makes no change.",
-				},
 			},
 			"required": []string{"ref"},
 		},
@@ -74,26 +70,28 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 			if _, hasMode := args["mode"]; hasMode {
 				return "", fmt.Errorf("doc_write has no %q parameter — it always creates or replaces the whole document. For mode-based edits (replace_body, append_body, upsert_section, ...) use doc_edit", "mode")
 			}
+			if _, hasRevision := args["expected_revision"]; hasRevision {
+				return "", fmt.Errorf("doc_write has no %q parameter — Thane tracks revision preconditions automatically. Omit it; read an existing document before replacing its whole body", "expected_revision")
+			}
 			title, _ := args["title"].(string)
 			description, _ := args["description"].(string)
-			expectedRevision, _ := args["expected_revision"].(string)
 			return dt.Write(ctx, documents.WriteArgs{
-				Ref:              ref,
-				Title:            title,
-				Description:      description,
-				Tags:             documentStringSliceArg(args["tags"]),
-				Frontmatter:      documentFrontmatterArg(args["frontmatter"]),
-				Body:             optionalStringArg(args, "body"),
-				JournalEntry:     stringArg(args, "journal_entry"),
-				ExpectedRevision: expectedRevision,
+				Ref:          ref,
+				Title:        title,
+				Description:  description,
+				Tags:         documentStringSliceArg(args["tags"]),
+				Frontmatter:  documentFrontmatterArg(args["frontmatter"]),
+				Body:         optionalStringArg(args, "body"),
+				JournalEntry: stringArg(args, "journal_entry"),
+				ReceiptScope: documentRevisionScope(ctx),
 			})
 		},
 	})
 
 	r.Register(&Tool{
 		Name:                 "doc_edit",
-		Description:          "Edit a managed markdown document without leaving semantic refs behind. Supports metadata-only updates, whole-body replacement, body append/prepend, and section-aware upsert/delete operations. On a revision-backed root, pass the revision returned by doc_read as expected_revision when another loop or operator may edit the same document; a stale edit fails instead of silently replacing newer work.",
-		ContentResolveExempt: []string{"ref", "mode", "section", "heading", "level", "title", "description", "tags", "frontmatter", "expected_revision"},
+		Description:          "Edit a managed markdown document without leaving semantic refs behind. Supports metadata-only updates, whole-body replacement, body append/prepend, and section-aware upsert/delete operations. On revision-backed roots Thane automatically uses this loop's last read as the comparison base. If another loop or operator changed the document, no edit occurs and the result includes a bounded diff to reconcile before retrying.",
+		ContentResolveExempt: []string{"ref", "mode", "section", "heading", "level", "title", "description", "tags", "frontmatter"},
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -139,10 +137,6 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 					"description":          "Optional extra frontmatter fields. Values may be strings or arrays of strings.",
 					"additionalProperties": true,
 				},
-				"expected_revision": map[string]any{
-					"type":        "string",
-					"description": "Optional compare-and-write token for revision-backed roots. Use the revision returned by doc_read; a stale token returns a conflict and makes no change.",
-				},
 			},
 			"required": []string{"ref", "mode"},
 		},
@@ -162,32 +156,34 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 			if _, hasContent := args["content"]; hasContent {
 				return "", fmt.Errorf("doc_edit's markdown parameter is %q (the %q parameter was renamed for consistency with doc_write) — re-call with body", "body", "content")
 			}
+			if _, hasRevision := args["expected_revision"]; hasRevision {
+				return "", fmt.Errorf("doc_edit has no %q parameter — Thane tracks revision preconditions automatically. Omit it and retry", "expected_revision")
+			}
 			content, _ := args["body"].(string)
 			section, _ := args["section"].(string)
 			heading, _ := args["heading"].(string)
 			title, _ := args["title"].(string)
 			description, _ := args["description"].(string)
-			expectedRevision, _ := args["expected_revision"].(string)
 			return dt.Edit(ctx, documents.EditArgs{
-				Ref:              ref,
-				Mode:             mode,
-				Body:             content,
-				Section:          section,
-				Heading:          heading,
-				Level:            numericArg(args["level"], 2, 6),
-				Title:            title,
-				Description:      description,
-				Tags:             documentStringSliceArg(args["tags"]),
-				Frontmatter:      documentFrontmatterArg(args["frontmatter"]),
-				ExpectedRevision: expectedRevision,
+				Ref:          ref,
+				Mode:         mode,
+				Body:         content,
+				Section:      section,
+				Heading:      heading,
+				Level:        numericArg(args["level"], 2, 6),
+				Title:        title,
+				Description:  description,
+				Tags:         documentStringSliceArg(args["tags"]),
+				Frontmatter:  documentFrontmatterArg(args["frontmatter"]),
+				ReceiptScope: documentRevisionScope(ctx),
 			})
 		},
 	})
 
 	r.Register(&Tool{
 		Name:                 "doc_journal_update",
-		Description:          "Append a timestamped note into a rolling managed journal document. The tool creates the document if needed, keeps created/updated timestamps current, groups entries by day/week/month window headings, and prunes older windows for you. On a revision-backed root, pass the revision returned by doc_read as expected_revision (or `absent` for a deliberate create) when another loop or operator may edit the same journal; a stale update fails instead of silently replacing newer work.",
-		ContentResolveExempt: []string{"ref", "window", "max_windows", "heading_level", "title", "description", "tags", "frontmatter", "expected_revision"},
+		Description:          "Append a timestamped note into a rolling managed journal document. The tool creates the document if needed, keeps created/updated timestamps current, groups entries by day/week/month window headings, and prunes older windows for you. On revision-backed roots Thane automatically protects the update against intervening edits; a conflict makes no change and returns a bounded diff to reconcile before retrying.",
+		ContentResolveExempt: []string{"ref", "window", "max_windows", "heading_level", "title", "description", "tags", "frontmatter"},
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -229,10 +225,6 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 					"description":          "Optional extra frontmatter fields. Values may be strings or arrays of strings.",
 					"additionalProperties": true,
 				},
-				"expected_revision": map[string]any{
-					"type":        "string",
-					"description": "Optional compare-and-write token for revision-backed roots. Use the revision returned by doc_read, or `absent` to require a new journal.",
-				},
 			},
 			"required": []string{"ref", "entry"},
 		},
@@ -245,21 +237,23 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 			if entry == "" {
 				return "", fmt.Errorf("entry is required")
 			}
+			if _, hasRevision := args["expected_revision"]; hasRevision {
+				return "", fmt.Errorf("doc_journal_update has no %q parameter — Thane tracks revision preconditions automatically. Omit it and retry", "expected_revision")
+			}
 			window, _ := args["window"].(string)
 			title, _ := args["title"].(string)
 			description, _ := args["description"].(string)
-			expectedRevision, _ := args["expected_revision"].(string)
 			return dt.JournalUpdate(ctx, documents.JournalUpdateArgs{
-				Ref:              ref,
-				Entry:            entry,
-				Window:           window,
-				MaxWindows:       numericArg(args["max_windows"], 0, 365),
-				HeadingLevel:     numericArg(args["heading_level"], 2, 6),
-				Title:            title,
-				Description:      description,
-				Tags:             documentStringSliceArg(args["tags"]),
-				Frontmatter:      documentFrontmatterArg(args["frontmatter"]),
-				ExpectedRevision: expectedRevision,
+				Ref:          ref,
+				Entry:        entry,
+				Window:       window,
+				MaxWindows:   numericArg(args["max_windows"], 0, 365),
+				HeadingLevel: numericArg(args["heading_level"], 2, 6),
+				Title:        title,
+				Description:  description,
+				Tags:         documentStringSliceArg(args["tags"]),
+				Frontmatter:  documentFrontmatterArg(args["frontmatter"]),
+				ReceiptScope: documentRevisionScope(ctx),
 			})
 		},
 	})

--- a/internal/tools/document_mutation_tools.go
+++ b/internal/tools/document_mutation_tools.go
@@ -15,8 +15,8 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 
 	r.Register(&Tool{
 		Name:                 "doc_write",
-		Description:          "Write (replace) a managed markdown document by semantic ref like `kb:article.md`. This tool owns frontmatter integrity for title, description, tags, created, and updated timestamps, and it can append a stamped entry to a standard `Journal` section so the model can think in documents instead of filesystem paths. For brand-new documents prefer doc_create, which collision-checks the corpus and normalizes placement first — doc_write creating a fresh ref is for destinations that are already deliberate.",
-		ContentResolveExempt: []string{"ref", "title", "description", "tags", "frontmatter"},
+		Description:          "Write (replace) a managed markdown document by semantic ref like `kb:article.md`. This tool owns frontmatter integrity for title, description, tags, created, and updated timestamps, and it can append a stamped entry to a standard `Journal` section so the model can think in documents instead of filesystem paths. For brand-new documents prefer doc_create, which collision-checks the corpus and normalizes placement first — doc_write creating a fresh ref is for destinations that are already deliberate. On a revision-backed root, pass the revision returned by doc_read as expected_revision (or `absent` for a deliberate create) when another loop or operator may edit the same document; a stale write fails instead of silently replacing newer work.",
+		ContentResolveExempt: []string{"ref", "title", "description", "tags", "frontmatter", "expected_revision"},
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -50,6 +50,10 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 					"type":        "string",
 					"description": "Optional timestamped note to append under the managed `Journal` section while writing the current document state.",
 				},
+				"expected_revision": map[string]any{
+					"type":        "string",
+					"description": "Optional compare-and-write token for revision-backed roots: use the revision returned by doc_read, or `absent` to require that a new ref does not already exist. A stale token returns the current revision and makes no change.",
+				},
 			},
 			"required": []string{"ref"},
 		},
@@ -72,22 +76,24 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 			}
 			title, _ := args["title"].(string)
 			description, _ := args["description"].(string)
+			expectedRevision, _ := args["expected_revision"].(string)
 			return dt.Write(ctx, documents.WriteArgs{
-				Ref:          ref,
-				Title:        title,
-				Description:  description,
-				Tags:         documentStringSliceArg(args["tags"]),
-				Frontmatter:  documentFrontmatterArg(args["frontmatter"]),
-				Body:         optionalStringArg(args, "body"),
-				JournalEntry: stringArg(args, "journal_entry"),
+				Ref:              ref,
+				Title:            title,
+				Description:      description,
+				Tags:             documentStringSliceArg(args["tags"]),
+				Frontmatter:      documentFrontmatterArg(args["frontmatter"]),
+				Body:             optionalStringArg(args, "body"),
+				JournalEntry:     stringArg(args, "journal_entry"),
+				ExpectedRevision: expectedRevision,
 			})
 		},
 	})
 
 	r.Register(&Tool{
 		Name:                 "doc_edit",
-		Description:          "Edit a managed markdown document without leaving semantic refs behind. Supports metadata-only updates, whole-body replacement, body append/prepend, and section-aware upsert/delete operations.",
-		ContentResolveExempt: []string{"ref", "mode", "section", "heading", "level", "title", "description", "tags", "frontmatter"},
+		Description:          "Edit a managed markdown document without leaving semantic refs behind. Supports metadata-only updates, whole-body replacement, body append/prepend, and section-aware upsert/delete operations. On a revision-backed root, pass the revision returned by doc_read as expected_revision when another loop or operator may edit the same document; a stale edit fails instead of silently replacing newer work.",
+		ContentResolveExempt: []string{"ref", "mode", "section", "heading", "level", "title", "description", "tags", "frontmatter", "expected_revision"},
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -133,6 +139,10 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 					"description":          "Optional extra frontmatter fields. Values may be strings or arrays of strings.",
 					"additionalProperties": true,
 				},
+				"expected_revision": map[string]any{
+					"type":        "string",
+					"description": "Optional compare-and-write token for revision-backed roots. Use the revision returned by doc_read; a stale token returns a conflict and makes no change.",
+				},
 			},
 			"required": []string{"ref", "mode"},
 		},
@@ -157,25 +167,27 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 			heading, _ := args["heading"].(string)
 			title, _ := args["title"].(string)
 			description, _ := args["description"].(string)
+			expectedRevision, _ := args["expected_revision"].(string)
 			return dt.Edit(ctx, documents.EditArgs{
-				Ref:         ref,
-				Mode:        mode,
-				Body:        content,
-				Section:     section,
-				Heading:     heading,
-				Level:       numericArg(args["level"], 2, 6),
-				Title:       title,
-				Description: description,
-				Tags:        documentStringSliceArg(args["tags"]),
-				Frontmatter: documentFrontmatterArg(args["frontmatter"]),
+				Ref:              ref,
+				Mode:             mode,
+				Body:             content,
+				Section:          section,
+				Heading:          heading,
+				Level:            numericArg(args["level"], 2, 6),
+				Title:            title,
+				Description:      description,
+				Tags:             documentStringSliceArg(args["tags"]),
+				Frontmatter:      documentFrontmatterArg(args["frontmatter"]),
+				ExpectedRevision: expectedRevision,
 			})
 		},
 	})
 
 	r.Register(&Tool{
 		Name:                 "doc_journal_update",
-		Description:          "Append a timestamped note into a rolling managed journal document. The tool creates the document if needed, keeps created/updated timestamps current, groups entries by day/week/month window headings, and prunes older windows for you.",
-		ContentResolveExempt: []string{"ref", "window", "max_windows", "heading_level", "title", "description", "tags", "frontmatter"},
+		Description:          "Append a timestamped note into a rolling managed journal document. The tool creates the document if needed, keeps created/updated timestamps current, groups entries by day/week/month window headings, and prunes older windows for you. On a revision-backed root, pass the revision returned by doc_read as expected_revision (or `absent` for a deliberate create) when another loop or operator may edit the same journal; a stale update fails instead of silently replacing newer work.",
+		ContentResolveExempt: []string{"ref", "window", "max_windows", "heading_level", "title", "description", "tags", "frontmatter", "expected_revision"},
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -217,6 +229,10 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 					"description":          "Optional extra frontmatter fields. Values may be strings or arrays of strings.",
 					"additionalProperties": true,
 				},
+				"expected_revision": map[string]any{
+					"type":        "string",
+					"description": "Optional compare-and-write token for revision-backed roots. Use the revision returned by doc_read, or `absent` to require a new journal.",
+				},
 			},
 			"required": []string{"ref", "entry"},
 		},
@@ -232,16 +248,18 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 			window, _ := args["window"].(string)
 			title, _ := args["title"].(string)
 			description, _ := args["description"].(string)
+			expectedRevision, _ := args["expected_revision"].(string)
 			return dt.JournalUpdate(ctx, documents.JournalUpdateArgs{
-				Ref:          ref,
-				Entry:        entry,
-				Window:       window,
-				MaxWindows:   numericArg(args["max_windows"], 0, 365),
-				HeadingLevel: numericArg(args["heading_level"], 2, 6),
-				Title:        title,
-				Description:  description,
-				Tags:         documentStringSliceArg(args["tags"]),
-				Frontmatter:  documentFrontmatterArg(args["frontmatter"]),
+				Ref:              ref,
+				Entry:            entry,
+				Window:           window,
+				MaxWindows:       numericArg(args["max_windows"], 0, 365),
+				HeadingLevel:     numericArg(args["heading_level"], 2, 6),
+				Title:            title,
+				Description:      description,
+				Tags:             documentStringSliceArg(args["tags"]),
+				Frontmatter:      documentFrontmatterArg(args["frontmatter"]),
+				ExpectedRevision: expectedRevision,
 			})
 		},
 	})

--- a/internal/tools/document_revision_scope.go
+++ b/internal/tools/document_revision_scope.go
@@ -1,0 +1,30 @@
+package tools
+
+import (
+	"context"
+	"strings"
+)
+
+// documentRevisionScope identifies the model consciousness whose document
+// reads should protect later writes. A loop/conversation pair is stable across
+// turns without leaking receipts between concurrent conversations; request is
+// only a last-resort scope for one-shot callers.
+func documentRevisionScope(ctx context.Context) string {
+	parts := make([]string, 0, 2)
+	if loopID := strings.TrimSpace(LoopIDFromContext(ctx)); loopID != "" {
+		parts = append(parts, "loop:"+loopID)
+	}
+	if conversationID := strings.TrimSpace(ConversationIDFromContext(ctx)); conversationID != "" && conversationID != "default" {
+		parts = append(parts, "conversation:"+conversationID)
+	}
+	if len(parts) > 0 {
+		return strings.Join(parts, "/")
+	}
+	if sessionID := strings.TrimSpace(SessionIDFromContext(ctx)); sessionID != "" {
+		return "session:" + sessionID
+	}
+	if requestID := strings.TrimSpace(RequestIDFromContext(ctx)); requestID != "" {
+		return "request:" + requestID
+	}
+	return ""
+}

--- a/internal/tools/document_tools.go
+++ b/internal/tools/document_tools.go
@@ -438,6 +438,9 @@ func readDocumentFacet(ctx context.Context, dt *documents.Tools, ref, level stri
 		"faceted":          faceted,
 		"levels_available": available,
 	}
+	if doc.Revision != "" {
+		result["revision"] = doc.Revision
+	}
 	if title := strings.TrimSpace(doc.Title); title != "" {
 		result["title"] = title
 	}

--- a/internal/tools/document_tools.go
+++ b/internal/tools/document_tools.go
@@ -52,7 +52,7 @@ func RegisterDocumentTools(r *Registry, dt *documents.Tools) {
 			}
 			level, _ := args["level"].(string)
 			if level = strings.TrimSpace(level); level == "" {
-				return dt.Read(ctx, documents.RefArgs{Ref: ref})
+				return dt.Read(ctx, documents.RefArgs{Ref: ref, ReceiptScope: documentRevisionScope(ctx)})
 			}
 			return readDocumentFacet(ctx, dt, ref, level)
 		},
@@ -419,7 +419,7 @@ func readDocumentFacet(ctx context.Context, dt *documents.Tools, ref, level stri
 	if !looppkg.IsFacetKey(level) {
 		return "", fmt.Errorf("unknown level %q; valid levels are %s", level, strings.Join(looppkg.FacetKeys(), ", "))
 	}
-	doc, err := dt.Record(ctx, ref)
+	doc, err := dt.RecordWithReceipt(ctx, documents.RefArgs{Ref: ref, ReceiptScope: documentRevisionScope(ctx)})
 	if err != nil {
 		return "", err
 	}
@@ -437,9 +437,6 @@ func readDocumentFacet(ctx context.Context, dt *documents.Tools, ref, level stri
 		"level":            level,
 		"faceted":          faceted,
 		"levels_available": available,
-	}
-	if doc.Revision != "" {
-		result["revision"] = doc.Revision
 	}
 	if title := strings.TrimSpace(doc.Title); title != "" {
 		result["title"] = title

--- a/internal/tools/document_tools_test.go
+++ b/internal/tools/document_tools_test.go
@@ -143,6 +143,67 @@ func TestDocWriteHandlerAppendsJournalEntry(t *testing.T) {
 	}
 }
 
+func TestDocumentMutationToolsExposeAndForwardExpectedRevision(t *testing.T) {
+	t.Parallel()
+
+	reg, store := newTestDocumentRegistry(t)
+	body := "Existing body."
+	if _, err := store.Write(t.Context(), documents.WriteArgs{Ref: "kb:existing.md", Body: &body}); err != nil {
+		t.Fatalf("seed existing document: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		args map[string]any
+	}{
+		{
+			name: "doc_write",
+			args: map[string]any{
+				"ref":               "kb:new.md",
+				"body":              "New body.",
+				"expected_revision": "absent",
+			},
+		},
+		{
+			name: "doc_edit",
+			args: map[string]any{
+				"ref":               "kb:existing.md",
+				"mode":              "append_body",
+				"body":              "New line.",
+				"expected_revision": "rev-1",
+			},
+		},
+		{
+			name: "doc_journal_update",
+			args: map[string]any{
+				"ref":               "kb:journal.md",
+				"entry":             "New entry.",
+				"expected_revision": "absent",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tool := reg.Get(tc.name)
+			if tool == nil {
+				t.Fatalf("%s not registered", tc.name)
+			}
+			properties, ok := tool.Parameters["properties"].(map[string]any)
+			if !ok {
+				t.Fatalf("%s properties have unexpected shape", tc.name)
+			}
+			if _, ok := properties["expected_revision"]; !ok {
+				t.Fatalf("%s schema omits expected_revision", tc.name)
+			}
+			_, err := tool.Handler(t.Context(), tc.args)
+			if err == nil || !strings.Contains(err.Error(), "expected_revision requires a revision-backed document root") {
+				t.Fatalf("%s error = %v, want forwarded expected_revision policy error", tc.name, err)
+			}
+		})
+	}
+}
+
 func TestDocumentSearchAndLinksHandlersSupportStructuredNavigation(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tools/document_tools_test.go
+++ b/internal/tools/document_tools_test.go
@@ -143,14 +143,10 @@ func TestDocWriteHandlerAppendsJournalEntry(t *testing.T) {
 	}
 }
 
-func TestDocumentMutationToolsExposeAndForwardExpectedRevision(t *testing.T) {
+func TestDocumentMutationToolsHideRevisionPreconditions(t *testing.T) {
 	t.Parallel()
 
-	reg, store := newTestDocumentRegistry(t)
-	body := "Existing body."
-	if _, err := store.Write(t.Context(), documents.WriteArgs{Ref: "kb:existing.md", Body: &body}); err != nil {
-		t.Fatalf("seed existing document: %v", err)
-	}
+	reg, _ := newTestDocumentRegistry(t)
 
 	tests := []struct {
 		name string
@@ -193,12 +189,12 @@ func TestDocumentMutationToolsExposeAndForwardExpectedRevision(t *testing.T) {
 			if !ok {
 				t.Fatalf("%s properties have unexpected shape", tc.name)
 			}
-			if _, ok := properties["expected_revision"]; !ok {
-				t.Fatalf("%s schema omits expected_revision", tc.name)
+			if _, ok := properties["expected_revision"]; ok {
+				t.Fatalf("%s schema exposes internal expected_revision", tc.name)
 			}
 			_, err := tool.Handler(t.Context(), tc.args)
-			if err == nil || !strings.Contains(err.Error(), "expected_revision requires a revision-backed document root") {
-				t.Fatalf("%s error = %v, want forwarded expected_revision policy error", tc.name, err)
+			if err == nil || !strings.Contains(err.Error(), "tracks revision preconditions automatically") {
+				t.Fatalf("%s error = %v, want legacy-parameter redirect", tc.name, err)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- retain each writable git-backed document read as a hidden loop/conversation receipt instead of exposing revision hashes to the model
- apply creation and stale-write preconditions inside Go for `doc_write`, `doc_edit`, and `doc_journal_update`
- return `applied: false` plus a bounded base-to-current patch on conflict, then advance the hidden receipt for a reconciled retry
- return the commit identity produced by the commit path and compare the Git parent during the HEAD update

## Why

Git history makes an overwrite recoverable, but it does not stop two loops from reading the same dossier and serially committing incompatible replacements. Multi-writer contact dossiers need optimistic concurrency before both the core loop and archivist can write them.

Revision hashes are implementation machinery, though. Making the model copy a hash from `doc_read` into every mutation spends attention on bookkeeping Go can own more reliably. The smoother contract is semantic: read a document, edit it, and receive the intervening diff if another writer won the race.

This is the first implementation phase of #1463.

## User impact

On writable git-backed roots, `doc_read` now remembers the current revision for that loop/conversation without returning it. Later managed mutations use the receipt automatically. A stale mutation leaves newer content untouched and returns a bounded `changed_since_read` patch; if the patch is unavailable or too large, the result includes a bounded current excerpt. The receipt advances to current HEAD so a reconciled retry needs no revision parameter.

Whole-document replacement of an existing document requires a prior read. Structured edits and creates derive a fresh current/absent base internally. Already-dirty operator edits are rejected. Arbitrary editors are not filesystem-locked and can still race in the narrow worktree replacement window; the docs state that boundary explicitly and Git history remains recoverable.

## Test plan

- [x] `just ci`
- [x] prove two concurrent writers sharing one base produce exactly one commit and one conflict
- [x] prove stale and dirty-worktree writes preserve current bytes
- [x] prove model-facing reads and mutations expose no revision hashes or precondition parameters
- [x] prove a stale mutation returns the intervening diff and a reconciled retry succeeds from the advanced receipt
- [x] prove blind scoped whole-document replacement is declined with a read-first trailhead
- [x] prove conflict truncation preserves UTF-8 and result bounds
- [x] prove untracked git-root drafts remain readable without advertising mutation tokens

Refs #1463