### PR TITLE
fix(app): close both restart-time races against the stores

### DIFF
--- a/internal/app/new_logging.go
+++ b/internal/app/new_logging.go
@@ -19,6 +19,31 @@ import (
 // moment it is busiest.
 const contentArchiverFirstRunAfter = 5 * time.Minute
 
+// contentArchiverLoop schedules archive passes: the first only after
+// firstRunAfter (the boot-burst hold — content a day stale can wait
+// five minutes; the boot burst cannot), then one per interval until
+// ctx is cancelled. runPass is injected so the schedule is testable
+// apart from the Archiver.
+func contentArchiverLoop(ctx context.Context, firstRunAfter, interval time.Duration, runPass func(context.Context)) {
+	first := time.NewTimer(firstRunAfter)
+	defer first.Stop()
+	select {
+	case <-ctx.Done():
+		return
+	case <-first.C:
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		runPass(ctx)
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
 // initLogging reconfigures the logger with the desired stdout policy and
 // structured dataset storage. It also opens the SQLite log index, content
 // writer, and registers background workers for log index pruning and content
@@ -173,42 +198,19 @@ func (a *App) initLogging(augmentedDirs []string) error {
 				archiveDir := cfg.Logging.ContentArchiveDirPath(logRoot)
 				archiver := logging.NewArchiver(a.indexDB, archiveDir, logger)
 				a.deferWorker("content-archiver", func(ctx context.Context) error {
-					go func() {
-						// Hold the first pass past the boot write burst,
-						// for the same reason the loop-event recorder
-						// delays its first prune: a 30-minute DELETE
-						// pass against logs.db at the exact moment the
-						// indexer is busiest costs SQLITE_BUSY failures
-						// on both sides (observed at every deploy), and
-						// content a day stale can wait five minutes.
-						first := time.NewTimer(contentArchiverFirstRunAfter)
-						defer first.Stop()
-						select {
-						case <-ctx.Done():
-							return
-						case <-first.C:
+					go contentArchiverLoop(ctx, contentArchiverFirstRunAfter, 24*time.Hour, func(ctx context.Context) {
+						before := time.Now().Add(-archiveDur)
+						runCtx, cancel := context.WithTimeout(ctx, 30*time.Minute)
+						n, err := archiver.Archive(runCtx, before)
+						cancel()
+						if err != nil {
+							logger.Warn("content archive failed", "error", err, "before", before)
+						} else if n > 0 {
+							logger.Info("content archived", "requests", n, "before", before)
+						} else {
+							logger.Debug("content archive ran; nothing to archive", "before", before)
 						}
-						ticker := time.NewTicker(24 * time.Hour)
-						defer ticker.Stop()
-						for {
-							before := time.Now().Add(-archiveDur)
-							runCtx, cancel := context.WithTimeout(ctx, 30*time.Minute)
-							n, err := archiver.Archive(runCtx, before)
-							cancel()
-							if err != nil {
-								logger.Warn("content archive failed", "error", err, "before", before)
-							} else if n > 0 {
-								logger.Info("content archived", "requests", n, "before", before)
-							} else {
-								logger.Debug("content archive ran; nothing to archive", "before", before)
-							}
-							select {
-							case <-ctx.Done():
-								return
-							case <-ticker.C:
-							}
-						}
-					}()
+					})
 					return nil
 				})
 				logger.Info("content archival enabled", "archive_after", archiveDur)

--- a/internal/app/new_logging.go
+++ b/internal/app/new_logging.go
@@ -12,6 +12,13 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/logging"
 )
 
+// contentArchiverFirstRunAfter delays the archiver's first pass past
+// the startup write burst, mirroring the loop-event recorder's first-
+// prune delay (introspection.recorderFirstPruneAfter) and for the same
+// reason: both fight the log indexer for the logs.db write lock at the
+// moment it is busiest.
+const contentArchiverFirstRunAfter = 5 * time.Minute
+
 // initLogging reconfigures the logger with the desired stdout policy and
 // structured dataset storage. It also opens the SQLite log index, content
 // writer, and registers background workers for log index pruning and content
@@ -167,6 +174,20 @@ func (a *App) initLogging(augmentedDirs []string) error {
 				archiver := logging.NewArchiver(a.indexDB, archiveDir, logger)
 				a.deferWorker("content-archiver", func(ctx context.Context) error {
 					go func() {
+						// Hold the first pass past the boot write burst,
+						// for the same reason the loop-event recorder
+						// delays its first prune: a 30-minute DELETE
+						// pass against logs.db at the exact moment the
+						// indexer is busiest costs SQLITE_BUSY failures
+						// on both sides (observed at every deploy), and
+						// content a day stale can wait five minutes.
+						first := time.NewTimer(contentArchiverFirstRunAfter)
+						defer first.Stop()
+						select {
+						case <-ctx.Done():
+							return
+						case <-first.C:
+						}
 						ticker := time.NewTicker(24 * time.Hour)
 						defer ticker.Stop()
 						for {

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -95,17 +95,19 @@ func (a *App) Serve(ctx context.Context) error {
 		}
 	}
 
-	// Serve waits on shutdownDone before returning: everything after the
-	// server drain below — archiving conversations, ending sessions, the
-	// shutdown checkpoint — reads the stores that the deferred
-	// a.shutdown() closes the moment Serve returns. Without the wait,
-	// those tail steps race the close and lose ("sql: database is
-	// closed" at every restart), which meant the shutdown checkpoint
-	// silently never happened.
-	shutdownDone := make(chan struct{})
-	go func() {
-		defer close(shutdownDone)
-		<-ctx.Done()
+	// Serve synchronizes with these tasks before returning: everything
+	// after the server drain below — archiving conversations, ending
+	// sessions, the shutdown checkpoint — reads the stores that the
+	// deferred a.shutdown() closes the moment Serve returns. Without
+	// the synchronization, those tail steps race the close and lose
+	// ("sql: database is closed" at every restart), which meant the
+	// shutdown checkpoint silently never happened. The abort path
+	// covers the fatal-server-error return, where the goroutine would
+	// otherwise stay parked on ctx.Done and fire the whole tail into
+	// closed stores when the command caller's deferred cancel finally
+	// runs.
+	tasks := newShutdownTasks(a.logger, shutdownTasksTimeout)
+	tasks.watch(ctx, func() {
 		a.logger.Info("shutdown signal received")
 
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -156,27 +158,22 @@ func (a *App) Serve(ctx context.Context) error {
 		if _, err := a.checkpointer.CreateShutdown(); err != nil {
 			a.logger.Error("failed to create shutdown checkpoint", "error", err)
 		}
-	}()
+	})
 
 	// Start the primary API server. This blocks until the server is shut
 	// down (via context cancellation or fatal error).
 	if err := a.server.Start(ctx); err != nil {
 		if ctx.Err() == nil {
+			tasks.finish(true)
 			return fmt.Errorf("server failed: %w", err)
 		}
 	}
 
-	// Only a cancelled ctx means the shutdown goroutine is running; on a
-	// fatal server error it is still parked on ctx.Done and waiting here
-	// would hang. The timeout is a backstop against a wedged tail step —
-	// resources still close, but loudly instead of racily.
-	if ctx.Err() != nil {
-		select {
-		case <-shutdownDone:
-		case <-time.After(60 * time.Second):
-			a.logger.Warn("shutdown tasks still running at exit; closing resources anyway")
-		}
-	}
+	// finish(fatal) when ctx is somehow still alive: Start returning nil
+	// without a cancelled ctx should not happen, but if it does, the
+	// watcher must be released without running tail work — Serve is
+	// about to close the stores either way.
+	tasks.finish(ctx.Err() == nil)
 
 	a.logger.Info("Thane stopped")
 	if guard != nil && guard.Tripped() {

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -95,7 +95,16 @@ func (a *App) Serve(ctx context.Context) error {
 		}
 	}
 
+	// Serve waits on shutdownDone before returning: everything after the
+	// server drain below — archiving conversations, ending sessions, the
+	// shutdown checkpoint — reads the stores that the deferred
+	// a.shutdown() closes the moment Serve returns. Without the wait,
+	// those tail steps race the close and lose ("sql: database is
+	// closed" at every restart), which meant the shutdown checkpoint
+	// silently never happened.
+	shutdownDone := make(chan struct{})
 	go func() {
+		defer close(shutdownDone)
 		<-ctx.Done()
 		a.logger.Info("shutdown signal received")
 
@@ -154,6 +163,18 @@ func (a *App) Serve(ctx context.Context) error {
 	if err := a.server.Start(ctx); err != nil {
 		if ctx.Err() == nil {
 			return fmt.Errorf("server failed: %w", err)
+		}
+	}
+
+	// Only a cancelled ctx means the shutdown goroutine is running; on a
+	// fatal server error it is still parked on ctx.Done and waiting here
+	// would hang. The timeout is a backstop against a wedged tail step —
+	// resources still close, but loudly instead of racily.
+	if ctx.Err() != nil {
+		select {
+		case <-shutdownDone:
+		case <-time.After(60 * time.Second):
+			a.logger.Warn("shutdown tasks still running at exit; closing resources anyway")
 		}
 	}
 

--- a/internal/app/shutdown_tasks.go
+++ b/internal/app/shutdown_tasks.go
@@ -1,0 +1,67 @@
+package app
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// shutdownTasksTimeout bounds how long Serve waits for the shutdown
+// tail before closing resources anyway — a backstop against a wedged
+// tail step, degrading loudly instead of racily.
+const shutdownTasksTimeout = 60 * time.Second
+
+// shutdownTasks coordinates the post-drain shutdown tail (archive
+// conversations, MQTT offline, shutdown checkpoint) with Serve's
+// return. The contract it exists to enforce: any tail work that runs,
+// runs to completion before Serve returns and its deferred shutdown()
+// closes the stores the tail reads — and on a fatal server error,
+// where ctx was never cancelled, the tail must not run at all, not
+// even later when the command caller's deferred cancel finally fires.
+type shutdownTasks struct {
+	logger  *slog.Logger
+	timeout time.Duration
+	done    chan struct{}
+	abort   chan struct{}
+}
+
+func newShutdownTasks(logger *slog.Logger, timeout time.Duration) *shutdownTasks {
+	return &shutdownTasks{
+		logger:  logger,
+		timeout: timeout,
+		done:    make(chan struct{}),
+		abort:   make(chan struct{}),
+	}
+}
+
+// watch arms the tail: it runs once ctx is cancelled. An abort releases
+// the watcher without running it. If cancel and abort race, the select
+// may pick either — safe both ways, because finish always waits for
+// done, so a tail that does start completes before resources close.
+func (s *shutdownTasks) watch(ctx context.Context, tail func()) {
+	go func() {
+		defer close(s.done)
+		select {
+		case <-ctx.Done():
+		case <-s.abort:
+			return
+		}
+		tail()
+	}()
+}
+
+// finish synchronizes Serve's return with the watcher. fatal means
+// Serve is returning without a cancelled ctx (server error): the
+// watcher is released via abort so the tail never fires against the
+// stores the caller is about to close. Either way finish waits for the
+// watcher to acknowledge, bounded by the timeout.
+func (s *shutdownTasks) finish(fatal bool) {
+	if fatal {
+		close(s.abort)
+	}
+	select {
+	case <-s.done:
+	case <-time.After(s.timeout):
+		s.logger.Warn("shutdown tasks still running at exit; closing resources anyway")
+	}
+}

--- a/internal/app/shutdown_tasks_test.go
+++ b/internal/app/shutdown_tasks_test.go
@@ -1,0 +1,143 @@
+package app
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestShutdownTasksTailCompletesBeforeFinishReturns pins the ordering
+// contract that produced "sql: database is closed" at every restart:
+// finish (and therefore Serve's return, and therefore the deferred
+// store close) must not complete while the shutdown tail is mid-work.
+func TestShutdownTasksTailCompletesBeforeFinishReturns(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	tasks := newShutdownTasks(testLogger(), time.Minute)
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var completed atomic.Bool
+	tasks.watch(ctx, func() {
+		close(entered)
+		<-release
+		completed.Store(true)
+	})
+
+	cancel()
+	<-entered // the tail is now running
+
+	finished := make(chan struct{})
+	go func() {
+		tasks.finish(false)
+		close(finished)
+	}()
+
+	select {
+	case <-finished:
+		t.Fatal("finish returned while the tail was still running")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(release)
+	select {
+	case <-finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("finish never returned after the tail completed")
+	}
+	if !completed.Load() {
+		t.Fatal("finish returned without the tail having completed")
+	}
+}
+
+// TestShutdownTasksFatalAbortSkipsTail pins the fatal-server-error
+// path: the watcher is released without running the tail, and a later
+// cancel (the command caller's deferred cancel) must not fire the tail
+// into stores the caller already closed.
+func TestShutdownTasksFatalAbortSkipsTail(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	tasks := newShutdownTasks(testLogger(), time.Minute)
+
+	var ran atomic.Bool
+	tasks.watch(ctx, func() { ran.Store(true) })
+
+	tasks.finish(true) // returns once the watcher acknowledges the abort
+	cancel()           // the late cancel arrives after Serve returned
+
+	time.Sleep(50 * time.Millisecond)
+	if ran.Load() {
+		t.Fatal("tail ran despite the fatal abort")
+	}
+}
+
+// TestShutdownTasksWedgedTailDegradesLoudly: the timeout backstop
+// returns instead of hanging exit forever.
+func TestShutdownTasksWedgedTailDegradesLoudly(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	tasks := newShutdownTasks(testLogger(), 30*time.Millisecond)
+
+	wedge := make(chan struct{})
+	t.Cleanup(func() { close(wedge) })
+	tasks.watch(ctx, func() { <-wedge })
+
+	cancel()
+	start := time.Now()
+	tasks.finish(false)
+	if elapsed := time.Since(start); elapsed < 30*time.Millisecond {
+		t.Fatalf("finish returned after %v, before the %v backstop", elapsed, 30*time.Millisecond)
+	}
+}
+
+// TestContentArchiverLoopHoldsFirstPass: no pass before the boot-burst
+// hold elapses, one promptly after.
+func TestContentArchiverLoopHoldsFirstPass(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	passes := make(chan time.Time, 4)
+	start := time.Now()
+	go contentArchiverLoop(ctx, 60*time.Millisecond, time.Hour, func(context.Context) {
+		passes <- time.Now()
+	})
+
+	select {
+	case at := <-passes:
+		if since := at.Sub(start); since < 60*time.Millisecond {
+			t.Fatalf("first pass ran %v after start, before the 60ms hold", since)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no pass ran after the hold elapsed")
+	}
+}
+
+// TestContentArchiverLoopCancelDuringHoldRunsNothing: cancellation
+// inside the hold exits the loop without ever archiving.
+func TestContentArchiverLoopCancelDuringHoldRunsNothing(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var ran atomic.Bool
+	done := make(chan struct{})
+	go func() {
+		contentArchiverLoop(ctx, time.Hour, time.Hour, func(context.Context) { ran.Store(true) })
+		close(done)
+	}()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("loop did not exit on cancellation during the hold")
+	}
+	if ran.Load() {
+		t.Fatal("a pass ran despite cancellation during the hold")
+	}
+}


### PR DESCRIPTION
## The shutdown checkpoint has been losing a race it was never told it was running

Every restart of production logs the same three lines: `failed to enumerate active sessions`, `failed to end session`, and `failed to create shutdown checkpoint`, all with `sql: database is closed`. The mechanism is structural: `Serve` starts a shutdown goroutine (drain the servers, archive active conversations, publish MQTT offline, write the shutdown checkpoint), but `Serve` itself returns the moment `server.Start` unblocks — and the deferred `a.shutdown()` then closes every store while the goroutine is still working through its tail. The archive/end-session/checkpoint steps have been racing the resource close at every single restart, and mostly losing. The most concrete casualty: the shutdown checkpoint — the thing that exists to capture state at exactly this moment — has silently not been happening.

`Serve` now waits on the shutdown goroutine before returning. The wait only arms when the context was actually cancelled, because on a fatal server error the goroutine is still parked on `ctx.Done()` and waiting for it would hang the error path. A 60-second backstop covers a wedged tail step: resources still close, but with a WARN naming what happened instead of a silent race.

## And the boot-time mirror image: the archiver vs. the write burst

The other end of a restart had its own collision. The content archiver's first pass ran immediately at boot — a DELETE pass over logs.db with a 30-minute budget, launched at the exact moment the boot write burst has the log indexer busiest. This morning's deploy showed both casualties in one minute: `loop event journal write failed … SQLITE_BUSY` (a 56-event batch dropped) and `content archive failed: delete tool rows for 250 requests: database is locked`. The loop-event recorder already solves this exact problem for its first prune — `recorderFirstPruneAfter` holds it five minutes past boot, with a comment explaining why. The archiver now gets the same five-minute hold: content a day stale can wait five minutes; the boot burst cannot.

## Scope

Deliberately small and behavioral-only at the seams: no store, checkpoint, or archiver logic changes. The SQLITE_BUSY class isn't fully extinct — a daily archive tick can still coincide with a heavy write burst mid-day — but the every-deploy collision was the observed producer, and deeper work (smaller archiver transactions) can stand on its own evidence if the residual ever shows up.

## Test plan

- [x] `just ci` green locally (full gate, fresh worktree)
- [x] Existing serve/app suites green — the wait changes shutdown ordering, which is exactly what the existing tests exercise around Serve's lifecycle
- [ ] Post-deploy: restart produces zero `sql: database is closed` errors and a checkpoint actually lands; no SQLITE_BUSY cluster in the first minute after boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
