### PR TITLE
feat(talents): let a file declare ignore: true instead of earning the boot notice forever

### DIFF
--- a/internal/model/talents/loader.go
+++ b/internal/model/talents/loader.go
@@ -68,12 +68,15 @@ type Frontmatter struct {
 	// article scanner can honor it; meaningless on talents themselves.
 	Audience string
 	// Ignore declares a file in the talents directory that is
-	// deliberately not a talent — a README, an authoring guide. The
-	// loader skips it silently, unlike a file with no frontmatter at
-	// all, which earns a once-per-process notice because a silent skip
-	// is also what guidance stripped of its frontmatter looks like.
-	// Honored only as a whole-file marker (see TalentsVerified); the KB
-	// article path expresses the same intent with audience: internal.
+	// deliberately not loaded — a README, an authoring guide, or a
+	// real talent the operator has parked (ignore supersedes any other
+	// keys the node declares, so one added line silences a talent
+	// without deleting its metadata). The loader skips it silently,
+	// unlike a file with no frontmatter at all, which earns a
+	// once-per-process notice because a silent skip is also what
+	// guidance stripped of its frontmatter looks like. Honored only as
+	// a whole-file marker (see TalentsVerified); the KB article path
+	// expresses the same intent with audience: internal.
 	Ignore bool
 }
 
@@ -146,8 +149,8 @@ func noteSkippedUndeclared(ctx context.Context, path string) {
 }
 
 // noteSkippedDeclared reports, once per file per process and only at
-// Debug, a file that declared ignore: true — a chosen state, not a
-// condition anyone needs to act on.
+// Debug, a file that declared ignore: true and nothing else — a chosen
+// state, not a condition anyone needs to act on.
 func noteSkippedDeclared(ctx context.Context, path string) {
 	if _, already := skipNoticed.LoadOrStore("ignore\x00"+path, struct{}{}); already {
 		return
@@ -156,14 +159,28 @@ func noteSkippedDeclared(ctx context.Context, path string) {
 		"path", path)
 }
 
+// noteSkippedMuted reports, once per file per process, a real talent
+// parked by ignore: true. Info rather than Debug: the mute is chosen,
+// but muted guidance whose absence nobody can see is the same silent
+// loss the no-frontmatter notice exists to prevent — one line names it.
+func noteSkippedMuted(ctx context.Context, path string) {
+	if _, already := skipNoticed.LoadOrStore("muted\x00"+path, struct{}{}); already {
+		return
+	}
+	logging.Logger(ctx).Info("skipping talent: parked by ignore: true",
+		"path", path)
+}
+
 // fileDeclaresIgnore reports whether blocks mark the whole file as
-// deliberately not-a-talent. Only a lone node declaring nothing but
-// ignore: true qualifies; ignore beside real guidance — other nodes,
-// or other keys in the same node — is an authoring error, because
-// honoring it would silently drop the guidance and refusing it names
-// the mistake.
-func fileDeclaresIgnore(blocks []Block, path string) (bool, error) {
-	ignored := false
+// deliberately not-a-talent. On a single-node file, ignore: true
+// supersedes everything else the node declares — by operator choice,
+// so adding the one line to a real talent's frontmatter parks that
+// talent without deleting its metadata, and removing the line restores
+// it. mutedGuidance distinguishes that parked talent (named once at
+// Info) from a bare marker like a README (Debug). Ignore across
+// multiple nodes stays an authoring error: which nodes it silences is
+// ambiguous, and a guess would drop guidance silently.
+func fileDeclaresIgnore(blocks []Block, path string) (ignored, mutedGuidance bool, err error) {
 	for _, block := range blocks {
 		if block.Frontmatter.Ignore {
 			ignored = true
@@ -171,17 +188,15 @@ func fileDeclaresIgnore(blocks []Block, path string) (bool, error) {
 		}
 	}
 	if !ignored {
-		return false, nil
+		return false, false, nil
 	}
 	if len(blocks) > 1 {
-		return false, fmt.Errorf("talent %s: ignore: true marks a whole file, but this file has %d frontmatter nodes; split the non-talent prose into its own file", path, len(blocks))
+		return false, false, fmt.Errorf("talent %s: ignore: true in a multi-node file is refused — which nodes it silences would be a guess; give the ignored prose its own file", path)
 	}
 	fm := blocks[0].Frontmatter
-	if fm.Name != "" || len(fm.Tags) > 0 || len(fm.TagsAll) > 0 ||
-		fm.Kind != "" || fm.Teaser != "" || len(fm.NextTags) > 0 || fm.Audience != "" {
-		return false, fmt.Errorf("talent %s: ignore: true must be the only frontmatter key, but this file also declares talent metadata; remove the other keys or remove ignore — a file carrying both looks like guidance, and skipping it would drop that guidance silently", path)
-	}
-	return true, nil
+	mutedGuidance = fm.Name != "" || len(fm.Tags) > 0 || len(fm.TagsAll) > 0 ||
+		fm.Kind != "" || fm.Teaser != "" || len(fm.NextTags) > 0 || fm.Audience != ""
+	return true, mutedGuidance, nil
 }
 
 // Talents reads all .md files from the talents directory, parses their
@@ -241,15 +256,23 @@ func (l *Loader) TalentsVerified(ctx context.Context, verifier VerifyPathFunc, c
 			return nil, fmt.Errorf("talent %s: %w", path, err)
 		}
 		// ignore: true is the deliberate sibling of the no-frontmatter
-		// skip above: the file has declared it is not a talent, so
-		// there is nothing to notice an operator about. It marks whole
-		// files only — an ignore node sharing a file with real guidance
-		// would silently drop that guidance, which is the exact failure
-		// the notices in this loader exist to prevent.
-		if ignored, err := fileDeclaresIgnore(blocks, path); err != nil {
+		// skip above, and it supersedes everything else in the file: a
+		// lone marker is a permanent non-talent (a README, skipped at
+		// Debug), while ignore atop real talent metadata is the
+		// operator's one-line mute switch — honored, and named once at
+		// Info, because muted guidance whose absence nobody can see is
+		// the same silent loss the notices in this loader exist to
+		// prevent.
+		ignored, mutedGuidance, err := fileDeclaresIgnore(blocks, path)
+		if err != nil {
 			return nil, err
-		} else if ignored {
-			noteSkippedDeclared(ctx, path)
+		}
+		if ignored {
+			if mutedGuidance {
+				noteSkippedMuted(ctx, path)
+			} else {
+				noteSkippedDeclared(ctx, path)
+			}
 			continue
 		}
 		filename := strings.TrimSuffix(f, ".md")

--- a/internal/model/talents/loader.go
+++ b/internal/model/talents/loader.go
@@ -67,6 +67,14 @@ type Frontmatter struct {
 	// into model context even when tagged. Parsed here so the KB
 	// article scanner can honor it; meaningless on talents themselves.
 	Audience string
+	// Ignore declares a file in the talents directory that is
+	// deliberately not a talent — a README, an authoring guide. The
+	// loader skips it silently, unlike a file with no frontmatter at
+	// all, which earns a once-per-process notice because a silent skip
+	// is also what guidance stripped of its frontmatter looks like.
+	// Honored only as a whole-file marker (see TalentsVerified); the KB
+	// article path expresses the same intent with audience: internal.
+	Ignore bool
 }
 
 // Block represents a single parsed frontmatter + content pair from a
@@ -137,6 +145,38 @@ func noteSkippedUndeclared(ctx context.Context, path string) {
 		"path", path)
 }
 
+// noteSkippedDeclared reports, once per file per process and only at
+// Debug, a file that declared ignore: true — a chosen state, not a
+// condition anyone needs to act on.
+func noteSkippedDeclared(ctx context.Context, path string) {
+	if _, already := skipNoticed.LoadOrStore("ignore\x00"+path, struct{}{}); already {
+		return
+	}
+	logging.Logger(ctx).Debug("skipping markdown file in talents directory: declares ignore: true",
+		"path", path)
+}
+
+// fileDeclaresIgnore reports whether blocks mark the whole file as
+// deliberately not-a-talent. Only a lone ignore node qualifies; ignore
+// beside real guidance nodes is an authoring error, because honoring it
+// would silently drop the guidance and refusing it names the mistake.
+func fileDeclaresIgnore(blocks []Block, path string) (bool, error) {
+	ignored := false
+	for _, block := range blocks {
+		if block.Frontmatter.Ignore {
+			ignored = true
+			break
+		}
+	}
+	if !ignored {
+		return false, nil
+	}
+	if len(blocks) > 1 {
+		return false, fmt.Errorf("talent %s: ignore: true marks a whole file, but this file has %d frontmatter nodes; split the non-talent prose into its own file", path, len(blocks))
+	}
+	return true, nil
+}
+
 // Talents reads all .md files from the talents directory, parses their
 // YAML frontmatter, and returns one Talent per file. Tags are extracted
 // from frontmatter; Content has the frontmatter stripped. Use
@@ -192,6 +232,18 @@ func (l *Loader) TalentsVerified(ctx context.Context, verifier VerifyPathFunc, c
 		blocks, err := parseBlocksStrict(raw)
 		if err != nil {
 			return nil, fmt.Errorf("talent %s: %w", path, err)
+		}
+		// ignore: true is the deliberate sibling of the no-frontmatter
+		// skip above: the file has declared it is not a talent, so
+		// there is nothing to notice an operator about. It marks whole
+		// files only — an ignore node sharing a file with real guidance
+		// would silently drop that guidance, which is the exact failure
+		// the notices in this loader exist to prevent.
+		if ignored, err := fileDeclaresIgnore(blocks, path); err != nil {
+			return nil, err
+		} else if ignored {
+			noteSkippedDeclared(ctx, path)
+			continue
 		}
 		filename := strings.TrimSuffix(f, ".md")
 		fileTalents, err := talentsFromBlocks(blocks, filename, path)
@@ -395,8 +447,8 @@ func ParseFrontmatterMetadata(raw string) (Frontmatter, string) {
 // "---" lines and is followed by the body content up to the next
 // node boundary (or EOF). A node boundary is a "---" line followed by
 // a recognized frontmatter key (name, tags, tags_all, kind, teaser,
-// next_tags, audience); a "---" followed by anything else stays as body
-// content (a markdown horizontal rule).
+// next_tags, audience, ignore); a "---" followed by anything else stays
+// as body content (a markdown horizontal rule).
 //
 // Single-node files (the historical shape) return a length-1 slice.
 // Multi-node files return one [Block] per node. Returns a length-1
@@ -536,7 +588,7 @@ func splitAtNextNodeBoundary(body string) (content, remainder string) {
 // markdown horizontal rule (followed by prose or a different key).
 func isFrontmatterKey(key string) bool {
 	switch key {
-	case "name", "tags", "tags_all", "kind", "teaser", "next_tags", "audience":
+	case "name", "tags", "tags_all", "kind", "teaser", "next_tags", "audience", "ignore":
 		return true
 	default:
 		return false
@@ -575,6 +627,10 @@ func parseFrontmatterLines(frontmatter string) Frontmatter {
 			value := strings.TrimSpace(strings.TrimPrefix(line, "audience:"))
 			value = strings.Trim(value, `"'`)
 			meta.Audience = value
+		case strings.HasPrefix(line, "ignore:"):
+			value := strings.TrimSpace(strings.TrimPrefix(line, "ignore:"))
+			value = strings.Trim(value, `"'`)
+			meta.Ignore = strings.EqualFold(value, "true")
 		default:
 			continue
 		}

--- a/internal/model/talents/loader.go
+++ b/internal/model/talents/loader.go
@@ -157,9 +157,11 @@ func noteSkippedDeclared(ctx context.Context, path string) {
 }
 
 // fileDeclaresIgnore reports whether blocks mark the whole file as
-// deliberately not-a-talent. Only a lone ignore node qualifies; ignore
-// beside real guidance nodes is an authoring error, because honoring it
-// would silently drop the guidance and refusing it names the mistake.
+// deliberately not-a-talent. Only a lone node declaring nothing but
+// ignore: true qualifies; ignore beside real guidance — other nodes,
+// or other keys in the same node — is an authoring error, because
+// honoring it would silently drop the guidance and refusing it names
+// the mistake.
 func fileDeclaresIgnore(blocks []Block, path string) (bool, error) {
 	ignored := false
 	for _, block := range blocks {
@@ -173,6 +175,11 @@ func fileDeclaresIgnore(blocks []Block, path string) (bool, error) {
 	}
 	if len(blocks) > 1 {
 		return false, fmt.Errorf("talent %s: ignore: true marks a whole file, but this file has %d frontmatter nodes; split the non-talent prose into its own file", path, len(blocks))
+	}
+	fm := blocks[0].Frontmatter
+	if fm.Name != "" || len(fm.Tags) > 0 || len(fm.TagsAll) > 0 ||
+		fm.Kind != "" || fm.Teaser != "" || len(fm.NextTags) > 0 || fm.Audience != "" {
+		return false, fmt.Errorf("talent %s: ignore: true must be the only frontmatter key, but this file also declares talent metadata; remove the other keys or remove ignore — a file carrying both looks like guidance, and skipping it would drop that guidance silently", path)
 	}
 	return true, nil
 }

--- a/internal/model/talents/loader_test.go
+++ b/internal/model/talents/loader_test.go
@@ -1159,20 +1159,19 @@ func TestTalentsIgnoreFrontmatterSkipsDeliberately(t *testing.T) {
 	}
 }
 
-// TestTalentsIgnoreBesideGuidanceIsRefused: honoring ignore on a file
-// that also carries real nodes would drop that guidance silently — the
-// exact failure the loader's notices exist to prevent — so it is an
-// authoring error instead.
-func TestTalentsIgnoreBesideGuidanceIsRefused(t *testing.T) {
+// TestTalentsIgnoreInMultiNodeFileIsRefused: which nodes an ignore
+// would silence in a multi-node file is a guess, and a guess drops
+// guidance silently — so it is an authoring error instead.
+func TestTalentsIgnoreInMultiNodeFileIsRefused(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "mixed.md", "---\nignore: true\n---\n# Notes\n---\nname: real\ntags: ["+TagAlways+"]\n---\n# Real\nGuidance.")
 
 	_, err := NewLoader(dir).Talents()
 	if err == nil {
-		t.Fatal("want error for ignore beside guidance nodes, got nil")
+		t.Fatal("want error for ignore in a multi-node file, got nil")
 	}
-	if !strings.Contains(err.Error(), "ignore: true marks a whole file") {
-		t.Fatalf("error %q does not name the whole-file rule", err)
+	if !strings.Contains(err.Error(), "which nodes it silences would be a guess") {
+		t.Fatalf("error %q does not name the ambiguity rationale", err)
 	}
 }
 
@@ -1190,18 +1189,20 @@ func TestRepoREADMEDeclaresIgnore(t *testing.T) {
 	}
 }
 
-// TestTalentsIgnoreMustStandAlone: ignore beside other frontmatter keys
-// in the same node looks like guidance, and skipping it would drop that
-// guidance silently — so the loader refuses it.
-func TestTalentsIgnoreMustStandAlone(t *testing.T) {
+// TestTalentsIgnoreSupersedesTalentMetadata pins the park-a-talent
+// switch: ignore: true wins over everything else the node declares, by
+// operator choice — one added line silences a real talent without
+// deleting its metadata, and removing the line restores it.
+func TestTalentsIgnoreSupersedesTalentMetadata(t *testing.T) {
 	dir := t.TempDir()
-	writeFile(t, dir, "confused.md", "---\nignore: true\ntags: ["+TagAlways+"]\n---\n# Confused\nGuidance or not?")
+	writeFile(t, dir, "parked.md", "---\nignore: true\nname: parked\ntags: ["+TagAlways+"]\nkind: doctrine\n---\n# Parked\nSilenced but intact.")
+	writeFile(t, dir, "core.md", "---\ntags: ["+TagAlways+"]\n---\n# Core\nAlways loaded.")
 
-	_, err := NewLoader(dir).Talents()
-	if err == nil {
-		t.Fatal("want error for ignore beside other frontmatter keys, got nil")
+	talents, err := NewLoader(dir).Talents()
+	if err != nil {
+		t.Fatalf("Talents() error = %v", err)
 	}
-	if !strings.Contains(err.Error(), "must be the only frontmatter key") {
-		t.Fatalf("error %q does not name the stand-alone rule", err)
+	if len(talents) != 1 || talents[0].Name != "core" {
+		t.Fatalf("talents = %+v, want just core — the parked talent must stay silenced", talents)
 	}
 }

--- a/internal/model/talents/loader_test.go
+++ b/internal/model/talents/loader_test.go
@@ -1137,3 +1137,55 @@ func TestTalents_EntryPointAliasNormalizesToTrailhead(t *testing.T) {
 		t.Errorf("Kind = %q, want %q (legacy entry_point should normalize)", all[0].Kind, KindTrailhead)
 	}
 }
+
+// TestTalentsIgnoreFrontmatterSkipsDeliberately pins the deliberate
+// sibling of the no-frontmatter skip: a file declaring only
+// ignore: true is skipped without error and without the once-per-boot
+// notice — the mechanism that lets a README (with the marker) live in
+// the directory quietly, while a file with no frontmatter at all keeps
+// earning the notice, because that is also what stripped guidance
+// looks like.
+func TestTalentsIgnoreFrontmatterSkipsDeliberately(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "README.md", "---\nignore: true\n---\n# Talents\nAuthoring guide, not guidance.")
+	writeFile(t, dir, "core.md", "---\ntags: ["+TagAlways+"]\n---\n# Core\nAlways loaded.")
+
+	talents, err := NewLoader(dir).Talents()
+	if err != nil {
+		t.Fatalf("Talents() error = %v", err)
+	}
+	if len(talents) != 1 || talents[0].Name != "core" {
+		t.Fatalf("talents = %+v, want just core", talents)
+	}
+}
+
+// TestTalentsIgnoreBesideGuidanceIsRefused: honoring ignore on a file
+// that also carries real nodes would drop that guidance silently — the
+// exact failure the loader's notices exist to prevent — so it is an
+// authoring error instead.
+func TestTalentsIgnoreBesideGuidanceIsRefused(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "mixed.md", "---\nignore: true\n---\n# Notes\n---\nname: real\ntags: ["+TagAlways+"]\n---\n# Real\nGuidance.")
+
+	_, err := NewLoader(dir).Talents()
+	if err == nil {
+		t.Fatal("want error for ignore beside guidance nodes, got nil")
+	}
+	if !strings.Contains(err.Error(), "ignore: true marks a whole file") {
+		t.Fatalf("error %q does not name the whole-file rule", err)
+	}
+}
+
+// TestRepoREADMEDeclaresIgnore keeps the shipped README carrying the
+// marker this mechanism exists for: if someone strips its frontmatter,
+// every deployment goes back to a boot notice about it.
+func TestRepoREADMEDeclaresIgnore(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "..", "talents", "README.md"))
+	if err != nil {
+		t.Skipf("repo talents/README.md not readable from test dir: %v", err)
+	}
+	meta, _ := ParseFrontmatterMetadata(string(data))
+	if !meta.Ignore {
+		t.Fatal("talents/README.md must declare ignore: true so deployments skip it quietly")
+	}
+}

--- a/internal/model/talents/loader_test.go
+++ b/internal/model/talents/loader_test.go
@@ -1189,3 +1189,19 @@ func TestRepoREADMEDeclaresIgnore(t *testing.T) {
 		t.Fatal("talents/README.md must declare ignore: true so deployments skip it quietly")
 	}
 }
+
+// TestTalentsIgnoreMustStandAlone: ignore beside other frontmatter keys
+// in the same node looks like guidance, and skipping it would drop that
+// guidance silently — so the loader refuses it.
+func TestTalentsIgnoreMustStandAlone(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "confused.md", "---\nignore: true\ntags: ["+TagAlways+"]\n---\n# Confused\nGuidance or not?")
+
+	_, err := NewLoader(dir).Talents()
+	if err == nil {
+		t.Fatal("want error for ignore beside other frontmatter keys, got nil")
+	}
+	if !strings.Contains(err.Error(), "must be the only frontmatter key") {
+		t.Fatalf("error %q does not name the stand-alone rule", err)
+	}
+}

--- a/talents/README.md
+++ b/talents/README.md
@@ -24,12 +24,15 @@ opens with no frontmatter is not guidance and is never injected — but the
 loader also names it once at boot, because a silent skip is exactly what a
 talent stripped of its frontmatter would look like. A file that is
 *deliberately* not a talent says so instead: open it with a frontmatter block
-declaring only `ignore: true` — that is how this README sits here quietly —
-and the loader skips it without the boot notice (a single Debug line is all
-that remains). `ignore:` must stand alone and marks whole files only: the
-loader refuses a file that pairs it with other frontmatter keys or with real
-guidance nodes, because honoring either would drop that guidance silently.
-The filename plays no part in any of this.
+declaring `ignore: true` — that is how this README sits here quietly — and
+the loader skips it without the boot notice (a single Debug line is all that
+remains; a parked talent is instead named once at Info, so muted guidance
+never disappears invisibly). `ignore:` supersedes everything else the node
+declares, on purpose:
+adding the one line to a real talent's frontmatter parks that talent without
+deleting its metadata, and removing the line restores it. It marks whole
+files only — the loader refuses it in a multi-node file, where which nodes it
+silences would be a guess. The filename plays no part in any of this.
 
 A file that does declare frontmatter must declare `tags:`, and the loader
 refuses one that does not. Silence is not a shorthand for "every turn": an

--- a/talents/README.md
+++ b/talents/README.md
@@ -25,10 +25,11 @@ loader also names it once at boot, because a silent skip is exactly what a
 talent stripped of its frontmatter would look like. A file that is
 *deliberately* not a talent says so instead: open it with a frontmatter block
 declaring only `ignore: true` — that is how this README sits here quietly —
-and the loader skips it without comment. `ignore:` marks whole files only;
-the loader refuses a file that mixes an ignore node with real guidance nodes,
-because honoring it would drop that guidance silently. The filename plays no
-part in any of this.
+and the loader skips it without the boot notice (a single Debug line is all
+that remains). `ignore:` must stand alone and marks whole files only: the
+loader refuses a file that pairs it with other frontmatter keys or with real
+guidance nodes, because honoring either would drop that guidance silently.
+The filename plays no part in any of this.
 
 A file that does declare frontmatter must declare `tags:`, and the loader
 refuses one that does not. Silence is not a shorthand for "every turn": an

--- a/talents/README.md
+++ b/talents/README.md
@@ -1,3 +1,7 @@
+---
+ignore: true
+---
+
 # Talents
 
 Talents are markdown files that shape the model's posture and decision-making in
@@ -16,9 +20,15 @@ right shape, and the loader does the rest.
 ## Every talent declares when it applies
 
 Frontmatter is what makes a file a talent. A `.md` file in this directory that
-opens with no frontmatter is not guidance and is never injected — that is how
-this README sits here safely, and it is the only rule that decides. The
-filename plays no part in it.
+opens with no frontmatter is not guidance and is never injected — but the
+loader also names it once at boot, because a silent skip is exactly what a
+talent stripped of its frontmatter would look like. A file that is
+*deliberately* not a talent says so instead: open it with a frontmatter block
+declaring only `ignore: true` — that is how this README sits here quietly —
+and the loader skips it without comment. `ignore:` marks whole files only;
+the loader refuses a file that mixes an ignore node with real guidance nodes,
+because honoring it would drop that guidance silently. The filename plays no
+part in any of this.
 
 A file that does declare frontmatter must declare `tags:`, and the loader
 refuses one that does not. Silence is not a shorthand for "every turn": an


### PR DESCRIPTION
## A file should be able to say "I am not a talent" instead of being noticed forever

Production logs one INFO per boot: `skipping markdown file in talents directory: no frontmatter, so not a talent path=…/core/talents/README.md`. The notice is doing its job — a silent skip is also exactly what real guidance stripped of its frontmatter would look like, and the loader's own docstring says so — but the README is the *deliberate* case, and it has no way to say so. It re-earns the notice at every boot, forever: a chosen state narrated as a condition, the log audit's antipattern in miniature.

## `ignore: true` — and it supersedes, by operator choice

A file in the talents directory can now open with a frontmatter block declaring `ignore: true`, and the marker supersedes everything else the node declares. That makes it two tools in one: a bare marker lets a README live in the directory quietly, and the same line added atop a real talent's frontmatter **parks that talent** without dismantling its metadata — remove the line and it returns intact. (The review round initially pushed toward refusing `ignore` beside other keys; the maintainer chose supersede, and the loader now implements that deliberately.)

The silent-loss guarantee holds through visibility rather than refusal, scaled to the stakes: a bare ignore-only file skips at a single Debug line; a parked talent is named once per process at Info (`skipping talent: parked by ignore: true`), because muted guidance whose absence nobody can see is the same silent total loss the loader's notices exist to prevent; and a file with **no** frontmatter keeps the once-per-boot INFO that catches accidental stripping. The one refusal that remains is `ignore` in a multi-node file — which nodes it silences would be a guess, and a guess drops guidance silently.

The shipped `talents/README.md` carries the marker with its authoring prose updated to the full contract, and `TestRepoREADMEDeclaresIgnore` pins it so a future strip puts deployments back on the boot notice rather than silently regressing.

## ⚠️ Deploy ordering: binary before backport

The **old** loader treats any frontmattered file as a declared talent and refuses one without `tags:` — so adding `ignore: true` to prod's `core/talents/README.md` before the new binary is running turns the live talent load into an error (the loader re-reads the directory every loop turn). Order of operations: merge → release → prod picks up the binary → then push the staged README backport. The generated defaults mirror excludes the README, so the embedded set is unaffected either way.

## Test plan

- [x] `just ci` green locally (fresh worktree)
- [x] `TestTalentsIgnoreFrontmatterSkipsDeliberately` (bare marker skips silently), `TestTalentsIgnoreSupersedesTalentMetadata` (the park switch: ignore + name/tags/kind honored, talent absent, no error), `TestTalentsIgnoreInMultiNodeFileIsRefused` (ambiguity refusal), `TestRepoREADMEDeclaresIgnore` (shipped README keeps its marker)
- [x] Existing loader suites (multi-node, strict parsing, kind/tag validation) unchanged and green
- [ ] Post-deploy + backport: the README boot notice disappears from prod logs; a parked talent shows the one-line Info; a talent stripped of frontmatter still produces the notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)
