### PR TITLE
fix(companion): classify calendar_sharing_disabled as a setting, not a fault

### DIFF
--- a/internal/integrations/companion/calendar_snapshot.go
+++ b/internal/integrations/companion/calendar_snapshot.go
@@ -365,6 +365,12 @@ func (s *CalendarSnapshot) recordSharingDisabled(account string) {
 	s.sharingOff[account] = true
 	s.failures[account] = 0
 	s.retryAt[account] = s.now().Add(calendarSnapshotMaxBackoff)
+	// The operator's choice takes effect in the prompt immediately:
+	// events fetched while sharing was still on must not keep rendering
+	// beside the disabled flag — a connected Mac never hits the render
+	// cutoff, so without this the stale snapshot would outlive the
+	// setting indefinitely.
+	delete(s.snapshots, account)
 	s.mu.Unlock()
 	if transition {
 		s.logger.Info("calendar sharing disabled in the companion app; probing quietly",

--- a/internal/integrations/companion/calendar_snapshot.go
+++ b/internal/integrations/companion/calendar_snapshot.go
@@ -3,6 +3,7 @@ package companion
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sort"
@@ -104,6 +105,13 @@ type CalendarSnapshot struct {
 	retryAt   map[string]time.Time
 	capable   map[string]string // account → sorted capable client_ids fingerprint
 	attempts  map[string]time.Time
+	// sharingOff marks accounts whose companion refused with
+	// calendar_sharing_disabled — an operator setting, not a fault.
+	// Deliberately NOT cleared by the capability-fingerprint reset:
+	// connection churn on a still-disabled account must stay silent,
+	// while the reset's retryAt clearing already re-probes each fresh
+	// connection immediately.
+	sharingOff map[string]bool
 
 	nudge chan struct{}
 }
@@ -122,18 +130,19 @@ func newCalendarSnapshot(list calendarProviderLister, call func(context.Context,
 		homeZone = time.Local
 	}
 	return &CalendarSnapshot{
-		list:      list,
-		call:      call,
-		homeZone:  homeZone,
-		now:       time.Now,
-		logger:    logger.With("component", "calendar_snapshot"),
-		snapshots: make(map[string]accountCalendarSnapshot),
-		pinned:    make(map[string]string),
-		failures:  make(map[string]int),
-		retryAt:   make(map[string]time.Time),
-		capable:   make(map[string]string),
-		attempts:  make(map[string]time.Time),
-		nudge:     make(chan struct{}, 1),
+		list:       list,
+		call:       call,
+		homeZone:   homeZone,
+		now:        time.Now,
+		logger:     logger.With("component", "calendar_snapshot"),
+		snapshots:  make(map[string]accountCalendarSnapshot),
+		pinned:     make(map[string]string),
+		failures:   make(map[string]int),
+		retryAt:    make(map[string]time.Time),
+		capable:    make(map[string]string),
+		attempts:   make(map[string]time.Time),
+		sharingOff: make(map[string]bool),
+		nudge:      make(chan struct{}, 1),
 	}
 }
 
@@ -299,6 +308,14 @@ func (s *CalendarSnapshot) refreshAccount(ctx context.Context, account, clientID
 		if ctx.Err() != nil {
 			return
 		}
+		// A refusal that encodes configuration is not a fault: the
+		// operator switched calendar sharing off on purpose, and no
+		// amount of retrying changes a setting.
+		var refusal *Error
+		if errors.As(err, &refusal) && refusal.Code == calendarErrCodeSharingDisabled {
+			s.recordSharingDisabled(account)
+			return
+		}
 		s.recordFailure(account, err)
 		return
 	}
@@ -311,8 +328,10 @@ func (s *CalendarSnapshot) refreshAccount(ctx context.Context, account, clientID
 
 	s.mu.Lock()
 	recovered := s.failures[account] > 0
+	restored := s.sharingOff[account]
 	s.failures[account] = 0
 	delete(s.retryAt, account)
+	delete(s.sharingOff, account)
 	s.snapshots[account] = accountCalendarSnapshot{
 		Account:   account,
 		ClientID:  clientID,
@@ -321,8 +340,35 @@ func (s *CalendarSnapshot) refreshAccount(ctx context.Context, account, clientID
 		Truncated: resp.Truncated,
 	}
 	s.mu.Unlock()
+	if restored {
+		s.logger.Info("calendar sharing re-enabled", "account", account, "events", len(resp.Events))
+	}
 	if recovered {
 		s.logger.Info("calendar snapshot recovered", "account", account, "events", len(resp.Events))
+	}
+}
+
+// calendarErrCodeSharingDisabled is the companion app's refusal code for
+// an account whose operator has calendar sharing switched off.
+const calendarErrCodeSharingDisabled = "calendar_sharing_disabled"
+
+// recordSharingDisabled handles that refusal as what it is — a chosen
+// setting, not a fault. The account takes no failure count and no WARN;
+// the transition logs once at Info, and the account re-probes quietly at
+// the backoff cap so a flipped setting is noticed within the cap even
+// without a reconnect (a reconnect re-probes immediately: the
+// capability-fingerprint reset clears retryAt but not sharingOff, so
+// connection churn on a still-disabled account stays silent).
+func (s *CalendarSnapshot) recordSharingDisabled(account string) {
+	s.mu.Lock()
+	transition := !s.sharingOff[account]
+	s.sharingOff[account] = true
+	s.failures[account] = 0
+	s.retryAt[account] = s.now().Add(calendarSnapshotMaxBackoff)
+	s.mu.Unlock()
+	if transition {
+		s.logger.Info("calendar sharing disabled in the companion app; probing quietly",
+			"account", account)
 	}
 }
 
@@ -369,6 +415,10 @@ func (s *CalendarSnapshot) TagContext(context.Context, agentctx.ContextRequest) 
 	for account, at := range s.attempts {
 		attempts[account] = at
 	}
+	sharingOff := make(map[string]bool, len(s.sharingOff))
+	for account, off := range s.sharingOff {
+		sharingOff[account] = off
+	}
 	s.mu.RUnlock()
 
 	// Connectivity means calendar-capable connectivity: an account whose
@@ -390,7 +440,9 @@ func (s *CalendarSnapshot) TagContext(context.Context, agentctx.ContextRequest) 
 		if !connected[snap.Account] && now.Sub(snap.FetchedAt) > calendarSnapshotRenderCutoff {
 			continue
 		}
-		accounts = append(accounts, s.renderAccount(snap, now, connected[snap.Account]))
+		row := s.renderAccount(snap, now, connected[snap.Account])
+		row.SharingDisabled = sharingOff[snap.Account]
+		accounts = append(accounts, row)
 	}
 	// The honest-absence row: a capable companion is connected but no
 	// fetch has ever succeeded. Without it, a permission-blocked Mac and
@@ -401,6 +453,7 @@ func (s *CalendarSnapshot) TagContext(context.Context, agentctx.ContextRequest) 
 			continue
 		}
 		row := renderedCalendarAccount{Account: account, Client: clientID, Unavailable: true}
+		row.SharingDisabled = sharingOff[account]
 		if at, ok := attempts[account]; ok {
 			row.LastAttemptAge = promptfmt.FormatDeltaOnly(at, now)
 		}
@@ -444,6 +497,14 @@ type renderedCalendarAccount struct {
 	// design forbids.
 	Unavailable    bool   `json:"unavailable,omitempty"`
 	LastAttemptAge string `json:"last_attempt_age,omitempty"`
+
+	// SharingDisabled names the cause when the companion is connected
+	// but refuses calendar reads: the operator has calendar sharing
+	// switched off in the companion app. This absence is chosen —
+	// don't suggest fixing connectivity or permissions; the operator
+	// can enable it in the companion app's Settings > Calendar if they
+	// want this account's calendar visible.
+	SharingDisabled bool `json:"sharing_disabled,omitempty"`
 }
 
 // renderedCalendarEvent reuses the tool renderer's field vocabulary. The

--- a/internal/integrations/companion/calendar_snapshot_test.go
+++ b/internal/integrations/companion/calendar_snapshot_test.go
@@ -799,22 +799,49 @@ func TestCalendarSnapshotSharingDisabledIsAStateNotAFault(t *testing.T) {
 }
 
 // TestCalendarSnapshotRenderNamesSharingDisabled: the model reads the
-// cause, not just the absence.
+// cause, not just the absence — and events fetched while sharing was
+// still on stop rendering the moment the operator turns it off, since
+// a connected Mac never reaches the render cutoff that would otherwise
+// age them out.
 func TestCalendarSnapshotRenderNamesSharingDisabled(t *testing.T) {
 	base := time.Date(2026, 8, 31, 10, 0, 0, 0, time.UTC)
+	now := base
 	fake := &calendarFake{
 		infos: []ProviderInfo{calendarProvider("deepslate", "mac-mini")},
-		err: &Error{
-			Code:    "calendar_sharing_disabled",
-			Message: "Calendar sharing is disabled in the macOS companion app.",
-		},
+		response: snapshotCalendarResponse{Events: []snapshotCalendarEvent{{
+			Title: "Private Standup",
+			Start: base.Add(time.Hour).Format(time.RFC3339),
+			End:   base.Add(2 * time.Hour).Format(time.RFC3339),
+		}}},
 	}
 	s := snapshotUnderTest(t, fake, base)
-	s.refreshAll(context.Background())
+	s.now = func() time.Time { return now }
 
+	// Sharing on: the event renders.
+	s.refreshAll(context.Background())
 	block, err := s.TagContext(context.Background(), agentctx.ContextRequest{})
 	if err != nil {
 		t.Fatalf("TagContext: %v", err)
+	}
+	if !strings.Contains(block, "Private Standup") {
+		t.Fatalf("expected the fetched event to render while sharing is on:\n%s", block)
+	}
+
+	// The operator turns sharing off: the cached events leave the
+	// prompt immediately, and the block names the cause.
+	fake.err = &Error{
+		Code:    "calendar_sharing_disabled",
+		Message: "Calendar sharing is disabled in the macOS companion app.",
+	}
+	now = now.Add(calendarSnapshotInterval + time.Second)
+	s.refreshAll(context.Background())
+
+	block, err = s.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	if strings.Contains(block, "Private Standup") {
+		t.Errorf("previously cached events still render after sharing was disabled:\n%s", block)
 	}
 	if !strings.Contains(block, `"sharing_disabled":true`) {
 		t.Errorf("rendered block missing sharing_disabled cause:\n%s", block)

--- a/internal/integrations/companion/calendar_snapshot_test.go
+++ b/internal/integrations/companion/calendar_snapshot_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -720,5 +721,102 @@ func TestCalendarSnapshotUnavailableRowCarriesNoSnapshotAge(t *testing.T) {
 	out, _ := s.TagContext(context.Background(), agentctx.ContextRequest{})
 	if strings.Contains(out, `"snapshot_age"`) {
 		t.Fatalf("a row stating no snapshot exists must not carry an empty age:\n%s", out)
+	}
+}
+
+// TestCalendarSnapshotSharingDisabledIsAStateNotAFault pins the
+// classification the production deepslate account needed: the
+// companion's calendar_sharing_disabled refusal is an operator setting.
+// No WARN, no failure count — one Info on the transition in, silence
+// through re-probes and connection churn, and one Info on the way out.
+func TestCalendarSnapshotSharingDisabledIsAStateNotAFault(t *testing.T) {
+	base := time.Date(2026, 8, 31, 10, 0, 0, 0, time.UTC)
+	now := base
+	fake := &calendarFake{
+		infos: []ProviderInfo{calendarProvider("deepslate", "mac-mini")},
+		err: &Error{
+			Code:    "calendar_sharing_disabled",
+			Message: "Calendar sharing is disabled in the macOS companion app.",
+		},
+	}
+	var logBuf strings.Builder
+	s := newCalendarSnapshot(fake.list, fake.call, chicagoZone(t),
+		slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	s.now = func() time.Time { return now }
+
+	s.refreshAll(context.Background())
+
+	if got := strings.Count(logBuf.String(), "level=WARN"); got != 0 {
+		t.Errorf("WARN lines = %d, want 0\nlog:\n%s", got, logBuf.String())
+	}
+	if got := strings.Count(logBuf.String(), "calendar sharing disabled"); got != 1 {
+		t.Errorf("disabled-transition Info lines = %d, want 1\nlog:\n%s", got, logBuf.String())
+	}
+	s.mu.RLock()
+	failures, sharingOff := s.failures["deepslate"], s.sharingOff["deepslate"]
+	s.mu.RUnlock()
+	if failures != 0 {
+		t.Errorf("failures = %d, want 0 — a setting is not a fault", failures)
+	}
+	if !sharingOff {
+		t.Fatal("sharingOff not recorded")
+	}
+
+	// Quiet: passes inside the probe window do not call, connection
+	// churn (fingerprint reset clears retryAt) re-probes silently, and
+	// a still-disabled probe logs nothing new.
+	for i := 0; i < 5; i++ {
+		s.refreshAll(context.Background())
+	}
+	if len(fake.calls) != 1 {
+		t.Fatalf("probe window eroded: %d calls, want 1", len(fake.calls))
+	}
+	fake.infos = []ProviderInfo{calendarProviderIncarnation("deepslate", "mac-mini", "conn-2")}
+	s.refreshAll(context.Background()) // reconnect → immediate silent re-probe
+	if len(fake.calls) != 2 {
+		t.Fatalf("reconnect did not re-probe: %d calls", len(fake.calls))
+	}
+	if got := strings.Count(logBuf.String(), "calendar sharing disabled"); got != 1 {
+		t.Errorf("still-disabled re-probe logged again: %d transition lines\nlog:\n%s", got, logBuf.String())
+	}
+
+	// The operator flips the setting back on: the next probe restores
+	// the account with one Info and a real snapshot.
+	fake.err = nil
+	fake.response = snapshotCalendarResponse{}
+	now = now.Add(calendarSnapshotMaxBackoff + time.Second)
+	s.refreshAll(context.Background())
+	if got := strings.Count(logBuf.String(), "calendar sharing re-enabled"); got != 1 {
+		t.Errorf("re-enabled Info lines = %d, want 1\nlog:\n%s", got, logBuf.String())
+	}
+	s.mu.RLock()
+	_, haveSnap := s.snapshots["deepslate"]
+	stillOff := s.sharingOff["deepslate"]
+	s.mu.RUnlock()
+	if !haveSnap || stillOff {
+		t.Fatalf("restore incomplete: snapshot=%v sharingOff=%v", haveSnap, stillOff)
+	}
+}
+
+// TestCalendarSnapshotRenderNamesSharingDisabled: the model reads the
+// cause, not just the absence.
+func TestCalendarSnapshotRenderNamesSharingDisabled(t *testing.T) {
+	base := time.Date(2026, 8, 31, 10, 0, 0, 0, time.UTC)
+	fake := &calendarFake{
+		infos: []ProviderInfo{calendarProvider("deepslate", "mac-mini")},
+		err: &Error{
+			Code:    "calendar_sharing_disabled",
+			Message: "Calendar sharing is disabled in the macOS companion app.",
+		},
+	}
+	s := snapshotUnderTest(t, fake, base)
+	s.refreshAll(context.Background())
+
+	block, err := s.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	if !strings.Contains(block, `"sharing_disabled":true`) {
+		t.Errorf("rendered block missing sharing_disabled cause:\n%s", block)
 	}
 }

--- a/internal/integrations/companion/handler_test.go
+++ b/internal/integrations/companion/handler_test.go
@@ -3,6 +3,7 @@ package companion
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -800,5 +801,106 @@ func TestCanonicalPathNoDeprecation(t *testing.T) {
 	readJSON(t, conn, &ok)
 	if ok.Deprecation != nil {
 		t.Errorf("canonical path auth_ok carried a deprecation notice: %+v", ok.Deprecation)
+	}
+}
+
+// TestRegistryCallPreservesStructuredRefusal pins the request-boundary
+// contract the calendar snapshot classifies on: a companion answering
+// Success:false with a structured Error must reach callers as the same
+// "code: message" text the path always produced AND classify by code
+// via errors.As. The snapshot lifecycle tests inject *Error directly,
+// so only this test would catch a regression that flattens the refusal
+// back into fmt.Errorf at the boundary.
+func TestRegistryCallPreservesStructuredRefusal(t *testing.T) {
+	registry := NewRegistry(nil)
+	handler := NewHandler(testTokenIndex(), registry, nil)
+	mux := http.NewServeMux()
+	mux.Handle("GET /v1/companion/ws", handler)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	wsURL := "ws" + srv.URL[len("http"):] + "/v1/companion/ws"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	var authReq authRequired
+	readJSON(t, conn, &authReq)
+	conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	if err := conn.WriteJSON(authMessage{
+		Type:       typeAuth,
+		Token:      "test-secret",
+		ClientName: "Calendar Host",
+		ClientID:   "test-uuid-refusal",
+	}); err != nil {
+		t.Fatalf("send auth: %v", err)
+	}
+	var ok authOK
+	readJSON(t, conn, &ok)
+
+	conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	if err := conn.WriteJSON(registerCapabilitiesMessage{
+		ID:   1,
+		Type: typeRegisterCaps,
+		Capabilities: []Capability{{
+			Name:    "macos.calendar",
+			Version: "1",
+			Methods: []string{"list_events"},
+		}},
+	}); err != nil {
+		t.Fatalf("send capability registration: %v", err)
+	}
+	var ack Message
+	readJSON(t, conn, &ack)
+	if !ack.Success {
+		t.Fatalf("expected successful capability ack, got %+v", ack)
+	}
+
+	answered := make(chan error, 1)
+	go func() {
+		var req companionRequestMessage
+		conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+		if err := conn.ReadJSON(&req); err != nil {
+			answered <- fmt.Errorf("read companion request: %w", err)
+			return
+		}
+		conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+		answered <- conn.WriteJSON(Message{
+			ID:      req.ID,
+			Type:    typeResult,
+			Success: false,
+			Error: &Error{
+				Code:    "calendar_sharing_disabled",
+				Message: "Calendar sharing is disabled in the macOS companion app.",
+			},
+		})
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err = registry.Call(ctx, CallRequest{
+		Account:    "nugget",
+		Capability: "macos.calendar",
+		Method:     "list_events",
+	})
+	if err == nil {
+		t.Fatal("expected the structured refusal as an error, got nil")
+	}
+	if sendErr := <-answered; sendErr != nil {
+		t.Fatal(sendErr)
+	}
+
+	const wantText = "calendar_sharing_disabled: Calendar sharing is disabled in the macOS companion app."
+	if err.Error() != wantText {
+		t.Errorf("error text = %q, want byte-identical %q", err.Error(), wantText)
+	}
+	var refusal *Error
+	if !errors.As(err, &refusal) {
+		t.Fatalf("errors.As failed to recover *Error from %T", err)
+	}
+	if refusal.Code != "calendar_sharing_disabled" {
+		t.Errorf("recovered code = %q, want calendar_sharing_disabled", refusal.Code)
 	}
 }

--- a/internal/integrations/companion/message.go
+++ b/internal/integrations/companion/message.go
@@ -57,6 +57,16 @@ type Error struct {
 	Message string `json:"message"`
 }
 
+// Error implements the error interface so a companion refusal can be
+// classified by Code via errors.As without losing the wire text. The
+// format is byte-identical to the "code: message" string the request
+// path has always produced — some refusals encode configuration rather
+// than failure (calendar_sharing_disabled), and flattening them to a
+// string forced consumers to treat every refusal as a fault.
+func (e *Error) Error() string {
+	return e.Code + ": " + e.Message
+}
+
 // authRequired is the first message the server sends after WebSocket upgrade.
 type authRequired struct {
 	Type    string `json:"type"`

--- a/internal/integrations/companion/provider.go
+++ b/internal/integrations/companion/provider.go
@@ -259,7 +259,9 @@ func (r *Registry) Call(ctx context.Context, req CallRequest) (json.RawMessage, 
 		}
 		if !msg.Success {
 			if msg.Error != nil {
-				return nil, fmt.Errorf("%s: %s", msg.Error.Code, msg.Error.Message)
+				// Returned as-is (same "code: message" text) so callers
+				// can classify by Code via errors.As.
+				return nil, msg.Error
 			}
 			return nil, fmt.Errorf("companion request failed")
 		}

--- a/talents/companion.md
+++ b/talents/companion.md
@@ -70,6 +70,11 @@ How to work here:
   snapshot-age, stale, and offline fields over assumptions about
   freshness; when it reads truncated, or you need more than two days
   out, pull the window you need with `macos_calendar_events`.
+  An account marked `sharing_disabled` has calendar sharing switched
+  off in its companion app by the operator — a chosen setting, not a
+  fault. Don't retry, and don't diagnose connectivity or permissions;
+  if the operator wants that account visible, they enable it in the
+  companion app's Settings > Calendar.
 - These are read surfaces — inspect before you expect to change
   anything. Writing host data (e.g. creating calendar events) is gated
   separately and is not available just because a read tool is.


### PR DESCRIPTION
## A setting is not a fault

Production's `deepslate` account has calendar sharing switched off in its macOS companion app. That is an operator choice — and the calendar snapshot kept diagnosing it as a failure: `calendar snapshot refresh failed; backing off` at WARN, re-earned on every reconnect cycle, forever, for a state that no amount of retrying will change. The existing `recordFailure` coalescing was doing its job for real faults (lid-closed Macs, flaky links); the mismatch was upstream of it, in treating a capability statement as an error at all.

## Classification rides structure, not string matching

The companion protocol already carries a structured refusal — `{code, message}` — but the request path flattened it into `fmt.Errorf("%s: %s", …)`, so consumers could only string-match. The `Error` type now implements the error interface with byte-identical text, the request path returns it unflattened, and the snapshot classifies by `Code`. Every other consumer sees exactly the string it always saw; the only new capability is `errors.As`.

A `calendar_sharing_disabled` refusal now becomes a quiet per-account state: no failure count, no WARN. The transition in logs once at Info; re-probes and connection churn stay silent (the capability-fingerprint reset deliberately clears `retryAt` but not the sharing state, so a fresh connection re-probes immediately without re-narrating); the account keeps probing at the backoff cap so a flipped setting is noticed within two hours even without a reconnect; and the first successful fetch logs `calendar sharing re-enabled` on its way to restoring the snapshot.

## The model reads the cause, not just the absence

The rendered Calendar block gains `sharing_disabled` beside the existing `unavailable`, so a connected-but-refusing account stops reading like a permission-blocked Mac. The field's doc and the companion talent both teach the operational meaning: this absence is chosen — don't retry, don't diagnose connectivity, and the operator can flip it in the companion app's Settings > Calendar if they want the account visible. (The talent edit rides in `talents/`; note the prod talents backport is its own step per the usual deploy flow.)

## Test plan

- [x] `just ci` green locally (full gate, fresh worktree)
- [x] `TestCalendarSnapshotSharingDisabledIsAStateNotAFault` — drives the full lifecycle against the production shape: no WARN, one Info in, silent re-probe and silent reconnect churn, quiet probe window at the cap, one Info out with the snapshot restored
- [x] `TestCalendarSnapshotRenderNamesSharingDisabled` — the block carries `"sharing_disabled":true`
- [x] Existing snapshot/backoff/reconnect suites and companion package green under `-race`
- [ ] Post-deploy: deepslate shows `sharing_disabled` in the Calendar block and produces zero calendar WARNs

Closes #1475

🤖 Generated with [Claude Code](https://claude.com/claude-code)
