### PR TITLE
fix: reserve WARN and ERROR for conditions an operator should act on

### DIFF
--- a/internal/integrations/unifi/poller.go
+++ b/internal/integrations/unifi/poller.go
@@ -237,7 +237,10 @@ func (p *Poller) tolerateFailure(err error, summary map[string]any) error {
 		return fmt.Errorf("UniFi controller failing for %d consecutive polls: %w", n, err)
 	}
 
-	p.cfg.Logger.Warn("UniFi poll failed; tolerating as transient",
+	// Debug, not Warn: a tolerated failure is by definition not yet a
+	// problem — the threshold crossing above is the operator signal, and
+	// the dashboard summary below carries the streak in the meantime.
+	p.cfg.Logger.Debug("UniFi poll failed; tolerating as transient",
 		"consecutive_failures", n,
 		"threshold", threshold,
 		"error", err,

--- a/internal/model/fleet/providers/anthropic.go
+++ b/internal/model/fleet/providers/anthropic.go
@@ -837,16 +837,20 @@ type CacheBreakpointDrop struct {
 // request rejection.
 //
 // Returns the list of drops it performed so callers can fold them
-// into a single observability line; the function also continues to
-// emit Warn logs for each drop so production alerting still fires
-// without depending on aggregated logs.
+// into a single observability line (see logOutboundCacheMarkers).
+// Over-the-cap drops also emit a Warn each — a request asking for more
+// than four breakpoints means the assembly plan changed and someone
+// should look. Under-minimum drops log at Debug: a small trailing
+// section under the cacheable minimum is a structural fact of the
+// prompt shape that recurs on every request, and warning about normal
+// operation buries the warns that matter.
 //
 // The guard policy:
 //
 //  1. For each system block that carries a cache_control, compute the
 //     prefix length through that block. If the prefix is below the
-//     model-specific minimum, strip cache_control and warn. The block
-//     itself remains; only the breakpoint is removed.
+//     model-specific minimum, strip cache_control. The block itself
+//     remains; only the breakpoint is removed.
 //  2. Count surviving system breakpoints plus the one blanket tool
 //     cache (if any). If the total still exceeds 4, drop the tool
 //     cache first — it is an undifferentiated "cache the last tool"
@@ -867,7 +871,7 @@ func applyCacheBreakpointGuards(blocks []anthropicContent, tools []anthropicTool
 			continue
 		}
 		if prefixChars/estimatedCharsPerToken < minTokens {
-			logger.Warn("dropping under-minimum Anthropic cache breakpoint",
+			logger.Debug("dropping under-minimum Anthropic cache breakpoint",
 				"model", model,
 				"block_index", i,
 				"prefix_chars", prefixChars,

--- a/internal/platform/logging/datasets.go
+++ b/internal/platform/logging/datasets.go
@@ -213,9 +213,16 @@ func classifyDatasetAttr(attr slog.Attr, projection *datasetProjection, groups [
 		}
 	}
 
-	switch key {
-	case slog.TimeKey, slog.LevelKey, slog.MessageKey, slog.SourceKey:
-		return
+	// Same contract as IndexHandler.classifyAttr: only top-level keys that
+	// collide with the record's own fields are reserved, and "source" is
+	// not one of them — built-in source location arrives via record.PC,
+	// so an attr named "source" is always caller data and must survive
+	// into the payload.
+	if len(groups) == 0 {
+		switch key {
+		case slog.TimeKey, slog.LevelKey, slog.MessageKey:
+			return
+		}
 	}
 	projection.Attrs[qualifiedKey] = attrValue(attr)
 }

--- a/internal/platform/logging/datasets_test.go
+++ b/internal/platform/logging/datasets_test.go
@@ -457,3 +457,23 @@ func TestDatasetHandler_EnabledWithStdoutOnly(t *testing.T) {
 		t.Error("Enabled(info) = false, want true with stdout enabled")
 	}
 }
+
+func TestDatasetProjection_SourceAttrSurvivesIntoPayload(t *testing.T) {
+	record := slog.NewRecord(time.Now(), slog.LevelWarn, "context source ran long", 0)
+	record.AddAttrs(
+		slog.String("source", "tag_context"),
+		slog.String("detail", "metacognitive"),
+	)
+
+	projection := (&DatasetHandler{}).projectRecord(record)
+
+	// The envelope's own source field is derived from component/subsystem;
+	// an attr literally named "source" is caller data and must survive
+	// into the payload instead of being eaten as slog.SourceKey.
+	if got := projection.Attrs["source"]; got != "tag_context" {
+		t.Errorf("payload source = %v, want %q", got, "tag_context")
+	}
+	if got := projection.Attrs["detail"]; got != "metacognitive" {
+		t.Errorf("payload detail = %v, want %q", got, "metacognitive")
+	}
+}

--- a/internal/platform/logging/indexer.go
+++ b/internal/platform/logging/indexer.go
@@ -578,10 +578,17 @@ func (h *IndexHandler) classifyAttr(a slog.Attr, entry *indexEntry, extras map[s
 		return
 	}
 
-	// Skip built-in keys that are already stored as dedicated fields.
-	switch key {
-	case slog.TimeKey, slog.LevelKey, slog.MessageKey, slog.SourceKey:
-		return
+	// Skip top-level keys that collide with the record's own dedicated
+	// fields. slog.SourceKey is deliberately NOT here: built-in source
+	// location arrives via record.PC (stored as source_file/source_line),
+	// never as an attr, so an attr literally named "source" can only be
+	// caller data — eating it silently destroyed the discriminator on
+	// several production warns before this was understood.
+	if len(groups) == 0 {
+		switch key {
+		case slog.TimeKey, slog.LevelKey, slog.MessageKey:
+			return
+		}
 	}
 
 	extras[qualifiedKey] = attrValue(a)

--- a/internal/platform/logging/indexer_test.go
+++ b/internal/platform/logging/indexer_test.go
@@ -1033,3 +1033,37 @@ func TestSeverityRingCapsAndTruncates(t *testing.T) {
 		t.Errorf("message not truncated: %d runes", len([]rune(sum.Recent[0].Msg)))
 	}
 }
+
+func TestIndexHandler_SourceAttrSurvivesIntoAttrs(t *testing.T) {
+	db := openTestDB(t)
+	inner := slog.NewJSONHandler(discardWriter{}, nil)
+	h := NewIndexHandler(inner, db)
+
+	logger := slog.New(h)
+	logger.Warn("gated context provider failed",
+		"source", "always_provider", "msg", "reserved")
+	h.Close()
+
+	var attrs sql.NullString
+	if err := db.QueryRow(`SELECT attrs FROM log_entries LIMIT 1`).Scan(&attrs); err != nil {
+		t.Fatal(err)
+	}
+	if !attrs.Valid {
+		t.Fatal("attrs should not be null")
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(attrs.String), &parsed); err != nil {
+		t.Fatalf("parse attrs JSON: %v", err)
+	}
+	// "source" is caller data — built-in source location arrives via
+	// record.PC, never as an attr — so it must land in attrs rather
+	// than being eaten as a reserved key. The eaten variant silently
+	// destroyed the discriminator on several production warns.
+	if got := parsed["source"]; got != "always_provider" {
+		t.Errorf("source = %v, want %q", got, "always_provider")
+	}
+	// Top-level attrs shadowing the record's own fields stay reserved.
+	if _, ok := parsed["msg"]; ok {
+		t.Error("top-level msg attr should remain reserved")
+	}
+}

--- a/internal/server/api/ollama_server.go
+++ b/internal/server/api/ollama_server.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -92,7 +93,12 @@ func (s *OllamaServer) Start(ctx context.Context) error {
 		addr = "0.0.0.0"
 	}
 	s.logger.Info("starting Ollama-compatible API server", "address", addr, "port", s.port)
-	return s.server.ListenAndServe()
+	// ErrServerClosed is the expected return on graceful Shutdown; don't surface
+	// it as an error (App.Serve would log it). Mirrors the other API servers.
+	if err := s.server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+	return nil
 }
 
 // Shutdown gracefully stops the server.

--- a/internal/state/documents/store.go
+++ b/internal/state/documents/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -291,8 +292,19 @@ func (s *Store) refreshRoot(ctx context.Context, root, dir string) error {
 		}
 		if needVerify {
 			if err := s.verifyDocumentForConsumer(ctx, root, rel, "document_index"); err != nil {
-				s.logger.Warn("document index skipped file blocked by signature policy",
-					"root", root, "path", rel, "error", err)
+				// An interrupted pass (shutdown, deadline) proves nothing
+				// about the file; abort the walk quietly instead of
+				// warning about a policy that never got to speak — and
+				// instead of deleting index rows the next pass would
+				// only rebuild.
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+				msg := "document index skipped file blocked by signature policy"
+				if errors.Is(err, ErrVerificationUnavailable) {
+					msg = "document index skipped file; signature verification could not run"
+				}
+				s.logger.Warn(msg, "root", root, "path", rel, "error", err)
 				if err := s.deleteIndexedDocumentRows(ctx, root, rel); err != nil {
 					return err
 				}

--- a/internal/state/documents/verification.go
+++ b/internal/state/documents/verification.go
@@ -2,6 +2,7 @@ package documents
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,6 +10,25 @@ import (
 	"strings"
 	"time"
 )
+
+// ErrVerificationUnavailable marks a refusal whose signature check could
+// not run — git killed, context canceled, repository unreadable — as
+// opposed to content that actually failed signature policy. Both refuse
+// the read (failing closed is the point of a trust boundary), but they
+// send the investigation to different places: one is an infrastructure
+// fault, the other a trust decision about signers and history.
+var ErrVerificationUnavailable = errors.New("signature verification unavailable")
+
+// verificationUnavailableError carries the consumer-facing refusal text
+// unchanged while letting callers classify it via
+// errors.Is(err, ErrVerificationUnavailable).
+type verificationUnavailableError struct{ msg string }
+
+func (e *verificationUnavailableError) Error() string { return e.msg }
+
+func (e *verificationUnavailableError) Is(target error) bool {
+	return target == ErrVerificationUnavailable
+}
 
 func (s *Store) verifyDocumentForConsumer(ctx context.Context, root, relPath, consumer string) error {
 	root = normalizeRootName(root)
@@ -224,8 +244,9 @@ func (s *Store) handleVerificationFailure(root, relPath, consumer string, result
 	// "blocked by signature policy" when git was killed buys an
 	// investigation into signers and history that were never involved.
 	if result.Status == SignatureUnavailable {
-		return fmt.Errorf("document %s:%s could not be verified for %s (refused because this root requires verification, not because the content failed it): %s",
-			root, relPath, consumer, message)
+		return &verificationUnavailableError{msg: fmt.Sprintf(
+			"document %s:%s could not be verified for %s (refused because this root requires verification, not because the content failed it): %s",
+			root, relPath, consumer, message)}
 	}
 	return fmt.Errorf("document %s:%s blocked by signature policy for %s: %s", root, relPath, consumer, message)
 }

--- a/internal/state/documents/verification_test.go
+++ b/internal/state/documents/verification_test.go
@@ -2,6 +2,7 @@ package documents
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -198,5 +199,53 @@ func TestStoreVerifyMutationPath_AllowsUnprotectedManagedRoot(t *testing.T) {
 
 	if err := store.VerifyMutationPath(context.Background(), target, "file_tools_write"); err != nil {
 		t.Fatalf("unprotected managed root should allow raw file mutation: %v", err)
+	}
+}
+
+// TestHandleVerificationFailureClassifiesUnavailable pins the seam the
+// index scan logs across: a check that could not run answers true to
+// errors.Is(err, ErrVerificationUnavailable), while a genuine policy
+// block does not — and the consumer-facing message stays unchanged in
+// both shapes.
+func TestHandleVerificationFailureClassifiesUnavailable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		status          SignatureStatus
+		wantUnavailable bool
+		wantSubstring   string
+	}{
+		{
+			name:            "unavailable check classifies as infrastructure fault",
+			status:          SignatureUnavailable,
+			wantUnavailable: true,
+			wantSubstring:   "could not be verified",
+		},
+		{
+			name:            "failed signature classifies as policy block",
+			status:          SignatureFailed,
+			wantUnavailable: false,
+			wantSubstring:   "blocked by signature policy",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := (&Store{}).handleVerificationFailure("core", "a.md", "document_index", SignatureVerification{
+				Mode:    VerificationRequired,
+				Status:  tc.status,
+				Message: "git status failed: signal: killed",
+			})
+			if err == nil {
+				t.Fatal("want error, got nil")
+			}
+			if got := errors.Is(err, ErrVerificationUnavailable); got != tc.wantUnavailable {
+				t.Errorf("errors.Is(err, ErrVerificationUnavailable) = %v, want %v", got, tc.wantUnavailable)
+			}
+			if !strings.Contains(err.Error(), tc.wantSubstring) {
+				t.Errorf("error %q missing %q", err.Error(), tc.wantSubstring)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## A warning that fires on every request is not a warning

A seven-day audit of production's logs.db (2026-08-31) counted 28,515 WARN rows and 599 ERROR rows. Four messages produced ~95% of the WARN volume, and the biggest single contributor — 18,285 identical rows — was one external outage narrated one full-severity line at a time. When normal operation and known-degraded states speak at WARN, the level stops carrying information: the one warn that matters arrives pre-buried. This PR is the first, purely mechanical pass from that audit: every change here makes an existing log line mean what it says, without touching any behavior an operator depends on. The structural fixes the audit also surfaced (sync-failure coalescing, telemetry collection running inside context assembly, a shutdown-ordering race, the content archiver's boot-time collision) are deliberately not here — they change behavior and each deserves its own PR.

## The archive was eating the one attr that explained these warns

The deepest fix is in the logging sinks themselves. Both the SQLite index handler and the dataset projection skipped any attribute whose key matched `slog.SourceKey`, on the theory that it shadowed the record's built-in source location. But in a custom handler the built-in source never arrives as an attribute — it is derived from `record.PC` and stored as `source_file`/`source_line` — so the skip only ever destroyed caller data. Some two dozen call sites pass a `"source"` discriminator, including the tag-context slow-source and gated-provider warns, and none of it ever reached logs.db: the very warns this audit needed to attribute were undiagnosable in storage, verified on production where three days of `warnSlowContextSource` rows carried no `$.source` at all. The sinks now reserve only the top-level keys that genuinely shadow the record (`time`, `level`, `msg`), stop reserving anything inside groups, and both sinks pin the new contract with tests. This supersedes renaming the call sites: the trap itself is gone.

## Levels corrected to match what each line actually reports

**`http: Server closed` is not an error.** `OllamaServer.Start` returned `ListenAndServe`'s sentinel unfiltered, so every graceful shutdown logged `ollama API server failed` at ERROR — twelve times last week, one per restart. It now filters `http.ErrServerClosed` exactly as `openai_server.go` and the CardDAV server already do.

**A tolerated failure is not yet a problem.** The UniFi poller's `tolerateFailure` docstring says a transient failure is "absorbed silently," then warned anyway on every sub-threshold poll (60 last week). The tolerated path now logs at Debug; the threshold crossing still surfaces the sustained outage and the dashboard summary still carries the streak.

**A structural fact of the prompt shape is not an anomaly.** The under-minimum cache-breakpoint guard warned per drop, and production shows the same block index under the same minimum on every request — 277 identical warns a week describing the system working as designed. The per-drop line is now Debug; `logOutboundCacheMarkers` still reports every drop on the aggregated line, and the over-the-cap drops keep their Warn because those genuinely mean the assembly plan changed.

**"Blocked by signature policy" was claiming trust decisions it never made.** The document index scan logged one message for two very different refusals: content that failed signature policy, and a check that never got to run (git killed, context canceled at shutdown). `handleVerificationFailure` already drew this distinction in its error text; a new `ErrVerificationUnavailable` classification makes it machine-readable without changing a byte of the consumer-facing message, and the scan now logs each shape under its own headline. An interrupted pass goes further: it aborts the walk quietly instead of warning per file about a policy that never spoke — and instead of deleting index rows that the next boot would only rebuild.

## What this buys the next audit

The next time someone greps a week of production WARNs, the survivors should each be worth reading: the docroot-sync storm remains (coalescing is the next PR), but the shutdown-noise ERRORs, the per-request structural warns, and the per-poll transients are gone, and every warn that names a `source` finally lands with its discriminator intact.

## Test plan

- [x] `just ci` green locally (full gate, fresh worktree)
- [x] New tests: `TestIndexHandler_SourceAttrSurvivesIntoAttrs`, `TestDatasetProjection_SourceAttrSurvivesIntoPayload`, `TestHandleVerificationFailureClassifiesUnavailable`
- [x] Existing guards unchanged: cache-breakpoint drop list still returned and asserted; UniFi threshold behavior still covered by `TestPoller_ToleratesTransientFailures`
- [ ] Post-deploy: confirm `source` lands in logs.db attrs on the tag-context warns, and shutdown produces no `ollama API server failed` ERROR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
