### PR TITLE
feat: teach archivist canonical contact dossiers

### DIFF
--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -518,6 +518,14 @@ call reports every independently correctable projection violation together.
 The generic document tools remain available for operator recovery, but models
 should not author dossier structure through them.
 
+The archivist uses the same contract-owned door. Contact-shaped queue subjects
+and contact evidence discovered in closed sessions are resolved through the
+structured directory, reconciled with the existing canonical dossier, and
+republished through `contact_dossier_write`. The generic `kb:dossiers/`
+namespace remains the home for entities, areas, routines, and themes; it is
+never a fallback location for a contact, because that would split one person's
+history across two document roots.
+
 Fresh `thane init` workspaces declare and establish the root with the agent's
 signing key, required signature verification, and this context policy:
 

--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -524,7 +524,11 @@ structured directory, reconciled with the existing canonical dossier, and
 republished through `contact_dossier_write`. The generic `kb:dossiers/`
 namespace remains the home for entities, areas, routines, and themes; it is
 never a fallback location for a contact, because that would split one person's
-history across two document roots.
+history across two document roots. Before replacement, the archivist checks
+whether `doc_read` truncated the current dossier and walks its outline and
+sections when necessary. An unreadable remainder or unavailable canonical
+writer defers the durable queue item behind ready work rather than losing it or
+letting it block the queue.
 
 Fresh `thane init` workspaces declare and establish the root with the agent's
 signing key, required signature verification, and this context policy:

--- a/internal/app/coreloop_docs_parity_test.go
+++ b/internal/app/coreloop_docs_parity_test.go
@@ -143,13 +143,18 @@ func TestArchivistUsesCanonicalContactDossiers(t *testing.T) {
 	if slices.Contains(spec.ExcludeTools, "contact_dossier_write") {
 		t.Error("archivist excludes contact_dossier_write despite teaching it as the canonical contact door")
 	}
+	normalizedTask := strings.Join(strings.Fields(spec.Task), " ")
 	for _, want := range []string{
 		"contacts:<uuid>.md",
 		"contact_dossier_write",
 		"Never create or maintain a contact dossier under `kb:dossiers/`",
 		"complete status-line, teaser, digest, and full projections",
+		"response's `truncated` marker",
+		"call `doc_outline`, verify that outline is not truncated",
+		"recover every top-level section with `doc_section`",
+		"call `queue_defer`",
 	} {
-		if !strings.Contains(spec.Task, want) {
+		if !strings.Contains(normalizedTask, want) {
 			t.Errorf("archivist task does not teach %q", want)
 		}
 	}

--- a/internal/app/coreloop_docs_parity_test.go
+++ b/internal/app/coreloop_docs_parity_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/nugget/thane-ai-agent/internal/app/coreloops"
@@ -120,6 +122,35 @@ func TestEmbeddedDocumentsMatchTheRepoSources(t *testing.T) {
 		}
 		if string(source) != string(embedded) {
 			t.Errorf("loops/%s.md and its embedded copy differ; run `just generate`", name)
+		}
+	}
+}
+
+// TestArchivistUsesCanonicalContactDossiers pins the model-facing routing
+// contract that keeps one person's history out of the generic dossier root.
+// A configured runtime exposes contact_dossier_write through the archivist's
+// contacts tag; the shipped task must teach the loop to choose it.
+func TestArchivistUsesCanonicalContactDossiers(t *testing.T) {
+	spec, err := decodeCoreLoopDefinition(filepath.Join("..", "..", "loops", "archivist.md"))
+	if err != nil {
+		t.Fatalf("decode archivist definition: %v", err)
+	}
+	for _, tag := range []string{"contacts", "documents"} {
+		if !slices.Contains(spec.Tags, tag) {
+			t.Errorf("archivist tags = %#v, want %q so the canonical dossier tools are reachable", spec.Tags, tag)
+		}
+	}
+	if slices.Contains(spec.ExcludeTools, "contact_dossier_write") {
+		t.Error("archivist excludes contact_dossier_write despite teaching it as the canonical contact door")
+	}
+	for _, want := range []string{
+		"contacts:<uuid>.md",
+		"contact_dossier_write",
+		"Never create or maintain a contact dossier under `kb:dossiers/`",
+		"complete status-line, teaser, digest, and full projections",
+	} {
+		if !strings.Contains(spec.Task, want) {
+			t.Errorf("archivist task does not teach %q", want)
 		}
 	}
 }

--- a/internal/app/loop_queue_tools.go
+++ b/internal/app/loop_queue_tools.go
@@ -21,13 +21,14 @@ const (
 // buildLoopQueueTools returns the loop-private work-queue tools for one
 // consumer loop. The loop's own name is captured in the closure at
 // hydration time and used as the queue partition key, so the model never
-// sees or types it and can only ever drain, ack, or enqueue into its own
+// sees or types it and can only ever drain, ack, defer, or enqueue into its own
 // partition. Attached via Spec.RuntimeTools, so these tools are
 // advertised only on this loop's iterations — never registered globally.
 //
 // This is the consumer side of the queue-consumer pattern (issue #1024):
-// a self-paced loop pulls a batch from its durable inbox, processes it,
-// acks what it finished, and enqueues any newly-discovered subjects.
+// a self-paced loop pulls a batch from its durable inbox, processes it, acks
+// what it finished, defers work blocked on external prerequisites, and
+// enqueues any newly-discovered subjects.
 // Trigger rate (producers calling Enqueue) is fully decoupled from work
 // rate (this loop's sleep cadence).
 func buildLoopQueueTools(store *loopqueue.Store, loopName string) []looppkg.RuntimeTool {
@@ -80,7 +81,7 @@ func buildLoopQueueTools(store *loopqueue.Store, loopName string) []looppkg.Runt
 		{
 			Name: "queue_ack",
 			Description: "Mark a queue item done and remove it from your queue. Pass the subject you got from queue_pull. " +
-				"Idempotent: acking a subject that is no longer queued is a harmless no-op. Ack each item once you have folded its evidence into the dossiers.",
+				"Idempotent: acking a subject that is no longer queued is a harmless no-op. Ack only after its evidence is durably folded or you made an evidence-based no-change decision; use queue_defer when an external prerequisite blocks completion.",
 			SkipContentResolve: true,
 			Parameters: map[string]any{
 				"type": "object",
@@ -101,6 +102,32 @@ func buildLoopQueueTools(store *loopqueue.Store, loopName string) []looppkg.Runt
 					return "", err
 				}
 				return fmt.Sprintf(`{"status":"ok","subject":%q}`, subject), nil
+			},
+		},
+		{
+			Name: "queue_defer",
+			Description: "Keep a pulled item pending but move it behind every item currently in your queue. " +
+				"Use this when an external prerequisite or an unreadable/truncated source prevents a safe write now. The original evidence remains queued and a future producer can promote it again. Do not defer ordinary no-change work; queue_ack that as complete.",
+			SkipContentResolve: true,
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"subject": map[string]any{
+						"type":        "string",
+						"description": "The subject (queue key) to retain for a later iteration, exactly as returned by queue_pull.",
+					},
+				},
+				"required": []string{"subject"},
+			},
+			Handler: func(ctx context.Context, args map[string]any) (string, error) {
+				subject := strings.TrimSpace(stringMapValue(args, "subject"))
+				if subject == "" {
+					return "", fmt.Errorf("subject is required")
+				}
+				if err := store.Defer(ctx, loopName, subject); err != nil {
+					return "", err
+				}
+				return fmt.Sprintf(`{"status":"deferred","subject":%q}`, subject), nil
 			},
 		},
 		{

--- a/internal/app/loop_queue_tools_test.go
+++ b/internal/app/loop_queue_tools_test.go
@@ -1,0 +1,62 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
+	"github.com/nugget/thane-ai-agent/internal/state/loopqueue"
+)
+
+func TestQueueDeferToolRetainsWorkAndMovesItBehindThePartition(t *testing.T) {
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("open memory database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store, err := loopqueue.NewStore(db, nil)
+	if err != nil {
+		t.Fatalf("new loop queue: %v", err)
+	}
+	if err := store.Enqueue(t.Context(), "archivist", "contact:blocked", 5, []byte(`{"source":"session"}`)); err != nil {
+		t.Fatalf("enqueue blocked: %v", err)
+	}
+	if err := store.Enqueue(t.Context(), "archivist", "session:ready", 0, []byte(`{}`)); err != nil {
+		t.Fatalf("enqueue ready: %v", err)
+	}
+
+	tools := buildLoopQueueTools(store, "archivist")
+	var deferToolNameFound bool
+	for _, tool := range tools {
+		if tool.Name != "queue_defer" {
+			continue
+		}
+		deferToolNameFound = true
+		result, err := tool.Handler(context.Background(), map[string]any{"subject": "contact:blocked"})
+		if err != nil {
+			t.Fatalf("queue_defer: %v", err)
+		}
+		var response map[string]string
+		if err := json.Unmarshal([]byte(result), &response); err != nil {
+			t.Fatalf("decode queue_defer result: %v", err)
+		}
+		if response["status"] != "deferred" || response["subject"] != "contact:blocked" {
+			t.Fatalf("queue_defer result = %v", response)
+		}
+	}
+	if !deferToolNameFound {
+		t.Fatal("queue_defer runtime tool was not generated")
+	}
+
+	items, err := store.Peek(t.Context(), "archivist", 10)
+	if err != nil {
+		t.Fatalf("peek: %v", err)
+	}
+	if len(items) != 2 || items[0].DedupKey != "session:ready" || items[1].DedupKey != "contact:blocked" {
+		t.Fatalf("deferred queue order = %#v", items)
+	}
+	if got := string(items[1].Payload); got != `{"source":"session"}` {
+		t.Fatalf("deferred payload = %q", got)
+	}
+}

--- a/internal/state/loopqueue/queue_store.go
+++ b/internal/state/loopqueue/queue_store.go
@@ -153,6 +153,44 @@ func (s *Store) PeekAll(ctx context.Context, consumerLoop string) ([]Item, error
 	return s.peek(ctx, consumerLoop, 0)
 }
 
+// Defer keeps one pending item while moving it behind every item currently in
+// the same consumer partition. It is the non-destructive escape hatch for a
+// consumer blocked on an external prerequisite: unlike [Store.Ack], no
+// evidence is removed, and unlike [Store.Enqueue], the original payload is
+// retained. The original enqueue timestamp also remains the queue-age and
+// completion-latency anchor. A later producer enqueue may promote the item
+// again.
+func (s *Store) Defer(ctx context.Context, consumerLoop, dedupKey string) error {
+	consumerLoop = strings.TrimSpace(consumerLoop)
+	dedupKey = strings.TrimSpace(dedupKey)
+	if consumerLoop == "" || dedupKey == "" {
+		return fmt.Errorf("loopqueue: consumer_loop and dedup_key are required")
+	}
+	now := time.Now().UTC()
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE loop_queue
+		SET priority = (
+				SELECT COALESCE(MIN(pending.priority), 0) - 1
+				FROM loop_queue AS pending
+				WHERE pending.consumer_loop = ? AND pending.status = ?
+			),
+			attempts = attempts + 1,
+			updated_at = ?
+		WHERE consumer_loop = ? AND dedup_key = ? AND status = ?
+	`, consumerLoop, StatusPending, now, consumerLoop, dedupKey, StatusPending)
+	if err != nil {
+		return fmt.Errorf("loopqueue: defer %s/%s: %w", consumerLoop, dedupKey, err)
+	}
+	updated, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("loopqueue: defer %s/%s: %w", consumerLoop, dedupKey, err)
+	}
+	if updated == 0 {
+		return fmt.Errorf("loopqueue: cannot defer missing pending item %s/%s", consumerLoop, dedupKey)
+	}
+	return nil
+}
+
 func (s *Store) peek(ctx context.Context, consumerLoop string, limit int) ([]Item, error) {
 	consumerLoop = strings.TrimSpace(consumerLoop)
 	if consumerLoop == "" {

--- a/internal/state/loopqueue/queue_store_test.go
+++ b/internal/state/loopqueue/queue_store_test.go
@@ -197,6 +197,71 @@ func TestStore_PriorityOrdering(t *testing.T) {
 	}
 }
 
+func TestStore_DeferPreservesItemBehindCurrentWork(t *testing.T) {
+	s := newTestStore(t)
+	for _, tc := range []struct {
+		key      string
+		priority int
+		payload  string
+	}{
+		{key: "blocked", priority: 10, payload: `{"evidence":"keep"}`},
+		{key: "ordinary", priority: 0, payload: `{}`},
+		{key: "already-low", priority: -3, payload: `{}`},
+	} {
+		if err := s.Enqueue(t.Context(), "archivist", tc.key, tc.priority, []byte(tc.payload)); err != nil {
+			t.Fatalf("enqueue %s: %v", tc.key, err)
+		}
+	}
+	before, err := s.Peek(t.Context(), "archivist", 10)
+	if err != nil {
+		t.Fatalf("peek before defer: %v", err)
+	}
+	var originalEnqueuedAt time.Time
+	for _, item := range before {
+		if item.DedupKey == "blocked" {
+			originalEnqueuedAt = item.EnqueuedAt
+		}
+	}
+
+	if err := s.Defer(t.Context(), "archivist", "blocked"); err != nil {
+		t.Fatalf("defer blocked: %v", err)
+	}
+	items, err := s.Peek(t.Context(), "archivist", 10)
+	if err != nil {
+		t.Fatalf("peek: %v", err)
+	}
+	gotOrder := []string{items[0].DedupKey, items[1].DedupKey, items[2].DedupKey}
+	wantOrder := []string{"ordinary", "already-low", "blocked"}
+	for i := range wantOrder {
+		if gotOrder[i] != wantOrder[i] {
+			t.Fatalf("drain order = %v, want %v", gotOrder, wantOrder)
+		}
+	}
+	if got := string(items[2].Payload); got != `{"evidence":"keep"}` {
+		t.Errorf("deferred payload = %q, want original evidence", got)
+	}
+	if got := items[2].EnqueuedAt; !got.Equal(originalEnqueuedAt) {
+		t.Errorf("deferred enqueued_at = %v, want original %v", got, originalEnqueuedAt)
+	}
+	var attempts int
+	if err := s.db.QueryRowContext(t.Context(), `
+		SELECT attempts FROM loop_queue
+		WHERE consumer_loop = 'archivist' AND dedup_key = 'blocked'
+	`).Scan(&attempts); err != nil {
+		t.Fatalf("read attempts: %v", err)
+	}
+	if attempts != 1 {
+		t.Errorf("attempts = %d, want 1", attempts)
+	}
+}
+
+func TestStore_DeferRejectsMissingItem(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.Defer(t.Context(), "archivist", "missing"); err == nil {
+		t.Fatal("defer missing item returned nil error")
+	}
+}
+
 func TestStore_PartitionIsolation(t *testing.T) {
 	s := newTestStore(t)
 	if err := s.Enqueue(t.Context(), "archivist", "session:1", 0, nil); err != nil {

--- a/loops/archivist.md
+++ b/loops/archivist.md
@@ -116,8 +116,11 @@ durable queue holds that).
    note the quiet and sleep long.
 2. **Process each item.**
    - For a `session:<id>` item: read it with `archive_session_transcript`
-     and fold any new evidence into the dossiers it touches. (You do NOT
-     write the session's title/tags — the Go-side summarizer owns that.)
+     and fold any new evidence into the dossiers it touches. When the
+     evidence is about a person, resolve the human name or alias with
+     `contact_lookup` before treating it as contact evidence; a guessed name
+     is not a canonical contact identity. (You do NOT write the session's
+     title/tags — the Go-side summarizer owns that.)
    - For a subject item: walk the silos. Search **both the canonical
      handle and the human aliases** — the handle (e.g.
      `entity:binary_sensor.game_room_door`) appears in facts and
@@ -129,21 +132,32 @@ durable queue holds that).
      the documents tools to read any existing dossier and adjacent KB
      content. Record every alias you discover in the dossier's Aliases
      section so future passes don't re-derive them.
-3. **Write or refresh the dossier(s)** as managed documents under the
-   `kb:dossiers/` namespace via the documents tools. All document refs
-   MUST use the canonical `root:path` form — for the game room door the
-   ref is `kb:dossiers/entity-binary_sensor-game_room_door.md`, not a
-   bare `dossiers/...` path (bare paths fail with an invalid-ref error).
-   Structure each claim with an evidence citation — an archive session
-   ID, a fact category+key, a document ref, or a working-memory
-   conversation ID — so a reader can check any claim against its source.
+3. **Write each dossier through its owning surface.** Every claim carries an
+   evidence citation — an archive session ID, a fact category+key, a document
+   ref, or a working-memory conversation ID — so a reader can check it.
+   - A contact is the contract-owned exception. Resolve an active structured
+     contact and use its exact canonical UUID. Read the current
+     `contacts:<uuid>.md` with `doc_read` when it exists, reconcile the new
+     evidence with that whole dossier, then call `contact_dossier_write` with
+     the complete status-line, teaser, digest, and full projections. Go owns
+     the ref, private subject tag, frontmatter, headings, and revision receipt.
+     Never create or maintain a contact dossier under `kb:dossiers/`; that
+     would fork one person's history across two sources. If the canonical
+     contact root is unavailable, record that outcome in archivist.md and
+     handle the item without creating a fallback document.
+   - Every non-contact subject remains an ordinary managed document under the
+     `kb:dossiers/` namespace. Use canonical `root:path` refs — for the game
+     room door, `kb:dossiers/entity-binary_sensor-game_room_door.md`, never a
+     bare `dossiers/...` path. Read the existing document before replacing it.
 4. **Ack every item you handle** — Call `queue_ack` with each item's
-   subject once you have handled it, whether or not it produced a dossier.
+   subject only after every warranted dossier write succeeded, or after an
+   explicit decision that the evidence changes nothing or its canonical
+   owning surface is unavailable. Correct a validation or revision-conflict
+   error before acking; never report a write as complete when it failed.
    Acking means "I am done with this item," not "I created a dossier": a
-   session with nothing worth folding is still acked — read it, decide there
-   is nothing, ack it. Unacked items return every iteration forever and
-   starve the queue (an empty item at the head blocks everything behind it),
-   so never leave a handled item unacked.
+   session with nothing worth folding is still acked. Unacked items return
+   every iteration forever and starve the queue (an empty item at the head
+   blocks everything behind it), so do not abandon a handled item unacked.
 5. **Enqueue what you discovered** — When folding a subject in surfaces
    a related subject worth its own dossier (a connected entity, a sibling
    area), call `queue_enqueue` to add it to your queue for a future
@@ -193,10 +207,18 @@ subject benefits from reading just this paragraph.
 - Dossiers that reference this one: `kb:dossiers/<other-subject>.md`, …
 ```
 
-Every claim line carries citations. If you cannot back a claim with
-specific evidence from the corpus, do not assert it — note it as an open
-question instead. Synthesis is connecting things you can defend, not
-generating plausible-sounding text.
+Every claim line carries citations. If you cannot back a claim with specific
+evidence from the corpus, do not assert it — note it as an open question
+instead. Synthesis is connecting things you can defend, not generating
+plausible-sounding text.
+
+For a contact, pass the four projections to `contact_dossier_write`; do not
+author the outer document structure shown above. The `full` projection carries
+the durable evidence under detail-level headings such as `### Subject`,
+`### Aliases`, `### Relationship Summary`, `### Claims`, `### Open Questions`,
+and `### Connections`. The status line is the one-line current truth, the
+teaser is the reason to open the dossier, and the digest must stand alone as
+enough relationship context to act. All four describe the same revision.
 
 ## What you are NOT for
 
@@ -205,6 +227,8 @@ generating plausible-sounding text.
   dossiers.
 - Writing facts on the model's behalf. The interactive agent has its own
   `remember_fact` instinct. Your job is synthesis above that layer.
+- Creating a second contact dossier in a generic document root. The structured
+  contact UUID and `contact_dossier_write` select the only canonical history.
 - Spawning loops or delegating. You are a single self-paced consumer; the
   only work you create is via `queue_enqueue` into your own queue.
 - Sending messages to the user or any channel. The archivist is silent;

--- a/loops/archivist.md
+++ b/loops/archivist.md
@@ -137,23 +137,33 @@ durable queue holds that).
    ref, or a working-memory conversation ID — so a reader can check it.
    - A contact is the contract-owned exception. Resolve an active structured
      contact and use its exact canonical UUID. Read the current
-     `contacts:<uuid>.md` with `doc_read` when it exists, reconcile the new
-     evidence with that whole dossier, then call `contact_dossier_write` with
-     the complete status-line, teaser, digest, and full projections. Go owns
-     the ref, private subject tag, frontmatter, headings, and revision receipt.
-     Never create or maintain a contact dossier under `kb:dossiers/`; that
-     would fork one person's history across two sources. If the canonical
-     contact root is unavailable, record that outcome in archivist.md and
-     handle the item without creating a fallback document.
+     `contacts:<uuid>.md` with `doc_read` when it exists and inspect the
+     response's `truncated` marker. A truncated read is not the whole dossier:
+     call `doc_outline`, verify that outline is not truncated, then recover
+     every top-level section with `doc_section`. If a section result is also
+     truncated, descend through its child headings; never replace the dossier
+     until every content-bearing leaf was returned without truncation. If the
+     outline or a leaf remains truncated, call `queue_defer` rather than
+     overwriting claims you could not read.
+     Reconcile the new evidence with the complete dossier, then call
+     `contact_dossier_write` with the complete status-line, teaser, digest, and
+     full projections. Go owns the ref, private subject tag, frontmatter,
+     headings, and revision receipt. Never create or maintain a contact dossier
+     under `kb:dossiers/`; that would fork one person's history across two
+     sources. If the canonical contact root or writer is unavailable, record
+     that outcome in archivist.md and call `queue_defer`; do not acknowledge
+     unpublished evidence or create a fallback document.
    - Every non-contact subject remains an ordinary managed document under the
      `kb:dossiers/` namespace. Use canonical `root:path` refs — for the game
      room door, `kb:dossiers/entity-binary_sensor-game_room_door.md`, never a
      bare `dossiers/...` path. Read the existing document before replacing it.
 4. **Ack every item you handle** — Call `queue_ack` with each item's
    subject only after every warranted dossier write succeeded, or after an
-   explicit decision that the evidence changes nothing or its canonical
-   owning surface is unavailable. Correct a validation or revision-conflict
-   error before acking; never report a write as complete when it failed.
+   evidence-based decision that the complete source changes nothing. Correct a
+   validation or revision-conflict error before acking; never report a write as
+   complete when it failed. When an external prerequisite or incomplete read
+   blocks safe completion, call `queue_defer` instead: the item stays durable
+   but moves behind all work currently ready to proceed.
    Acking means "I am done with this item," not "I created a dossier": a
    session with nothing worth folding is still acked. Unacked items return
    every iteration forever and starve the queue (an empty item at the head


### PR DESCRIPTION
## Summary

- route contact-shaped archivist queue work and contact evidence from closed sessions through the structured directory and `contact_dossier_write`
- require complete, untruncated dossier reconciliation before replacement, walking the outline and sections when the standard read is capped
- add loop-private `queue_defer` so unavailable writers or irrecoverably truncated sources remain durable while moving behind work that can proceed
- reserve `kb:dossiers/` for non-contact subjects and pin the canonical routing and recovery contracts in regression tests

## Why

PRs #1465 and #1466 established one canonical `contacts:<uuid>.md` history and a structured writer, but the archivist's shipped mandate still told it to write every subject under `kb:dossiers/`. That stale instruction could fork a person's longitudinal history across two document roots even though the correct tool was already available through the archivist's `contacts` capability.

Whole-document replacement also needs two explicit safety properties. A valid dossier can exceed the ordinary 16 KiB tool-result ceiling, so a truncated `doc_read` cannot be treated as complete source material. And a temporarily unavailable canonical writer cannot turn into either acknowledgement and evidence loss or a permanently blocking head-of-queue item. The archivist now verifies every read/outline/section truncation marker, while `queue_defer` preserves the original payload and queue-age anchor but moves the item below every currently pending item.

This is the steady-state stewardship slice of #1463. Deterministic identity, structure, facets, revision receipts, and queue deferral remain owned by Go; the model owns the evidence-backed synthesis and the decision that a contact-shaped subject belongs through that contract-owned door.

Refs #1463.

## User impact

Closed conversations and explicit `contact:<uuid>` queue work can now refresh the same signed dossier that interactive turns read and write. Human aliases must resolve to an active structured contact, all four projections describe one revision, and the archivist cannot overwrite claims hidden beyond a truncated read.

An unavailable contact root or unrecoverable source no longer causes either a legacy fallback document or permanent evidence loss. The work remains pending, moves behind ready items, records another attempt, and can be promoted again by fresh producer evidence.

The built-in loop definition ships with the binary. Installations that maintain an operator-owned `core:loops/archivist.md` override must advance that document separately before production will adopt the new mandate.

## Test plan

- [x] `just ci`
- [x] shipped archivist definition retains the `contacts` and `documents` capabilities and does not exclude `contact_dossier_write`
- [x] regression pins canonical contact routing, complete facet publication, truncation recovery, queue deferral, and prohibition on generic contact dossiers
- [x] queue-store tests prove defer preserves payload and original enqueue time, increments attempts, and moves below every current pending item
- [x] runtime-tool test proves `queue_defer` remains scoped to its loop partition and returns the durable deferred result
- [x] generated embedded loop document matches the repository source
