### PR TITLE
fix(logging): fixed-width timestamps so lexicographic order equals time order

### DIFF
--- a/internal/platform/logging/archiver.go
+++ b/internal/platform/logging/archiver.go
@@ -66,7 +66,7 @@ func (a *Archiver) Archive(ctx context.Context, before time.Time) (int, error) {
 		}
 	}()
 
-	cutoff := before.UTC().Format(time.RFC3339Nano)
+	cutoff := FormatTimestamp(before)
 	total := 0
 
 	for {

--- a/internal/platform/logging/content.go
+++ b/internal/platform/logging/content.go
@@ -111,7 +111,7 @@ type RequestContent struct {
 // history. Errors are logged but not returned — content retention is
 // best-effort and must never block request processing.
 func (w *ContentWriter) WriteRequest(ctx context.Context, rc RequestContent) {
-	now := time.Now().UTC().Format(time.RFC3339Nano)
+	now := FormatTimestamp(time.Now())
 
 	// Store system prompt (deduplicated by hash).
 	promptHash := hashPrompt(rc.SystemPrompt)

--- a/internal/platform/logging/indexer.go
+++ b/internal/platform/logging/indexer.go
@@ -498,7 +498,7 @@ func (h *IndexHandler) drain() {
 
 	for e := range h.shared.ch {
 		if _, err := stmt.Exec(
-			e.Timestamp.UTC().Format(time.RFC3339Nano),
+			FormatTimestamp(e.Timestamp),
 			e.Level,
 			e.Msg,
 			nullString(e.RequestID),
@@ -671,7 +671,7 @@ func nullInt(n int) sql.NullInt64 {
 // prunes DEBUG and TRACE entries while keeping INFO, WARN, and ERROR.
 // Returns the number of rows deleted.
 func Prune(db *sql.DB, maxAge time.Duration, minKeepLevel slog.Level) (int64, error) {
-	cutoff := time.Now().UTC().Add(-maxAge).Format(time.RFC3339Nano)
+	cutoff := FormatTimestamp(time.Now().Add(-maxAge))
 
 	// Build a list of levels to prune (those below minKeepLevel).
 	// Uses normalizeLevel so level strings match the DB values
@@ -850,14 +850,14 @@ func Query(db *sql.DB, params QueryParams) ([]LogEntry, error) {
 	}
 	if !params.Since.IsZero() {
 		query += " AND timestamp >= ?"
-		args = append(args, params.Since.UTC().Format(time.RFC3339Nano))
+		args = append(args, FormatTimestamp(params.Since))
 	}
 	until := params.Until
 	if until.IsZero() {
 		until = time.Now()
 	}
 	query += " AND timestamp <= ?"
-	args = append(args, until.UTC().Format(time.RFC3339Nano))
+	args = append(args, FormatTimestamp(until))
 
 	if params.Pattern != "" {
 		query += " AND msg LIKE '%' || ? || '%'"

--- a/internal/platform/logging/indexer_test.go
+++ b/internal/platform/logging/indexer_test.go
@@ -848,7 +848,7 @@ func TestQuery_TimestampRange(t *testing.T) {
 func TestQuery_ExtendedLogEntry(t *testing.T) {
 	db := openTestDB(t)
 
-	ts := time.Now().UTC().Format(time.RFC3339Nano)
+	ts := FormatTimestamp(time.Now())
 	_, err := db.Exec(
 		`INSERT INTO log_entries (timestamp, level, msg, request_id, session_id, conversation_id, subsystem)
 		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
@@ -902,7 +902,7 @@ func TestLevelsAtOrAbove(t *testing.T) {
 func TestQueryBySession(t *testing.T) {
 	db := openTestDB(t)
 
-	ts := time.Now().UTC().Format(time.RFC3339Nano)
+	ts := FormatTimestamp(time.Now())
 	for _, e := range []struct {
 		session, level, subsystem, msg string
 	}{

--- a/internal/platform/logging/live_requests.go
+++ b/internal/platform/logging/live_requests.go
@@ -137,7 +137,7 @@ func buildLiveRequestDetail(rc RequestContent, maxLen int, now time.Time) *Reque
 		OutputTokens:     rc.OutputTokens,
 		Exhausted:        rc.Exhausted,
 		ExhaustReason:    rc.ExhaustReason,
-		CreatedAt:        now.Format(time.RFC3339Nano),
+		CreatedAt:        FormatTimestamp(now),
 		Messages:         retainedMessages(rc.Messages, maxLen),
 		ToolCalls:        extractToolDetails(rc.Messages, maxLen),
 	}

--- a/internal/platform/logging/timestamp.go
+++ b/internal/platform/logging/timestamp.go
@@ -1,0 +1,37 @@
+package logging
+
+import "time"
+
+// TimestampLayout is the fixed-width UTC shape for every TEXT timestamp
+// this package writes and every literal bound it compares against them
+// (log_entries, retained request/tool content, live requests).
+//
+// The columns are TEXT and every window clause is a lexicographic
+// compare, so ordering correctness is a property of the string shape.
+// The previous shape, time.RFC3339Nano, trims trailing fractional
+// zeros — and trimmed fractions do not sort: ".1Z" > ".15Z" because
+// 'Z' (0x5A) outranks every digit, so a row stamped at .100s fell
+// outside a window ending at .150s. That inversion made
+// TestQuery_ExtendedLogEntry flake and silently clips real query
+// windows at sub-second edges. A zero-padded 9-digit fraction with a
+// forced-UTC zone is constant-width, so lexicographic order equals
+// time order.
+//
+// This is deliberately not [database.SQLiteTimestampLayout]: that is
+// the space-separated shape the driver emits when binding time.Time,
+// and these columns have always been the T-separated island written
+// via explicit Format calls. Mixing separators is its own documented
+// trap (space sorts before 'T'); staying T-form keeps new rows and
+// bounds ordering correctly against the years of existing rows, whose
+// only residual fuzz is the sub-second edge within their own trimmed
+// fractions — and those rows age out with retention.
+//
+// Always format through [FormatTimestamp]: the fixed width holds only
+// in UTC, where the zone renders as the single byte "Z".
+const TimestampLayout = "2006-01-02T15:04:05.000000000Z07:00"
+
+// FormatTimestamp returns t in [TimestampLayout], normalized to UTC so
+// the width — and therefore lexicographic ordering — is guaranteed.
+func FormatTimestamp(t time.Time) string {
+	return t.UTC().Format(TimestampLayout)
+}

--- a/internal/platform/logging/timestamp_test.go
+++ b/internal/platform/logging/timestamp_test.go
@@ -1,0 +1,90 @@
+package logging
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"testing"
+	"time"
+)
+
+// TestTimestampLayoutOrdersLexicographically pins the property every
+// window clause in this package depends on: for the shapes that made
+// RFC3339Nano misorder (trimmed fractions, bare seconds), the fixed-
+// width format's lexicographic order equals time order.
+func TestTimestampLayoutOrdersLexicographically(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+	instants := []time.Time{
+		base,                                    // .000000000 (RFC3339Nano renders no fraction at all)
+		base.Add(50 * time.Millisecond),         // .05
+		base.Add(100 * time.Millisecond),        // .1  — the trimmed shape that inverted
+		base.Add(100001 * time.Microsecond),     // .100001
+		base.Add(150 * time.Millisecond),        // .15 — RFC3339Nano sorts this BELOW .1
+		base.Add(999999999 * time.Nanosecond),   // .999999999
+		base.Add(time.Second),                   // next bare second
+		base.Add(time.Second + time.Nanosecond), // .000000001
+		time.Date(2026, 8, 31, 7, 0, 0, 5e8, time.FixedZone("CDT", -5*3600)), // non-UTC input normalizes
+	}
+
+	formatted := make([]string, len(instants))
+	for i, at := range instants {
+		formatted[i] = FormatTimestamp(at)
+		if len(formatted[i]) != len(FormatTimestamp(base)) {
+			t.Fatalf("variable width: %q", formatted[i])
+		}
+	}
+
+	sorted := append([]string(nil), formatted...)
+	sort.Strings(sorted)
+	byTime := append([]time.Time(nil), instants...)
+	sort.Slice(byTime, func(i, j int) bool { return byTime[i].Before(byTime[j]) })
+	for i, at := range byTime {
+		if want := FormatTimestamp(at); sorted[i] != want {
+			t.Fatalf("lexicographic order diverges from time order at %d: got %q, want %q\nall: %v",
+				i, sorted[i], want, formatted)
+		}
+	}
+
+	// The inversion this exists to kill, stated directly.
+	if FormatTimestamp(base.Add(100*time.Millisecond)) >= FormatTimestamp(base.Add(150*time.Millisecond)) {
+		t.Fatal(".1s must sort below .15s")
+	}
+}
+
+// TestQueryWindowSubsecondEdges drives the real write path and a real
+// window: a row stamped inside the window must land regardless of how
+// its fraction would have trimmed — the flake TestQuery_ExtendedLogEntry
+// exposed, pinned deterministically.
+func TestQueryWindowSubsecondEdges(t *testing.T) {
+	db := openTestDB(t)
+	inner := slog.NewJSONHandler(discardWriter{}, nil)
+	h := NewIndexHandler(inner, db)
+
+	base := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+	stamps := []time.Time{
+		base.Add(100 * time.Millisecond), // ".1" under the old format
+		base.Add(150 * time.Millisecond),
+		base.Add(2 * time.Second), // outside the window below
+	}
+	for i, at := range stamps {
+		rec := slog.NewRecord(at, slog.LevelInfo, fmt.Sprintf("row %d", i), 0)
+		if err := h.Handle(context.Background(), rec); err != nil {
+			t.Fatal(err)
+		}
+	}
+	h.Close()
+
+	got, err := Query(db, QueryParams{
+		Since: base,
+		Until: base.Add(151 * time.Millisecond),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("window [.0, .151] returned %d rows, want 2 (the sub-second rows)", len(got))
+	}
+}

--- a/internal/platform/telemetry/collector.go
+++ b/internal/platform/telemetry/collector.go
@@ -293,12 +293,14 @@ func (c *Collector) collectLoops(m *Metrics) {
 
 // collectRequests queries the log index for 24h request and error counts,
 // and computes approximate p50/p95 latencies from request durations.
+// The window anchors on the collector clock so tests can pin the
+// boundary-second behavior deterministically.
 func (c *Collector) collectRequests(ctx context.Context, m *Metrics) {
 	if c.src.LogsDB == nil {
 		return
 	}
 
-	now := time.Now().UTC()
+	now := c.clock().UTC()
 	// The log index's timestamp column compares lexicographically;
 	// logging.FormatTimestamp is its fixed-width shape. A seconds-only
 	// RFC3339 bound excluded every row in the boundary second (rows

--- a/internal/platform/telemetry/collector.go
+++ b/internal/platform/telemetry/collector.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
+	"github.com/nugget/thane-ai-agent/internal/platform/logging"
 	"github.com/nugget/thane-ai-agent/internal/platform/usage"
 	"github.com/nugget/thane-ai-agent/internal/runtime/loop"
 )
@@ -298,7 +299,11 @@ func (c *Collector) collectRequests(ctx context.Context, m *Metrics) {
 	}
 
 	now := time.Now().UTC()
-	since := now.Add(-24 * time.Hour).Format(time.RFC3339)
+	// The log index's timestamp column compares lexicographically;
+	// logging.FormatTimestamp is its fixed-width shape. A seconds-only
+	// RFC3339 bound excluded every row in the boundary second (rows
+	// carry fractions, and "." sorts below "Z").
+	since := logging.FormatTimestamp(now.Add(-24 * time.Hour))
 
 	// Count distinct request IDs (non-empty) in the last 24h.
 	var reqCount int

--- a/internal/platform/telemetry/collector_test.go
+++ b/internal/platform/telemetry/collector_test.go
@@ -11,6 +11,7 @@ import (
 
 	_ "modernc.org/sqlite"
 
+	"github.com/nugget/thane-ai-agent/internal/platform/logging"
 	"github.com/nugget/thane-ai-agent/internal/runtime/loop"
 )
 
@@ -358,5 +359,36 @@ func TestCollect_TruncatedColdSnapshotNotCached(t *testing.T) {
 	}
 	if replay := c.Collect(context.Background()); replay == truncated {
 		t.Fatal("a snapshot collected under a dead ctx must not be cached")
+	}
+}
+
+// TestCollect_RequestsBoundarySecond pins the window's lower edge: a
+// row stamped fractionally inside the 24h boundary second must count.
+// The old seconds-only RFC3339 bound excluded every such row ('.'
+// sorts below 'Z' against the index's fractional timestamps), so this
+// test fails against that bound and holds the fixed-width formatter in
+// place.
+func TestCollect_RequestsBoundarySecond(t *testing.T) {
+	db := openTestLogsDB(t)
+
+	fixed := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+	edge := fixed.Add(-24 * time.Hour).Add(300 * time.Millisecond)
+	if _, err := db.Exec(
+		`INSERT INTO log_entries (timestamp, level, msg, request_id, session_id, conversation_id, subsystem, tool, model)
+		 VALUES (?, 'ERROR', 'boundary row', 'req-edge', '', '', '', '', '')`,
+		logging.FormatTimestamp(edge),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	c := NewCollector(Sources{LogsDB: db})
+	c.now = func() time.Time { return fixed }
+
+	m := c.Collect(context.Background())
+	if m.Requests24h != 1 {
+		t.Errorf("Requests24h = %d, want 1 (boundary-second row must count)", m.Requests24h)
+	}
+	if m.Errors24h != 1 {
+		t.Errorf("Errors24h = %d, want 1 (boundary-second row must count)", m.Errors24h)
 	}
 }


### PR DESCRIPTION
## A TEXT timestamp column is only as ordered as its widest-varying row

While re-running CI on #1480, `TestQuery_ExtendedLogEntry` flaked — "got 0 entries, want 1" — and the diagnosis turned out to be a genuine ordering bug, not test noise. Every timestamp the logging package writes and every window bound it compares is `time.RFC3339Nano`, and RFC3339Nano **trims trailing fractional zeros**. Trimmed fractions do not sort: `'Z'` (0x5A) outranks every digit, so `…00.1Z` compares *greater than* `…00.15Z`, and a row stamped at .100s falls outside a window ending at .150s. The flake was the visible symptom; the same inversion silently clips real query windows — `logs_query`, the `/v1` log surface, prune and archive cutoffs — at sub-second edges, nondeterministically.

The repo already knows this class of trap: `database.SQLiteTimestampLayout` documents the space-vs-T separator miscompare for driver-bound columns. But the logging tables are a different, self-consistent island — T-separated, written via explicit `Format` calls since the beginning (production rows confirm the shape) — so the fix belongs beside them, not in a migration to the driver canon that would mis-sort against years of existing rows.

## Fixed width, no migration

`logging.TimestampLayout` is a zero-padded 9-digit-fraction, forced-UTC shape — constant 30 bytes, so lexicographic order equals time order — and `logging.FormatTimestamp` is the single formatter for all seven sites: the index write path, both `Query` bounds, the prune cutoff, the content-retention write and archive cutoff, and the live-request display stamp. Existing trimmed-fraction rows need no rewrite: T-form new bounds order correctly against T-form old rows everywhere except within a shared sub-second — the residual is bounded at one second on pre-fix rows, and those rows age out entirely with the index's retention. No multi-gigabyte migration, no index rebuild, no plan change (the bounds stay raw column compares on `idx_log_timestamp`).

The telemetry collector's 24h window had a sibling defect — a seconds-only RFC3339 bound excludes every row in its boundary second (`'.'` sorts below `'Z'`) — and now uses the same formatter.

## What stays out, deliberately

The driver-canon islands (columns bound as `time.Time` — archive, checkpoints) carry the same trimmed-fraction property inside `SQLiteTimestampLayout` itself (`.999999999` trims). Their windows are self-consistent driver-form on both sides, so exposure is the same sub-second-edge class, in tables where windows are conversational timescales; changing the *driver's* emission is a different, wider decision and is not smuggled into this fix.

## Test plan

- [x] `just ci` green locally (fresh worktree)
- [x] `TestTimestampLayoutOrdersLexicographically` — pins order-equals-time across the shapes that inverted (bare second, `.05`, `.1` vs `.100001` vs `.15`, `.999999999`, second boundary, non-UTC input), plus constant width and the `.1 < .15` inversion stated directly
- [x] `TestQueryWindowSubsecondEdges` — the flake's scenario made deterministic through the real handler write path: sub-second rows land inside a sub-second window
- [x] `TestQuery_ExtendedLogEntry` and the full logging + telemetry suites green across repeated runs
- [ ] Post-deploy: none needed beyond normal operation — new rows are fixed-width immediately; pre-fix rows retire with retention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
