### PR TITLE
perf(ha): serve watchlist state reads from a TTL cache refreshed by our own event feed

### DIFF
--- a/internal/app/new_awareness.go
+++ b/internal/app/new_awareness.go
@@ -147,9 +147,19 @@ func (a *App) initAwareness(s *newState) error {
 	var (
 		watchlistProvider *awareness.WatchlistProvider
 		loopSubProvider   *awareness.LoopSubscriptionProvider
+		haStateReads      *homeassistant.StateReadCache
 	)
 	if a.ha != nil {
-		watchlistProvider = awareness.NewWatchlistProvider(watchlistStore, a.ha, logger)
+		// The read cache sits between the renderers and the REST
+		// client so the serial context walk stops paying one HTTP
+		// round-trip per subscribed entity per turn (#1473). It is
+		// constructed here, before the state watcher exists, and its
+		// event tap is attached in the watcher section below — the
+		// same deferred-wiring pattern the state-window provider uses.
+		// The registry client stays the concrete a.ha: registry reads
+		// are a different interface with their own cache.
+		haStateReads = homeassistant.NewStateReadCache(a.ha)
+		watchlistProvider = awareness.NewWatchlistProvider(watchlistStore, haStateReads, logger)
 		watchlistProvider.SetRegistryClient(a.ha)
 		a.loop.RegisterAlwaysContextProvider(watchlistProvider)
 
@@ -160,7 +170,7 @@ func (a *App) initAwareness(s *newState) error {
 		// scope_tag indirection. Loop-scoped, not always-on: a loop's
 		// declared watch set is its eyes, and a task-mode worker keeps
 		// its eyes while shedding the ambient identity (#1363).
-		loopSubProvider = awareness.NewLoopSubscriptionProvider(a.loopRegistry, watchlistStore, a.ha, logger)
+		loopSubProvider = awareness.NewLoopSubscriptionProvider(a.loopRegistry, watchlistStore, haStateReads, logger)
 		loopSubProvider.SetRegistryClient(a.ha)
 		a.loop.RegisterLoopScopedContextProvider(loopSubProvider)
 
@@ -516,6 +526,12 @@ func (a *App) initAwareness(s *newState) error {
 		watcher := homeassistant.NewStateWatcher(a.haWS.Events(), filter, limiter, handler, logger)
 		if s.personTracker != nil {
 			watcher.AddStateChangeHandler(s.personTracker.HandleHAStateChange)
+		}
+		// Keep the read cache push-fresh for every entity the ingest
+		// filter admits; entities outside the filter stay TTL-bounded
+		// read-through, which is the cache's correctness floor anyway.
+		if haStateReads != nil {
+			watcher.AddStateChangeHandler(haStateReads.HandleStateChange)
 		}
 		a.haStateWatcher = watcher
 		a.ingestFilterRebuild = func() {

--- a/internal/integrations/homeassistant/state_read_cache.go
+++ b/internal/integrations/homeassistant/state_read_cache.go
@@ -48,8 +48,9 @@ type StateReadCache struct {
 	ttl   time.Duration
 	now   func() time.Time // injectable clock; nil uses time.Now
 
-	mu      sync.RWMutex
-	entries map[string]stateCacheEntry
+	mu       sync.RWMutex
+	entries  map[string]stateCacheEntry
+	inflight map[string]*inflightFetch
 }
 
 type stateCacheEntry struct {
@@ -57,15 +58,31 @@ type stateCacheEntry struct {
 	at    time.Time
 }
 
+// inflightFetch coalesces concurrent misses for one entity: the first
+// caller fetches, everyone else waits on done. state/err are written
+// before done closes, so readers after <-done see them without a lock.
+type inflightFetch struct {
+	done  chan struct{}
+	state *State
+	err   error
+}
+
+// stateReadFetchTimeout bounds the shared read-through fetch. The fetch
+// runs on a detached context on purpose: it serves every caller waiting
+// on the same entity, so one caller's cancellation must not poison the
+// result for the rest — an abandoning caller just stops waiting.
+const stateReadFetchTimeout = 15 * time.Second
+
 // NewStateReadCache wraps inner (the REST client in production) with
 // the read cache. Register [StateReadCache.HandleStateChange] on the
 // state watcher to keep ingest-covered entities push-fresh; the cache
 // works (TTL-bounded) without it.
 func NewStateReadCache(inner stateReader) *StateReadCache {
 	return &StateReadCache{
-		inner:   inner,
-		ttl:     stateReadCacheTTL,
-		entries: make(map[string]stateCacheEntry),
+		inner:    inner,
+		ttl:      stateReadCacheTTL,
+		entries:  make(map[string]stateCacheEntry),
+		inflight: make(map[string]*inflightFetch),
 	}
 }
 
@@ -77,10 +94,15 @@ func (c *StateReadCache) clock() time.Time {
 }
 
 // GetState serves the cached entity state when it is younger than the
-// TTL, otherwise fetches through and repopulates. A fetch error passes
-// through unchanged — a stale entry is never substituted for a live
-// failure, so sentinel handling downstream keeps seeing what it sees
-// today.
+// TTL, otherwise fetches through and repopulates. Concurrent misses for
+// the same entity coalesce onto one fetch — at a TTL boundary every
+// assembling loop misses together, and without coalescing the cache
+// would recreate exactly the per-loop REST fan-out it exists to
+// amortize. A fetch error passes through unchanged — a stale entry is
+// never substituted for a live failure, so sentinel handling downstream
+// keeps seeing what it sees today. A caller whose ctx dies stops
+// waiting; the shared fetch completes on its own detached bound and
+// still repopulates for everyone else.
 func (c *StateReadCache) GetState(ctx context.Context, entityID string) (*State, error) {
 	now := c.clock()
 	c.mu.RLock()
@@ -90,12 +112,53 @@ func (c *StateReadCache) GetState(ctx context.Context, entityID string) (*State,
 		return entry.state, nil
 	}
 
-	state, err := c.inner.GetState(ctx, entityID)
-	if err != nil {
-		return nil, err
+	c.mu.Lock()
+	// Re-check under the write lock: an event or a completed fetch may
+	// have landed while we waited for it.
+	if entry, ok := c.entries[entityID]; ok && c.clock().Sub(entry.at) < c.ttl {
+		c.mu.Unlock()
+		return entry.state, nil
 	}
-	c.store(entityID, cloneState(state), now)
-	return state, nil
+	if fl, ok := c.inflight[entityID]; ok {
+		c.mu.Unlock()
+		select {
+		case <-fl.done:
+			return fl.state, fl.err
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	fl := &inflightFetch{done: make(chan struct{})}
+	c.inflight[entityID] = fl
+	c.mu.Unlock()
+
+	go c.fetch(entityID, fl)
+
+	select {
+	case <-fl.done:
+		return fl.state, fl.err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// fetch performs the shared read-through for one entity and completes
+// the in-flight slot. The store is timestamped at fetch start, so an
+// event that arrives mid-flight (stamped later) wins over this
+// response in the monotonic store.
+func (c *StateReadCache) fetch(entityID string, fl *inflightFetch) {
+	ctx, cancel := context.WithTimeout(context.Background(), stateReadFetchTimeout)
+	defer cancel()
+	at := c.clock()
+	state, err := c.inner.GetState(ctx, entityID)
+	if err == nil {
+		c.store(entityID, cloneState(state), at)
+	}
+	fl.state, fl.err = state, err
+	c.mu.Lock()
+	delete(c.inflight, entityID)
+	c.mu.Unlock()
+	close(fl.done)
 }
 
 // HandleStateChange is a [StateChangeHandler]: it refreshes the cache
@@ -109,28 +172,42 @@ func (c *StateReadCache) HandleStateChange(change StateChangedData) {
 	c.store(change.NewState.EntityID, cloneState(change.NewState), c.clock())
 }
 
-// store inserts under the cap: at capacity it first sweeps expired
-// entries, then evicts the single stalest one — the cap is a backstop
-// against an unexpectedly wide event feed, not a tuning knob.
+// store installs an entry, monotonic per entity and bounded overall. A
+// write stamped strictly older than the existing entry is dropped: a
+// slow fetch completion (stamped at fetch start) must not roll the
+// cache back over an event that arrived mid-flight, and an older
+// concurrent fetch must not clobber a newer one. Same-instant writes
+// overwrite, so the in-order event stream always advances the entry
+// even under a coarse test clock. Under the cap, expired entries sweep
+// first and then the single stalest entry is evicted — seeded from the
+// map, never from the incoming timestamp, so an old-stamped insert
+// still makes room for itself.
 func (c *StateReadCache) store(entityID string, state *State, at time.Time) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if _, exists := c.entries[entityID]; !exists && len(c.entries) >= stateReadCacheMaxEntries {
+	if existing, exists := c.entries[entityID]; exists {
+		if at.Before(existing.at) {
+			return
+		}
+		c.entries[entityID] = stateCacheEntry{state: state, at: at}
+		return
+	}
+	if len(c.entries) >= stateReadCacheMaxEntries {
+		now := c.clock()
 		for id, entry := range c.entries {
-			if at.Sub(entry.at) >= c.ttl {
+			if now.Sub(entry.at) >= c.ttl {
 				delete(c.entries, id)
 			}
 		}
 		if len(c.entries) >= stateReadCacheMaxEntries {
-			oldestID, oldestAt := "", at
+			var oldestID string
+			var oldestAt time.Time
 			for id, entry := range c.entries {
-				if entry.at.Before(oldestAt) {
+				if oldestID == "" || entry.at.Before(oldestAt) {
 					oldestID, oldestAt = id, entry.at
 				}
 			}
-			if oldestID != "" {
-				delete(c.entries, oldestID)
-			}
+			delete(c.entries, oldestID)
 		}
 	}
 	c.entries[entityID] = stateCacheEntry{state: state, at: at}

--- a/internal/integrations/homeassistant/state_read_cache.go
+++ b/internal/integrations/homeassistant/state_read_cache.go
@@ -1,0 +1,173 @@
+package homeassistant
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// stateReadCacheTTL bounds how stale a cached entity state may be
+// served, regardless of how the entry arrived. The bound is deliberately
+// uniform: the event feed that refreshes entries can silently miss
+// updates three different ways (a reconnect window is not replayed, the
+// event channel evicts oldest on overflow, and the ingest rate limiter
+// suppresses a chatty entity's newest changes), so no entry is trusted
+// past the TTL no matter its source. Expiry falls through to one REST
+// fetch, which repopulates the entry for every concurrent reader.
+const stateReadCacheTTL = 30 * time.Second
+
+// stateReadCacheMaxEntries caps the cache. Read-through entries are
+// bounded by the subscription sets that fetch them and event entries by
+// the ingest filter, so the cap is a backstop, not a working limit.
+const stateReadCacheMaxEntries = 1024
+
+// stateReader is the slice of the REST client the cache decorates —
+// structurally identical to awareness.StateGetter, declared locally so
+// the dependency points from awareness to this package, not back.
+type stateReader interface {
+	GetState(ctx context.Context, entityID string) (*State, error)
+	GetStates(ctx context.Context) ([]State, error)
+	GetStateHistory(ctx context.Context, entityID string, startTime, endTime time.Time) ([]State, error)
+	GetWeatherForecasts(ctx context.Context, entityID, forecastType string) ([]map[string]any, error)
+}
+
+// StateReadCache decorates per-entity state reads with a short-TTL
+// cache refreshed opportunistically from the state_changed event feed.
+// It exists for the serial context-assembly walk (#1473): the watchlist
+// renderers pay one REST round-trip per concrete subscribed entity per
+// turn for state that mostly just flowed through our own WebSocket.
+// With the cache, entities on the ingest feed are served push-fresh
+// from memory, and everything else amortizes one fetch per TTL across
+// every concurrently assembling loop. Bulk, history, and forecast reads
+// pass through untouched — the glob path already memoizes per render.
+//
+// Returned states are shared and must be treated as read-only, the same
+// contract the event fan-out already imposes.
+type StateReadCache struct {
+	inner stateReader
+	ttl   time.Duration
+	now   func() time.Time // injectable clock; nil uses time.Now
+
+	mu      sync.RWMutex
+	entries map[string]stateCacheEntry
+}
+
+type stateCacheEntry struct {
+	state *State
+	at    time.Time
+}
+
+// NewStateReadCache wraps inner (the REST client in production) with
+// the read cache. Register [StateReadCache.HandleStateChange] on the
+// state watcher to keep ingest-covered entities push-fresh; the cache
+// works (TTL-bounded) without it.
+func NewStateReadCache(inner stateReader) *StateReadCache {
+	return &StateReadCache{
+		inner:   inner,
+		ttl:     stateReadCacheTTL,
+		entries: make(map[string]stateCacheEntry),
+	}
+}
+
+func (c *StateReadCache) clock() time.Time {
+	if c.now != nil {
+		return c.now()
+	}
+	return time.Now()
+}
+
+// GetState serves the cached entity state when it is younger than the
+// TTL, otherwise fetches through and repopulates. A fetch error passes
+// through unchanged — a stale entry is never substituted for a live
+// failure, so sentinel handling downstream keeps seeing what it sees
+// today.
+func (c *StateReadCache) GetState(ctx context.Context, entityID string) (*State, error) {
+	now := c.clock()
+	c.mu.RLock()
+	entry, ok := c.entries[entityID]
+	c.mu.RUnlock()
+	if ok && now.Sub(entry.at) < c.ttl {
+		return entry.state, nil
+	}
+
+	state, err := c.inner.GetState(ctx, entityID)
+	if err != nil {
+		return nil, err
+	}
+	c.store(entityID, cloneState(state), now)
+	return state, nil
+}
+
+// HandleStateChange is a [StateChangeHandler]: it refreshes the cache
+// from the event feed. It runs synchronously on the state-watcher loop,
+// so it only clones and stores. NewState is non-nil by the watcher's
+// contract.
+func (c *StateReadCache) HandleStateChange(change StateChangedData) {
+	if change.NewState == nil {
+		return
+	}
+	c.store(change.NewState.EntityID, cloneState(change.NewState), c.clock())
+}
+
+// store inserts under the cap: at capacity it first sweeps expired
+// entries, then evicts the single stalest one — the cap is a backstop
+// against an unexpectedly wide event feed, not a tuning knob.
+func (c *StateReadCache) store(entityID string, state *State, at time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, exists := c.entries[entityID]; !exists && len(c.entries) >= stateReadCacheMaxEntries {
+		for id, entry := range c.entries {
+			if at.Sub(entry.at) >= c.ttl {
+				delete(c.entries, id)
+			}
+		}
+		if len(c.entries) >= stateReadCacheMaxEntries {
+			oldestID, oldestAt := "", at
+			for id, entry := range c.entries {
+				if entry.at.Before(oldestAt) {
+					oldestID, oldestAt = id, entry.at
+				}
+			}
+			if oldestID != "" {
+				delete(c.entries, oldestID)
+			}
+		}
+	}
+	c.entries[entityID] = stateCacheEntry{state: state, at: at}
+}
+
+// cloneState copies the state and shallow-copies its attributes map, so
+// a stored entry cannot be mutated through the shared event payload
+// (nested attribute values keep the fan-out's read-only contract).
+func cloneState(s *State) *State {
+	if s == nil {
+		return nil
+	}
+	clone := *s
+	if s.Attributes != nil {
+		clone.Attributes = make(map[string]any, len(s.Attributes))
+		for k, v := range s.Attributes {
+			clone.Attributes[k] = v
+		}
+	}
+	return &clone
+}
+
+// GetStates passes through: the bulk snapshot is fetched at most once
+// per render and memoized there, and populating 15k entities into a
+// per-entity cache would trade a bounded map for the whole firehose.
+func (c *StateReadCache) GetStates(ctx context.Context) ([]State, error) {
+	return c.inner.GetStates(ctx)
+}
+
+// GetStateHistory passes through: history is a recorder query, not
+// current state.
+func (c *StateReadCache) GetStateHistory(ctx context.Context, entityID string, startTime, endTime time.Time) ([]State, error) {
+	return c.inner.GetStateHistory(ctx, entityID, startTime, endTime)
+}
+
+// GetWeatherForecasts passes through: forecasts are not state_changed
+// payloads and have their own cadence.
+func (c *StateReadCache) GetWeatherForecasts(ctx context.Context, entityID, forecastType string) ([]map[string]any, error) {
+	return c.inner.GetWeatherForecasts(ctx, entityID, forecastType)
+}

--- a/internal/integrations/homeassistant/state_read_cache_test.go
+++ b/internal/integrations/homeassistant/state_read_cache_test.go
@@ -3,6 +3,7 @@ package homeassistant
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 )
@@ -165,5 +166,200 @@ func TestStateReadCacheCapEvictsStalest(t *testing.T) {
 	}
 	if size > stateReadCacheMaxEntries {
 		t.Errorf("cache size %d exceeds cap %d", size, stateReadCacheMaxEntries)
+	}
+}
+
+// gatedStateReader blocks GetState until the gate opens, counting calls.
+type gatedStateReader struct {
+	mu    sync.Mutex
+	calls int
+	gate  chan struct{}
+	state State
+}
+
+func (g *gatedStateReader) GetState(_ context.Context, entityID string) (*State, error) {
+	g.mu.Lock()
+	g.calls++
+	g.mu.Unlock()
+	<-g.gate
+	s := g.state
+	s.EntityID = entityID
+	return &s, nil
+}
+
+func (g *gatedStateReader) callCount() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.calls
+}
+
+func (g *gatedStateReader) GetStates(context.Context) ([]State, error) { return nil, nil }
+func (g *gatedStateReader) GetStateHistory(context.Context, string, time.Time, time.Time) ([]State, error) {
+	return nil, nil
+}
+func (g *gatedStateReader) GetWeatherForecasts(context.Context, string, string) ([]map[string]any, error) {
+	return nil, nil
+}
+
+// testClock is a lock-guarded clock for tests whose fetch goroutines
+// read it concurrently with the test advancing it.
+type testClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func (c *testClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *testClock) Set(t time.Time) {
+	c.mu.Lock()
+	c.t = t
+	c.mu.Unlock()
+}
+
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for !cond() {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s", what)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
+// TestStateReadCacheCoalescesConcurrentMisses: at a TTL boundary every
+// loop misses together; exactly one fetch must serve them all, or the
+// cache recreates the fan-out it exists to remove.
+func TestStateReadCacheCoalescesConcurrentMisses(t *testing.T) {
+	t.Parallel()
+
+	gated := &gatedStateReader{gate: make(chan struct{}), state: State{State: "22.5"}}
+	c := NewStateReadCache(gated)
+
+	const readers = 8
+	var wg sync.WaitGroup
+	errs := make([]error, readers)
+	for i := 0; i < readers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, errs[i] = c.GetState(context.Background(), "sensor.shared")
+		}(i)
+	}
+
+	waitFor(t, "the leader to reach the reader", func() bool { return gated.callCount() >= 1 })
+	close(gated.gate)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("reader %d: %v", i, err)
+		}
+	}
+	if got := gated.callCount(); got != 1 {
+		t.Fatalf("inner calls = %d, want 1 (concurrent misses must coalesce)", got)
+	}
+}
+
+// TestStateReadCacheWaiterCancellationDoesNotPoisonFetch: an abandoning
+// caller gets its ctx error, while the shared fetch completes on its
+// detached bound and repopulates for everyone else.
+func TestStateReadCacheWaiterCancellationDoesNotPoisonFetch(t *testing.T) {
+	t.Parallel()
+
+	gated := &gatedStateReader{gate: make(chan struct{}), state: State{State: "locked"}}
+	c := NewStateReadCache(gated)
+
+	leaderDone := make(chan error, 1)
+	go func() {
+		_, err := c.GetState(context.Background(), "lock.front")
+		leaderDone <- err
+	}()
+	waitFor(t, "the leader to reach the reader", func() bool { return gated.callCount() >= 1 })
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := c.GetState(canceled, "lock.front"); err == nil {
+		t.Fatal("canceled waiter must return its ctx error, not block")
+	}
+
+	close(gated.gate)
+	if err := <-leaderDone; err != nil {
+		t.Fatalf("leader: %v", err)
+	}
+	got, err := c.GetState(context.Background(), "lock.front")
+	if err != nil || got.State != "locked" {
+		t.Fatalf("cache not populated after waiter cancellation: %v %v", got, err)
+	}
+	if gated.callCount() != 1 {
+		t.Fatalf("inner calls = %d, want 1", gated.callCount())
+	}
+}
+
+// TestStateReadCacheEventDuringFetchWins: a state_changed event that
+// lands while a REST fetch is in flight is newer truth; the late fetch
+// completion must not roll the cache back over it.
+func TestStateReadCacheEventDuringFetchWins(t *testing.T) {
+	t.Parallel()
+
+	gated := &gatedStateReader{gate: make(chan struct{}), state: State{State: "rest-stale"}}
+	c := NewStateReadCache(gated)
+	clk := &testClock{t: time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)}
+	c.now = clk.Now
+
+	leaderDone := make(chan struct{})
+	go func() {
+		defer close(leaderDone)
+		_, _ = c.GetState(context.Background(), "binary_sensor.door")
+	}()
+	waitFor(t, "the leader to reach the reader", func() bool { return gated.callCount() >= 1 })
+
+	clk.Set(clk.Now().Add(time.Second))
+	c.HandleStateChange(StateChangedData{NewState: &State{EntityID: "binary_sensor.door", State: "open"}})
+	close(gated.gate)
+	<-leaderDone
+
+	got, err := c.GetState(context.Background(), "binary_sensor.door")
+	if err != nil {
+		t.Fatalf("GetState: %v", err)
+	}
+	if got.State != "open" {
+		t.Fatalf("cache = %q, want the mid-flight event value %q", got.State, "open")
+	}
+}
+
+// TestStateReadCacheCapEvictionSeedsFromMap: an insert stamped older
+// than every existing entry must still make room for itself — the
+// eviction candidate seeds from the map, not the incoming timestamp.
+func TestStateReadCacheCapEvictionSeedsFromMap(t *testing.T) {
+	t.Parallel()
+
+	c := NewStateReadCache(&fakeStateReader{})
+	clk := &testClock{t: time.Date(2026, 8, 31, 13, 0, 0, 0, time.UTC)}
+	c.now = clk.Now
+
+	for i := 0; i < stateReadCacheMaxEntries; i++ {
+		c.HandleStateChange(StateChangedData{NewState: &State{
+			EntityID: fmt.Sprintf("sensor.future_%d", i), State: "x",
+		}})
+	}
+
+	// The straggler is stamped an hour earlier than everything cached.
+	clk.Set(clk.Now().Add(-time.Hour))
+	c.HandleStateChange(StateChangedData{NewState: &State{EntityID: "sensor.straggler", State: "y"}})
+
+	c.mu.RLock()
+	_, present := c.entries["sensor.straggler"]
+	size := len(c.entries)
+	c.mu.RUnlock()
+	if !present {
+		t.Fatal("old-stamped insert was refused instead of evicting the stalest entry")
+	}
+	if size > stateReadCacheMaxEntries {
+		t.Fatalf("cache size %d exceeds cap %d", size, stateReadCacheMaxEntries)
 	}
 }

--- a/internal/integrations/homeassistant/state_read_cache_test.go
+++ b/internal/integrations/homeassistant/state_read_cache_test.go
@@ -1,0 +1,169 @@
+package homeassistant
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// fakeStateReader counts calls and returns a scripted state.
+type fakeStateReader struct {
+	getStateCalls int
+	state         *State
+	err           error
+}
+
+func (f *fakeStateReader) GetState(_ context.Context, entityID string) (*State, error) {
+	f.getStateCalls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	s := *f.state
+	s.EntityID = entityID
+	return &s, nil
+}
+
+func (f *fakeStateReader) GetStates(context.Context) ([]State, error) { return nil, nil }
+func (f *fakeStateReader) GetStateHistory(context.Context, string, time.Time, time.Time) ([]State, error) {
+	return nil, nil
+}
+func (f *fakeStateReader) GetWeatherForecasts(context.Context, string, string) ([]map[string]any, error) {
+	return nil, nil
+}
+
+func cacheUnderTest(f *fakeStateReader, at time.Time) (*StateReadCache, *time.Time) {
+	c := NewStateReadCache(f)
+	now := at
+	c.now = func() time.Time { return now }
+	return c, &now
+}
+
+// TestStateReadCacheReadThroughAndTTL: the first read fetches, reads
+// within the TTL serve memory, and expiry falls through and
+// repopulates.
+func TestStateReadCacheReadThroughAndTTL(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeStateReader{state: &State{State: "22.5", Attributes: map[string]any{"unit": "°C"}}}
+	c, now := cacheUnderTest(fake, time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC))
+
+	ctx := context.Background()
+	if _, err := c.GetState(ctx, "sensor.office_temp"); err != nil {
+		t.Fatalf("GetState: %v", err)
+	}
+	for i := 0; i < 5; i++ {
+		if _, err := c.GetState(ctx, "sensor.office_temp"); err != nil {
+			t.Fatalf("cached GetState: %v", err)
+		}
+	}
+	if fake.getStateCalls != 1 {
+		t.Fatalf("inner calls = %d, want 1 (reads within TTL serve memory)", fake.getStateCalls)
+	}
+
+	*now = now.Add(stateReadCacheTTL + time.Second)
+	if _, err := c.GetState(ctx, "sensor.office_temp"); err != nil {
+		t.Fatalf("expired GetState: %v", err)
+	}
+	if fake.getStateCalls != 2 {
+		t.Fatalf("inner calls = %d, want 2 (expiry falls through)", fake.getStateCalls)
+	}
+}
+
+// TestStateReadCacheEventPrimesAndRefreshes: an event-fed entry serves
+// without any REST call, and a newer event replaces it.
+func TestStateReadCacheEventPrimesAndRefreshes(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeStateReader{state: &State{State: "unused"}}
+	c, _ := cacheUnderTest(fake, time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC))
+
+	c.HandleStateChange(StateChangedData{NewState: &State{
+		EntityID: "binary_sensor.garage", State: "off",
+	}})
+	got, err := c.GetState(context.Background(), "binary_sensor.garage")
+	if err != nil {
+		t.Fatalf("GetState: %v", err)
+	}
+	if got.State != "off" || fake.getStateCalls != 0 {
+		t.Fatalf("event-primed read: state=%q calls=%d, want off/0", got.State, fake.getStateCalls)
+	}
+
+	c.HandleStateChange(StateChangedData{NewState: &State{
+		EntityID: "binary_sensor.garage", State: "on",
+	}})
+	got, _ = c.GetState(context.Background(), "binary_sensor.garage")
+	if got.State != "on" {
+		t.Fatalf("event refresh not served: state=%q, want on", got.State)
+	}
+}
+
+// TestStateReadCacheClonesEventPayloads: mutating the shared event
+// payload after delivery must not corrupt the stored entry.
+func TestStateReadCacheClonesEventPayloads(t *testing.T) {
+	t.Parallel()
+
+	c, _ := cacheUnderTest(&fakeStateReader{}, time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC))
+	shared := &State{EntityID: "light.kitchen", State: "on", Attributes: map[string]any{"brightness": 200}}
+	c.HandleStateChange(StateChangedData{NewState: shared})
+
+	shared.State = "corrupted"
+	shared.Attributes["brightness"] = -1
+
+	got, err := c.GetState(context.Background(), "light.kitchen")
+	if err != nil {
+		t.Fatalf("GetState: %v", err)
+	}
+	if got.State != "on" || got.Attributes["brightness"] != 200 {
+		t.Fatalf("stored entry mutated through shared payload: %+v", got)
+	}
+}
+
+// TestStateReadCacheErrorPassesThrough: a fetch error surfaces
+// unchanged and never substitutes a stale entry.
+func TestStateReadCacheErrorPassesThrough(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeStateReader{state: &State{State: "ok"}}
+	c, now := cacheUnderTest(fake, time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC))
+
+	ctx := context.Background()
+	if _, err := c.GetState(ctx, "lock.front"); err != nil {
+		t.Fatalf("prime: %v", err)
+	}
+	*now = now.Add(stateReadCacheTTL + time.Second)
+	fake.err = fmt.Errorf("ha unreachable")
+	if _, err := c.GetState(ctx, "lock.front"); err == nil {
+		t.Fatal("expired read with failing inner must surface the error, not the stale entry")
+	}
+}
+
+// TestStateReadCacheCapEvictsStalest: at capacity the stalest entry
+// makes room; the cap never blocks a fresh store.
+func TestStateReadCacheCapEvictsStalest(t *testing.T) {
+	t.Parallel()
+
+	c, now := cacheUnderTest(&fakeStateReader{}, time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC))
+	for i := 0; i < stateReadCacheMaxEntries; i++ {
+		c.HandleStateChange(StateChangedData{NewState: &State{
+			EntityID: fmt.Sprintf("sensor.bulk_%d", i), State: "x",
+		}})
+		*now = now.Add(time.Millisecond)
+	}
+	c.HandleStateChange(StateChangedData{NewState: &State{EntityID: "sensor.newcomer", State: "y"}})
+
+	c.mu.RLock()
+	_, oldest := c.entries["sensor.bulk_0"]
+	_, newcomer := c.entries["sensor.newcomer"]
+	size := len(c.entries)
+	c.mu.RUnlock()
+	if oldest {
+		t.Error("stalest entry survived the cap eviction")
+	}
+	if !newcomer {
+		t.Error("fresh store blocked by the cap")
+	}
+	if size > stateReadCacheMaxEntries {
+		t.Errorf("cache size %d exceeds cap %d", size, stateReadCacheMaxEntries)
+	}
+}

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=69
-interfaces=87
+interfaces=88
 large_files=59
 set_mutators=122
 database_opens=9


### PR DESCRIPTION
## Thane was paying HA to be told what it just heard

The watchlist renderers — the always-on core watchlist and the per-loop subscription view — call `GetState` once per concrete subscribed entity per turn, serially, inside the shared context-assembly walk. Each call is a REST round-trip to Home Assistant for state that, for wake- and transition-mode subscriptions, flowed through thane's own WebSocket firehose moments earlier. Production measures this as the `*awareness.LoopSubscriptionProvider` chronic slow-source warn at ~310ms per turn, every turn (#1473). The glob and registry paths already avoid this with a memoized bulk snapshot; only the two concrete-ID `GetState` sites were left paying retail.

## Why the cache trusts the TTL, not the firehose

The obvious design — believe the event feed — fails three quiet ways, all verified in the watcher and websocket code: a reconnect is silent (the events channel is created once and reused; HA does not replay the outage window), the event channel evicts oldest on overflow, and the ingest rate limiter suppresses a chatty entity's *newest* changes before any handler sees them. Any one of these turns a trusting cache into a liar with no tell.

So `StateReadCache` inverts the trust: **the TTL (30s) is the correctness contract, and events are only an accelerator.** Every entry expires at the TTL regardless of how it arrived; expiry falls through to one REST fetch that repopulates the entry for every concurrently assembling loop. The event tap is an ordinary `StateChangeHandler` registered beside the person tracker — zero changes to the watcher or websocket layers, no new reconnect hooks, no pre-filter taps — and it keeps ingest-covered entities push-fresh between fetches. Worst-case staleness is 30 seconds uniformly, which for ambient world-state in a prompt is indistinguishable from the assembly latency it replaces. Errors pass through unchanged (a stale entry is never substituted for a live failure, so sentinel/last-known-good handling downstream sees exactly what it sees today), stored entries are cloned so the shared event payload cannot mutate them, and a 1024-entry cap with sweep-then-evict-stalest is the backstop against an unexpectedly wide feed.

## What this deliberately does not do

Plain render-mode subscriptions are outside the ingest filter, so they get TTL-bounded read-through rather than push freshness — no worse than today on slow-cadence loops, amortized across fast ones. Widening the ingest filter to cover them would change what *every* watcher handler sees (person tracking, transition windows, wakes) and deserves its own evidence-backed change; the issue notes this residual. Bulk (`GetStates`), history, and forecast reads pass through: populating a per-entity cache from a 15k-entity snapshot would trade a bounded map for the whole firehose.

## Test plan

- [x] `just ci` green locally (fresh worktree; architecture baseline regenerated for the one new interface)
- [x] New: read-through + TTL expiry, event prime/refresh without REST, clone-vs-shared-payload corruption, error pass-through (stale never substitutes), cap eviction — all under `-race`
- [x] App wiring builds; providers take the cache through the existing `StateGetter` seam, registry reads keep the concrete client
- [ ] Post-deploy: `context source ran long … LoopSubscriptionProvider` leaves the steady-state logs; HA REST call volume from the render path drops

Closes #1473

🤖 Generated with [Claude Code](https://claude.com/claude-code)
