### PR TITLE
feat: add canonical contact dossier root

### DIFF
--- a/cmd/thane/init.go
+++ b/cmd/thane/init.go
@@ -301,6 +301,10 @@ func runInit(w io.Writer, dir string, opts initOptions) error {
 	if err != nil {
 		return fmt.Errorf("bootstrap core identity: %w", err)
 	}
+	dossierConfigured, dossierCreated, err := bootstrapContactDossierRoot(ctx, coreConfigPath, absDir, slog.Default())
+	if err != nil {
+		return err
+	}
 
 	configuredOperatorID, dataDir, operatorConfigured, err := readOperatorBootstrapConfig(coreConfigPath, absDir)
 	if err != nil {
@@ -319,6 +323,13 @@ func runInit(w io.Writer, dir string, opts initOptions) error {
 		describeCorePosture(w, result, why)
 	} else {
 		fmt.Fprintf(w, "  · %s (core identity exists, skipping)\n", result.CoreDir)
+	}
+	if dossierConfigured {
+		if dossierCreated {
+			fmt.Fprintf(w, "  ✓ %s (signed contact dossier root)\n", filepath.Join(absDir, platformconfig.ContactsRootName))
+		} else {
+			fmt.Fprintf(w, "  · %s (contact dossier root exists, skipping)\n", filepath.Join(absDir, platformconfig.ContactsRootName))
+		}
 	}
 	if contactBootstrap != nil {
 		if err := contactBootstrap.close(); err != nil {

--- a/cmd/thane/init_contact_dossiers.go
+++ b/cmd/thane/init_contact_dossiers.go
@@ -11,30 +11,16 @@ import (
 
 	"github.com/nugget/thane-ai-agent/internal/platform/checkout"
 	platformconfig "github.com/nugget/thane-ai-agent/internal/platform/config"
+	"github.com/nugget/thane-ai-agent/internal/platform/paths"
 	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
-	"gopkg.in/yaml.v3"
 )
 
 func bootstrapContactDossierRoot(ctx context.Context, configPath, workspace string, logger *slog.Logger) (bool, bool, error) {
-	data, err := os.ReadFile(configPath)
+	cfg, err := platformconfig.LoadWithWorkspace(configPath, workspace)
 	if err != nil {
-		return false, false, fmt.Errorf("read core config for contact dossier root: %w", err)
+		return false, false, fmt.Errorf("load core config for contact dossier root: %w", err)
 	}
-	var cfg struct {
-		Roots map[string]platformconfig.RootEntry `yaml:"roots"`
-	}
-	if err := yaml.Unmarshal([]byte(os.ExpandEnv(string(data))), &cfg); err != nil {
-		return false, false, fmt.Errorf("parse core config for contact dossier root: %w", err)
-	}
-	var entry platformconfig.RootEntry
-	found := false
-	for name, candidate := range cfg.Roots {
-		if strings.TrimSuffix(strings.TrimSpace(name), ":") == platformconfig.ContactsRootName {
-			entry = candidate
-			found = true
-			break
-		}
-	}
+	entry, found := cfg.DocRoots[platformconfig.ContactsRootName]
 	if !found {
 		return false, false, nil
 	}
@@ -45,9 +31,28 @@ func bootstrapContactDossierRoot(ctx context.Context, configPath, workspace stri
 		return true, false, fmt.Errorf("roots.%s must declare seed_signers before thane init can establish it", platformconfig.ContactsRootName)
 	}
 
-	signingKey, err := resolveInitSigningKey(workspace, entry.Git.SigningKey)
+	rootPaths := make(map[string]string, len(cfg.Paths)+3)
+	for name, path := range cfg.Paths {
+		rootPaths[name] = path
+	}
+	rootPaths[platformconfig.CoreRootName] = cfg.CoreRoot()
+	rootPaths[platformconfig.SelfRootName] = cfg.SelfRoot()
+	rootPaths[platformconfig.ContactsRootName] = cfg.ContactsRoot()
+	resolver := paths.New(rootPaths)
+
+	signingKey, err := resolver.Resolve(entry.Git.SigningKey)
 	if err != nil {
 		return true, false, fmt.Errorf("resolve roots.%s.git.signing_key: %w", platformconfig.ContactsRootName, err)
+	}
+	repoPath := strings.TrimSpace(entry.Git.RepoPath)
+	if repoPath == "" {
+		repoPath = cfg.ContactsRoot()
+	} else if repoPath, err = resolver.Resolve(repoPath); err != nil {
+		return true, false, fmt.Errorf("resolve roots.%s.git.repo_path: %w", platformconfig.ContactsRootName, err)
+	}
+	resolvedRoot, err := checkout.ResolveRoot(repoPath, cfg.ContactsRoot())
+	if err != nil {
+		return true, false, fmt.Errorf("resolve roots.%s.git.repo_path: %w", platformconfig.ContactsRootName, err)
 	}
 	seeds := make([]provenance.TrustedSigner, 0, len(entry.SeedSigners))
 	for _, seed := range entry.SeedSigners {
@@ -60,15 +65,15 @@ func bootstrapContactDossierRoot(ctx context.Context, configPath, workspace stri
 		})
 	}
 
-	rootPath := filepath.Join(workspace, platformconfig.ContactsRootName)
-	_, statErr := os.Stat(filepath.Join(rootPath, ".git"))
+	_, statErr := os.Stat(filepath.Join(resolvedRoot.RepoPath, ".git"))
 	created := errors.Is(statErr, os.ErrNotExist)
 	if statErr != nil && !created {
 		return true, false, fmt.Errorf("stat contact dossier repository: %w", statErr)
 	}
 	signed, err := checkout.OpenSigned(ctx, checkout.SignedSpec{
 		Name:           "contacts.dossiers",
-		WorktreePath:   rootPath,
+		WorktreePath:   resolvedRoot.WorktreePath,
+		RepoPath:       resolvedRoot.RepoPath,
 		SigningKeyPath: signingKey,
 		SeedSigners:    seeds,
 		Logger:         logger,
@@ -79,36 +84,8 @@ func bootstrapContactDossierRoot(ctx context.Context, configPath, workspace stri
 	if err := signed.VerifyHead(ctx); err != nil {
 		return true, false, fmt.Errorf("verify contact dossier root birth: %w", err)
 	}
-	if _, err := provenance.VerifyAdmission(ctx, rootPath, seeds); err != nil {
+	if _, err := provenance.VerifyAdmission(ctx, resolvedRoot.RepoPath, seeds); err != nil {
 		return true, false, fmt.Errorf("verify contact dossier root admission: %w", err)
 	}
 	return true, created, nil
-}
-
-func resolveInitSigningKey(workspace, raw string) (string, error) {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		return "", errors.New("signing key is empty")
-	}
-	if strings.HasPrefix(raw, platformconfig.CoreRootName+":") {
-		rel := strings.TrimPrefix(raw, platformconfig.CoreRootName+":")
-		rel = filepath.Clean(filepath.FromSlash(rel))
-		if rel == "." || filepath.IsAbs(rel) || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-			return "", fmt.Errorf("invalid core-relative signing key %q", raw)
-		}
-		return filepath.Join(workspace, platformconfig.CoreRootName, rel), nil
-	}
-	if strings.HasPrefix(raw, "~") {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", fmt.Errorf("resolve home directory: %w", err)
-		}
-		switch {
-		case raw == "~":
-			return home, nil
-		case strings.HasPrefix(raw, "~/"):
-			return filepath.Join(home, raw[2:]), nil
-		}
-	}
-	return filepath.Abs(raw)
 }

--- a/cmd/thane/init_contact_dossiers.go
+++ b/cmd/thane/init_contact_dossiers.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/checkout"
+	platformconfig "github.com/nugget/thane-ai-agent/internal/platform/config"
+	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
+	"gopkg.in/yaml.v3"
+)
+
+func bootstrapContactDossierRoot(ctx context.Context, configPath, workspace string, logger *slog.Logger) (bool, bool, error) {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return false, false, fmt.Errorf("read core config for contact dossier root: %w", err)
+	}
+	var cfg struct {
+		Roots map[string]platformconfig.RootEntry `yaml:"roots"`
+	}
+	if err := yaml.Unmarshal([]byte(os.ExpandEnv(string(data))), &cfg); err != nil {
+		return false, false, fmt.Errorf("parse core config for contact dossier root: %w", err)
+	}
+	var entry platformconfig.RootEntry
+	found := false
+	for name, candidate := range cfg.Roots {
+		if strings.TrimSuffix(strings.TrimSpace(name), ":") == platformconfig.ContactsRootName {
+			entry = candidate
+			found = true
+			break
+		}
+	}
+	if !found {
+		return false, false, nil
+	}
+	if !entry.Git.Enabled || !entry.Git.SignCommits {
+		return true, false, fmt.Errorf("roots.%s must enable signed commits so thane init can establish its dossier history", platformconfig.ContactsRootName)
+	}
+	if len(entry.SeedSigners) == 0 {
+		return true, false, fmt.Errorf("roots.%s must declare seed_signers before thane init can establish it", platformconfig.ContactsRootName)
+	}
+
+	signingKey, err := resolveInitSigningKey(workspace, entry.Git.SigningKey)
+	if err != nil {
+		return true, false, fmt.Errorf("resolve roots.%s.git.signing_key: %w", platformconfig.ContactsRootName, err)
+	}
+	seeds := make([]provenance.TrustedSigner, 0, len(entry.SeedSigners))
+	for _, seed := range entry.SeedSigners {
+		seeds = append(seeds, provenance.TrustedSigner{
+			Principal:   seed.Principal,
+			PublicKey:   seed.Key,
+			Comment:     seed.Label,
+			ValidAfter:  seed.ValidAfter,
+			ValidBefore: seed.ValidBefore,
+		})
+	}
+
+	rootPath := filepath.Join(workspace, platformconfig.ContactsRootName)
+	_, statErr := os.Stat(filepath.Join(rootPath, ".git"))
+	created := errors.Is(statErr, os.ErrNotExist)
+	if statErr != nil && !created {
+		return true, false, fmt.Errorf("stat contact dossier repository: %w", statErr)
+	}
+	signed, err := checkout.OpenSigned(ctx, checkout.SignedSpec{
+		Name:           "contacts.dossiers",
+		WorktreePath:   rootPath,
+		SigningKeyPath: signingKey,
+		SeedSigners:    seeds,
+		Logger:         logger,
+	})
+	if err != nil {
+		return true, false, fmt.Errorf("bootstrap contact dossier root: %w", err)
+	}
+	if err := signed.VerifyHead(ctx); err != nil {
+		return true, false, fmt.Errorf("verify contact dossier root birth: %w", err)
+	}
+	if _, err := provenance.VerifyAdmission(ctx, rootPath, seeds); err != nil {
+		return true, false, fmt.Errorf("verify contact dossier root admission: %w", err)
+	}
+	return true, created, nil
+}
+
+func resolveInitSigningKey(workspace, raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", errors.New("signing key is empty")
+	}
+	if strings.HasPrefix(raw, platformconfig.CoreRootName+":") {
+		rel := strings.TrimPrefix(raw, platformconfig.CoreRootName+":")
+		rel = filepath.Clean(filepath.FromSlash(rel))
+		if rel == "." || filepath.IsAbs(rel) || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return "", fmt.Errorf("invalid core-relative signing key %q", raw)
+		}
+		return filepath.Join(workspace, platformconfig.CoreRootName, rel), nil
+	}
+	if strings.HasPrefix(raw, "~") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory: %w", err)
+		}
+		switch {
+		case raw == "~":
+			return home, nil
+		case strings.HasPrefix(raw, "~/"):
+			return filepath.Join(home, raw[2:]), nil
+		}
+	}
+	return filepath.Abs(raw)
+}

--- a/cmd/thane/init_test.go
+++ b/cmd/thane/init_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	platformconfig "github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/state/contacts"
 	"gopkg.in/yaml.v3"
 )
@@ -42,7 +43,7 @@ func TestRunInit_FreshDirectory(t *testing.T) {
 	out := buf.String()
 
 	// Verify directory structure.
-	for _, sub := range []string{"core", "db", filepath.Join("core", "talents")} {
+	for _, sub := range []string{"core", "contacts", "db", filepath.Join("core", "talents")} {
 		info, err := os.Stat(filepath.Join(dir, sub))
 		if err != nil {
 			t.Errorf("expected directory %s: %v", sub, err)
@@ -149,6 +150,7 @@ func TestRunInit_FreshDirectory(t *testing.T) {
 		Person struct {
 			ContactBindings map[string]string `yaml:"contact_bindings"`
 		} `yaml:"person"`
+		Roots map[string]platformconfig.RootEntry `yaml:"roots"`
 	}
 	configData, err := os.ReadFile(filepath.Join(dir, "core", "config.yaml"))
 	if err != nil {
@@ -163,6 +165,31 @@ func TestRunInit_FreshDirectory(t *testing.T) {
 	}
 	if generated.Person.ContactBindings == nil || len(generated.Person.ContactBindings) != 0 {
 		t.Fatalf("generated person.contact_bindings = %#v, want explicit empty map", generated.Person.ContactBindings)
+	}
+	contactsRoot, ok := generated.Roots[platformconfig.ContactsRootName]
+	if !ok || contactsRoot.Context.Advertise != platformconfig.RootAdvertiseExactSubject {
+		t.Fatalf("generated contacts root = %#v, want exact-subject policy", contactsRoot)
+	}
+	if !contactsRoot.Git.Enabled || !contactsRoot.Git.SignCommits || contactsRoot.Git.VerifySignatures != "required" {
+		t.Fatalf("generated contacts git policy = %#v", contactsRoot.Git)
+	}
+	contactsDir := filepath.Join(dir, platformconfig.ContactsRootName)
+	for _, args := range [][]string{
+		{"rev-list", "--count", "HEAD"},
+		{"status", "--short", "--untracked-files=all"},
+		{"verify-commit", "HEAD"},
+	} {
+		cmd := exec.Command("git", append([]string{"-C", contactsDir}, args...)...)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %s in contacts root: %v\n%s", strings.Join(args, " "), err, out)
+		}
+		if args[0] == "rev-list" && strings.TrimSpace(string(out)) != "1" {
+			t.Fatalf("contacts root commit count = %q, want 1", strings.TrimSpace(string(out)))
+		}
+		if args[0] == "status" && strings.TrimSpace(string(out)) != "" {
+			t.Fatalf("contacts root status = %q, want clean", strings.TrimSpace(string(out)))
+		}
 	}
 
 	contactStore, err := contacts.Open(filepath.Join(dir, "db", "contacts.db"), nil)

--- a/cmd/thane/init_test.go
+++ b/cmd/thane/init_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"io"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -239,6 +242,43 @@ func TestRunInit_FreshDirectory(t *testing.T) {
 		if info.Size() == 0 {
 			t.Errorf("archive skeleton: %s is empty", rel)
 		}
+	}
+}
+
+func TestBootstrapContactDossierRootHonorsRepoPath(t *testing.T) {
+	dir := t.TempDir()
+	if err := runInit(io.Discard, dir, initOptions{SelfSigned: true, OperatorName: "Test Operator"}); err != nil {
+		t.Fatalf("runInit: %v", err)
+	}
+	contactsDir := filepath.Join(dir, platformconfig.ContactsRootName)
+	if err := os.RemoveAll(contactsDir); err != nil {
+		t.Fatalf("remove standalone contacts root: %v", err)
+	}
+
+	configPath := filepath.Join(dir, platformconfig.CoreRootName, "config.yaml")
+	configData, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	old := "            signing_key: core:identity/signing_ed25519"
+	replacement := "            repo_path: " + dir + "\n" + old
+	configData = []byte(strings.Replace(string(configData), old, replacement, 1))
+	if err := os.WriteFile(configPath, configData, 0o600); err != nil {
+		t.Fatalf("write config with repo_path: %v", err)
+	}
+
+	configured, created, err := bootstrapContactDossierRoot(context.Background(), configPath, dir, slog.Default())
+	if err != nil {
+		t.Fatalf("bootstrapContactDossierRoot: %v", err)
+	}
+	if !configured || !created {
+		t.Fatalf("configured=%v created=%v, want both true", configured, created)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".git")); err != nil {
+		t.Fatalf("configured backing repository was not initialized: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(contactsDir, ".git")); !os.IsNotExist(err) {
+		t.Fatalf("contacts worktree unexpectedly became a separate repository: %v", err)
 	}
 }
 

--- a/docs/model-facing-context.md
+++ b/docs/model-facing-context.md
@@ -381,6 +381,12 @@ Providers own domain matching and materialization. A
 model-authored facet can describe why it is useful, but it cannot grant itself
 injection or assign its own rank.
 
+For a private per-subject corpus, configure the document root with
+`advertise: exact_subject`. That mode requires an exact match between a
+canonical request subject and a document tag; it deliberately supplies no
+ambient or lexical evidence. Contact dossiers use this so `contact:<uuid>` can
+surface only `contacts:<uuid>.md`, never a neighboring person's dossier.
+
 Advertising should be cheaper than materializing. Do not read a full document
 or render an expensive view merely to discover that the discriminator will
 drop it. Estimates are admission hints, not permission to overflow: the

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -275,7 +275,7 @@ being reimplemented in each loop prompt.
 | Tool | Description |
 |------|-------------|
 | `contact_save` | Create or update a contact with vCard properties. |
-| `contact_lookup` | Search by name, query, kind, or property. |
+| `contact_lookup` | Search by name, query, kind, or property. Exact rich results include the canonical UUID and configured contact-dossier ref. |
 | `contact_whereabouts` | Fuse a contact's room, HA zone, and bound-device location sources with provenance, freshness, and explicit room conflicts. |
 | `contact_forget` | Delete a contact. |
 | `contact_list` | List and filter contacts. |
@@ -288,7 +288,7 @@ being reimplemented in each loop prompt.
 
 | Tool | Description |
 |------|-------------|
-| `contact_owner` | Return the runtime operator contact. Protected tag; name retained for compatibility. |
+| `contact_owner` | Return the runtime operator contact, canonical UUID, configured dossier ref, and active operator channels. Protected tag; name retained for compatibility. |
 
 Operator channel activity recency is reported with delta fields such as
 `last_active_delta`.

--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -500,9 +500,10 @@ fresh install with nowhere for those documents to land.
 contact directory. Its canonical document is
 `contacts:<canonical-contact-uuid>.md`; using the UUID rather than a name keeps
 the dossier stable across renames. Every dossier must carry the matching
-`contact:<uuid>` frontmatter tag and the complete status-line / teaser / digest
-/ full facet ladder. Go enforces that shape before any managed write reaches
-the worktree or Git history.
+`contact:<uuid>` as its only frontmatter tag and the complete status-line /
+teaser / digest / full facet ladder. The single-tag rule prevents a broader
+subject such as `household` from advertising a private dossier. Go enforces
+that shape before any managed write reaches the worktree or Git history.
 
 The boundary is strict: SQLite contacts remain authoritative for UUIDs,
 structured identity, communication properties, trust zones, Home Assistant

--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -137,6 +137,10 @@ The current policy fields are:
 - `git.sign_commits`: signs and commits each managed write/delete.
 - `git.verify_signatures`: sets the consumer policy: `none`, `warn`,
   or `required`.
+- `context.advertise`: controls bounded document offers: `never`,
+  capability-`tagged`, `always` ambient, or `exact_subject`. The last mode
+  offers a document only when one of its tags exactly matches a canonical
+  request subject; it has no lexical or ambient fallback.
 
 ### Signed roots
 
@@ -449,15 +453,16 @@ of truth. The generated tools still write through document roots. That
 keeps path resolution, indexing, provenance, and root-level integrity
 policy in one subsystem.
 
-## Special Case: the Derived Roots, `core` and `self`
+## Special Case: the Derived Roots
 
-Two roots are reserved. Both come from the workspace — `{workspace.path}/core`
-and `{workspace.path}/self` — and neither takes a path from `roots:`. You may
-still name either one there to set policy; a path given alongside policy is
-ignored.
+Three root names are reserved: `core`, `self`, and `contacts`. Their paths come
+from the workspace, and none takes a path from `roots:`. You may name them
+there to set policy; a path given alongside policy is ignored. `core` and
+`self` are always registered. `contacts` is opt-in and is registered only when
+its policy is declared.
 
-They are two roots rather than one because they answer to different
-authorities, and that difference is the whole point of the split.
+`core` and `self` are separate roots because they answer to different
+authorities, and that difference is the whole point of their split.
 
 `core` is what an operator declares Thane to be, and what constrains it:
 axioms, persona, mission, the runtime config, talents, and loop definitions.
@@ -485,9 +490,51 @@ That distinction is why the injection had to follow the document rather than
 stay pointed at `core`: an ego loop writing to one root while the prompt reads
 another leaves the agent composing self-reflection it never reads back.
 
-Both are derived rather than declared because the core service loops write
-`self` on every install. A root an operator had to remember to declare would
-leave a fresh install with nowhere for those documents to land.
+Both are always registered because the core service loops write `self` on
+every install. A root an operator had to remember to declare would leave a
+fresh install with nowhere for those documents to land.
+
+### Contact dossiers
+
+`contacts` is the optional longitudinal document side of the structured
+contact directory. Its canonical document is
+`contacts:<canonical-contact-uuid>.md`; using the UUID rather than a name keeps
+the dossier stable across renames. Every dossier must carry the matching
+`contact:<uuid>` frontmatter tag and the complete status-line / teaser / digest
+/ full facet ladder. Go enforces that shape before any managed write reaches
+the worktree or Git history.
+
+The boundary is strict: SQLite contacts remain authoritative for UUIDs,
+structured identity, communication properties, trust zones, Home Assistant
+bindings, and companion attribution. Dossier prose is relationship synthesis,
+not a way to mutate those fields. `contact_lookup` and `contact_owner` expose a
+bounded dossier ref; `doc_read` opens it when the prose is useful.
+
+Fresh `thane init` workspaces declare and establish the root with the agent's
+signing key, required signature verification, and this context policy:
+
+```yaml
+roots:
+  contacts:
+    authoring: managed
+    context:
+      advertise: exact_subject
+    seed_signers:
+      - principal: thane@provenance.local
+        key: "ssh-ed25519 AAAA..." # core/identity/signing_ed25519.pub
+        label: agent
+    git:
+      enabled: true
+      sign_commits: true
+      verify_signatures: required
+      signing_key: core:identity/signing_ed25519
+```
+
+`exact_subject` is the privacy and attention boundary: a request carrying
+`contact:<uuid>` may receive that contact's compact dossier projection, while
+unrelated dossiers get neither ambient nor loose lexical offers. Existing
+workspaces can add the same declaration and re-run `thane init` to establish
+the signed sibling repository before deployment.
 
 ## The Human-Level Rule
 

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -202,11 +202,10 @@ embeddings:
   # falls back to the default model resource/provider selection.
   baseurl: ""
 # Workspace configures the agent's sandboxed file system access.
-# The workspace root is also the anchor for Thane's two derived
-# document roots. {workspace.path}/core holds what the operator
-# declares Thane to be — axioms.md, persona.md, mission.md — and
-# {workspace.path}/self holds what Thane has made of that, written
-# by the core service loops: ego.md, metacognitive.md, archivist.md.
+# The workspace root also anchors Thane's derived document roots.
+# {workspace.path}/core holds what the operator declares Thane to be;
+# {workspace.path}/self holds what Thane has made of that; and the
+# optional {workspace.path}/contacts holds contact dossiers.
 workspace:
   # ReadOnlyDirs are additional directories the agent can read from
   # but not write to. Useful for compatibility or reference roots that
@@ -237,16 +236,14 @@ workspace:
 #         signing_key: ~/Thane/core/identity/signing_ed25519
 # 
 # Typical names: kb (curated knowledge), generated (model-produced
-# durable outputs), scratchpad (low-integrity work area), dossiers.
-# The core: name is reserved and always derived from
-# {workspace.path}/core; declaring it under roots: lets you set
-# policy for it but the path is ignored.
+# durable outputs), and scratchpad (low-integrity work area). The core,
+# self, and contacts names are reserved and derived from workspace.path;
+# declaring them under roots: sets policy, while any path is ignored.
 roots:
   generated:
-    # Path is the directory the root resolves to. Supports ~
-    # expansion at resolver construction time. For the reserved
-    # core: name this is ignored; the path is always derived from
-    # workspace.path.
+    # Path is the directory the root resolves to. Supports ~ expansion at
+    # resolver construction time. For reserved derived roots (core, self,
+    # and contacts) this is ignored; their paths come from workspace.path.
     path: ./generated
     # Indexing controls whether markdown files in this root are
     # scanned into the document index. Omit to keep indexing enabled.
@@ -306,15 +303,17 @@ roots:
       # enforce, and the right shape when an entire corpus is only
       # relevant while a capability is active.
       # 
-      # It applies to injection only, so it requires inject: tagged.
-      # Gating search the same way would need the document store to see
-      # active capability tags, which it deliberately does not.
+      # It applies to tagged injection and tagged advertising. Gating search
+      # the same way would need the document store to see active capability
+      # tags, which it deliberately does not.
       requires_tag: ""
       # Advertise controls whether this root's documents may offer
       # themselves to context assembly through the advertisement rail
       # (#1431): "never" (default), "tagged" (offers only while
-      # RequiresTag's capability tag is active), or "always" (ambient
-      # offers on every eligible turn). Advertising is a third door
+      # RequiresTag's capability tag is active), "always" (ambient offers
+      # on every eligible turn), or "exact_subject" (offers only when a
+      # document tag exactly matches a canonical request subject).
+      # Advertising is a third door
       # beside Inject and Search rather than a mode of either: injection
       # pushes whole documents on a tag, search answers an explicit ask,
       # and advertising lets a document compete for a bounded slice of
@@ -357,10 +356,9 @@ roots:
     # establish or re-establish on its own.
     seed_signers: []
   kb:
-    # Path is the directory the root resolves to. Supports ~
-    # expansion at resolver construction time. For the reserved
-    # core: name this is ignored; the path is always derived from
-    # workspace.path.
+    # Path is the directory the root resolves to. Supports ~ expansion at
+    # resolver construction time. For reserved derived roots (core, self,
+    # and contacts) this is ignored; their paths come from workspace.path.
     path: ./knowledge
     # Indexing controls whether markdown files in this root are
     # scanned into the document index. Omit to keep indexing enabled.
@@ -474,15 +472,17 @@ roots:
       # enforce, and the right shape when an entire corpus is only
       # relevant while a capability is active.
       # 
-      # It applies to injection only, so it requires inject: tagged.
-      # Gating search the same way would need the document store to see
-      # active capability tags, which it deliberately does not.
+      # It applies to tagged injection and tagged advertising. Gating search
+      # the same way would need the document store to see active capability
+      # tags, which it deliberately does not.
       requires_tag: ""
       # Advertise controls whether this root's documents may offer
       # themselves to context assembly through the advertisement rail
       # (#1431): "never" (default), "tagged" (offers only while
-      # RequiresTag's capability tag is active), or "always" (ambient
-      # offers on every eligible turn). Advertising is a third door
+      # RequiresTag's capability tag is active), "always" (ambient offers
+      # on every eligible turn), or "exact_subject" (offers only when a
+      # document tag exactly matches a canonical request subject).
+      # Advertising is a third door
       # beside Inject and Search rather than a mode of either: injection
       # pushes whole documents on a tag, search answers an explicit ask,
       # and advertising lets a document compete for a bounded slice of
@@ -544,10 +544,9 @@ roots:
         valid_after: ""
         valid_before: ""
   scratchpad:
-    # Path is the directory the root resolves to. Supports ~
-    # expansion at resolver construction time. For the reserved
-    # core: name this is ignored; the path is always derived from
-    # workspace.path.
+    # Path is the directory the root resolves to. Supports ~ expansion at
+    # resolver construction time. For reserved derived roots (core, self,
+    # and contacts) this is ignored; their paths come from workspace.path.
     path: ./scratchpad
     # Indexing controls whether markdown files in this root are
     # scanned into the document index. Omit to keep indexing enabled.
@@ -607,15 +606,17 @@ roots:
       # enforce, and the right shape when an entire corpus is only
       # relevant while a capability is active.
       # 
-      # It applies to injection only, so it requires inject: tagged.
-      # Gating search the same way would need the document store to see
-      # active capability tags, which it deliberately does not.
+      # It applies to tagged injection and tagged advertising. Gating search
+      # the same way would need the document store to see active capability
+      # tags, which it deliberately does not.
       requires_tag: ""
       # Advertise controls whether this root's documents may offer
       # themselves to context assembly through the advertisement rail
       # (#1431): "never" (default), "tagged" (offers only while
-      # RequiresTag's capability tag is active), or "always" (ambient
-      # offers on every eligible turn). Advertising is a third door
+      # RequiresTag's capability tag is active), "always" (ambient offers
+      # on every eligible turn), or "exact_subject" (offers only when a
+      # document tag exactly matches a canonical request subject).
+      # Advertising is a third door
       # beside Inject and Search rather than a mode of either: injection
       # pushes whole documents on a tag, search answers an explicit ask,
       # and advertising lets a document compete for a bounded slice of

--- a/internal/app/document_root_admission.go
+++ b/internal/app/document_root_admission.go
@@ -107,12 +107,17 @@ func documentRootPaths(cfg *config.Config, logger *slog.Logger) map[string]strin
 }
 
 func declaresDocumentRoot(roots map[string]config.DocumentRootConfig, want string) bool {
-	for name := range roots {
+	_, ok := declaredDocumentRoot(roots, want)
+	return ok
+}
+
+func declaredDocumentRoot(roots map[string]config.DocumentRootConfig, want string) (config.DocumentRootConfig, bool) {
+	for name, root := range roots {
 		if strings.TrimSuffix(strings.TrimSpace(name), ":") == want {
-			return true
+			return root, true
 		}
 	}
-	return false
+	return config.DocumentRootConfig{}, false
 }
 
 // missingDerivedRoot reports a derived root that does not exist on disk.

--- a/internal/app/document_root_admission.go
+++ b/internal/app/document_root_admission.go
@@ -44,11 +44,12 @@ func resolveRootPaths(root, rootPath string, gitCfg config.DocumentRootGitConfig
 }
 
 // documentRootPaths returns the path prefixes for this instance's document
-// roots, with the reserved derived roots — core and self — forced to the
-// locations derived from workspace.path.
+// roots, with reserved derived roots forced to locations beneath
+// workspace.path. Core and self are always present; contacts is present when
+// its policy is explicitly declared.
 //
 // The derived roots are what make this worth centralizing. They carry
-// policy under roots.core / roots.self but never a path, so they are
+// policy under roots.core / roots.self / roots.contacts but never a path, so they are
 // simply absent from cfg.Paths as loaded and appear only once derived.
 // Any caller that enumerates roots without this step silently omits them
 // — which for a per-root check means reporting on every root except the
@@ -60,14 +61,14 @@ func resolveRootPaths(root, rootPath string, gitCfg config.DocumentRootGitConfig
 // The returned map is a copy. Creating the directories is left to the
 // caller, so read-only callers stay read-only.
 func documentRootPaths(cfg *config.Config, logger *slog.Logger) map[string]string {
-	out := make(map[string]string, len(cfg.Paths)+2)
+	out := make(map[string]string, len(cfg.Paths)+3)
 	for name, path := range cfg.Paths {
 		out[name] = path
 	}
 	if cfg.Workspace.Path == "" {
 		return out
 	}
-	// Both derived roots get the same treatment, so adding one is an
+	// Derived roots get the same treatment, so adding one is an
 	// entry here rather than a second copy of this loop. A slice, not a
 	// map: iteration order decides log order, and a diagnostic that
 	// shuffles between runs reads as two different problems.
@@ -77,7 +78,11 @@ func documentRootPaths(cfg *config.Config, logger *slog.Logger) map[string]strin
 	}{
 		{config.CoreRootName, cfg.CoreRoot()},
 		{config.SelfRootName, cfg.SelfRoot()},
+		{config.ContactsRootName, cfg.ContactsRoot()},
 	} {
+		if derivedRoot.name == config.ContactsRootName && !declaresDocumentRoot(cfg.DocRoots, config.ContactsRootName) {
+			continue
+		}
 		rootName, derived := derivedRoot.name, derivedRoot.path
 		if derived == "" {
 			continue
@@ -101,13 +106,22 @@ func documentRootPaths(cfg *config.Config, logger *slog.Logger) map[string]strin
 	return out
 }
 
+func declaresDocumentRoot(roots map[string]config.DocumentRootConfig, want string) bool {
+	for name := range roots {
+		if strings.TrimSuffix(strings.TrimSpace(name), ":") == want {
+			return true
+		}
+	}
+	return false
+}
+
 // missingDerivedRoot reports a derived root that does not exist on disk.
 //
 // For a declared root, silence is right: validate creates nothing, and serve
 // bootstraps a missing signing root and births it, so calling it unadmitted
 // would be a false alarm about a root that does not exist to judge.
 //
-// That reasoning does not carry to core and self. Serve signs the birth commit
+// That reasoning does not carry to derived roots. Serve signs the birth commit
 // it creates with the root's own signing key, and admission then demands that
 // commit be signed by a declared seed signer. Where the two differ — the common
 // case for a derived root, whose seed signers name the operator while its
@@ -122,9 +136,14 @@ func missingDerivedRoot(cfg *config.Config, root string, mode documents.Verifica
 	if !config.IsDerivedRootName(root) {
 		return RootAdmission{}, false
 	}
-	path := cfg.CoreRoot()
-	if root == config.SelfRootName {
+	var path string
+	switch root {
+	case config.CoreRootName:
+		path = cfg.CoreRoot()
+	case config.SelfRootName:
 		path = cfg.SelfRoot()
+	case config.ContactsRootName:
+		path = cfg.ContactsRoot()
 	}
 	// RepoPath stays empty: it reports the repository admission judged, and
 	// admission never ran here. Naming a directory that does not exist would
@@ -246,7 +265,7 @@ func (a *App) verifyRootAdmission(root, rootPath string, rootCfg config.Document
 // serve would create and birth-commit it, so reporting it as unadmitted would
 // be a false alarm about a root that does not exist to judge.
 //
-// core and self are the exception, for the reason [missingDerivedRoot] gives:
+// Derived roots are the exception, for the reason [missingDerivedRoot] gives:
 // the bootstrap serve would perform is the very thing admission then refuses.
 func CheckRootAdmission(ctx context.Context, cfg *config.Config) []RootAdmission {
 	if cfg == nil || len(cfg.DocRoots) == 0 {

--- a/internal/app/document_root_admission_test.go
+++ b/internal/app/document_root_admission_test.go
@@ -270,3 +270,19 @@ func TestSelfRootIgnoresAConfiguredPath(t *testing.T) {
 		t.Errorf("self root = %q, want the derived %q; a configured path must not win", got, want)
 	}
 }
+
+func TestContactsRootIsDerivedOnlyWhenDeclared(t *testing.T) {
+	workspace := t.TempDir()
+	cfg := &config.Config{Workspace: config.WorkspaceConfig{Path: workspace}}
+	if _, ok := documentRootPaths(cfg, nil)[config.ContactsRootName]; ok {
+		t.Fatal("contacts root was registered without an explicit policy declaration")
+	}
+
+	cfg.DocRoots = map[string]config.DocumentRootConfig{
+		config.ContactsRootName: {Authoring: "managed"},
+	}
+	paths := documentRootPaths(cfg, nil)
+	if got, want := paths[config.ContactsRootName], filepath.Join(workspace, config.ContactsRootName); got != want {
+		t.Fatalf("contacts root = %q, want derived %q", got, want)
+	}
+}

--- a/internal/app/document_root_missing_test.go
+++ b/internal/app/document_root_missing_test.go
@@ -35,8 +35,9 @@ func TestCheckRootAdmissionReportsMissingDerivedRoots(t *testing.T) {
 	cfg := &config.Config{
 		Workspace: config.WorkspaceConfig{Path: workspace},
 		DocRoots: map[string]config.DocumentRootConfig{
-			config.CoreRootName: signedRoot(),
-			config.SelfRootName: signedRoot(),
+			config.CoreRootName:     signedRoot(),
+			config.SelfRootName:     signedRoot(),
+			config.ContactsRootName: signedRoot(),
 		},
 	}
 
@@ -47,7 +48,7 @@ func TestCheckRootAdmissionReportsMissingDerivedRoots(t *testing.T) {
 		byRoot[r.Root] = r
 	}
 
-	for _, root := range []string{config.CoreRootName, config.SelfRootName} {
+	for _, root := range []string{config.CoreRootName, config.SelfRootName, config.ContactsRootName} {
 		t.Run(root, func(t *testing.T) {
 			got, ok := byRoot[root]
 			if !ok {

--- a/internal/app/document_root_policy.go
+++ b/internal/app/document_root_policy.go
@@ -1,0 +1,39 @@
+package app
+
+import (
+	"strings"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/config"
+	"github.com/nugget/thane-ai-agent/internal/state/documents"
+)
+
+func documentRootPolicyFromConfig(rootCfg config.DocumentRootConfig) documents.RootPolicy {
+	policy := documents.RootPolicy{
+		Indexing:  true,
+		Authoring: documents.AuthoringManaged,
+		Git: documents.RootGitPolicy{
+			VerifySignatures: documents.VerificationNone,
+		},
+	}
+	if rootCfg.Indexing != nil {
+		policy.Indexing = *rootCfg.Indexing
+	}
+	if authoring := strings.TrimSpace(rootCfg.Authoring); authoring != "" {
+		policy.Authoring = documents.AuthoringMode(authoring)
+	}
+	gitCfg := rootCfg.Git
+	policy.Git.Enabled = gitCfg.Enabled
+	policy.Git.SignCommits = gitCfg.SignCommits
+	if verify := strings.TrimSpace(gitCfg.VerifySignatures); verify != "" {
+		policy.Git.VerifySignatures = documents.VerificationMode(verify)
+	}
+	policy.Git.RepoPath = strings.TrimSpace(gitCfg.RepoPath)
+	policy.Context = documents.RootContextPolicy{
+		Inject:      strings.TrimSpace(rootCfg.Context.Inject),
+		Search:      strings.TrimSpace(rootCfg.Context.Search),
+		Advertise:   strings.TrimSpace(rootCfg.Context.Advertise),
+		RequiresTag: strings.TrimSpace(rootCfg.Context.RequiresTag),
+		Untagged:    strings.TrimSpace(rootCfg.Context.Untagged),
+	}
+	return policy
+}

--- a/internal/app/document_roots.go
+++ b/internal/app/document_roots.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/platform/paths"
 	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
+	"github.com/nugget/thane-ai-agent/internal/state/contacts"
 	"github.com/nugget/thane-ai-agent/internal/state/documents"
 )
 
@@ -179,6 +180,12 @@ func (a *App) buildDocumentStoreOptions(documentRoots map[string]string, resolve
 		}
 
 		opts.RootPolicies[root] = policy
+		if root == contacts.DossierRootName {
+			if opts.RootValidators == nil {
+				opts.RootValidators = make(map[string]documents.RootWriteValidator)
+			}
+			opts.RootValidators[root] = contacts.ValidateDossierWrite
+		}
 
 		// Construct the writer first when this root signs commits.
 		// provenance.NewWithOptions runs ensureRepo (mkdir + git
@@ -320,36 +327,6 @@ func legacyInjectRoot(cfg *config.Config) string {
 		}
 	}
 	return "kb"
-}
-
-func documentRootPolicyFromConfig(rootCfg config.DocumentRootConfig) documents.RootPolicy {
-	policy := documents.RootPolicy{
-		Indexing:  true,
-		Authoring: documents.AuthoringManaged,
-		Git: documents.RootGitPolicy{
-			VerifySignatures: documents.VerificationNone,
-		},
-	}
-	if rootCfg.Indexing != nil {
-		policy.Indexing = *rootCfg.Indexing
-	}
-	if authoring := strings.TrimSpace(rootCfg.Authoring); authoring != "" {
-		policy.Authoring = documents.AuthoringMode(authoring)
-	}
-	gitCfg := rootCfg.Git
-	policy.Git.Enabled = gitCfg.Enabled
-	policy.Git.SignCommits = gitCfg.SignCommits
-	if verify := strings.TrimSpace(gitCfg.VerifySignatures); verify != "" {
-		policy.Git.VerifySignatures = documents.VerificationMode(verify)
-	}
-	policy.Git.RepoPath = strings.TrimSpace(gitCfg.RepoPath)
-	policy.Context = documents.RootContextPolicy{
-		Inject:      strings.TrimSpace(rootCfg.Context.Inject),
-		Search:      strings.TrimSpace(rootCfg.Context.Search),
-		RequiresTag: strings.TrimSpace(rootCfg.Context.RequiresTag),
-		Untagged:    strings.TrimSpace(rootCfg.Context.Untagged),
-	}
-	return policy
 }
 
 func (a *App) newDocumentRootProvenanceWriter(root, rootPath string, rootCfg config.DocumentRootConfig, resolver *paths.Resolver) (*documentRootProvenanceWriter, error) {

--- a/internal/app/document_roots_test.go
+++ b/internal/app/document_roots_test.go
@@ -89,6 +89,9 @@ func TestBuildDocumentStoreOptionsMapsConfigPolicy(t *testing.T) {
 			"kb:": {
 				Indexing:  &indexing,
 				Authoring: "read_only",
+				Context: config.RootContextPolicy{
+					Advertise: config.RootAdvertiseExactSubject,
+				},
 				Git: config.DocumentRootGitConfig{
 					Enabled:          true,
 					VerifySignatures: "warn",
@@ -108,8 +111,33 @@ func TestBuildDocumentStoreOptionsMapsConfigPolicy(t *testing.T) {
 	if !policy.Git.Enabled || policy.Git.VerifySignatures != documents.VerificationWarn {
 		t.Fatalf("policy.Git = %#v, want enabled warn verification", policy.Git)
 	}
+	if policy.Context.Advertise != config.RootAdvertiseExactSubject {
+		t.Fatalf("policy.Context.Advertise = %q, want exact_subject", policy.Context.Advertise)
+	}
 	if len(opts.RootWriters) != 0 {
 		t.Fatalf("RootWriters = %#v, want none without sign_commits", opts.RootWriters)
+	}
+}
+
+func TestBuildDocumentStoreOptionsWiresContactDossierValidator(t *testing.T) {
+	t.Parallel()
+	app := &App{cfg: &config.Config{
+		DocRoots: map[string]config.DocumentRootConfig{
+			config.ContactsRootName: {Authoring: "managed"},
+		},
+	}}
+	opts, err := app.buildDocumentStoreOptions(map[string]string{
+		config.ContactsRootName: t.TempDir(),
+	}, nil)
+	if err != nil {
+		t.Fatalf("buildDocumentStoreOptions: %v", err)
+	}
+	validator := opts.RootValidators[config.ContactsRootName]
+	if validator == nil {
+		t.Fatal("contacts root has no dossier write validator")
+	}
+	if err := validator(documents.DocumentWriteCandidate{Path: "notes.md", Body: "plain"}); err == nil {
+		t.Fatal("contacts root validator accepted a noncanonical document")
 	}
 }
 

--- a/internal/app/new_agent.go
+++ b/internal/app/new_agent.go
@@ -33,13 +33,16 @@ func (a *App) initAgentLoop(s *newState) error {
 	// LoopOptions instead of post-construction setters.
 	if cfg.Workspace.Path != "" {
 		cfg.Paths = documentRootPaths(cfg, logger)
-		// Both derived roots are created, because both are written on a
-		// default install: core holds what the operator declares, self
-		// holds what the loops write about themselves. A self root that
-		// only appeared once a loop first wrote would leave an operator
-		// unable to declare policy on a directory that does not exist.
-		for _, root := range []string{config.CoreRootName, config.SelfRootName} {
-			if err := os.MkdirAll(cfg.Paths[root], 0o755); err != nil {
+		// Core and self are created on every install; contacts joins them
+		// when its canonical dossier policy is declared. Creating derived
+		// roots before resolver construction keeps policy and filesystem
+		// identity from depending on which subsystem happens to write first.
+		for _, root := range []string{config.CoreRootName, config.SelfRootName, config.ContactsRootName} {
+			path := cfg.Paths[root]
+			if strings.TrimSpace(path) == "" {
+				continue
+			}
+			if err := os.MkdirAll(path, 0o755); err != nil {
 				return fmt.Errorf("create %s document root: %w", root, err)
 			}
 		}

--- a/internal/app/new_channels.go
+++ b/internal/app/new_channels.go
@@ -155,6 +155,7 @@ func (a *App) initChannels(s *newState) error {
 	})
 
 	contactTools := contacts.NewTools(contactStore)
+	contactTools.ConfigureDossierRoot(declaresDocumentRoot(a.cfg.DocRoots, contacts.DossierRootName))
 	if a.cfg.Identity.ContactName != "" {
 		contactTools.SetSelfContactName(a.cfg.Identity.ContactName)
 	}

--- a/internal/app/new_channels.go
+++ b/internal/app/new_channels.go
@@ -155,7 +155,9 @@ func (a *App) initChannels(s *newState) error {
 	})
 
 	contactTools := contacts.NewTools(contactStore)
-	contactTools.ConfigureDossierRoot(declaresDocumentRoot(a.cfg.DocRoots, contacts.DossierRootName))
+	dossierRoot, dossiersEnabled := declaredDocumentRoot(a.cfg.DocRoots, contacts.DossierRootName)
+	dossiersWritable := dossiersEnabled && documentRootPolicyFromConfig(dossierRoot).Authoring == documents.AuthoringManaged
+	contactTools.ConfigureDossierRoot(dossiersEnabled, dossiersWritable)
 	if a.cfg.Identity.ContactName != "" {
 		contactTools.SetSelfContactName(a.cfg.Identity.ContactName)
 	}

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -56,12 +56,13 @@ const DefaultWorkspace = "~/Thane"
 // ConfigFileName is the fixed name of the runtime config inside core.
 const ConfigFileName = "config.yaml"
 
-// CoreRootName and SelfRootName are the two document roots whose paths
-// are derived from the workspace rather than declared. Both may be named
-// in roots: to set policy, and neither takes a path from there.
+// CoreRootName, SelfRootName, and ContactsRootName are document roots whose
+// paths are derived from the workspace rather than declared. They may be
+// named in roots: to set policy, and none takes a path from there.
 const (
-	CoreRootName = "core"
-	SelfRootName = "self"
+	CoreRootName     = "core"
+	SelfRootName     = "self"
+	ContactsRootName = "contacts"
 )
 
 // legacyConfigLocations are the paths Thane searched before the config
@@ -244,11 +245,10 @@ type Config struct {
 	Embeddings EmbeddingsConfig `yaml:"embeddings"`
 
 	// Workspace configures the agent's sandboxed file system access.
-	// The workspace root is also the anchor for Thane's two derived
-	// document roots. {workspace.path}/core holds what the operator
-	// declares Thane to be — axioms.md, persona.md, mission.md — and
-	// {workspace.path}/self holds what Thane has made of that, written
-	// by the core service loops: ego.md, metacognitive.md, archivist.md.
+	// The workspace root also anchors Thane's derived document roots.
+	// {workspace.path}/core holds what the operator declares Thane to be;
+	// {workspace.path}/self holds what Thane has made of that; and the
+	// optional {workspace.path}/contacts holds contact dossiers.
 	Workspace WorkspaceConfig `yaml:"workspace"`
 
 	// Roots is the unified document-root config. Each entry names one
@@ -275,10 +275,9 @@ type Config struct {
 	//         signing_key: ~/Thane/core/identity/signing_ed25519
 	//
 	// Typical names: kb (curated knowledge), generated (model-produced
-	// durable outputs), scratchpad (low-integrity work area), dossiers.
-	// The core: name is reserved and always derived from
-	// {workspace.path}/core; declaring it under roots: lets you set
-	// policy for it but the path is ignored.
+	// durable outputs), and scratchpad (low-integrity work area). The core,
+	// self, and contacts names are reserved and derived from workspace.path;
+	// declaring them under roots: sets policy, while any path is ignored.
 	Roots map[string]RootEntry `yaml:"roots,omitempty"`
 
 	// Paths is the legacy directory-mapping block. Replaced by roots:.
@@ -1005,10 +1004,9 @@ type AllowedSigner struct {
 // (the entire entry is the path, all policy fields default) or a
 // mapping with explicit path: and policy fields.
 type RootEntry struct {
-	// Path is the directory the root resolves to. Supports ~
-	// expansion at resolver construction time. For the reserved
-	// core: name this is ignored; the path is always derived from
-	// workspace.path.
+	// Path is the directory the root resolves to. Supports ~ expansion at
+	// resolver construction time. For reserved derived roots (core, self,
+	// and contacts) this is ignored; their paths come from workspace.path.
 	Path string `yaml:"path"`
 
 	// Indexing controls whether markdown files in this root are
@@ -1109,6 +1107,12 @@ const (
 	// schedule root, whose freshest signal is worth a standing seat at
 	// the discriminator's table.
 	RootAdvertiseAlways = "always"
+	// RootAdvertiseExactSubject lets a document offer itself only when one
+	// of its tags exactly matches a canonical request subject. It is the
+	// posture for private per-subject corpora such as contact dossiers:
+	// relevant records get a trailhead without unrelated records spending
+	// ambient attention or matching on loose words.
+	RootAdvertiseExactSubject = "exact_subject"
 )
 
 // RootContextPolicy declares how one document root may reach a model.
@@ -1131,16 +1135,18 @@ type RootContextPolicy struct {
 	// enforce, and the right shape when an entire corpus is only
 	// relevant while a capability is active.
 	//
-	// It applies to injection only, so it requires inject: tagged.
-	// Gating search the same way would need the document store to see
-	// active capability tags, which it deliberately does not.
+	// It applies to tagged injection and tagged advertising. Gating search
+	// the same way would need the document store to see active capability
+	// tags, which it deliberately does not.
 	RequiresTag string `yaml:"requires_tag,omitempty"`
 
 	// Advertise controls whether this root's documents may offer
 	// themselves to context assembly through the advertisement rail
 	// (#1431): "never" (default), "tagged" (offers only while
-	// RequiresTag's capability tag is active), or "always" (ambient
-	// offers on every eligible turn). Advertising is a third door
+	// RequiresTag's capability tag is active), "always" (ambient offers
+	// on every eligible turn), or "exact_subject" (offers only when a
+	// document tag exactly matches a canonical request subject).
+	// Advertising is a third door
 	// beside Inject and Search rather than a mode of either: injection
 	// pushes whole documents on a tag, search answers an explicit ask,
 	// and advertising lets a document compete for a bounded slice of
@@ -1219,9 +1225,9 @@ func (p RootContextPolicy) Validate(rootName string) error {
 		return fmt.Errorf("roots.%s.context.search must be %q, %q, or %q, got %q", rootName, RootSearchDefault, RootSearchOnRequest, RootSearchNever, p.Search)
 	}
 	switch p.Advertise {
-	case "", RootAdvertiseNever, RootAdvertiseTagged, RootAdvertiseAlways:
+	case "", RootAdvertiseNever, RootAdvertiseTagged, RootAdvertiseAlways, RootAdvertiseExactSubject:
 	default:
-		return fmt.Errorf("roots.%s.context.advertise must be %q, %q, or %q, got %q", rootName, RootAdvertiseNever, RootAdvertiseTagged, RootAdvertiseAlways, p.Advertise)
+		return fmt.Errorf("roots.%s.context.advertise must be %q, %q, %q, or %q, got %q", rootName, RootAdvertiseNever, RootAdvertiseTagged, RootAdvertiseAlways, RootAdvertiseExactSubject, p.Advertise)
 	}
 	if p.Advertise == RootAdvertiseTagged && p.RequiresTag == "" {
 		return fmt.Errorf("roots.%s.context.advertise %q needs requires_tag to name the gating capability tag", rootName, RootAdvertiseTagged)
@@ -2789,7 +2795,7 @@ func (c *Config) normalizeRoots() error {
 			}
 			seen[trimmed] = name
 			pathValue := strings.TrimSpace(entry.Path)
-			// core: and self: are reserved — their paths are always
+			// Derived roots are reserved — their paths are always
 			// derived from workspace.path. Allow declaring either in
 			// roots: solely to set policy; ignore any path provided.
 			if IsDerivedRootName(trimmed) {
@@ -2799,7 +2805,7 @@ func (c *Config) normalizeRoots() error {
 				}
 			} else {
 				if pathValue == "" {
-					return fmt.Errorf("config: roots.%s.path must be set; only the derived roots (%s, %s) take their path from workspace.path", trimmed, CoreRootName, SelfRootName)
+					return fmt.Errorf("config: roots.%s.path must be set; only the derived roots (%s, %s, %s) take their path from workspace.path", trimmed, CoreRootName, SelfRootName, ContactsRootName)
 				}
 				c.Paths[trimmed] = entry.Path
 			}
@@ -3744,12 +3750,12 @@ func (c *Config) CoreRoot() string {
 // IsDerivedRootName reports whether a root takes its path from the
 // workspace rather than from roots:.
 //
-// The derived roots are load-bearing in a way declared roots are not: the
-// instance's own configuration lives in one and its core service loops write
-// the other on every install. Callers that need to treat "this root is missing"
-// as a problem rather than a preference use this to tell the two apart.
+// The derived roots are load-bearing in a way ordinary declared roots are not:
+// their stable refs depend on one workspace-relative location. Callers that
+// need to treat "this root is missing" as a problem rather than a preference
+// use this to distinguish them.
 func IsDerivedRootName(name string) bool {
-	return name == CoreRootName || name == SelfRootName
+	return name == CoreRootName || name == SelfRootName || name == ContactsRootName
 }
 
 // SelfRoot returns the fixed document root holding what Thane writes
@@ -3774,6 +3780,17 @@ func (c *Config) SelfRoot() string {
 		return ""
 	}
 	return filepath.Join(c.Workspace.Path, SelfRootName)
+}
+
+// ContactsRoot returns the fixed document root holding contact dossiers,
+// derived from [Workspace.Path] exactly as [CoreRoot] is. The root is opt-in:
+// callers only register it when contacts is explicitly declared under roots:.
+// When workspace.path is unset, ContactsRoot returns the empty string.
+func (c *Config) ContactsRoot() string {
+	if strings.TrimSpace(c.Workspace.Path) == "" {
+		return ""
+	}
+	return filepath.Join(c.Workspace.Path, ContactsRootName)
 }
 
 // CoreFile returns the absolute-or-relative path to a named file in the

--- a/internal/platform/config/config_root_context_test.go
+++ b/internal/platform/config/config_root_context_test.go
@@ -34,6 +34,7 @@ func TestRootContextPolicyValidate(t *testing.T) {
 			wantErr: "requires_tag gates tagged injection and tagged advertising",
 		},
 		{name: "always advertising", policy: RootContextPolicy{Advertise: RootAdvertiseAlways}},
+		{name: "exact subject advertising", policy: RootContextPolicy{Advertise: RootAdvertiseExactSubject}},
 		{
 			name:   "tagged advertising with its gate",
 			policy: RootContextPolicy{Advertise: RootAdvertiseTagged, RequiresTag: "schedule"},

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -1584,6 +1584,27 @@ func TestNormalizeRoots_CoreReservedAcceptsPolicyOnly(t *testing.T) {
 	}
 }
 
+func TestNormalizeRoots_ContactsReservedAcceptsPolicyOnly(t *testing.T) {
+	t.Parallel()
+	cfg := &Config{
+		Roots: map[string]RootEntry{
+			ContactsRootName: {
+				Authoring: "managed",
+				Context:   RootContextPolicy{Advertise: RootAdvertiseExactSubject},
+			},
+		},
+	}
+	if err := cfg.normalizeRoots(); err != nil {
+		t.Fatalf("normalizeRoots: %v", err)
+	}
+	if _, ok := cfg.Paths[ContactsRootName]; ok {
+		t.Errorf("contacts path must be derived; Paths = %#v", cfg.Paths)
+	}
+	if got := cfg.DocRoots[ContactsRootName].Context.Advertise; got != RootAdvertiseExactSubject {
+		t.Errorf("contacts advertise policy = %q, want %q", got, RootAdvertiseExactSubject)
+	}
+}
+
 // --- Ego loop validation ---
 
 // egoBaseConfig returns a Config with the ego loop enabled and a workspace

--- a/internal/platform/identity/bootstrap.go
+++ b/internal/platform/identity/bootstrap.go
@@ -334,12 +334,26 @@ type channelPolicy struct {
 	AllowedKeyTypes []string `yaml:"allowed_key_types"`
 }
 
-// coreRootPolicy carries the seed declaration for core in the generated
-// config. Only seed_signers is emitted: everything else about core's policy is
-// the operator's to author, but the seed set has to exist from birth or
-// admission has nothing to judge the root against.
+// coreRootPolicy carries one generated document-root declaration. Core emits
+// only seed_signers; contacts also emits its managed authoring, exact-subject
+// context, and signed-history policy so a fresh instance has a complete
+// dossier root without post-init path surgery.
 type coreRootPolicy struct {
-	SeedSigners []coreSeedSigner `yaml:"seed_signers,omitempty"`
+	Authoring   string                `yaml:"authoring,omitempty"`
+	Context     coreRootContextPolicy `yaml:"context,omitempty"`
+	SeedSigners []coreSeedSigner      `yaml:"seed_signers,omitempty"`
+	Git         coreRootGitPolicy     `yaml:"git,omitempty"`
+}
+
+type coreRootContextPolicy struct {
+	Advertise string `yaml:"advertise,omitempty"`
+}
+
+type coreRootGitPolicy struct {
+	Enabled          bool   `yaml:"enabled,omitempty"`
+	SignCommits      bool   `yaml:"sign_commits,omitempty"`
+	VerifySignatures string `yaml:"verify_signatures,omitempty"`
+	SigningKey       string `yaml:"signing_key,omitempty"`
 }
 
 type coreSeedSigner struct {
@@ -369,9 +383,32 @@ func coreSeedDeclaration(signing *SigningKeyPair, operator *OperatorSigner) core
 	}}}
 }
 
+func contactsRootDeclaration(signing *SigningKeyPair) coreRootPolicy {
+	return coreRootPolicy{
+		Authoring: "managed",
+		Context: coreRootContextPolicy{
+			Advertise: "exact_subject",
+		},
+		SeedSigners: []coreSeedSigner{{
+			Principal: provenance.AgentPrincipal,
+			Key:       strings.TrimSpace(signing.Public),
+			Label:     "agent",
+		}},
+		Git: coreRootGitPolicy{
+			Enabled:          true,
+			SignCommits:      true,
+			VerifySignatures: "required",
+			SigningKey:       "core:" + SigningPrivateKeyFile,
+		},
+	}
+}
+
 func renderCoreConfig(instanceName string, generatedAt time.Time, signing *SigningKeyPair, ca *CertificateAuthority, operator *OperatorSigner, operatorContactID string) ([]byte, error) {
 	cfg := coreConfig{
-		Roots:       map[string]coreRootPolicy{"core": coreSeedDeclaration(signing, operator)},
+		Roots: map[string]coreRootPolicy{
+			"core":     coreSeedDeclaration(signing, operator),
+			"contacts": contactsRootDeclaration(signing),
+		},
 		Version:     1,
 		GeneratedAt: generatedAt.Format(time.RFC3339),
 		Identity: identityPolicy{

--- a/internal/platform/identity/bootstrap_test.go
+++ b/internal/platform/identity/bootstrap_test.go
@@ -87,6 +87,19 @@ func TestBootstrapCoreCreatesSignedBirthCommit(t *testing.T) {
 	if cfg.Person.ContactBindings == nil || len(cfg.Person.ContactBindings) != 0 {
 		t.Fatalf("person.contact_bindings = %#v, want explicit empty map", cfg.Person.ContactBindings)
 	}
+	contactsRoot, ok := cfg.Roots["contacts"]
+	if !ok {
+		t.Fatal("generated config is missing roots.contacts")
+	}
+	if contactsRoot.Authoring != "managed" || contactsRoot.Context.Advertise != "exact_subject" {
+		t.Fatalf("generated contacts root policy = %#v", contactsRoot)
+	}
+	if !contactsRoot.Git.Enabled || !contactsRoot.Git.SignCommits || contactsRoot.Git.VerifySignatures != "required" || contactsRoot.Git.SigningKey != "core:"+SigningPrivateKeyFile {
+		t.Fatalf("generated contacts git policy = %#v", contactsRoot.Git)
+	}
+	if len(contactsRoot.SeedSigners) != 1 || contactsRoot.SeedSigners[0].Principal != "thane@provenance.local" {
+		t.Fatalf("generated contacts seed signers = %#v", contactsRoot.SeedSigners)
+	}
 	if cfg.Identity.SigningKey.Fingerprint != result.SigningKeyFingerprint {
 		t.Fatalf("signing fingerprint = %q, want %q", cfg.Identity.SigningKey.Fingerprint, result.SigningKeyFingerprint)
 	}

--- a/internal/state/contacts/dossier.go
+++ b/internal/state/contacts/dossier.go
@@ -1,0 +1,85 @@
+package contacts
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/state/documents"
+)
+
+// DossierRootName is the canonical managed document root for longitudinal
+// contact synthesis.
+const DossierRootName = "contacts"
+
+var dossierOutputContract = looppkg.OutputSpec{
+	Name: "contact_dossier",
+	Type: looppkg.OutputTypeMaintainedDocument,
+	Facets: []looppkg.FacetSpec{
+		{Name: looppkg.OutputFacetStatusLine},
+		{Name: looppkg.OutputFacetTeaser},
+		{Name: looppkg.OutputFacetDigest},
+	},
+}
+
+// DossierRef returns the stable document ref for a contact UUID.
+func DossierRef(id uuid.UUID) string {
+	return DossierRootName + ":" + id.String() + ".md"
+}
+
+// DossierSubject returns the canonical request-subject and frontmatter tag
+// that bind a dossier to its structured contact record.
+func DossierSubject(id uuid.UUID) string {
+	return "contact:" + id.String()
+}
+
+// ValidateDossierWrite enforces the contact dossier path, subject tag, and
+// complete facet ladder before a managed document write can mutate the root.
+func ValidateDossierWrite(candidate documents.DocumentWriteCandidate) error {
+	id, err := dossierIDFromPath(candidate.Path)
+	if err != nil {
+		return err
+	}
+
+	wantSubject := DossierSubject(id)
+	foundSubject := false
+	for _, tag := range candidate.Tags {
+		tag = strings.TrimSpace(tag)
+		if tag == wantSubject {
+			foundSubject = true
+			continue
+		}
+		if strings.HasPrefix(tag, "contact:") {
+			return fmt.Errorf("dossier %s carries mismatched contact tag %q; use exactly %q for its structured contact", candidate.Path, tag, wantSubject)
+		}
+	}
+	if !foundSubject {
+		return fmt.Errorf("dossier %s must carry frontmatter tag %q so request context can resolve it without guessing from prose", candidate.Path, wantSubject)
+	}
+
+	payload, faceted := looppkg.ParseFacetSections(candidate.Body)
+	if !faceted {
+		return fmt.Errorf("dossier %s must use the status_line, teaser, digest, and full facet ladder", candidate.Path)
+	}
+	if err := dossierOutputContract.ValidateFacetPayload(payload); err != nil {
+		return fmt.Errorf("dossier %s facet contract: %w", candidate.Path, err)
+	}
+	if got, want := strings.TrimSpace(candidate.Body), dossierOutputContract.RenderFacetDocument(payload); got != want {
+		return fmt.Errorf("dossier %s must use the canonical facet section order with no text outside those sections", candidate.Path)
+	}
+	return nil
+}
+
+func dossierIDFromPath(relPath string) (uuid.UUID, error) {
+	relPath = strings.TrimSpace(strings.ReplaceAll(relPath, `\`, "/"))
+	if relPath == "" || strings.Contains(relPath, "/") || !strings.HasSuffix(relPath, ".md") {
+		return uuid.Nil, fmt.Errorf("contacts root accepts only top-level <canonical-contact-uuid>.md dossiers; got %q", relPath)
+	}
+	rawID := strings.TrimSuffix(relPath, ".md")
+	id, err := uuid.Parse(rawID)
+	if err != nil || id == uuid.Nil || id.String() != rawID {
+		return uuid.Nil, fmt.Errorf("contacts root dossier filename must contain a canonical non-zero contact UUID; got %q", relPath)
+	}
+	return id, nil
+}

--- a/internal/state/contacts/dossier.go
+++ b/internal/state/contacts/dossier.go
@@ -43,19 +43,8 @@ func ValidateDossierWrite(candidate documents.DocumentWriteCandidate) error {
 	}
 
 	wantSubject := DossierSubject(id)
-	foundSubject := false
-	for _, tag := range candidate.Tags {
-		tag = strings.TrimSpace(tag)
-		if tag == wantSubject {
-			foundSubject = true
-			continue
-		}
-		if strings.HasPrefix(tag, "contact:") {
-			return fmt.Errorf("dossier %s carries mismatched contact tag %q; use exactly %q for its structured contact", candidate.Path, tag, wantSubject)
-		}
-	}
-	if !foundSubject {
-		return fmt.Errorf("dossier %s must carry frontmatter tag %q so request context can resolve it without guessing from prose", candidate.Path, wantSubject)
+	if len(candidate.Tags) != 1 || strings.TrimSpace(candidate.Tags[0]) != wantSubject {
+		return fmt.Errorf("dossier %s must carry exactly one frontmatter tag, %q, so no broader subject can advertise this private dossier", candidate.Path, wantSubject)
 	}
 
 	payload, faceted := looppkg.ParseFacetSections(candidate.Body)

--- a/internal/state/contacts/dossier_test.go
+++ b/internal/state/contacts/dossier_test.go
@@ -18,7 +18,7 @@ func validDossierCandidate(id uuid.UUID) documents.DocumentWriteCandidate {
 	}
 	return documents.DocumentWriteCandidate{
 		Path: id.String() + ".md",
-		Tags: []string{DossierSubject(id), "household"},
+		Tags: []string{DossierSubject(id)},
 		Body: dossierOutputContract.RenderFacetDocument(payload),
 	}
 }
@@ -50,14 +50,21 @@ func TestValidateDossierWrite(t *testing.T) {
 			mutate: func(candidate *documents.DocumentWriteCandidate) {
 				candidate.Tags = []string{"household"}
 			},
-			wantErr: "must carry frontmatter tag",
+			wantErr: "must carry exactly one frontmatter tag",
 		},
 		{
 			name: "mismatched subject",
 			mutate: func(candidate *documents.DocumentWriteCandidate) {
 				candidate.Tags = []string{"contact:019c76e4-2ff1-7918-8d6f-6c2488f5098e"}
 			},
-			wantErr: "mismatched contact tag",
+			wantErr: "must carry exactly one frontmatter tag",
+		},
+		{
+			name: "additional broad subject",
+			mutate: func(candidate *documents.DocumentWriteCandidate) {
+				candidate.Tags = append(candidate.Tags, "household")
+			},
+			wantErr: "no broader subject",
 		},
 		{
 			name: "missing facet",

--- a/internal/state/contacts/dossier_test.go
+++ b/internal/state/contacts/dossier_test.go
@@ -1,0 +1,106 @@
+package contacts
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/state/documents"
+)
+
+func validDossierCandidate(id uuid.UUID) documents.DocumentWriteCandidate {
+	payload := looppkg.FacetPayload{
+		StatusLine: "Relationship is current and steady.",
+		Teaser:     "Recent conversations clarified the operator's preferred collaboration style.",
+		Digest:     "The contact prefers direct technical collaboration and explicit source-of-truth boundaries.",
+		Full:       "# Relationship context\n\nCurrent synthesis with cited evidence.",
+	}
+	return documents.DocumentWriteCandidate{
+		Path: id.String() + ".md",
+		Tags: []string{DossierSubject(id), "household"},
+		Body: dossierOutputContract.RenderFacetDocument(payload),
+	}
+}
+
+func TestValidateDossierWrite(t *testing.T) {
+	id := uuid.MustParse("019c76e4-2ff1-7918-8d6f-6c2488f5098d")
+	tests := []struct {
+		name    string
+		mutate  func(*documents.DocumentWriteCandidate)
+		wantErr string
+	}{
+		{name: "canonical dossier"},
+		{
+			name: "nested path",
+			mutate: func(candidate *documents.DocumentWriteCandidate) {
+				candidate.Path = "people/" + candidate.Path
+			},
+			wantErr: "top-level",
+		},
+		{
+			name: "noncanonical uuid",
+			mutate: func(candidate *documents.DocumentWriteCandidate) {
+				candidate.Path = strings.ToUpper(strings.TrimSuffix(candidate.Path, ".md")) + ".md"
+			},
+			wantErr: "canonical non-zero",
+		},
+		{
+			name: "missing subject",
+			mutate: func(candidate *documents.DocumentWriteCandidate) {
+				candidate.Tags = []string{"household"}
+			},
+			wantErr: "must carry frontmatter tag",
+		},
+		{
+			name: "mismatched subject",
+			mutate: func(candidate *documents.DocumentWriteCandidate) {
+				candidate.Tags = []string{"contact:019c76e4-2ff1-7918-8d6f-6c2488f5098e"}
+			},
+			wantErr: "mismatched contact tag",
+		},
+		{
+			name: "missing facet",
+			mutate: func(candidate *documents.DocumentWriteCandidate) {
+				candidate.Body = strings.Replace(candidate.Body, "## Digest\n\nThe contact prefers direct technical collaboration and explicit source-of-truth boundaries.\n\n", "", 1)
+			},
+			wantErr: "digest is required",
+		},
+		{
+			name: "noncanonical preamble",
+			mutate: func(candidate *documents.DocumentWriteCandidate) {
+				candidate.Body = "stray preamble\n\n" + candidate.Body
+			},
+			wantErr: "canonical facet section order",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			candidate := validDossierCandidate(id)
+			if tt.mutate != nil {
+				tt.mutate(&candidate)
+			}
+			err := ValidateDossierWrite(candidate)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ValidateDossierWrite() error = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("ValidateDossierWrite() error = %v, want it to mention %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDossierIdentityHelpers(t *testing.T) {
+	id := uuid.MustParse("019c76e4-2ff1-7918-8d6f-6c2488f5098d")
+	if got, want := DossierRef(id), "contacts:019c76e4-2ff1-7918-8d6f-6c2488f5098d.md"; got != want {
+		t.Fatalf("DossierRef() = %q, want %q", got, want)
+	}
+	if got, want := DossierSubject(id), "contact:019c76e4-2ff1-7918-8d6f-6c2488f5098d"; got != want {
+		t.Fatalf("DossierSubject() = %q, want %q", got, want)
+	}
+}

--- a/internal/state/contacts/tools.go
+++ b/internal/state/contacts/tools.go
@@ -46,6 +46,7 @@ type Tools struct {
 	operatorContactID uuid.UUID
 	ownerContactName  string
 	ownerActivity     func() []OwnerChannelActivity
+	dossiersEnabled   bool
 }
 
 // NewTools creates contact tools using the given store.
@@ -70,6 +71,12 @@ func (t *Tools) ConfigureOperatorContactID(id uuid.UUID) {
 	t.operatorContactID = id
 }
 
+// ConfigureDossierRoot controls whether rich contact results expose the
+// deterministic managed-document trailhead for the contact.
+func (t *Tools) ConfigureDossierRoot(enabled bool) {
+	t.dossiersEnabled = enabled
+}
+
 // SetOwnerContactName sets the contact name used to resolve the
 // primary human operator contact for legacy configurations.
 func (t *Tools) SetOwnerContactName(name string) {
@@ -90,7 +97,7 @@ func (t *Tools) OwnerContact(_ string) (string, error) {
 		return "", err
 	}
 	var sb strings.Builder
-	sb.WriteString(formatContact(c))
+	sb.WriteString(t.formatContact(c))
 	if summary := t.formatOwnerActivitySummary(); summary != "" {
 		sb.WriteString("\n\n")
 		sb.WriteString(summary)
@@ -410,7 +417,7 @@ func (t *Tools) LookupContact(argsJSON string) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("get contact details: %w", err)
 		}
-		return formatContact(c), nil
+		return t.formatContact(c), nil
 	}
 
 	// Property filter.
@@ -1037,6 +1044,14 @@ func formatContact(c *Contact) string {
 	}
 
 	return sb.String()
+}
+
+func (t *Tools) formatContact(c *Contact) string {
+	formatted := formatContact(c)
+	if t == nil || !t.dossiersEnabled || c == nil || c.ID == uuid.Nil {
+		return formatted
+	}
+	return fmt.Sprintf("%s\nContact ID: %s\nDossier: %s (doc_read; if absent, create with tag %s and the standard Status Line/Teaser/Digest/Details sections)", formatted, c.ID, DossierRef(c.ID), DossierSubject(c.ID))
 }
 
 func (t *Tools) formatOwnerActivitySummary() string {

--- a/internal/state/contacts/tools.go
+++ b/internal/state/contacts/tools.go
@@ -47,6 +47,7 @@ type Tools struct {
 	ownerContactName  string
 	ownerActivity     func() []OwnerChannelActivity
 	dossiersEnabled   bool
+	dossiersWritable  bool
 }
 
 // NewTools creates contact tools using the given store.
@@ -72,9 +73,11 @@ func (t *Tools) ConfigureOperatorContactID(id uuid.UUID) {
 }
 
 // ConfigureDossierRoot controls whether rich contact results expose the
-// deterministic managed-document trailhead for the contact.
-func (t *Tools) ConfigureDossierRoot(enabled bool) {
+// deterministic dossier trailhead and whether that trailhead may suggest
+// creating an absent dossier.
+func (t *Tools) ConfigureDossierRoot(enabled, writable bool) {
 	t.dossiersEnabled = enabled
+	t.dossiersWritable = enabled && writable
 }
 
 // SetOwnerContactName sets the contact name used to resolve the
@@ -1051,7 +1054,11 @@ func (t *Tools) formatContact(c *Contact) string {
 	if t == nil || !t.dossiersEnabled || c == nil || c.ID == uuid.Nil {
 		return formatted
 	}
-	return fmt.Sprintf("%s\nContact ID: %s\nDossier: %s (doc_read; if absent, create with tag %s and the standard Status Line/Teaser/Digest/Details sections)", formatted, c.ID, DossierRef(c.ID), DossierSubject(c.ID))
+	trailhead := "doc_read"
+	if t.dossiersWritable {
+		trailhead += fmt.Sprintf("; if absent, create with tag %s and the standard Status Line/Teaser/Digest/Details sections", DossierSubject(c.ID))
+	}
+	return fmt.Sprintf("%s\nContact ID: %s\nDossier: %s (%s)", formatted, c.ID, DossierRef(c.ID), trailhead)
 }
 
 func (t *Tools) formatOwnerActivitySummary() string {

--- a/internal/state/contacts/tools_test.go
+++ b/internal/state/contacts/tools_test.go
@@ -724,7 +724,7 @@ func TestLookupContactIncludesConfiguredDossierTrailhead(t *testing.T) {
 		t.Fatalf("unconfigured dossier root leaked a dead trailhead: %s", without)
 	}
 
-	tools.ConfigureDossierRoot(true)
+	tools.ConfigureDossierRoot(true, false)
 	with, err := tools.LookupContact(`{"name":"Dossier Person"}`)
 	if err != nil {
 		t.Fatal(err)
@@ -733,6 +733,18 @@ func TestLookupContactIncludesConfiguredDossierTrailhead(t *testing.T) {
 		if !strings.Contains(with, want) {
 			t.Fatalf("configured result = %q, want %q", with, want)
 		}
+	}
+	if strings.Contains(with, "if absent, create") {
+		t.Fatalf("read-only dossier trailhead suggested creation: %s", with)
+	}
+
+	tools.ConfigureDossierRoot(true, true)
+	writable, err := tools.LookupContact(`{"name":"Dossier Person"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(writable, "if absent, create") {
+		t.Fatalf("managed dossier trailhead omitted creation: %s", writable)
 	}
 }
 

--- a/internal/state/contacts/tools_test.go
+++ b/internal/state/contacts/tools_test.go
@@ -706,6 +706,36 @@ func TestFormatContact_TrustZone(t *testing.T) {
 	}
 }
 
+func TestLookupContactIncludesConfiguredDossierTrailhead(t *testing.T) {
+	tools := newTestTools(t)
+	if _, err := tools.SaveContact(`{"name":"Dossier Person","kind":"individual"}`); err != nil {
+		t.Fatal(err)
+	}
+	contact, err := tools.store.FindByName("Dossier Person")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	without, err := tools.LookupContact(`{"name":"Dossier Person"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(without, "Dossier:") || strings.Contains(without, "Contact ID:") {
+		t.Fatalf("unconfigured dossier root leaked a dead trailhead: %s", without)
+	}
+
+	tools.ConfigureDossierRoot(true)
+	with, err := tools.LookupContact(`{"name":"Dossier Person"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"Contact ID: " + contact.ID.String(), "Dossier: " + DossierRef(contact.ID)} {
+		if !strings.Contains(with, want) {
+			t.Fatalf("configured result = %q, want %q", with, want)
+		}
+	}
+}
+
 func TestGenerateMissingEmbeddings(t *testing.T) {
 	tools := newTestTools(t)
 	tools.SetEmbeddingClient(&fakeEmbedder{embedding: []float32{0.5, 0.5}})

--- a/internal/state/documents/advertiser.go
+++ b/internal/state/documents/advertiser.go
@@ -155,6 +155,7 @@ func (d *DocumentAdvertiser) ContextAdvertisements(ctx context.Context, req agen
 			if policy.RequiresTag == "" || !req.ActiveTags[policy.RequiresTag] {
 				continue
 			}
+		case "exact_subject":
 		default:
 			continue
 		}
@@ -165,15 +166,24 @@ func (d *DocumentAdvertiser) ContextAdvertisements(ctx context.Context, req agen
 			continue
 		}
 
-		matches := []agentctx.ContextMatchSignal{{
-			Kind:     agentctx.ContextMatchAmbient,
-			Strength: d.freshnessStrength(row, now),
-		}}
-		if m, ok := lexicalMatch(req.UserMessage, row); ok {
-			matches = append(matches, m)
-		}
-		if m, ok := subjectMatch(subjects, row); ok {
-			matches = append(matches, m)
+		var matches []agentctx.ContextMatchSignal
+		if policy.Mode == "exact_subject" {
+			m, ok := subjectMatch(subjects, row)
+			if !ok {
+				continue
+			}
+			matches = []agentctx.ContextMatchSignal{m}
+		} else {
+			matches = []agentctx.ContextMatchSignal{{
+				Kind:     agentctx.ContextMatchAmbient,
+				Strength: d.freshnessStrength(row, now),
+			}}
+			if m, ok := lexicalMatch(req.UserMessage, row); ok {
+				matches = append(matches, m)
+			}
+			if m, ok := subjectMatch(subjects, row); ok {
+				matches = append(matches, m)
+			}
 		}
 
 		// The envelope is rendered now, with this offer's real values,

--- a/internal/state/documents/advertiser_test.go
+++ b/internal/state/documents/advertiser_test.go
@@ -195,6 +195,72 @@ func TestDocumentAdvertiserMatchEvidence(t *testing.T) {
 	}
 }
 
+func TestDocumentAdvertiserExactSubjectHasNoAmbientOrLexicalFallback(t *testing.T) {
+	store, dirs := newAdvertiseStore(t)
+	writeFile(t, filepath.Join(dirs["beta"], "other-dossier.md"), `---
+title: California Dossier
+tags: [california]
+---
+
+## Status Line
+
+California plans are quiet
+
+## Teaser
+
+The unrelated dossier has its own compact signal.
+
+## Details
+
+Unrelated detail.
+`)
+	if err := store.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	adv := NewDocumentAdvertiser(DocumentAdvertiserConfig{
+		Store: store,
+		RootPolicy: func(root string) DocumentRootAdvertisePolicy {
+			if root == "beta" {
+				return DocumentRootAdvertisePolicy{Mode: "exact_subject"}
+			}
+			return DocumentRootAdvertisePolicy{}
+		},
+		HomeZone: time.UTC,
+	})
+
+	for _, tc := range []struct {
+		name string
+		ctx  context.Context
+		req  agentctx.ContextRequest
+	}{
+		{name: "no subject", ctx: context.Background()},
+		{name: "lexical mention only", ctx: context.Background(), req: agentctx.ContextRequest{UserMessage: "tell me about the Utah trip"}},
+		{name: "unrelated subject", ctx: knowledge.WithSubjects(context.Background(), []string{"contact:someone-else"})},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ads, err := adv.ContextAdvertisements(tc.ctx, tc.req)
+			if err != nil {
+				t.Fatalf("ContextAdvertisements: %v", err)
+			}
+			if len(ads) != 0 {
+				t.Fatalf("exact-subject policy offered %v without an exact subject", ads)
+			}
+		})
+	}
+
+	ctx := knowledge.WithSubjects(context.Background(), []string{"utah"})
+	ads, err := adv.ContextAdvertisements(ctx, agentctx.ContextRequest{UserMessage: "unrelated words"})
+	if err != nil || len(ads) != 1 {
+		t.Fatalf("ContextAdvertisements exact subject: %v (%d ads)", err, len(ads))
+	}
+	if ads[0].Ref != "beta:dossier.md" {
+		t.Fatalf("exact-subject refs = %v, want only beta:dossier.md", ads)
+	}
+	if len(ads[0].Matches) != 1 || ads[0].Matches[0].Kind != agentctx.ContextMatchExactSubject {
+		t.Fatalf("exact-subject matches = %v, want only exact_subject evidence", ads[0].Matches)
+	}
+}
+
 func TestDocumentAdvertiserMaterializesWithEnvelopeAndTemplates(t *testing.T) {
 	store, dirs := newAdvertiseStore(t)
 	_ = dirs

--- a/internal/state/documents/mutate_policy.go
+++ b/internal/state/documents/mutate_policy.go
@@ -28,6 +28,18 @@ func (s *Store) writeDocumentFileAtRevision(ctx context.Context, root, relPath, 
 	if err := s.ensureRootAuthoringAllowed(root); err != nil {
 		return "", err
 	}
+	if validator := s.rootValidator(root); validator != nil {
+		frontmatter, body := splitFrontmatter(raw)
+		candidate := DocumentWriteCandidate{
+			Path:        filepath.ToSlash(relPath),
+			Tags:        append([]string(nil), frontmatter["tags"]...),
+			Frontmatter: frontmatter,
+			Body:        body,
+		}
+		if err := validator(candidate); err != nil {
+			return "", fmt.Errorf("validate %s write: %w", makeRef(root, relPath), err)
+		}
+	}
 	if writer := s.rootWriter(root); writer != nil {
 		message := documentWriteMessage("doc_write", root, relPath, raw)
 		expectedRevision = strings.TrimSpace(expectedRevision)

--- a/internal/state/documents/mutate_test.go
+++ b/internal/state/documents/mutate_test.go
@@ -2,6 +2,7 @@ package documents
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -47,6 +48,47 @@ func TestStoreWriteAndReadManagedDocument(t *testing.T) {
 	}
 	if !strings.Contains(record.Body, "Helpful body.") {
 		t.Fatalf("Read body = %q, want helpful body", record.Body)
+	}
+}
+
+func TestStoreRootValidatorRefusesBeforeMutation(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	called := false
+	store, err := NewStoreWithOptions(db, map[string]string{"contacts": rootDir}, nil, StoreOptions{
+		RootValidators: map[string]RootWriteValidator{
+			"contacts": func(candidate DocumentWriteCandidate) error {
+				called = true
+				if candidate.Path != "person.md" || len(candidate.Tags) != 1 || candidate.Tags[0] != "contact:test" || strings.TrimSpace(candidate.Body) != "body" {
+					t.Fatalf("validator candidate = %#v", candidate)
+				}
+				return fmt.Errorf("domain contract rejected")
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = store.Write(context.Background(), WriteArgs{
+		Ref:  "contacts:person.md",
+		Tags: []string{"contact:test"},
+		Body: stringPtr("body"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "domain contract rejected") {
+		t.Fatalf("Write() error = %v, want validator refusal", err)
+	}
+	if !called {
+		t.Fatal("root validator was not called")
+	}
+	if _, statErr := os.Stat(filepath.Join(rootDir, "person.md")); !os.IsNotExist(statErr) {
+		t.Fatalf("rejected write changed the filesystem; stat error = %v", statErr)
 	}
 }
 

--- a/internal/state/documents/policy.go
+++ b/internal/state/documents/policy.go
@@ -65,6 +65,7 @@ const (
 type RootContextPolicy struct {
 	Inject      string `json:"inject,omitempty"`
 	Search      string `json:"search,omitempty"`
+	Advertise   string `json:"advertise,omitempty"`
 	RequiresTag string `json:"requires_tag,omitempty"`
 	Untagged    string `json:"untagged,omitempty"`
 }
@@ -95,6 +96,15 @@ func (p RootContextPolicy) EffectiveSearch() string {
 	return p.Search
 }
 
+// EffectiveAdvertise resolves context-advertisement eligibility, defaulting
+// to never.
+func (p RootContextPolicy) EffectiveAdvertise() string {
+	if p.Advertise == "" {
+		return "never"
+	}
+	return p.Advertise
+}
+
 // RootGitPolicy describes git-backed provenance policy for a managed
 // document root.
 type RootGitPolicy struct {
@@ -121,6 +131,7 @@ type RootPolicySummary struct {
 type RootContextSummary struct {
 	Inject      string `json:"inject"`
 	Search      string `json:"search"`
+	Advertise   string `json:"advertise"`
 	RequiresTag string `json:"requires_tag,omitempty"`
 	// Untagged says what a document carrying no tags means here. It is
 	// emitted always rather than only when refusing, because it changes
@@ -212,13 +223,28 @@ type RootVerifier interface {
 	VerifyRoot(ctx context.Context) (SignatureVerification, error)
 }
 
+// DocumentWriteCandidate is the parsed semantic shape presented to a
+// root-specific write validator before any bytes reach the filesystem or Git.
+type DocumentWriteCandidate struct {
+	Path        string              `json:"path"`
+	Tags        []string            `json:"tags,omitempty"`
+	Frontmatter map[string][]string `json:"frontmatter,omitempty"`
+	Body        string              `json:"body"`
+}
+
+// RootWriteValidator enforces a domain contract on every managed write into
+// one root. Returning an error leaves both the worktree and Git history
+// unchanged.
+type RootWriteValidator func(DocumentWriteCandidate) error
+
 // StoreOptions configures optional root policy and backing writers for
 // [Store].
 type StoreOptions struct {
-	RootPolicies  map[string]RootPolicy
-	RootWriters   map[string]RootWriter
-	RootVerifiers map[string]RootVerifier
-	RootRevisers  map[string]RootReviser
+	RootPolicies   map[string]RootPolicy
+	RootWriters    map[string]RootWriter
+	RootVerifiers  map[string]RootVerifier
+	RootRevisers   map[string]RootReviser
+	RootValidators map[string]RootWriteValidator
 }
 
 func defaultRootPolicy() RootPolicy {
@@ -313,6 +339,24 @@ func normalizeRootRevisers(roots map[string]string, revisers map[string]RootRevi
 	return out
 }
 
+func normalizeRootValidators(roots map[string]string, validators map[string]RootWriteValidator) map[string]RootWriteValidator {
+	if len(validators) == 0 {
+		return nil
+	}
+	out := make(map[string]RootWriteValidator, len(validators))
+	for root, validator := range validators {
+		root = normalizeRootName(root)
+		if root == "" || validator == nil {
+			continue
+		}
+		if _, ok := roots[root]; !ok {
+			continue
+		}
+		out[root] = validator
+	}
+	return out
+}
+
 func normalizeRootName(root string) string {
 	return strings.TrimSuffix(strings.TrimSpace(root), ":")
 }
@@ -343,6 +387,7 @@ func (s *Store) rootPolicySummary(root string) RootPolicySummary {
 		Context: RootContextSummary{
 			Inject:      policy.Context.EffectiveInject(),
 			Search:      policy.Context.EffectiveSearch(),
+			Advertise:   policy.Context.EffectiveAdvertise(),
 			RequiresTag: policy.Context.RequiresTag,
 			Untagged:    policy.Context.EffectiveUntagged(),
 		},
@@ -371,4 +416,12 @@ func (s *Store) rootReviser(root string) RootReviser {
 		return nil
 	}
 	return s.rootRevisers[root]
+}
+
+func (s *Store) rootValidator(root string) RootWriteValidator {
+	root = normalizeRootName(root)
+	if s == nil || len(s.rootValidators) == 0 {
+		return nil
+	}
+	return s.rootValidators[root]
 }

--- a/internal/state/documents/policy_test.go
+++ b/internal/state/documents/policy_test.go
@@ -391,3 +391,13 @@ func TestRootSummaryTellsTheModelWhatUntaggedMeans(t *testing.T) {
 		})
 	}
 }
+
+func TestRootSummaryTellsTheModelAdvertisementPolicy(t *testing.T) {
+	t.Parallel()
+	store := &Store{rootPolicies: map[string]RootPolicy{
+		"contacts": {Context: RootContextPolicy{Advertise: "exact_subject"}},
+	}}
+	if got := store.rootPolicySummary("contacts").Context.Advertise; got != "exact_subject" {
+		t.Fatalf("summary advertise = %q, want exact_subject", got)
+	}
+}

--- a/internal/state/documents/store.go
+++ b/internal/state/documents/store.go
@@ -86,6 +86,7 @@ type Store struct {
 	rootWriters     map[string]RootWriter
 	rootVerifiers   map[string]RootVerifier
 	rootRevisers    map[string]RootReviser
+	rootValidators  map[string]RootWriteValidator
 	verificationMu  sync.Mutex
 	verification    map[string]SignatureVerification
 	logger          *slog.Logger
@@ -161,6 +162,7 @@ func NewStoreWithOptions(db *sql.DB, roots map[string]string, logger *slog.Logge
 		rootWriters:     normalizeRootWriters(normalizedRoots, opts.RootWriters),
 		rootVerifiers:   normalizeRootVerifiers(normalizedRoots, opts.RootVerifiers),
 		rootRevisers:    normalizeRootRevisers(normalizedRoots, opts.RootRevisers),
+		rootValidators:  normalizeRootValidators(normalizedRoots, opts.RootValidators),
 		verification:    make(map[string]SignatureVerification),
 		logger:          logger,
 		refreshInterval: defaultRefreshInterval,

--- a/internal/tools/contact_tools.go
+++ b/internal/tools/contact_tools.go
@@ -95,7 +95,7 @@ func (r *Registry) registerContactTools() {
 
 	r.Register(&Tool{
 		Name:        "contact_lookup",
-		Description: "Look up contacts from the directory. Search by name, query, kind, or property key/value. With no arguments, returns directory statistics.",
+		Description: "Look up contacts from the directory. Search by name, query, kind, or property key/value. An exact name result includes the canonical contact UUID and optional contacts:<uuid>.md dossier ref when the dossier root is configured; use doc_read for the dossier rather than treating its prose as structured identity authority. With no arguments, returns directory statistics.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -133,7 +133,7 @@ func (r *Registry) registerContactTools() {
 
 	r.Register(&Tool{
 		Name:        "contact_owner",
-		Description: "Return the primary operator contact record with rich details and contact properties, plus a structured summary of currently active operator-scoped channels. Uses identity.operator_contact_id when configured; otherwise supports the legacy name selector and finally the sole admin contact if exactly one exists.",
+		Description: "Return the primary operator contact record with rich details and contact properties, its canonical UUID and optional contacts:<uuid>.md dossier ref, plus a structured summary of currently active operator-scoped channels. Use doc_read for the dossier; its prose is longitudinal synthesis, while this contact record remains authoritative for structured identity and bindings. Uses identity.operator_contact_id when configured; otherwise supports the legacy name selector and finally the sole admin contact if exactly one exists.",
 		Parameters: map[string]any{
 			"type":       "object",
 			"properties": map[string]any{},


### PR DESCRIPTION
## Summary

- bootstrap a workspace-derived, signed `contacts:` document root for fresh installs
- enforce canonical UUID dossier paths, matching contact tags, and complete facet projections before managed writes
- expose bounded dossier refs from rich contact tools and advertise only exact contact-subject matches

## Why

PR #1464 supplied the hidden revision receipts and transactional multi-writer Git foundation. This is the first contact-specific slice of #1463: it gives each structured contact one deterministic longitudinal document without moving identity, trust, Home Assistant bindings, or companion attribution out of SQLite.

The exact-subject advertisement mode is deliberately stricter than normal document advertising. A contact dossier receives no ambient or lexical offer; Go only offers it when the request context carries the matching canonical `contact:<uuid>` subject.

Refs #1463.

## User impact

Fresh `thane init` workspaces now receive a clean, signed `contacts` repository and a generated policy that requires signed history. Existing workspaces opt in by adding the `roots.contacts` policy and rerunning `thane init`.

Rich `contact_lookup` and `contact_owner` results expose the stable dossier ref and a bounded create/read trailhead. No dossier is created automatically, and dossier prose cannot override structured contact authority.

## Test plan

- [x] `just ci`
- [x] fresh init creates a clean signed contacts repository and generated policy
- [x] invalid dossier paths, tags, or facet ladders are refused before filesystem mutation
- [x] exact-subject policy excludes ambient, lexical, and unrelated-contact offers
- [x] existing configurations remain opt-in