### PR TITLE
perf(telemetry): serve cached snapshots on the assembly path, index the hot queries

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -191,6 +191,7 @@ type App struct {
 	emailPoller        *email.Poller
 	mediaFeedPoller    *media.FeedPoller
 	telemetryPublisher *telemetry.Publisher
+	telCollector       *telemetry.Collector // shared; see App.telemetryCollector
 
 	// Set in initAwareness once the state watcher exists; invoked
 	// after any subscription-registry mutation (tool writes, spec

--- a/internal/app/new_introspection.go
+++ b/internal/app/new_introspection.go
@@ -68,29 +68,40 @@ func (a *App) telemetryDBPaths() map[string]string {
 	return dbPaths
 }
 
+// telemetryCollector returns the app-wide telemetry collector, creating
+// it on first use (App construction is single-threaded). The health
+// inspector and the MQTT publisher share the one instance so both
+// report the same numbers from one snapshot cache — the publisher's
+// fresh collections warm the inspector's assembly-path reads — while
+// neither owns the other's lifecycle: health works with MQTT disabled,
+// and whichever wires first creates it.
+func (a *App) telemetryCollector() *telemetry.Collector {
+	if a.telCollector == nil {
+		src := telemetry.Sources{
+			LoopRegistry: a.loopRegistry,
+			UsageStore:   a.usageStore,
+			ArchiveStore: a.archiveStore,
+			LogsDB:       a.indexDB,
+			DBPaths:      a.telemetryDBPaths(),
+			Logger:       a.logger,
+		}
+		if a.attachmentStore != nil {
+			src.AttachmentSource = a.attachmentStore
+		}
+		a.telCollector = telemetry.NewCollector(src)
+	}
+	return a.telCollector
+}
+
 // initInspector wires the health inspector — the single assembler
 // behind the system_health tool and the metacog context panel. Every
 // source closure is nil-safe and reads live App state at call time, so
 // components that come up later (the memory guard is stored in Serve)
 // or never (no remote doc roots) degrade to absent rows rather than
-// wiring errors. The telemetry collector here is deliberately separate
-// from the MQTT publisher's: that one only exists when MQTT telemetry
-// is enabled, and health must not depend on MQTT.
+// wiring errors.
 func (a *App) initInspector() {
-	telSources := telemetry.Sources{
-		LoopRegistry: a.loopRegistry,
-		UsageStore:   a.usageStore,
-		ArchiveStore: a.archiveStore,
-		LogsDB:       a.indexDB,
-		DBPaths:      a.telemetryDBPaths(),
-		Logger:       a.logger,
-	}
-	if a.attachmentStore != nil {
-		telSources.AttachmentSource = a.attachmentStore
-	}
-
 	src := introspection.HealthSources{
-		Telemetry:    telemetry.NewCollector(telSources),
+		Telemetry:    a.telemetryCollector(),
 		DataDir:      a.cfg.DataDir,
 		StartedAt:    time.Now(),
 		BuildVersion: buildinfo.Version,

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -752,27 +752,12 @@ func (a *App) initServers(s *newState) error {
 
 		a.mqttPub.RegisterSensors(telBuilder.StaticSensors())
 
-		dbPaths := a.telemetryDBPaths()
-
-		telSources := telemetry.Sources{
-			LoopRegistry: a.loopRegistry,
-			UsageStore:   a.usageStore,
-			ArchiveStore: a.archiveStore,
-			LogsDB:       a.indexDB,
-			DBPaths:      dbPaths,
-			Logger:       logger,
-		}
-		if a.attachmentStore != nil {
-			telSources.AttachmentSource = a.attachmentStore
-		}
-
-		telCollector := telemetry.NewCollector(telSources)
-		telPub := telemetry.NewPublisher(telCollector, a.mqttPub, telBuilder, logger)
+		telPub := telemetry.NewPublisher(a.telemetryCollector(), a.mqttPub, telBuilder, logger)
 		a.telemetryPublisher = telPub
 
 		logger.Info("mqtt telemetry enabled",
 			"interval", cfg.MQTT.Telemetry.Interval,
-			"db_paths", len(dbPaths),
+			"db_paths", len(a.telemetryDBPaths()),
 		)
 	}
 

--- a/internal/platform/logging/indexer.go
+++ b/internal/platform/logging/indexer.go
@@ -396,14 +396,28 @@ func Migrate(db *sql.DB) error {
 	CREATE INDEX IF NOT EXISTS idx_log_model ON log_entries(model);
 	CREATE INDEX IF NOT EXISTS idx_log_loop_id ON log_entries(loop_id);
 	CREATE INDEX IF NOT EXISTS idx_log_loop_name ON log_entries(loop_name);
-
-	-- Level-within-window queries ("errors in the last 24h") must not
-	-- choose idx_log_level and walk every row of that level ever
-	-- written; the composite makes them a bounded range scan.
-	CREATE INDEX IF NOT EXISTS idx_log_level_ts ON log_entries(level, timestamp);
 	`
 	if _, err := db.Exec(schema); err != nil {
 		return fmt.Errorf("migrate log index: %w", err)
+	}
+
+	// idx_log_level_ts makes level-within-window queries ("errors in the
+	// last 24h") a bounded range scan instead of a walk of every row of
+	// that level ever written. It is created as its own checked step, not
+	// folded into the multi-statement Exec above: the #1385 post-mortem
+	// found databases where that path reported success while declared
+	// indexes were absent, and this is the index the hot error-count
+	// query depends on — verify against sqlite_master so a boot that
+	// could not secure it fails loudly instead of running the expensive
+	// plan silently.
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_log_level_ts ON log_entries(level, timestamp)`); err != nil {
+		return fmt.Errorf("create idx_log_level_ts: %w", err)
+	}
+	var levelTSIndex string
+	if err := db.QueryRow(
+		`SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_log_level_ts'`,
+	).Scan(&levelTSIndex); err != nil {
+		return fmt.Errorf("verify idx_log_level_ts exists: %w", err)
 	}
 
 	// Content retention tables — created unconditionally (the schema

--- a/internal/platform/logging/indexer.go
+++ b/internal/platform/logging/indexer.go
@@ -396,6 +396,11 @@ func Migrate(db *sql.DB) error {
 	CREATE INDEX IF NOT EXISTS idx_log_model ON log_entries(model);
 	CREATE INDEX IF NOT EXISTS idx_log_loop_id ON log_entries(loop_id);
 	CREATE INDEX IF NOT EXISTS idx_log_loop_name ON log_entries(loop_name);
+
+	-- Level-within-window queries ("errors in the last 24h") must not
+	-- choose idx_log_level and walk every row of that level ever
+	-- written; the composite makes them a bounded range scan.
+	CREATE INDEX IF NOT EXISTS idx_log_level_ts ON log_entries(level, timestamp);
 	`
 	if _, err := db.Exec(schema); err != nil {
 		return fmt.Errorf("migrate log index: %w", err)

--- a/internal/platform/logging/indexer_test.go
+++ b/internal/platform/logging/indexer_test.go
@@ -1067,3 +1067,56 @@ func TestIndexHandler_SourceAttrSurvivesIntoAttrs(t *testing.T) {
 		t.Error("top-level msg attr should remain reserved")
 	}
 }
+
+// TestMigrate_LegacySchemaGainsLevelTimestampIndex pins the checked
+// migration step for idx_log_level_ts: a database created before the
+// index existed (the legacy production shape) must come out of Migrate
+// with the index verifiably present — the #1385 post-mortem found the
+// multi-statement path could report success while declared indexes
+// were absent.
+func TestMigrate_LegacySchemaGainsLevelTimestampIndex(t *testing.T) {
+	db, err := sql.Open("sqlite-thane", "file:"+t.TempDir()+"/legacy.db?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	// The pre-index production shape: table plus the original indexes,
+	// no idx_log_level_ts.
+	legacy := `
+	CREATE TABLE log_entries (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		timestamp TEXT NOT NULL,
+		level TEXT NOT NULL,
+		msg TEXT NOT NULL,
+		request_id TEXT,
+		session_id TEXT,
+		conversation_id TEXT,
+		subsystem TEXT,
+		tool TEXT,
+		model TEXT,
+		loop_id TEXT,
+		loop_name TEXT,
+		source_file TEXT,
+		source_line INTEGER,
+		attrs TEXT,
+		raw_file TEXT,
+		raw_line INTEGER
+	);
+	CREATE INDEX idx_log_timestamp ON log_entries(timestamp);
+	CREATE INDEX idx_log_level ON log_entries(level);
+	`
+	if _, err := db.Exec(legacy); err != nil {
+		t.Fatalf("create legacy schema: %v", err)
+	}
+
+	if err := Migrate(db); err != nil {
+		t.Fatalf("Migrate over legacy schema: %v", err)
+	}
+
+	var name string
+	err = db.QueryRow(`SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_log_level_ts'`).Scan(&name)
+	if err != nil {
+		t.Fatalf("idx_log_level_ts absent after Migrate: %v", err)
+	}
+}

--- a/internal/platform/telemetry/collector.go
+++ b/internal/platform/telemetry/collector.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"os"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
@@ -39,11 +40,29 @@ type Sources struct {
 	Logger           *slog.Logger
 }
 
+// collectorCacheTTL bounds how stale a served snapshot may be before a
+// background refresh is triggered. The heavy collectors scan a day of
+// log rows and the whole attachments table; on a production-sized
+// logs.db that is ~2s of query time, which once ran inline in context
+// assembly on every ops-panel render and starved everything scheduled
+// after it on the shared budget.
+const collectorCacheTTL = 5 * time.Minute
+
+// collectorRefreshTimeout is the detached budget for one background
+// refresh, deliberately independent of any caller's deadline.
+const collectorRefreshTimeout = 60 * time.Second
+
 // Collector aggregates operational metrics from multiple subsystems.
-// All collection methods are safe for concurrent use — each call
-// produces an independent [Metrics] snapshot.
+// All methods are safe for concurrent use. Snapshots returned by
+// Collect/CollectFresh are shared and must be treated as read-only.
 type Collector struct {
 	src Sources
+	ttl time.Duration
+	now func() time.Time // injectable clock; nil uses time.Now
+
+	mu         sync.Mutex
+	cached     *Metrics
+	refreshing bool
 }
 
 // NewCollector creates a Collector backed by the given sources.
@@ -51,15 +70,86 @@ func NewCollector(src Sources) *Collector {
 	if src.Logger == nil {
 		src.Logger = slog.Default()
 	}
-	return &Collector{src: src}
+	return &Collector{src: src, ttl: collectorCacheTTL}
 }
 
-// Collect gathers a point-in-time snapshot of all operational metrics.
+func (c *Collector) clock() time.Time {
+	if c.now != nil {
+		return c.now()
+	}
+	return time.Now()
+}
+
+// Collect returns the current snapshot without ever paying the
+// collection cost inline once a snapshot exists: a fresh cache is
+// returned as-is, a stale one is returned immediately while a single
+// background refresh (on its own detached budget) rebuilds it. Only a
+// cold start — no snapshot yet — collects synchronously under the
+// caller's ctx. This is the assembly-path contract: the ops panel
+// renders whatever is current, at most collectorCacheTTL old, and the
+// shared context budget never funds a day-of-logs scan. CollectedAt
+// tells readers how old the snapshot is.
+func (c *Collector) Collect(ctx context.Context) *Metrics {
+	c.mu.Lock()
+	cached := c.cached
+	if cached != nil {
+		if c.clock().UTC().Sub(cached.CollectedAt) >= c.ttl && !c.refreshing {
+			c.refreshing = true
+			go c.refresh()
+		}
+		c.mu.Unlock()
+		return cached
+	}
+	c.mu.Unlock()
+
+	m := c.collect(ctx)
+	// A snapshot truncated by the caller's deadline must not become the
+	// cache: it would serve zeros as facts for a full TTL.
+	if ctx.Err() == nil {
+		c.mu.Lock()
+		if c.cached == nil {
+			c.cached = m
+		}
+		c.mu.Unlock()
+	}
+	return m
+}
+
+// CollectFresh always performs a full collection under the caller's ctx
+// and replaces the cache. The MQTT publisher uses this: its cadence is
+// long, so serving it the cache would compound both delays into sensor
+// readings a TTL-plus-interval old.
+func (c *Collector) CollectFresh(ctx context.Context) *Metrics {
+	m := c.collect(ctx)
+	if ctx.Err() == nil {
+		c.mu.Lock()
+		c.cached = m
+		c.mu.Unlock()
+	}
+	return m
+}
+
+func (c *Collector) refresh() {
+	ctx, cancel := context.WithTimeout(context.Background(), collectorRefreshTimeout)
+	defer cancel()
+	m := c.collect(ctx)
+	c.mu.Lock()
+	// A refresh its own budget truncated keeps the old snapshot: stale
+	// real numbers beat fresh partial zeros, the next Collect retries,
+	// and the per-collector warns already name what timed out.
+	if ctx.Err() == nil {
+		c.cached = m
+	}
+	c.refreshing = false
+	c.mu.Unlock()
+}
+
+// collect gathers a point-in-time snapshot of all operational metrics.
 // Individual subsystem failures are logged and result in zero values
 // for the affected metrics — collection never returns an error.
-func (c *Collector) Collect(ctx context.Context) *Metrics {
+func (c *Collector) collect(ctx context.Context) *Metrics {
 	m := &Metrics{
-		CollectedAt: time.Now().UTC(),
+		CollectedAt: c.clock().UTC(),
 		DBSizes:     make(map[string]int64),
 	}
 

--- a/internal/platform/telemetry/collector.go
+++ b/internal/platform/telemetry/collector.go
@@ -16,9 +16,11 @@ import (
 )
 
 // ArchiveSource provides active session counts for telemetry without
-// coupling this package to the full memory package.
+// coupling this package to the full memory package. The context matters:
+// this runs on the collector's bounded refresh path, and a query that
+// ignores cancellation can wedge the refresh slot.
 type ArchiveSource interface {
-	ActiveSessionCount() (int, error)
+	ActiveSessionCount(ctx context.Context) (int, error)
 }
 
 // AttachmentSource provides aggregate attachment statistics without
@@ -85,10 +87,12 @@ func (c *Collector) clock() time.Time {
 // returned as-is, a stale one is returned immediately while a single
 // background refresh (on its own detached budget) rebuilds it. Only a
 // cold start — no snapshot yet — collects synchronously under the
-// caller's ctx. This is the assembly-path contract: the ops panel
-// renders whatever is current, at most collectorCacheTTL old, and the
-// shared context budget never funds a day-of-logs scan. CollectedAt
-// tells readers how old the snapshot is.
+// caller's ctx. This is the assembly-path contract: the shared context
+// budget never funds a day-of-logs scan. The TTL is the refresh
+// trigger, not an age bound — a stale snapshot keeps serving while a
+// refresh runs (or fails and is retried on later calls), so readers
+// that care about age must consult CollectedAt, which carries it
+// honestly.
 func (c *Collector) Collect(ctx context.Context) *Metrics {
 	c.mu.Lock()
 	cached := c.cached
@@ -104,42 +108,47 @@ func (c *Collector) Collect(ctx context.Context) *Metrics {
 
 	m := c.collect(ctx)
 	// A snapshot truncated by the caller's deadline must not become the
-	// cache: it would serve zeros as facts for a full TTL.
+	// cache: it would serve zeros as facts until a refresh replaced it.
 	if ctx.Err() == nil {
-		c.mu.Lock()
-		if c.cached == nil {
-			c.cached = m
-		}
-		c.mu.Unlock()
+		c.storeSnapshot(m)
 	}
 	return m
 }
 
 // CollectFresh always performs a full collection under the caller's ctx
-// and replaces the cache. The MQTT publisher uses this: its cadence is
-// long, so serving it the cache would compound both delays into sensor
-// readings a TTL-plus-interval old.
+// and offers it to the cache. The MQTT publisher uses this: its cadence
+// is long, so serving it the cache would compound both delays into
+// sensor readings a TTL-plus-interval old.
 func (c *Collector) CollectFresh(ctx context.Context) *Metrics {
 	m := c.collect(ctx)
 	if ctx.Err() == nil {
-		c.mu.Lock()
-		c.cached = m
-		c.mu.Unlock()
+		c.storeSnapshot(m)
 	}
 	return m
+}
+
+// storeSnapshot installs m unless a newer snapshot is already cached.
+// Collections run outside the lock, so a slow one finishing late must
+// not roll the cache back over a fresher rival's result.
+func (c *Collector) storeSnapshot(m *Metrics) {
+	c.mu.Lock()
+	if c.cached == nil || m.CollectedAt.After(c.cached.CollectedAt) {
+		c.cached = m
+	}
+	c.mu.Unlock()
 }
 
 func (c *Collector) refresh() {
 	ctx, cancel := context.WithTimeout(context.Background(), collectorRefreshTimeout)
 	defer cancel()
 	m := c.collect(ctx)
-	c.mu.Lock()
 	// A refresh its own budget truncated keeps the old snapshot: stale
 	// real numbers beat fresh partial zeros, the next Collect retries,
 	// and the per-collector warns already name what timed out.
 	if ctx.Err() == nil {
-		c.cached = m
+		c.storeSnapshot(m)
 	}
+	c.mu.Lock()
 	c.refreshing = false
 	c.mu.Unlock()
 }
@@ -155,7 +164,7 @@ func (c *Collector) collect(ctx context.Context) *Metrics {
 
 	c.collectDBSizes(m)
 	c.collectTokens(ctx, m)
-	c.collectSessions(m)
+	c.collectSessions(ctx, m)
 	c.collectLoops(m)
 	c.collectRequests(ctx, m)
 	c.collectAttachments(ctx, m)
@@ -186,12 +195,11 @@ func (c *Collector) collectTokens(ctx context.Context, m *Metrics) {
 	if c.src.UsageStore == nil {
 		return
 	}
-	_ = ctx // usage.Store methods don't take ctx yet
 
 	now := time.Now().UTC()
 	start := now.Add(-24 * time.Hour)
 
-	summary, err := c.src.UsageStore.Summary(start, now)
+	summary, err := c.src.UsageStore.SummaryContext(ctx, start, now)
 	if err != nil {
 		c.src.Logger.Warn("telemetry: token summary failed", "error", err)
 		return
@@ -200,7 +208,7 @@ func (c *Collector) collectTokens(ctx context.Context, m *Metrics) {
 	m.TokensOutput = summary.TotalOutputTokens
 	m.TokensCost = summary.TotalCostUSD
 
-	byModel, err := c.src.UsageStore.SummaryByModel(start, now)
+	byModel, err := c.src.UsageStore.SummaryByModelContext(ctx, start, now)
 	if err != nil {
 		c.src.Logger.Warn("telemetry: token by-model failed", "error", err)
 		return
@@ -218,9 +226,9 @@ func (c *Collector) collectTokens(ctx context.Context, m *Metrics) {
 }
 
 // collectSessions counts active sessions and estimates context utilization.
-func (c *Collector) collectSessions(m *Metrics) {
+func (c *Collector) collectSessions(ctx context.Context, m *Metrics) {
 	if c.src.ArchiveStore != nil {
-		count, err := c.src.ArchiveStore.ActiveSessionCount()
+		count, err := c.src.ArchiveStore.ActiveSessionCount(ctx)
 		if err != nil {
 			c.src.Logger.Warn("telemetry: active session count failed", "error", err)
 		} else {

--- a/internal/platform/telemetry/collector_test.go
+++ b/internal/platform/telemetry/collector_test.go
@@ -295,3 +295,68 @@ func openTestLogsDB(t *testing.T) *sql.DB {
 	}
 	return db
 }
+
+// TestCollect_ServesCacheAndRefreshesInBackground pins the assembly-path
+// contract: once a snapshot exists, Collect never pays collection cost
+// inline — a fresh cache is returned as-is and a stale one is served
+// immediately while one background refresh replaces it.
+func TestCollect_ServesCacheAndRefreshesInBackground(t *testing.T) {
+	current := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+	c := NewCollector(Sources{})
+	c.now = func() time.Time { return current }
+
+	first := c.Collect(context.Background())
+	if second := c.Collect(context.Background()); second != first {
+		t.Fatal("fresh cache should return the same snapshot")
+	}
+
+	// All writes to current happen before the Collect that spawns the
+	// refresh goroutine, so the fake clock needs no lock.
+	current = current.Add(collectorCacheTTL + time.Minute)
+	if stale := c.Collect(context.Background()); stale != first {
+		t.Fatal("stale read should serve the existing snapshot, not collect inline")
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		c.mu.Lock()
+		refreshed := c.cached != first
+		c.mu.Unlock()
+		if refreshed {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("background refresh never replaced the snapshot")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// TestCollectFresh_BypassesAndReplacesCache covers the publisher path.
+func TestCollectFresh_BypassesAndReplacesCache(t *testing.T) {
+	c := NewCollector(Sources{})
+	first := c.Collect(context.Background())
+	fresh := c.CollectFresh(context.Background())
+	if fresh == first {
+		t.Fatal("CollectFresh must produce a new snapshot")
+	}
+	if got := c.Collect(context.Background()); got != fresh {
+		t.Fatal("CollectFresh must replace the cache")
+	}
+}
+
+// TestCollect_TruncatedColdSnapshotNotCached: a cold collection cut off
+// by the caller's deadline must not become the cache — it would serve
+// zeros as facts for a full TTL.
+func TestCollect_TruncatedColdSnapshotNotCached(t *testing.T) {
+	c := NewCollector(Sources{})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	truncated := c.Collect(ctx)
+	if truncated == nil {
+		t.Fatal("Collect must still return a snapshot under a dead ctx")
+	}
+	if replay := c.Collect(context.Background()); replay == truncated {
+		t.Fatal("a snapshot collected under a dead ctx must not be cached")
+	}
+}

--- a/internal/platform/telemetry/collector_test.go
+++ b/internal/platform/telemetry/collector_test.go
@@ -20,7 +20,7 @@ type mockArchiveSource struct {
 	err   error
 }
 
-func (m *mockArchiveSource) ActiveSessionCount() (int, error) {
+func (m *mockArchiveSource) ActiveSessionCount(context.Context) (int, error) {
 	return m.count, m.err
 }
 

--- a/internal/platform/telemetry/publisher.go
+++ b/internal/platform/telemetry/publisher.go
@@ -50,9 +50,12 @@ func NewPublisher(collector *Collector, mqttPub MQTTPublisher, builder *SensorBu
 
 // Publish collects a fresh metrics snapshot and publishes all sensor
 // states to MQTT. Called by the mqtt-telemetry loop handler on each
-// iteration.
+// iteration. CollectFresh, not Collect: the publish cadence is long,
+// so serving the cache here would compound the TTL onto the interval
+// and age every sensor reading by both. This is also what keeps the
+// shared cache warm for the assembly-path readers.
 func (p *Publisher) Publish(ctx context.Context) error {
-	m := p.collector.Collect(ctx)
+	m := p.collector.CollectFresh(ctx)
 
 	// Track publish errors but don't abort — publish as many as possible.
 	var errs int

--- a/internal/platform/usage/store.go
+++ b/internal/platform/usage/store.go
@@ -160,7 +160,14 @@ func (s *Store) Record(ctx context.Context, rec Record) error {
 
 // Summary returns aggregated totals for records within [start, end).
 func (s *Store) Summary(start, end time.Time) (*Summary, error) {
-	row := s.db.QueryRow(
+	return s.SummaryContext(context.Background(), start, end)
+}
+
+// SummaryContext is Summary honoring ctx cancellation — background
+// collectors on a bounded budget use this so a wedged query cannot
+// outlive its caller's deadline.
+func (s *Store) SummaryContext(ctx context.Context, start, end time.Time) (*Summary, error) {
+	row := s.db.QueryRowContext(ctx,
 		`SELECT COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0),
 		        COALESCE(SUM(cache_creation_input_tokens), 0), COALESCE(SUM(cache_read_input_tokens), 0),
 		        COALESCE(SUM(cost_usd), 0)
@@ -180,38 +187,44 @@ func (s *Store) Summary(start, end time.Time) (*Summary, error) {
 // SummaryByModel returns per-model aggregated totals for records within
 // [start, end), ordered by cost descending.
 func (s *Store) SummaryByModel(start, end time.Time) ([]GroupedSummary, error) {
-	return s.summaryGroupedBy("model", start, end)
+	return s.summaryGroupedBy(context.Background(), "model", start, end)
+}
+
+// SummaryByModelContext is SummaryByModel honoring ctx cancellation;
+// see SummaryContext.
+func (s *Store) SummaryByModelContext(ctx context.Context, start, end time.Time) ([]GroupedSummary, error) {
+	return s.summaryGroupedBy(ctx, "model", start, end)
 }
 
 // SummaryByUpstreamModel returns per-upstream-model aggregated totals
 // for records within [start, end), ordered by cost descending.
 func (s *Store) SummaryByUpstreamModel(start, end time.Time) ([]GroupedSummary, error) {
-	return s.summaryGroupedBy("upstream_model", start, end)
+	return s.summaryGroupedBy(context.Background(), "upstream_model", start, end)
 }
 
 // SummaryByProvider returns per-provider aggregated totals for records
 // within [start, end), ordered by cost descending.
 func (s *Store) SummaryByProvider(start, end time.Time) ([]GroupedSummary, error) {
-	return s.summaryGroupedBy("provider", start, end)
+	return s.summaryGroupedBy(context.Background(), "provider", start, end)
 }
 
 // SummaryByResource returns per-resource aggregated totals for records
 // within [start, end), ordered by cost descending.
 func (s *Store) SummaryByResource(start, end time.Time) ([]GroupedSummary, error) {
-	return s.summaryGroupedBy("resource", start, end)
+	return s.summaryGroupedBy(context.Background(), "resource", start, end)
 }
 
 // SummaryByRole returns per-role aggregated totals for records within
 // [start, end), ordered by cost descending.
 func (s *Store) SummaryByRole(start, end time.Time) ([]GroupedSummary, error) {
-	return s.summaryGroupedBy("role", start, end)
+	return s.summaryGroupedBy(context.Background(), "role", start, end)
 }
 
 // SummaryByTask returns per-task aggregated totals for records within
 // [start, end), ordered by cost descending. Records with empty
 // task_name are grouped under the key "".
 func (s *Store) SummaryByTask(start, end time.Time) ([]GroupedSummary, error) {
-	return s.summaryGroupedBy("task_name", start, end)
+	return s.summaryGroupedBy(context.Background(), "task_name", start, end)
 }
 
 // SummaryByGroup dispatches the grouped summary query based on the
@@ -235,7 +248,7 @@ func (s *Store) SummaryByGroup(groupBy string, start, end time.Time) ([]GroupedS
 	}
 }
 
-func (s *Store) summaryGroupedBy(column string, start, end time.Time) ([]GroupedSummary, error) {
+func (s *Store) summaryGroupedBy(ctx context.Context, column string, start, end time.Time) ([]GroupedSummary, error) {
 	// column is always a compile-time constant from our own methods,
 	// never user input, so embedding it directly is safe.
 	query := fmt.Sprintf(
@@ -248,7 +261,7 @@ func (s *Store) summaryGroupedBy(column string, start, end time.Time) ([]Grouped
 		column, column,
 	)
 
-	rows, err := s.db.Query(query,
+	rows, err := s.db.QueryContext(ctx, query,
 		start.UTC().Format(time.RFC3339),
 		end.UTC().Format(time.RFC3339),
 	)

--- a/internal/state/memory/archive.go
+++ b/internal/state/memory/archive.go
@@ -442,6 +442,12 @@ func (s *ArchiveStore) migrateSessionTables() error {
 			ON sessions(conversation_id, started_at DESC);
 		CREATE INDEX IF NOT EXISTS idx_sessions_started
 			ON sessions(started_at DESC);
+		-- Open sessions are the rare rows in a table that only grows;
+		-- the partial index keeps every "still open?" query (active
+		-- count, orphan recovery, shutdown enumeration) off the full
+		-- table scan that once cost ~0.8s per ops-panel render.
+		CREATE INDEX IF NOT EXISTS idx_sessions_open
+			ON sessions(ended_at) WHERE ended_at IS NULL;
 
 		CREATE TABLE IF NOT EXISTS archive_iterations (
 			session_id TEXT NOT NULL,
@@ -666,10 +672,14 @@ func (s *ArchiveStore) migrate() error {
 			metadata TEXT
 		);
 
-		CREATE INDEX IF NOT EXISTS idx_sessions_conversation 
+		CREATE INDEX IF NOT EXISTS idx_sessions_conversation
 			ON sessions(conversation_id, started_at DESC);
-		CREATE INDEX IF NOT EXISTS idx_sessions_started 
+		CREATE INDEX IF NOT EXISTS idx_sessions_started
 			ON sessions(started_at DESC);
+		-- Mirrors migrateSessionTables: open sessions are the rare rows,
+		-- and every "still open?" query should hit the partial index.
+		CREATE INDEX IF NOT EXISTS idx_sessions_open
+			ON sessions(ended_at) WHERE ended_at IS NULL;
 
 		-- Import tracking for idempotent re-imports and purge support.
 		-- Maps external source IDs to archive session IDs so we can

--- a/internal/state/memory/archive.go
+++ b/internal/state/memory/archive.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -2124,10 +2125,11 @@ func (s *ArchiveStore) ActiveSession(conversationID string) (*Session, error) {
 // ActiveSessionCount returns the number of unclosed (active) sessions.
 // This is a lightweight query for telemetry dashboards — use
 // [ArchiveStore.ActiveSessionsWithLastActivity] when per-session
-// details are needed.
-func (s *ArchiveStore) ActiveSessionCount() (int, error) {
+// details are needed. It honors ctx because it runs on the telemetry
+// collector's bounded refresh path.
+func (s *ArchiveStore) ActiveSessionCount(ctx context.Context) (int, error) {
 	var count int
-	err := s.db.QueryRow(`SELECT COUNT(*) FROM sessions WHERE ended_at IS NULL`).Scan(&count)
+	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM sessions WHERE ended_at IS NULL`).Scan(&count)
 	return count, err
 }
 


### PR DESCRIPTION
## The ops panel was paying for a day of history on every render — and everyone behind it in line paid too

The metacog ops panel calls `Telemetry.Collect` inline while assembling context. Collection runs three 24-hour scans over logs.db (distinct request count, error count, and a per-request min/max latency aggregation) plus a whole-table attachments aggregate — about two seconds against production's logs.db, funded from the shared serial assembly budget. That number is the `metacognitive ~2s` chronic offender in the `context source ran long` warns (2,435 last week), and the starvation it causes is not hypothetical: the context-advertisement rail (#1433) failed 175 times in its first 30 hours with `enumerate advertisable documents: context deadline exceeded` — not because enumeration is slow, but because the budget was already spent by the time its turn came. The same collection also runs on the MQTT telemetry cadence, where `telemetry: attachment stats failed` with `context deadline exceeded` has fired 790 times all-time.

## Snapshots are cheap; collections are not — so callers get snapshots

`Collect` now serves a cached snapshot with a 5-minute TTL under an assembly-path contract: a fresh cache returns as-is; a stale cache returns *immediately* while a single background refresh — on its own detached 60-second budget, deliberately independent of any caller's deadline — rebuilds it; only a cold start (no snapshot yet) collects synchronously under the caller's ctx. Two guard rails keep the cache honest: a snapshot truncated by a dead caller ctx is never cached (it would serve zeros as facts for a full TTL), and a refresh that its own budget truncated keeps the old snapshot, because stale real numbers beat fresh partial zeros and the per-collector warns already name what timed out. `Metrics.CollectedAt` tells any reader how old its numbers are.

The MQTT publisher takes the other contract, `CollectFresh`: its cadence is long, so serving it the cache would compound TTL onto interval and age every Home Assistant sensor reading by both. Its fresh collections also warm the cache for the panel — which works because the inspector and the publisher now share one collector instance. The old wiring built two identical collectors; the sharing is done through a lazy accessor on App, so the health inspector still works with MQTT telemetry disabled and neither owns the other's lifecycle.

## And the queries themselves stop being expensive

Caching bounds *how often* the cost is paid; two indexes shrink the cost itself. `log_entries` gains a composite `(level, timestamp)` index so "errors in the last 24h" becomes a bounded range scan instead of a walk of every ERROR row ever written (the audit that found all this was itself misled by that scan). And `sessions` gains a partial index on open rows (`ended_at IS NULL`) — open sessions are the rare rows in a table that only grows, and the active-session count the collector takes was a ~0.8s full scan on production; orphan recovery and shutdown enumeration ride the same index. Both are `IF NOT EXISTS` in the schema-init paths existing databases replay at boot; the one-time index builds on production's logs.db are the same shape as the covering-index fix that shipped during the #1385 work.

## What this should change in production

The `context source ran long` warns for `metacognitive` should drop from ~2s to cache-read time, the advertisement rail should stop starving (its own failures were pure downstream effect), and the three `telemetry: … failed` warn families should go quiet except when a background refresh genuinely exceeds 60 seconds — which would then be worth reading about.

## Test plan

- [x] `just ci` green locally (full gate, fresh worktree)
- [x] New: `TestCollect_ServesCacheAndRefreshesInBackground` (assembly-path contract, injected clock), `TestCollectFresh_BypassesAndReplacesCache` (publisher contract), `TestCollect_TruncatedColdSnapshotNotCached` (zeros-as-facts guard) — telemetry package runs green under `-race`
- [x] Existing collector/publisher tests unchanged and green; memory + logging packages green with the new indexes
- [ ] Post-deploy: `context source ran long … metacognitive` gone from steady-state logs; advertiser failures stop; EXPLAIN QUERY PLAN on the error-count query shows `idx_log_level_ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
