### PR TITLE
fix(providers): tell a reasoning-only completion apart from an empty one

### DIFF
--- a/internal/model/fleet/providers/openaicompat.go
+++ b/internal/model/fleet/providers/openaicompat.go
@@ -320,7 +320,7 @@ func (c *OpenAICompatClient) chatResponseFromWire(wire *openAICompatChatResponse
 		// never answered" reads very differently from "the model said
 		// nothing". Sizes only; reasoning text stays out of logs.
 		if r := wire.Choices[0].Message.reasoningText(); r != "" {
-			return nil, fmt.Errorf("%s produced only reasoning for model %q (%d chars, finish_reason=%q): the answer never reached the content channel — token budget exhausted mid-think, or a runner template routing the final answer into the reasoning field",
+			return nil, fmt.Errorf("%s produced only reasoning for model %q (%d bytes, finish_reason=%q): the answer never reached the content channel — token budget exhausted mid-think, or a runner template routing the final answer into the reasoning field",
 				c.provider, wire.Model, len(r), result.StopReason)
 		}
 		return nil, fmt.Errorf("%s returned an empty assistant completion for model %q", c.provider, wire.Model)

--- a/internal/model/fleet/providers/openaicompat.go
+++ b/internal/model/fleet/providers/openaicompat.go
@@ -315,6 +315,14 @@ func (c *OpenAICompatClient) chatResponseFromWire(wire *openAICompatChatResponse
 		return nil, err
 	}
 	if strings.TrimSpace(result.Message.Content) == "" && len(result.Message.ToolCalls) == 0 {
+		// Same reasoning-only diagnosis as the streaming path: no
+		// answer to return either way, but "the model thought and
+		// never answered" reads very differently from "the model said
+		// nothing". Sizes only; reasoning text stays out of logs.
+		if r := wire.Choices[0].Message.reasoningText(); r != "" {
+			return nil, fmt.Errorf("%s produced only reasoning for model %q (%d chars, finish_reason=%q): the answer never reached the content channel — token budget exhausted mid-think, or a runner template routing the final answer into the reasoning field",
+				c.provider, wire.Model, len(r), result.StopReason)
+		}
 		return nil, fmt.Errorf("%s returned an empty assistant completion for model %q", c.provider, wire.Model)
 	}
 	return result, nil

--- a/internal/model/fleet/providers/openaicompat_stream.go
+++ b/internal/model/fleet/providers/openaicompat_stream.go
@@ -41,6 +41,7 @@ func (c *OpenAICompatClient) handleStreaming(ctx context.Context, requestedModel
 		toolAcc        = make(map[int]*openAICompatToolAccumulator)
 		done           bool
 		chunks         int
+		reasoningChars int
 		finishReason   string
 		upstreamID     string
 		firstToken     time.Time
@@ -93,6 +94,17 @@ func (c *OpenAICompatClient) handleStreaming(ctx context.Context, requestedModel
 			}
 			if choice.Delta.Role != "" {
 				role = choice.Delta.Role
+			}
+			// The thinking channel counts as generation for timing (the
+			// model is producing tokens, so prefill and queueing are
+			// over) and for the emptiness verdict below — but it is not
+			// content, so it neither accumulates nor streams to the
+			// callback.
+			if r := choice.Delta.reasoningText(); r != "" {
+				if firstToken.IsZero() {
+					firstToken = time.Now()
+				}
+				reasoningChars += len(r)
 			}
 			if choice.Delta.Content != "" {
 				// First content, not first frame: the role-only opener
@@ -171,8 +183,19 @@ func (c *OpenAICompatClient) handleStreaming(ctx context.Context, requestedModel
 	// a chunks>0 check and return Done:true with no content, no tool
 	// calls, and zero tokens — the fabricated success this client exists
 	// to refuse. Judge the same thing the non-streaming path judges:
-	// whether an assistant actually said or did anything.
+	// whether an assistant actually said or did anything. A stream that
+	// carried only reasoning is still a refusal — there is no answer to
+	// return — but it is a different diagnosis: the model was working
+	// (production saw 814-frame streams reported as "empty") and the
+	// answer never reached the content channel, either because the
+	// token budget died mid-think or because the runner's template
+	// routes the final answer into the reasoning field. Sizes only in
+	// the error; reasoning text stays out of logs.
 	if strings.TrimSpace(contentBuilder.String()) == "" && len(toolCalls) == 0 {
+		if reasoningChars > 0 {
+			return nil, fmt.Errorf("%s produced only reasoning for model %q (%d chars over %d frames, finish_reason=%q): the answer never reached the content channel — token budget exhausted mid-think, or a runner template routing the final answer into the reasoning field",
+				c.provider, requestedModel, reasoningChars, chunks, finishReason)
+		}
 		return nil, fmt.Errorf("%s returned an empty stream for model %q (frames=%d)", c.provider, requestedModel, chunks)
 	}
 

--- a/internal/model/fleet/providers/openaicompat_stream.go
+++ b/internal/model/fleet/providers/openaicompat_stream.go
@@ -41,7 +41,7 @@ func (c *OpenAICompatClient) handleStreaming(ctx context.Context, requestedModel
 		toolAcc        = make(map[int]*openAICompatToolAccumulator)
 		done           bool
 		chunks         int
-		reasoningChars int
+		reasoningBytes int
 		finishReason   string
 		upstreamID     string
 		firstToken     time.Time
@@ -104,7 +104,7 @@ func (c *OpenAICompatClient) handleStreaming(ctx context.Context, requestedModel
 				if firstToken.IsZero() {
 					firstToken = time.Now()
 				}
-				reasoningChars += len(r)
+				reasoningBytes += len(r)
 			}
 			if choice.Delta.Content != "" {
 				// First content, not first frame: the role-only opener
@@ -189,14 +189,43 @@ func (c *OpenAICompatClient) handleStreaming(ctx context.Context, requestedModel
 	// (production saw 814-frame streams reported as "empty") and the
 	// answer never reached the content channel, either because the
 	// token budget died mid-think or because the runner's template
-	// routes the final answer into the reasoning field. Sizes only in
-	// the error; reasoning text stays out of logs.
-	if strings.TrimSpace(contentBuilder.String()) == "" && len(toolCalls) == 0 {
-		if reasoningChars > 0 {
-			return nil, fmt.Errorf("%s produced only reasoning for model %q (%d chars over %d frames, finish_reason=%q): the answer never reached the content channel — token budget exhausted mid-think, or a runner template routing the final answer into the reasoning field",
-				c.provider, requestedModel, reasoningChars, chunks, finishReason)
+	// routes the final answer into the reasoning field. That verdict
+	// requires terminal evidence: a reasoning stream that closed
+	// silently is the runner/proxy truncation the guard further down
+	// already refuses, and must be named as such, not as a budget or
+	// template problem. Sizes only in the error; reasoning text stays
+	// out of logs.
+	//
+	// failStream narrates each refusal with the timing the success line
+	// carries — the production case was undiagnosable partly because a
+	// failed stream left no telemetry at all.
+	failStream := func(refusal error) (*llm.ChatResponse, error) {
+		attrs := []any{
+			"model", requestedModel,
+			"frames", chunks,
+			"reasoning_bytes", reasoningBytes,
+			"finish_reason", finishReason,
+			"total_ms", time.Since(trace.started).Milliseconds(),
+			"error", refusal.Error(),
 		}
-		return nil, fmt.Errorf("%s returned an empty stream for model %q (frames=%d)", c.provider, requestedModel, chunks)
+		if !firstToken.IsZero() {
+			attrs = append(attrs, "first_token_ms", firstToken.Sub(trace.started).Milliseconds())
+		}
+		trace.log.Debug("stream refused as not-a-completion", attrs...)
+		return nil, refusal
+	}
+	if strings.TrimSpace(contentBuilder.String()) == "" && len(toolCalls) == 0 {
+		silentClose := !done && finishReason == ""
+		switch {
+		case reasoningBytes > 0 && silentClose:
+			return failStream(fmt.Errorf("%s ended the stream for model %q without a terminal marker after %d frames and %d reasoning bytes (truncated response)",
+				c.provider, requestedModel, chunks, reasoningBytes))
+		case reasoningBytes > 0:
+			return failStream(fmt.Errorf("%s produced only reasoning for model %q (%d bytes over %d frames, finish_reason=%q): the answer never reached the content channel — token budget exhausted mid-think, or a runner template routing the final answer into the reasoning field",
+				c.provider, requestedModel, reasoningBytes, chunks, finishReason))
+		default:
+			return failStream(fmt.Errorf("%s returned an empty stream for model %q (frames=%d)", c.provider, requestedModel, chunks))
+		}
 	}
 
 	// Content alone does not mean the answer finished. A proxy or runner
@@ -208,7 +237,7 @@ func (c *OpenAICompatClient) handleStreaming(ctx context.Context, requestedModel
 	// [DONE] sentinel or a finish_reason on some choice. Servers vary in
 	// which they send, so either suffices; neither is silence.
 	if !done && finishReason == "" {
-		return nil, fmt.Errorf("%s ended the stream for model %q without a terminal marker after %d frames (truncated response)", c.provider, requestedModel, chunks)
+		return failStream(fmt.Errorf("%s ended the stream for model %q without a terminal marker after %d frames (truncated response)", c.provider, requestedModel, chunks))
 	}
 
 	result := &llm.ChatResponse{

--- a/internal/model/fleet/providers/openaicompat_test.go
+++ b/internal/model/fleet/providers/openaicompat_test.go
@@ -665,6 +665,17 @@ func TestOpenAICompatReasoningOnlyStreamIsDiagnosed(t *testing.T) {
 			wantIn: "empty stream",
 		},
 		{
+			// A reasoning stream that closed with no [DONE] and no
+			// finish_reason is the runner/proxy dying, not a budget or
+			// template problem — the reasoning-only diagnosis requires
+			// terminal evidence.
+			name: "reasoning then silent close is truncation, not budget death",
+			frames: []string{
+				`{"choices":[{"delta":{"reasoning":"deep in thought"}}]}`,
+			},
+			wantIn: "truncated response",
+		},
+		{
 			name: "reasoning then content is a real completion",
 			frames: []string{
 				`{"choices":[{"delta":{"reasoning":"think think"}}]}`,

--- a/internal/model/fleet/providers/openaicompat_test.go
+++ b/internal/model/fleet/providers/openaicompat_test.go
@@ -622,3 +622,122 @@ func TestOpenAICompatStreamLatencyMetrics(t *testing.T) {
 		})
 	}
 }
+
+// TestOpenAICompatReasoningOnlyStreamIsDiagnosed pins the difference
+// between a model that said nothing and a model that thought hard and
+// never answered. Production streams of 814 reasoning frames were
+// reported as "empty" because the thinking channel wasn't decoded —
+// the refusal is unchanged (there is no answer to return), but the
+// diagnosis must name what actually happened.
+func TestOpenAICompatReasoningOnlyStreamIsDiagnosed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		frames  []string
+		wantIn  string
+		wantOK  bool
+		wantOut string
+	}{
+		{
+			name: "ollama reasoning key with budget death",
+			frames: []string{
+				`{"choices":[{"delta":{"role":"assistant"}}]}`,
+				`{"choices":[{"delta":{"reasoning":"first I should"}}]}`,
+				`{"choices":[{"delta":{"reasoning":" consider"}}]}`,
+				`{"choices":[{"delta":{},"finish_reason":"length"}]}`,
+				"[DONE]",
+			},
+			wantIn: "produced only reasoning",
+		},
+		{
+			name: "deepseek reasoning_content key",
+			frames: []string{
+				`{"choices":[{"delta":{"reasoning_content":"hmm"}}]}`,
+				`{"choices":[{"delta":{},"finish_reason":"stop"}]}`,
+				"[DONE]",
+			},
+			wantIn: "produced only reasoning",
+		},
+		{
+			name:   "scaffolding-only keeps the empty-stream diagnosis",
+			frames: []string{`{"choices":[{"delta":{"role":"assistant"}}]}`, "[DONE]"},
+			wantIn: "empty stream",
+		},
+		{
+			name: "reasoning then content is a real completion",
+			frames: []string{
+				`{"choices":[{"delta":{"reasoning":"think think"}}]}`,
+				`{"choices":[{"delta":{"content":"the answer"}}]}`,
+				"[DONE]",
+			},
+			wantOK:  true,
+			wantOut: "the answer",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				for _, f := range tt.frames {
+					_, _ = w.Write([]byte("data: " + f + "\n\n"))
+				}
+			}))
+			defer srv.Close()
+
+			var streamed strings.Builder
+			c := NewOpenAICompatClient(srv.URL, "", "test", "res", nil, 0)
+			resp, err := c.ChatStream(context.Background(), "m", []llm.Message{{Role: "user", Content: "hi"}}, nil, func(ev llm.StreamEvent) {
+				if ev.Kind == llm.KindToken {
+					streamed.WriteString(ev.Token)
+				}
+			})
+			if tt.wantOK {
+				if err != nil {
+					t.Fatalf("ChatStream: %v", err)
+				}
+				if resp.Message.Content != tt.wantOut {
+					t.Errorf("content = %q, want %q", resp.Message.Content, tt.wantOut)
+				}
+				// Reasoning must not leak into the token stream.
+				if streamed.String() != tt.wantOut {
+					t.Errorf("streamed tokens = %q, want %q", streamed.String(), tt.wantOut)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("want error, got success: %#v", resp)
+			}
+			if !strings.Contains(err.Error(), tt.wantIn) {
+				t.Errorf("error %q missing %q", err.Error(), tt.wantIn)
+			}
+		})
+	}
+}
+
+// TestOpenAICompatReasoningOnlyCompletionIsDiagnosed covers the
+// non-streaming sibling of the same seam.
+func TestOpenAICompatReasoningOnlyCompletionIsDiagnosed(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"model":"m","choices":[{"message":{"role":"assistant","reasoning":"deep thoughts"},"finish_reason":"length"}]}`))
+	}))
+	defer srv.Close()
+
+	c := NewOpenAICompatClient(srv.URL, "", "test", "res", nil, 0)
+	_, err := c.Chat(context.Background(), "m", []llm.Message{{Role: "user", Content: "hi"}}, nil)
+	if err == nil {
+		t.Fatal("want error for a reasoning-only completion")
+	}
+	if !strings.Contains(err.Error(), "produced only reasoning") {
+		t.Errorf("error %q missing reasoning diagnosis", err.Error())
+	}
+	if !strings.Contains(err.Error(), `finish_reason="length"`) {
+		t.Errorf("error %q missing finish_reason", err.Error())
+	}
+}

--- a/internal/model/fleet/providers/openaicompat_wire.go
+++ b/internal/model/fleet/providers/openaicompat_wire.go
@@ -180,12 +180,48 @@ type openAICompatMessageResponse struct {
 	Role      string                      `json:"role,omitempty"`
 	Content   any                         `json:"content,omitempty"`
 	ToolCalls []openAICompatToolCallDelta `json:"tool_calls,omitempty"`
+	// The thinking channel of reasoning models, separate from content.
+	// Runners disagree on the key: Ollama emits "reasoning",
+	// DeepSeek-style servers emit "reasoning_content". Decoded so a
+	// reasoning-only completion can be told apart from an empty one —
+	// undecoded, a gpt-oss answer that died mid-think reported as
+	// "empty" with hundreds of frames.
+	Reasoning        string `json:"reasoning,omitempty"`
+	ReasoningContent string `json:"reasoning_content,omitempty"`
+}
+
+// reasoningText returns whichever reasoning-channel key the server
+// populated ("" when neither).
+func (m *openAICompatMessageResponse) reasoningText() string {
+	if m == nil {
+		return ""
+	}
+	if m.Reasoning != "" {
+		return m.Reasoning
+	}
+	return m.ReasoningContent
 }
 
 type openAICompatChatDelta struct {
 	Role      string                      `json:"role,omitempty"`
 	Content   string                      `json:"content,omitempty"`
 	ToolCalls []openAICompatToolCallDelta `json:"tool_calls,omitempty"`
+	// See openAICompatMessageResponse: the same two spellings of the
+	// thinking channel, delivered incrementally.
+	Reasoning        string `json:"reasoning,omitempty"`
+	ReasoningContent string `json:"reasoning_content,omitempty"`
+}
+
+// reasoningText returns whichever reasoning-channel key this delta
+// carries ("" when neither).
+func (d *openAICompatChatDelta) reasoningText() string {
+	if d == nil {
+		return ""
+	}
+	if d.Reasoning != "" {
+		return d.Reasoning
+	}
+	return d.ReasoningContent
 }
 
 type openAICompatToolCallDelta struct {

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=69
 interfaces=87
-large_files=58
+large_files=59
 set_mutators=122
 database_opens=9


### PR DESCRIPTION
## "Empty stream (frames=814)" was a model thinking hard and never being heard

The 2026-08-31 audit found nine production failures of the new `openai_compat` provider (#1405, the spark gpt-oss:120b cutover) shaped like `returned an empty stream for model "gpt-oss:120b" (frames=814)` — hundreds of frames, declared empty. The wire types never decoded the thinking channel: gpt-oss streams its reasoning as `delta.reasoning`, the reader recognized only `delta.content` and tool calls, so an answer that died mid-think was silently discarded frame by frame and then refused under a diagnosis that points at a dead runner. The distinction matters operationally — this provider is the local failover target, and "the runner returned nothing" versus "the model exhausted its token budget before leaving the reasoning channel" versus "the runner's chat template routes the final answer into the reasoning field" lead to three different fixes, only one of which is thane's.

## What changes

The wire structs decode both spellings of the channel — Ollama's `reasoning` and DeepSeek-style `reasoning_content` — on the streaming delta and the non-streaming message, with a shared accessor. The refusal contract is untouched: a completion with no content and no tool calls has no answer to return, and fabricating an empty success is exactly what this client exists to refuse. But the reasoning-only case now gets its own error naming the reasoning volume, frame count, and `finish_reason` — `finish_reason="length"` says raise the budget; `"stop"` with a full reasoning channel says fix the runner template. Reasoning text itself stays out of the error string deliberately: it would land in logs, and thinking content doesn't belong there. Sizes tell the story.

Two smaller consequences fall out naturally. Reasoning deltas now count as generation for the time-to-first-token measurement — the model is producing tokens, so prefill and queueing are over, and a reasoning model no longer reports a zero first-token time on a stream that then fails. And reasoning stays out of both the callback token stream and the accumulated content, pinned by test, so nothing upstream starts seeing thinking as answer text.

## What this deliberately does not do

It does not surface reasoning to the llm layer — `llm.ChatResponse` has no thinking representation today, and inventing one is a model-facing design decision (how the iteration layer, transcripts, and logging should treat thinking) that deserves its own arc, not a rider on a diagnosis fix.

## Test plan

- [x] `just ci` green locally (full gate, fresh worktree; architecture baseline regenerated via `scripts/architecture.sh update` for the test-file growth)
- [x] New: `TestOpenAICompatReasoningOnlyStreamIsDiagnosed` (both channel spellings, budget-death and template shapes, scaffolding-only still reports "empty stream", reasoning-then-content completes with reasoning excluded from the callback stream) and `TestOpenAICompatReasoningOnlyCompletionIsDiagnosed` (non-streaming sibling, asserts finish_reason lands in the error)
- [x] Existing empty-stream/truncation/finish_reason suites unchanged and green
- [ ] Post-deploy: the next spark gpt-oss failure logs the reasoning diagnosis with finish_reason, settling whether the fix is num_predict or the runner template

🤖 Generated with [Claude Code](https://claude.com/claude-code)
