### PR TITLE
fix(app): coalesce document root sync logging across persistent states

### DIFF
--- a/internal/app/document_root_syncer.go
+++ b/internal/app/document_root_syncer.go
@@ -301,10 +301,17 @@ func (s *docRootSyncer) runOnce(ctx context.Context) syncState {
 // syncLogCoalesceAfter, instead of narrating one identical WARN per
 // pass; the passes in between log at Debug so the forensic record stays
 // complete.
+//
+// The mutex is held across the gate transition AND its emission (here
+// and in logOutcome): released in between, a concurrent pass could
+// reset the gate and narrate recovery before this pass narrates its
+// failure, leaving the log stream showing a failure newer than the
+// recovery while the gate reads clear. Contention is one pass per
+// interval per root, so narrating under the lock costs nothing.
 func (s *docRootSyncer) logFailure(err error, detail string) {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	n, warn := s.failGate.admit(s.clock(), detail)
-	s.mu.Unlock()
 	if warn {
 		s.logger.Warn("document root sync failed",
 			"root", s.root, "error", err, "consecutive_failures", n)
@@ -319,19 +326,19 @@ func (s *docRootSyncer) logFailure(err error, detail string) {
 // steady clean pass demoted to Debug — one Info per interval per root
 // narrating "nothing changed" is what buried the warns that mattered.
 func (s *docRootSyncer) logOutcome(res checkout.SyncResult) {
+	// One lock span for the whole transition — gate mutations and their
+	// narration stay ordered against a concurrent pass (see logFailure).
 	s.mu.Lock()
-	recovered := s.failGate.reset()
-	s.mu.Unlock()
-	if recovered > 0 {
+	defer s.mu.Unlock()
+
+	if recovered := s.failGate.reset(); recovered > 0 {
 		s.logger.Info("document root sync recovered",
 			"root", s.root, "outcome", res.Outcome, "failed_passes", recovered)
 	}
 
 	switch res.Outcome {
 	case checkout.SyncBlocked, checkout.SyncDiverged, checkout.SyncRemoteBehind:
-		s.mu.Lock()
 		n, warn := s.attentionGate.admit(s.clock(), string(res.Outcome)+": "+res.Detail)
-		s.mu.Unlock()
 		if warn {
 			s.logger.Warn("document root sync needs attention",
 				"root", s.root, "outcome", res.Outcome, "detail", res.Detail,
@@ -342,10 +349,7 @@ func (s *docRootSyncer) logOutcome(res checkout.SyncResult) {
 				"consecutive_passes", n)
 		}
 	default:
-		s.mu.Lock()
-		cleared := s.attentionGate.reset()
-		s.mu.Unlock()
-		if cleared > 0 {
+		if cleared := s.attentionGate.reset(); cleared > 0 {
 			s.logger.Info("document root sync attention cleared",
 				"root", s.root, "outcome", res.Outcome, "attention_passes", cleared)
 		}

--- a/internal/app/document_root_syncer.go
+++ b/internal/app/document_root_syncer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/platform/checkout"
@@ -143,6 +144,49 @@ type docRootSyncer struct {
 	registry         *checkout.SyncStateRegistry
 	logger           *slog.Logger
 	now              func() time.Time // injectable clock; nil uses time.Now
+
+	// mu guards the log gates: the ticker in Run and an on-demand pass
+	// (the operability POST endpoint) can drive runOnce concurrently.
+	mu            sync.Mutex
+	failGate      syncLogGate
+	attentionGate syncLogGate
+}
+
+// syncLogCoalesceAfter bounds how long a persistent, unchanged failure
+// or attention state stays quiet between WARN reminders.
+const syncLogCoalesceAfter = time.Hour
+
+// syncLogGate coalesces a condition that repeats every pass into log
+// lines that carry information: admit passes on the first occurrence,
+// on a change of detail, and once per syncLogCoalesceAfter as a
+// reminder; everything in between belongs at Debug. A multi-day remote
+// outage once produced 18,285 identical WARN rows — 64% of a
+// production week — one full-severity line per pass at a time.
+type syncLogGate struct {
+	detail string
+	warnAt time.Time
+	count  int
+}
+
+// admit records one more pass of the condition and reports whether this
+// pass should log at full severity, along with the streak length.
+func (g *syncLogGate) admit(now time.Time, detail string) (int, bool) {
+	g.count++
+	changed := detail != g.detail
+	g.detail = detail
+	if changed || now.Sub(g.warnAt) >= syncLogCoalesceAfter {
+		g.warnAt = now
+		return g.count, true
+	}
+	return g.count, false
+}
+
+// reset clears the gate and returns how many passes the condition
+// lasted, so the clearing pass can say what it recovered from.
+func (g *syncLogGate) reset() int {
+	n := g.count
+	*g = syncLogGate{}
+	return n
 }
 
 func (s *docRootSyncer) clock() time.Time {
@@ -218,7 +262,7 @@ func (s *docRootSyncer) runOnce(ctx context.Context) syncState {
 	if err != nil {
 		st.OK = false
 		st.Detail = err.Error()
-		s.logger.Warn("document root sync failed", "root", s.root, "error", err)
+		s.logFailure(err, st.Detail)
 		s.recordState(ctx, st)
 		return st
 	}
@@ -229,14 +273,7 @@ func (s *docRootSyncer) runOnce(ctx context.Context) syncState {
 	st.LocalHead, st.RemoteHead = res.LocalHead, res.RemoteHead
 	st.Detail = res.Detail
 
-	switch res.Outcome {
-	case checkout.SyncBlocked, checkout.SyncDiverged, checkout.SyncRemoteBehind:
-		s.logger.Warn("document root sync needs attention",
-			"root", s.root, "outcome", res.Outcome, "detail", res.Detail)
-	default:
-		s.logger.Info("document root sync",
-			"root", s.root, "outcome", res.Outcome, "ahead", res.Ahead, "behind", res.Behind)
-	}
+	s.logOutcome(res)
 
 	// A fast-forward moved the worktree; re-index so reads see the new content
 	// without waiting for the periodic refresher.
@@ -257,6 +294,69 @@ func (s *docRootSyncer) runOnce(ctx context.Context) syncState {
 		s.registry.AdvanceRemote(s.root, res.RemoteHead)
 	}
 	return st
+}
+
+// logFailure reports a failed sync pass. A persistent outage — a remote
+// down for days — warns on arrival, on a change of error, and once per
+// syncLogCoalesceAfter, instead of narrating one identical WARN per
+// pass; the passes in between log at Debug so the forensic record stays
+// complete.
+func (s *docRootSyncer) logFailure(err error, detail string) {
+	s.mu.Lock()
+	n, warn := s.failGate.admit(s.clock(), detail)
+	s.mu.Unlock()
+	if warn {
+		s.logger.Warn("document root sync failed",
+			"root", s.root, "error", err, "consecutive_failures", n)
+		return
+	}
+	s.logger.Debug("document root sync still failing",
+		"root", s.root, "error", err, "consecutive_failures", n)
+}
+
+// logOutcome reports a successful pass: recovery from a failure streak,
+// attention outcomes coalesced the same way failures are, and the
+// steady clean pass demoted to Debug — one Info per interval per root
+// narrating "nothing changed" is what buried the warns that mattered.
+func (s *docRootSyncer) logOutcome(res checkout.SyncResult) {
+	s.mu.Lock()
+	recovered := s.failGate.reset()
+	s.mu.Unlock()
+	if recovered > 0 {
+		s.logger.Info("document root sync recovered",
+			"root", s.root, "outcome", res.Outcome, "failed_passes", recovered)
+	}
+
+	switch res.Outcome {
+	case checkout.SyncBlocked, checkout.SyncDiverged, checkout.SyncRemoteBehind:
+		s.mu.Lock()
+		n, warn := s.attentionGate.admit(s.clock(), string(res.Outcome)+": "+res.Detail)
+		s.mu.Unlock()
+		if warn {
+			s.logger.Warn("document root sync needs attention",
+				"root", s.root, "outcome", res.Outcome, "detail", res.Detail,
+				"consecutive_passes", n)
+		} else {
+			s.logger.Debug("document root sync still needs attention",
+				"root", s.root, "outcome", res.Outcome, "detail", res.Detail,
+				"consecutive_passes", n)
+		}
+	default:
+		s.mu.Lock()
+		cleared := s.attentionGate.reset()
+		s.mu.Unlock()
+		if cleared > 0 {
+			s.logger.Info("document root sync attention cleared",
+				"root", s.root, "outcome", res.Outcome, "attention_passes", cleared)
+		}
+		if res.Outcome == checkout.SyncClean {
+			s.logger.Debug("document root sync",
+				"root", s.root, "outcome", res.Outcome, "ahead", res.Ahead, "behind", res.Behind)
+		} else {
+			s.logger.Info("document root sync",
+				"root", s.root, "outcome", res.Outcome, "ahead", res.Ahead, "behind", res.Behind)
+		}
+	}
 }
 
 // Run drives runOnce immediately and then on the configured interval until the

--- a/internal/app/document_root_syncer_test.go
+++ b/internal/app/document_root_syncer_test.go
@@ -1,7 +1,9 @@
 package app
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
 	"strings"
@@ -410,5 +412,111 @@ func TestRunOnceErrorRecordsState(t *testing.T) {
 	}
 	if got, ok := reg.Get("kb"); !ok || got.OK {
 		t.Errorf("registry state = %+v, ok=%v; want recorded not-OK", got, ok)
+	}
+}
+
+// TestRunOnceCoalescesPersistentFailure drives the exact shape of the
+// 2026-08-31 production storm — the same fetch error pass after pass
+// for days — and asserts the gate: WARN on arrival, Debug in between,
+// a WARN reminder once the coalesce window lapses, a fresh WARN when
+// the error changes, and an Info recovery carrying the streak length.
+func TestRunOnceCoalescesPersistentFailure(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	errDNS := fmt.Errorf("fetch: dns lookup failed")
+	errRefused := fmt.Errorf("fetch: connection refused")
+	eng := &fakeEngine{
+		errs:    []error{errDNS, errDNS, errDNS, errRefused, nil},
+		results: []checkout.SyncResult{{}, {}, {}, {}, {Outcome: checkout.SyncClean}},
+	}
+
+	current := time.Date(2026, 8, 24, 9, 40, 0, 0, time.UTC)
+	s := &docRootSyncer{
+		root:     "kb",
+		engine:   eng,
+		request:  checkout.SyncRequest{Branch: "main"},
+		registry: checkout.NewSyncStateRegistry(),
+		logger:   logger,
+		now:      func() time.Time { return current },
+	}
+
+	ctx := context.Background()
+	s.runOnce(ctx) // errDNS: first failure → WARN
+	s.runOnce(ctx) // errDNS again → Debug
+	current = current.Add(2 * time.Hour)
+	s.runOnce(ctx) // errDNS, window lapsed → WARN reminder
+	s.runOnce(ctx) // errRefused: error changed → WARN
+	s.runOnce(ctx) // success → Info recovery, Debug steady line
+
+	out := buf.String()
+	count := func(substr string) int {
+		return strings.Count(out, substr)
+	}
+	if got := count(`level=WARN msg="document root sync failed"`); got != 3 {
+		t.Errorf("WARN failed lines = %d, want 3\nlog:\n%s", got, out)
+	}
+	if got := count(`level=DEBUG msg="document root sync still failing"`); got != 1 {
+		t.Errorf("DEBUG still-failing lines = %d, want 1\nlog:\n%s", got, out)
+	}
+	if got := count(`level=INFO msg="document root sync recovered"`); got != 1 {
+		t.Errorf("INFO recovered lines = %d, want 1\nlog:\n%s", got, out)
+	}
+	if !strings.Contains(out, "failed_passes=4") {
+		t.Errorf("recovery line missing failed_passes=4\nlog:\n%s", out)
+	}
+	// The steady clean pass narrates at Debug, not Info. The closing
+	// quote keeps this from matching the recovered/cleared messages.
+	if got := count(`level=INFO msg="document root sync"`); got != 0 {
+		t.Errorf("INFO steady lines = %d, want 0\nlog:\n%s", got, out)
+	}
+	if got := count(`level=DEBUG msg="document root sync"`); got == 0 {
+		t.Errorf("expected a DEBUG steady line\nlog:\n%s", out)
+	}
+}
+
+// TestRunOnceCoalescesAttentionOutcomes pins the same gate on the
+// needs-attention path: a diverged root warns once, repeats at Debug,
+// and logs an Info clearing line when the outcome returns to normal.
+func TestRunOnceCoalescesAttentionOutcomes(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	eng := &fakeEngine{
+		results: []checkout.SyncResult{
+			{Outcome: checkout.SyncDiverged, Detail: "local and remote diverged"},
+			{Outcome: checkout.SyncDiverged, Detail: "local and remote diverged"},
+			{Outcome: checkout.SyncFastForwarded},
+		},
+	}
+
+	current := time.Date(2026, 8, 24, 9, 40, 0, 0, time.UTC)
+	s := &docRootSyncer{
+		root:     "kb",
+		engine:   eng,
+		request:  checkout.SyncRequest{Branch: "main"},
+		registry: checkout.NewSyncStateRegistry(),
+		logger:   logger,
+		now:      func() time.Time { return current },
+	}
+
+	ctx := context.Background()
+	s.runOnce(ctx)
+	s.runOnce(ctx)
+	s.runOnce(ctx)
+
+	out := buf.String()
+	if got := strings.Count(out, `level=WARN msg="document root sync needs attention"`); got != 1 {
+		t.Errorf("WARN attention lines = %d, want 1\nlog:\n%s", got, out)
+	}
+	if got := strings.Count(out, `level=DEBUG msg="document root sync still needs attention"`); got != 1 {
+		t.Errorf("DEBUG attention lines = %d, want 1\nlog:\n%s", got, out)
+	}
+	if got := strings.Count(out, `level=INFO msg="document root sync attention cleared"`); got != 1 {
+		t.Errorf("INFO cleared lines = %d, want 1\nlog:\n%s", got, out)
+	}
+	// A fast-forward is content movement and keeps its Info line.
+	if got := strings.Count(out, `level=INFO msg="document root sync"`); got != 1 {
+		t.Errorf("INFO sync lines = %d, want 1\nlog:\n%s", got, out)
 	}
 }


### PR DESCRIPTION
## An outage should be a story with a beginning, reminders, and an end — not 18,285 identical sentences

The 2026-08-31 production log audit found that a single multi-day Forgejo outage (its postgres container unreachable, Aug 24–29) accounted for 64% of a week's WARN volume: five roots, one identical `document root sync failed` WARN every ~2 minutes each, for five days. Nothing in those 18,285 rows said anything the first five didn't. Meanwhile the syncer already had a transition machine — `classifySyncStateTransition`, attention/recovered, wired to the operator notifier — but it only classified *successful* syncs whose outcome needs attention. A pass where the engine itself errored bypassed all of it and went straight to `logger.Warn`, every time.

## The gate

This PR gives `runOnce` a small `syncLogGate`: a repeating condition logs at WARN on arrival, on any change of detail, and once an hour as a reminder; every pass in between logs the same content at Debug, so the forensic record stays complete while the WARN stream carries only state changes. Recovery is part of the story too — the first successful pass after a streak logs an Info with `failed_passes`, so "it came back after 3,650 attempts" is one greppable line instead of an inference from silence.

The same gate covers the other repeating narrator: a root stuck in `diverged`/`blocked`/`remote_behind` warned identically every interval forever. It now warns on entry, on outcome/detail change, and hourly, with an Info `attention cleared` line when the outcome returns to normal. And the steady-state line got the same scrutiny — a clean pass every 60 seconds per root logged at Info is ~7,200 rows/day of "nothing changed," so `clean` now narrates at Debug while `fast_forwarded` and `pushed` keep their Info, because those are the passes where content actually moved.

The gates sit behind a mutex: the ticker in `Run` and the operability POST endpoint can drive passes concurrently.

## What the same outage would log after this PR

Five roots × (one WARN on arrival + one WARN per detail change + ~24 reminder WARNs/day + one Info recovery) ≈ 120 WARNs/day instead of ~3,650 — and each one now carries `consecutive_failures`, so the reminder rows state the streak instead of impersonating a fresh incident.

## Test plan

- [x] `just ci` green locally (full gate, fresh worktree)
- [x] `TestRunOnceCoalescesPersistentFailure` — drives the production storm shape: WARN/Debug/reminder/error-change/recovery, against an injected clock
- [x] `TestRunOnceCoalescesAttentionOutcomes` — diverged warns once, repeats at Debug, clears at Info; fast-forward keeps its Info
- [x] Existing runOnce/transition tests unchanged and green
- [ ] Post-deploy: next remote outage produces a bounded WARN stream with `consecutive_failures` attrs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
