### PR TITLE
fix(contacts): require canonical archive citation IDs

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -276,7 +276,7 @@ being reimplemented in each loop prompt.
 |------|-------------|
 | `contact_save` | Create or update a contact with vCard properties. |
 | `contact_lookup` | Search by name, query, kind, or property. Exact rich results include the canonical UUID and configured contact-dossier ref. |
-| `contact_dossier_write` | Create or replace a canonical contact dossier from four structured projections; Go owns its ref, private tag, frontmatter, and section layout. Available only for a managed-writable `contacts` root. |
+| `contact_dossier_write` | Create or replace a canonical contact dossier from four structured projections; Go owns its ref, private tag, frontmatter, and section layout, and requires full canonical UUIDs in archive-session citations. Available only for a managed-writable `contacts` root. |
 | `contact_whereabouts` | Fuse a contact's room, HA zone, and bound-device location sources with provenance, freshness, and explicit room conflicts. |
 | `contact_forget` | Delete a contact. |
 | `contact_list` | List and filter contacts. |

--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -530,6 +530,13 @@ sections when necessary. An unreadable remainder or unavailable canonical
 writer defers the durable queue item behind ready work rather than losing it or
 letting it block the queue.
 
+Archive evidence in a contact dossier uses
+`archive:session:<full-session-uuid>`. Archive tools accept short prefixes as
+an interactive convenience, but durable dossier citations do not: imported
+sessions can share a prefix, making a shortened citation impossible to resolve
+unambiguously. `contact_dossier_write` and the contacts-root validator reject
+those ambiguous citations before Git changes.
+
 Fresh `thane init` workspaces declare and establish the root with the agent's
 signing key, required signature verification, and this context policy:
 

--- a/internal/app/coreloop_docs_parity_test.go
+++ b/internal/app/coreloop_docs_parity_test.go
@@ -149,6 +149,8 @@ func TestArchivistUsesCanonicalContactDossiers(t *testing.T) {
 		"contact_dossier_write",
 		"Never create or maintain a contact dossier under `kb:dossiers/`",
 		"complete status-line, teaser, digest, and full projections",
+		"archive:session:<full-session-uuid>",
+		"never an 8-character prefix",
 		"response's `truncated` marker",
 		"call `doc_outline`, verify that outline is not truncated",
 		"recover every top-level section with `doc_section`",

--- a/internal/state/contacts/dossier.go
+++ b/internal/state/contacts/dossier.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/google/uuid"
@@ -25,6 +27,8 @@ var dossierOutputContract = looppkg.OutputSpec{
 		{Name: looppkg.OutputFacetDigest},
 	},
 }
+
+var archiveSessionCitationPattern = regexp.MustCompile(`archive:session([:-])([[:alnum:]-]*)`)
 
 // DossierWriteArgs carries the content projections for one canonical contact
 // dossier. The contact UUID selects the structured identity; Go derives the
@@ -99,8 +103,15 @@ func (t *Tools) WriteDossier(ctx context.Context, args DossierWriteArgs) (string
 		Digest:     args.Digest,
 		Full:       args.Full,
 	}
+	var validationErrs []error
 	if err := dossierOutputContract.ValidateFacetPayload(payload); err != nil {
-		return "", fmt.Errorf("contact dossier projections are invalid; correct every listed field and retry once: %w", err)
+		validationErrs = append(validationErrs, err)
+	}
+	if err := validateDossierEvidenceCitations(args.Full); err != nil {
+		validationErrs = append(validationErrs, err)
+	}
+	if len(validationErrs) > 0 {
+		return "", fmt.Errorf("contact dossier projections are invalid; correct every listed field and retry once: %w", errors.Join(validationErrs...))
 	}
 	body := dossierOutputContract.RenderFacetDocument(payload)
 	return t.dossierWrite(ctx, documents.WriteArgs{
@@ -143,10 +154,45 @@ func ValidateDossierWrite(candidate documents.DocumentWriteCandidate) error {
 	if err := dossierOutputContract.ValidateFacetPayload(payload); err != nil {
 		return fmt.Errorf("dossier %s facet contract: %w", candidate.Path, err)
 	}
+	if err := validateDossierEvidenceCitations(payload.Full); err != nil {
+		return fmt.Errorf("dossier %s evidence contract: %w", candidate.Path, err)
+	}
 	if got, want := strings.TrimSpace(candidate.Body), dossierOutputContract.RenderFacetDocument(payload); got != want {
 		return fmt.Errorf("dossier %s must use the canonical facet section order with no text outside those sections", candidate.Path)
 	}
 	return nil
+}
+
+// validateDossierEvidenceCitations keeps archive claims independently
+// checkable. Archive tools accept short session prefixes for interactive
+// convenience, but imported sessions can share those prefixes; durable
+// citations therefore need the full canonical UUID.
+func validateDossierEvidenceCitations(full string) error {
+	matches := archiveSessionCitationPattern.FindAllStringSubmatch(full, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]struct{}, len(matches))
+	invalid := make([]string, 0)
+	for _, match := range matches {
+		citation := match[0]
+		rawID := match[2]
+		id, err := uuid.Parse(rawID)
+		if match[1] == ":" && err == nil && id != uuid.Nil && id.String() == rawID {
+			continue
+		}
+		if _, duplicate := seen[citation]; duplicate {
+			continue
+		}
+		seen[citation] = struct{}{}
+		invalid = append(invalid, citation)
+	}
+	if len(invalid) == 0 {
+		return nil
+	}
+	sort.Strings(invalid)
+	return fmt.Errorf("full has archive-session citation(s) [%s] without a full canonical UUID; replace each with archive:session:<full-session-uuid> from archive_search or archive_sessions because short prefixes can be ambiguous", strings.Join(invalid, ", "))
 }
 
 func dossierIDFromPath(relPath string) (uuid.UUID, error) {

--- a/internal/state/contacts/dossier.go
+++ b/internal/state/contacts/dossier.go
@@ -107,7 +107,7 @@ func (t *Tools) WriteDossier(ctx context.Context, args DossierWriteArgs) (string
 	if err := dossierOutputContract.ValidateFacetPayload(payload); err != nil {
 		validationErrs = append(validationErrs, err)
 	}
-	if err := validateDossierEvidenceCitations(args.Full); err != nil {
+	if err := validateDossierEvidenceCitations(payload); err != nil {
 		validationErrs = append(validationErrs, err)
 	}
 	if len(validationErrs) > 0 {
@@ -151,11 +151,15 @@ func ValidateDossierWrite(candidate documents.DocumentWriteCandidate) error {
 	if !faceted {
 		return fmt.Errorf("dossier %s must use the status_line, teaser, digest, and full facet ladder", candidate.Path)
 	}
+	var validationErrs []error
 	if err := dossierOutputContract.ValidateFacetPayload(payload); err != nil {
-		return fmt.Errorf("dossier %s facet contract: %w", candidate.Path, err)
+		validationErrs = append(validationErrs, fmt.Errorf("facet contract: %w", err))
 	}
-	if err := validateDossierEvidenceCitations(payload.Full); err != nil {
-		return fmt.Errorf("dossier %s evidence contract: %w", candidate.Path, err)
+	if err := validateDossierEvidenceCitations(payload); err != nil {
+		validationErrs = append(validationErrs, fmt.Errorf("evidence contract: %w", err))
+	}
+	if len(validationErrs) > 0 {
+		return fmt.Errorf("dossier %s projections are invalid; correct every listed field and retry once: %w", candidate.Path, errors.Join(validationErrs...))
 	}
 	if got, want := strings.TrimSpace(candidate.Body), dossierOutputContract.RenderFacetDocument(payload); got != want {
 		return fmt.Errorf("dossier %s must use the canonical facet section order with no text outside those sections", candidate.Path)
@@ -167,32 +171,40 @@ func ValidateDossierWrite(candidate documents.DocumentWriteCandidate) error {
 // checkable. Archive tools accept short session prefixes for interactive
 // convenience, but imported sessions can share those prefixes; durable
 // citations therefore need the full canonical UUID.
-func validateDossierEvidenceCitations(full string) error {
-	matches := archiveSessionCitationPattern.FindAllStringSubmatch(full, -1)
-	if len(matches) == 0 {
-		return nil
+func validateDossierEvidenceCitations(payload looppkg.FacetPayload) error {
+	fields := []struct {
+		name  string
+		value string
+	}{
+		{name: "status_line", value: payload.StatusLine},
+		{name: "teaser", value: payload.Teaser},
+		{name: "digest", value: payload.Digest},
+		{name: "full", value: payload.Full},
 	}
 
-	seen := make(map[string]struct{}, len(matches))
+	seen := make(map[string]struct{})
 	invalid := make([]string, 0)
-	for _, match := range matches {
-		citation := match[0]
-		rawID := match[2]
-		id, err := uuid.Parse(rawID)
-		if match[1] == ":" && err == nil && id != uuid.Nil && id.String() == rawID {
-			continue
+	for _, field := range fields {
+		for _, match := range archiveSessionCitationPattern.FindAllStringSubmatch(field.value, -1) {
+			citation := match[0]
+			rawID := match[2]
+			id, err := uuid.Parse(rawID)
+			if match[1] == ":" && err == nil && id != uuid.Nil && id.String() == rawID {
+				continue
+			}
+			key := field.name + "\x00" + citation
+			if _, duplicate := seen[key]; duplicate {
+				continue
+			}
+			seen[key] = struct{}{}
+			invalid = append(invalid, field.name+"="+citation)
 		}
-		if _, duplicate := seen[citation]; duplicate {
-			continue
-		}
-		seen[citation] = struct{}{}
-		invalid = append(invalid, citation)
 	}
 	if len(invalid) == 0 {
 		return nil
 	}
 	sort.Strings(invalid)
-	return fmt.Errorf("full has archive-session citation(s) [%s] without a full canonical UUID; replace each with archive:session:<full-session-uuid> from archive_search or archive_sessions because short prefixes can be ambiguous", strings.Join(invalid, ", "))
+	return fmt.Errorf("archive-session citation(s) [%s] do not use a full canonical UUID; replace each with archive:session:<full-session-uuid> from archive_search or archive_sessions because short prefixes can be ambiguous", strings.Join(invalid, ", "))
 }
 
 func dossierIDFromPath(relPath string) (uuid.UUID, error) {

--- a/internal/state/contacts/dossier_test.go
+++ b/internal/state/contacts/dossier_test.go
@@ -26,7 +26,7 @@ func validDossierCandidate(id uuid.UUID) documents.DocumentWriteCandidate {
 		StatusLine: "Relationship is current and steady.",
 		Teaser:     "Recent conversations clarified the operator's preferred collaboration style.",
 		Digest:     "The contact prefers direct technical collaboration and explicit source-of-truth boundaries.",
-		Full:       "# Relationship context\n\nCurrent synthesis with cited evidence.",
+		Full:       "# Relationship context\n\nCurrent synthesis — evidence: archive:session:019c52f0-9ce8-7708-867f-35da2e6b4777.",
 	}
 	return documents.DocumentWriteCandidate{
 		Path: id.String() + ".md",
@@ -92,6 +92,27 @@ func TestValidateDossierWrite(t *testing.T) {
 			},
 			wantErr: "canonical facet section order",
 		},
+		{
+			name: "short archive session citation",
+			mutate: func(candidate *documents.DocumentWriteCandidate) {
+				candidate.Body = strings.Replace(candidate.Body, "archive:session:019c52f0-9ce8-7708-867f-35da2e6b4777", "archive:session:019c52f0", 1)
+			},
+			wantErr: "full canonical UUID",
+		},
+		{
+			name: "legacy archive session separator",
+			mutate: func(candidate *documents.DocumentWriteCandidate) {
+				candidate.Body = strings.Replace(candidate.Body, "archive:session:", "archive:session-", 1)
+			},
+			wantErr: "archive:session:<full-session-uuid>",
+		},
+		{
+			name: "noncanonical archive session uuid",
+			mutate: func(candidate *documents.DocumentWriteCandidate) {
+				candidate.Body = strings.Replace(candidate.Body, "019c52f0-9ce8-7708-867f-35da2e6b4777", "019C52F0-9CE8-7708-867F-35DA2E6B4777", 1)
+			},
+			wantErr: "full canonical UUID",
+		},
 	}
 
 	for _, tt := range tests {
@@ -111,6 +132,50 @@ func TestValidateDossierWrite(t *testing.T) {
 				t.Fatalf("ValidateDossierWrite() error = %v, want it to mention %q", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestWriteDossierRejectsEveryAmbiguousArchiveSessionCitation(t *testing.T) {
+	tools := newTestTools(t)
+	if _, err := tools.SaveContact(`{"name":"Dossier Person","kind":"individual"}`); err != nil {
+		t.Fatal(err)
+	}
+	contact, err := tools.store.FindByName("Dossier Person")
+	if err != nil {
+		t.Fatal(err)
+	}
+	writer := &recordingDossierWriter{}
+	tools.ConfigureDossierRoot(true, true)
+	tools.ConfigureDossierDocuments(writer.Write)
+
+	_, err = tools.WriteDossier(context.Background(), DossierWriteArgs{
+		ContactID:  contact.ID.String(),
+		StatusLine: "Current.",
+		Teaser:     "Useful hook.",
+		Digest:     "Enough context to act.",
+		Full: "Two claims. — evidence: archive:session:019c52f0\n" +
+			"Another claim. — evidence: archive:session:01a056ae\n" +
+			"Repeated first claim. — evidence: archive:session:019c52f0",
+	})
+	if err == nil {
+		t.Fatal("WriteDossier() accepted ambiguous archive session citations")
+	}
+	for _, want := range []string{
+		"correct every listed field",
+		"archive:session:019c52f0",
+		"archive:session:01a056ae",
+		"archive:session:<full-session-uuid>",
+		"short prefixes can be ambiguous",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("WriteDossier() error = %v, want it to mention %q", err, want)
+		}
+	}
+	if strings.Count(err.Error(), "archive:session:019c52f0") != 1 {
+		t.Errorf("WriteDossier() error = %v, want duplicate invalid citation reported once", err)
+	}
+	if writer.calls != 0 {
+		t.Fatalf("ambiguous citations reached writer %d times", writer.calls)
 	}
 }
 
@@ -194,12 +259,18 @@ func TestWriteDossierReportsAllProjectionViolationsBeforeWriting(t *testing.T) {
 		StatusLine: strings.Repeat("s", 121),
 		Teaser:     "Useful hook.",
 		Digest:     strings.Repeat("d", 2049),
-		Full:       "Complete detail.",
+		Full:       "Complete detail. — evidence: archive:session:019c52f0",
 	})
 	if err == nil {
 		t.Fatal("WriteDossier() accepted invalid projections")
 	}
-	for _, want := range []string{"correct every listed field", "status_line is 121 characters", "digest is 2049 characters"} {
+	for _, want := range []string{
+		"correct every listed field",
+		"status_line is 121 characters",
+		"digest is 2049 characters",
+		"archive:session:019c52f0",
+		"full canonical UUID",
+	} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("WriteDossier() error = %v, want it to mention %q", err, want)
 		}

--- a/internal/state/contacts/dossier_test.go
+++ b/internal/state/contacts/dossier_test.go
@@ -150,9 +150,9 @@ func TestWriteDossierRejectsEveryAmbiguousArchiveSessionCitation(t *testing.T) {
 
 	_, err = tools.WriteDossier(context.Background(), DossierWriteArgs{
 		ContactID:  contact.ID.String(),
-		StatusLine: "Current.",
-		Teaser:     "Useful hook.",
-		Digest:     "Enough context to act.",
+		StatusLine: "Current. — evidence: archive:session:019c1111",
+		Teaser:     "Useful hook. — evidence: archive:session:019c2222",
+		Digest:     "Enough context to act. — evidence: archive:session:019c3333",
 		Full: "Two claims. — evidence: archive:session:019c52f0\n" +
 			"Another claim. — evidence: archive:session:01a056ae\n" +
 			"Repeated first claim. — evidence: archive:session:019c52f0",
@@ -162,8 +162,11 @@ func TestWriteDossierRejectsEveryAmbiguousArchiveSessionCitation(t *testing.T) {
 	}
 	for _, want := range []string{
 		"correct every listed field",
-		"archive:session:019c52f0",
-		"archive:session:01a056ae",
+		"status_line=archive:session:019c1111",
+		"teaser=archive:session:019c2222",
+		"digest=archive:session:019c3333",
+		"full=archive:session:019c52f0",
+		"full=archive:session:01a056ae",
 		"archive:session:<full-session-uuid>",
 		"short prefixes can be ambiguous",
 	} {
@@ -176,6 +179,33 @@ func TestWriteDossierRejectsEveryAmbiguousArchiveSessionCitation(t *testing.T) {
 	}
 	if writer.calls != 0 {
 		t.Fatalf("ambiguous citations reached writer %d times", writer.calls)
+	}
+}
+
+func TestValidateDossierWriteReportsFacetAndEvidenceViolationsTogether(t *testing.T) {
+	id := uuid.MustParse("019c76e4-2ff1-7918-8d6f-6c2488f5098d")
+	candidate := validDossierCandidate(id)
+	candidate.Body = dossierOutputContract.RenderFacetDocument(looppkg.FacetPayload{
+		StatusLine: strings.Repeat("s", 121),
+		Teaser:     "Useful hook.",
+		Digest:     "Enough context to act.",
+		Full:       "Complete detail. — evidence: archive:session:019c52f0",
+	})
+
+	err := ValidateDossierWrite(candidate)
+	if err == nil {
+		t.Fatal("ValidateDossierWrite() accepted invalid projections")
+	}
+	for _, want := range []string{
+		"correct every listed field",
+		"facet contract",
+		"status_line is 121 characters",
+		"evidence contract",
+		"full=archive:session:019c52f0",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("ValidateDossierWrite() error = %v, want it to mention %q", err, want)
+		}
 	}
 }
 

--- a/internal/tools/contact_dossier_tool_test.go
+++ b/internal/tools/contact_dossier_tool_test.go
@@ -63,6 +63,12 @@ func TestContactDossierWriteToolOwnsStructureAndRevisionScope(t *testing.T) {
 			t.Errorf("%s description = %q, want %q", field, description, budget)
 		}
 	}
+	fullDescription := properties["full"].(map[string]any)["description"].(string)
+	for _, want := range []string{"archive:session:<full-session-uuid>", "full canonical session UUID", "short prefixes can be ambiguous"} {
+		if !strings.Contains(fullDescription, want) {
+			t.Errorf("full description = %q, want %q", fullDescription, want)
+		}
+	}
 	wantRequired := []string{"contact_id", "status_line", "teaser", "digest", "full"}
 	if got := tool.Parameters["required"].([]string); !reflect.DeepEqual(got, wantRequired) {
 		t.Fatalf("required fields = %#v, want %#v", got, wantRequired)

--- a/internal/tools/contact_tools.go
+++ b/internal/tools/contact_tools.go
@@ -334,6 +334,9 @@ func registerContactDossierWriteTool(r *Registry, contactTools *contacts.Tools) 
 	required := []string{"contact_id"}
 	for _, field := range fields {
 		description := field.Guidance + looppkg.FormatGuidance(field.Format)
+		if field.Key == "full" {
+			description += " Cite archive-session evidence as archive:session:<full-session-uuid>; the full canonical session UUID is required because short prefixes can be ambiguous."
+		}
 		if field.MaxRunes > 0 {
 			description = fmt.Sprintf("%s Maximum %d characters — a ceiling, not a target; compose comfortably under it.", description, field.MaxRunes)
 		}
@@ -350,7 +353,7 @@ func registerContactDossierWriteTool(r *Registry, contactTools *contacts.Tools) 
 
 	r.Register(&Tool{
 		Name:               "contact_dossier_write",
-		Description:        "Create or replace one contact's canonical longitudinal dossier. Pass only the canonical contact UUID and all four content projections; Go verifies the structured contact and owns the document ref, private contact tag, frontmatter, section headings, and ordering. Use this for evolving relationship context, preferences, recurring themes, and evidence synthesis—not structured identity, trust, Home Assistant bindings, or companion attribution. Every projection is validated together and every violation is returned in one error. Read an existing dossier with doc_read before replacing it so Thane can protect against intervening writes.",
+		Description:        "Create or replace one contact's canonical longitudinal dossier. Pass only the canonical contact UUID and all four content projections; Go verifies the structured contact and owns the document ref, private contact tag, frontmatter, section headings, and ordering. Use this for evolving relationship context, preferences, recurring themes, and evidence synthesis—not structured identity, trust, Home Assistant bindings, or companion attribution. Archive-session evidence must cite the full canonical session UUID so every claim remains checkable. Every projection is validated together and every violation is returned in one error. Read an existing dossier with doc_read before replacing it so Thane can protect against intervening writes.",
 		SkipContentResolve: true,
 		Parameters: map[string]any{
 			"type":       "object",

--- a/loops/archivist.md
+++ b/loops/archivist.md
@@ -135,6 +135,10 @@ durable queue holds that).
 3. **Write each dossier through its owning surface.** Every claim carries an
    evidence citation — an archive session ID, a fact category+key, a document
    ref, or a working-memory conversation ID — so a reader can check it.
+   Archive-session citations always use
+   `archive:session:<full-session-uuid>`, never an 8-character prefix: imports
+   can share a prefix, turning a shortened durable citation into an ambiguous
+   one that cannot be checked later.
    - A contact is the contract-owned exception. Resolve an active structured
      contact and use its exact canonical UUID. Read the current
      `contacts:<uuid>.md` with `doc_read` when it exists and inspect the
@@ -203,8 +207,8 @@ subject benefits from reading just this paragraph.
 
 ## Claims
 
-- <claim> — evidence: archive:session-019c598e, fact:home/game_room_door
-- <claim> — evidence: archive:session-019c5990
+- <claim> — evidence: archive:session:019c598e-7f5c-7123-8f31-0123456789ab, fact:home/game_room_door
+- <claim> — evidence: archive:session:019c5990-8a6d-7456-9b42-abcdef012345
 - <claim> — evidence: contact:019c76e4 notes field
 
 ## Open questions


### PR DESCRIPTION
## Summary

- reject shortened or noncanonical archive-session citations before a contact dossier reaches Git
- enforce the same evidence rule through `contact_dossier_write` and the generic contacts-root validator
- teach the archivist, tool schema, and operator documentation to cite full canonical session UUIDs
- report every projection and citation violation together so the model can correct the request in one retry

## Why

The production proof for #1463 successfully exercised canonical contact dossier stewardship, but it also exposed ambiguous 8-character session prefixes in durable evidence citations. Imported archive sessions can share those prefixes, so a later reader cannot reliably inspect the claimed source.

This closes that contract gap at the write boundary rather than depending on prompt compliance alone.

## User impact

Contact dossier evidence remains independently checkable. If the archivist proposes an ambiguous citation, Thane refuses the write without changing Git and returns one actionable error naming every invalid citation and the required canonical form.

## Test plan

- [x] `just ci`
- [x] dedicated writer rejects and deduplicates ambiguous citations
- [x] contacts-root validator rejects short, legacy-separator, and noncanonical UUID forms
- [x] model-facing tool and shipped archivist mandate parity assertions pass

Refs #1463
