### PR TITLE
feat: add bounded contact dossier backfill

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -90,6 +90,25 @@ filesystem paths, signer principals, or the contents of `.allowed_signers`.
 | `GET` | `/v1/archive/search` | Full-text archive search. |
 | `GET` | `/v1/archive/messages` | Archived message query. |
 | `GET` | `/v1/archive/stats` | Archive statistics. |
+| `POST` | `/v1/archive/contact-dossier-backfill` | Advance one bounded page of the durable, one-time contact-dossier backfill (`?limit`, default 50, max 200). |
+
+The backfill endpoint is an operator operation (`archive:write` in the native
+API contract), not a model tool or an autonomous-loop behavior. It freezes a
+cutoff on its first call, pages active contact subjects and then historical
+closed sessions with durable keyset cursors, and adds catch-up work below fresh
+session-close work. Repeat the request until `complete` is true:
+
+```sh
+curl -sS -X POST \
+  'http://127.0.0.1:8080/v1/archive/contact-dossier-backfill?limit=50'
+```
+
+Retries and restarts are safe. Pending subjects and subjects in the retained
+queue-completion journal are skipped, while the durable cursor prevents the
+already-traversed archive from being scanned again. Once complete, future calls
+are no-ops rather than recurring full-archive scans. The archivist is not woken
+by the endpoint; it drains the resulting backlog at its normal self-paced
+cadence.
 
 ### Checkpoints and Companion Apps
 

--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -563,6 +563,36 @@ unrelated dossiers get neither ambient nor loose lexical offers. Existing
 workspaces can add the same declaration and re-run `thane init` to establish
 the signed sibling repository before deployment.
 
+Contact lifecycle does not rename or silently erase this history:
+
+- Renaming a structured contact leaves `contacts:<uuid>.md` in place. The next
+  structured dossier write derives the new display title while the UUID path,
+  citations, and Git history remain continuous.
+- Forgetting a contact soft-deletes the structured row. The canonical writer
+  then refuses new writes because the UUID is no longer an active contact, but
+  the dossier file and its signed history remain until an operator explicitly
+  moves or deletes the document.
+- Merging contacts is deliberate rather than inferred. Choose the surviving
+  structured UUID, reconcile any useful claims and citations into that
+  contact's dossier through `contact_dossier_write`, then forget the duplicate.
+  The duplicate dossier is retained unless the operator explicitly archives it
+  with `doc_move` to another suitable managed root or removes it with
+  `doc_delete`.
+- `doc_move` and `doc_delete` are recovery and lifecycle operations, not normal
+  dossier-authoring doors. A deletion removes the live document but remains a
+  signed deletion in the source root's Git history; forgetting or merging a
+  structured contact never performs that step automatically.
+
+An existing installation can seed historical stewardship explicitly through
+`POST /v1/archive/contact-dossier-backfill`. Each call handles at most 200
+source records, with a durable frozen cutoff and keyset cursor. Active contact
+subjects are queued first, followed by closed, non-empty conversational
+sessions; automation traffic is omitted, recent queue work is coalesced, and
+historical entries sit below fresh session-close work. The operator repeats
+bounded calls until `complete` is true. Completion is permanent operational
+state: the endpoint becomes a no-op, while new session evidence continues
+through the normal steady-state enqueue path.
+
 ## The Human-Level Rule
 
 If you find yourself thinking:

--- a/internal/app/archivist_session_close_wake.go
+++ b/internal/app/archivist_session_close_wake.go
@@ -4,42 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/channels/messages"
 	"github.com/nugget/thane-ai-agent/internal/runtime/archivist"
 )
-
-// archivistAutomationOrigins are conversation-id prefixes whose sessions
-// carry no dossier-worthy evidence: autonomous service-loop iterations,
-// scheduled-task runs, metacognitive bookkeeping, and auxiliary utility
-// traffic. Sessions from these origins are never enqueued for the archivist.
-//
-// This is a denylist on purpose — any origin NOT named here (interactive
-// channels like signal-/email-, delegate work, external events) is treated
-// as archivable, so the rare substantive case is never silently dropped.
-// The archivist-queue flood that motivated this (issue #1024) was exactly
-// these: loop- service iterations, sched- automation, metacog- bookkeeping.
-var archivistAutomationOrigins = []string{
-	"loop-",         // self-paced service loops (metacognitive, pollers, HA automations)
-	"sched-",        // scheduled tasks
-	"metacog-",      // metacognitive bookkeeping
-	"owu-auxiliary", // open-webui auxiliary requests ONLY — real OWU chats are owu-<hash> and stay archivable
-}
-
-// isArchivableSession reports whether a closed session is worth folding into
-// dossiers, judged solely from its conversation origin — a deterministic
-// property, no LLM call or content scan. Automation/auxiliary origins are
-// skipped; everything else is archivable.
-func isArchivableSession(conversationID string) bool {
-	for _, prefix := range archivistAutomationOrigins {
-		if strings.HasPrefix(conversationID, prefix) {
-			return false
-		}
-	}
-	return true
-}
 
 // enqueueSessionCloseWork records a closed session as a pending work item in
 // the archivist's durable queue, keyed dedup on "session:<id>" so the same
@@ -58,7 +27,7 @@ func (a *App) enqueueSessionCloseWork(ctx context.Context, sessionID, conversati
 	if sessionID == "" {
 		return fmt.Errorf("empty session_id")
 	}
-	if !isArchivableSession(conversationID) {
+	if !archivist.IsArchivableSession(conversationID) {
 		if a.logger != nil {
 			a.logger.Debug("archivist: skipping non-archival session origin",
 				"session_id", sessionID,

--- a/internal/app/archivist_session_close_wake_test.go
+++ b/internal/app/archivist_session_close_wake_test.go
@@ -174,8 +174,8 @@ func TestIsArchivableSession(t *testing.T) {
 		{"owu-auxiliary", false}, // only the fixed auxiliary id is skipped
 	}
 	for _, tc := range cases {
-		if got := isArchivableSession(tc.conv); got != tc.want {
-			t.Errorf("isArchivableSession(%q) = %v, want %v", tc.conv, got, tc.want)
+		if got := archivist.IsArchivableSession(tc.conv); got != tc.want {
+			t.Errorf("archivist.IsArchivableSession(%q) = %v, want %v", tc.conv, got, tc.want)
 		}
 	}
 }

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -21,6 +21,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/identity"
 	"github.com/nugget/thane-ai-agent/internal/platform/telemetry"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agent"
+	"github.com/nugget/thane-ai-agent/internal/runtime/archivist"
 	"github.com/nugget/thane-ai-agent/internal/server/api"
 	cdav "github.com/nugget/thane-ai-agent/internal/server/carddav"
 	"github.com/nugget/thane-ai-agent/internal/server/web"
@@ -58,6 +59,16 @@ func (a *App) initServers(s *newState) error {
 	server.SetMemoryStore(a.mem)
 	server.SetArchiveStore(a.archiveStore)
 	server.UseContactStore(a.contactStore)
+	if a.archivistDefinitionEnabled() {
+		contactBackfill := archivist.NewContactDossierBackfill(
+			a.contactStore,
+			a.archiveStore,
+			a.loopQueue,
+			a.opStore,
+			logger,
+		)
+		server.ConfigureContactDossierBackfill(contactBackfill.Run)
+	}
 	server.UseLoopDefinitionRegistry(a.loopDefinitionRegistry)
 	if a.documentStore != nil {
 		server.UseDocumentReader(a.documentStore.Read)

--- a/internal/runtime/archivist/contact_backfill.go
+++ b/internal/runtime/archivist/contact_backfill.go
@@ -282,11 +282,10 @@ func (b *ContactDossierBackfill) enqueueSubject(
 
 	payload := messages.LoopNotifyPayload{
 		Events: []messages.LoopEventPayload{{
-			Source:     "contact_dossier_backfill",
-			Type:       eventType,
-			ID:         id,
-			Summary:    summary,
-			ObservedAt: b.now().UTC(),
+			Source:  "contact_dossier_backfill",
+			Type:    eventType,
+			ID:      id,
+			Summary: summary,
 		}},
 	}
 	raw, err := json.Marshal(payload)

--- a/internal/runtime/archivist/contact_backfill.go
+++ b/internal/runtime/archivist/contact_backfill.go
@@ -1,0 +1,354 @@
+package archivist
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/channels/messages"
+	"github.com/nugget/thane-ai-agent/internal/platform/opstate"
+	"github.com/nugget/thane-ai-agent/internal/state/contacts"
+	"github.com/nugget/thane-ai-agent/internal/state/loopqueue"
+	"github.com/nugget/thane-ai-agent/internal/state/memory"
+)
+
+const (
+	contactBackfillNamespace = "archivist:contact_dossier_backfill"
+	contactBackfillStateKey  = "v1"
+	contactBackfillVersion   = 1
+
+	// Historical catch-up stays behind ordinary session-close work. The
+	// archivist remains self-paced, and a large one-time import cannot starve
+	// fresh evidence merely because it entered the queue first.
+	contactBackfillPriority = -10
+
+	// DefaultContactBackfillLimit is the source-record limit used when an
+	// operator omits or supplies a non-positive batch size.
+	DefaultContactBackfillLimit = 50
+	// MaxContactBackfillLimit caps one operator request so historical work is
+	// always admitted to the queue in bounded increments.
+	MaxContactBackfillLimit = 200
+)
+
+const (
+	backfillPhaseContacts = "contacts"
+	backfillPhaseSessions = "sessions"
+	backfillPhaseComplete = "complete"
+)
+
+// automationSessionOrigins are conversation-ID prefixes whose sessions carry
+// no dossier-worthy evidence: autonomous service-loop iterations,
+// scheduled-task runs, metacognitive bookkeeping, and auxiliary utility
+// traffic. This is deliberately a denylist: any unrecognized origin remains
+// archivable so a rare substantive source is not silently dropped.
+var automationSessionOrigins = []string{
+	"loop-",
+	"sched-",
+	"metacog-",
+	"owu-auxiliary",
+}
+
+// ContactDossierBackfill advances the explicit one-time historical traversal
+// one bounded page at a time. It never wakes the archivist; enqueued subjects
+// are drained on the loop's normal self-paced cadence.
+type ContactDossierBackfill struct {
+	listContacts func(time.Time, string, int) ([]*contacts.Contact, bool, error)
+	listSessions func(time.Time, string, int) ([]*memory.Session, bool, error)
+	hasRecent    func(context.Context, string, string) (bool, error)
+	enqueue      func(context.Context, string, string, int, []byte) error
+	getState     func(string, string) (string, error)
+	setState     func(string, string, string) error
+	logger       *slog.Logger
+	now          func() time.Time
+
+	mu sync.Mutex
+}
+
+// ContactDossierBackfillResult describes one bounded advancement. Counts are
+// for this call rather than lifetime totals; Complete is durable and later
+// calls return a no-op result.
+type ContactDossierBackfillResult struct {
+	Phase             string    `json:"phase"`
+	NextPhase         string    `json:"next_phase,omitempty"`
+	Cutoff            time.Time `json:"cutoff"`
+	Scanned           int       `json:"scanned"`
+	Enqueued          int       `json:"enqueued"`
+	SkippedRecent     int       `json:"skipped_recent"`
+	SkippedEmpty      int       `json:"skipped_empty"`
+	SkippedAutomation int       `json:"skipped_automation"`
+	Complete          bool      `json:"complete"`
+}
+
+type contactDossierBackfillState struct {
+	Version       int       `json:"version"`
+	Cutoff        time.Time `json:"cutoff"`
+	Phase         string    `json:"phase"`
+	ContactCursor string    `json:"contact_cursor,omitempty"`
+	SessionCursor string    `json:"session_cursor,omitempty"`
+	Complete      bool      `json:"complete"`
+}
+
+// NewContactDossierBackfill constructs the one-time contact-dossier backfill.
+func NewContactDossierBackfill(
+	contactSource *contacts.Store,
+	sessionSource *memory.ArchiveStore,
+	queue *loopqueue.Store,
+	state *opstate.Store,
+	logger *slog.Logger,
+) *ContactDossierBackfill {
+	backfill := &ContactDossierBackfill{
+		logger: logger,
+		now:    time.Now,
+	}
+	if contactSource != nil {
+		backfill.listContacts = contactSource.ListActivePage
+	}
+	if sessionSource != nil {
+		backfill.listSessions = sessionSource.ListClosedSessionsPage
+	}
+	if queue != nil {
+		backfill.hasRecent = queue.HasRecentWork
+		backfill.enqueue = queue.Enqueue
+	}
+	if state != nil {
+		backfill.getState = state.Get
+		backfill.setState = state.Set
+	}
+	return backfill
+}
+
+// Run advances at most limit source records and durably records the resulting
+// cursor. Limits outside the supported range are clamped to safe defaults.
+func (b *ContactDossierBackfill) Run(ctx context.Context, limit int) (ContactDossierBackfillResult, error) {
+	if b == nil || b.listContacts == nil || b.listSessions == nil || b.hasRecent == nil ||
+		b.enqueue == nil || b.getState == nil || b.setState == nil {
+		return ContactDossierBackfillResult{}, fmt.Errorf("contact dossier backfill is not configured")
+	}
+	if limit <= 0 {
+		limit = DefaultContactBackfillLimit
+	}
+	if limit > MaxContactBackfillLimit {
+		limit = MaxContactBackfillLimit
+	}
+	if err := ctx.Err(); err != nil {
+		return ContactDossierBackfillResult{}, err
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	state, initialized, err := b.loadState()
+	if err != nil {
+		return ContactDossierBackfillResult{}, err
+	}
+	if initialized {
+		// Freeze the traversal boundary before any queue mutation. If the
+		// process stops mid-page, retrying may revisit work but can never widen
+		// the snapshot to sessions or contacts that arrived afterward.
+		if err := b.saveState(state); err != nil {
+			return ContactDossierBackfillResult{}, err
+		}
+	}
+	if state.Complete {
+		return ContactDossierBackfillResult{
+			Phase:    backfillPhaseComplete,
+			Cutoff:   state.Cutoff,
+			Complete: true,
+		}, nil
+	}
+
+	result := ContactDossierBackfillResult{
+		Phase:  state.Phase,
+		Cutoff: state.Cutoff,
+	}
+	switch state.Phase {
+	case backfillPhaseContacts:
+		err = b.runContactPage(ctx, &state, &result, limit)
+	case backfillPhaseSessions:
+		err = b.runSessionPage(ctx, &state, &result, limit)
+	default:
+		return ContactDossierBackfillResult{}, fmt.Errorf("contact dossier backfill has invalid phase %q", state.Phase)
+	}
+	if err != nil {
+		return ContactDossierBackfillResult{}, err
+	}
+	if err := b.saveState(state); err != nil {
+		return ContactDossierBackfillResult{}, err
+	}
+
+	result.NextPhase = state.Phase
+	result.Complete = state.Complete
+	if b.logger != nil {
+		b.logger.Info("contact dossier backfill advanced",
+			"phase", result.Phase,
+			"next_phase", result.NextPhase,
+			"scanned", result.Scanned,
+			"enqueued", result.Enqueued,
+			"skipped_recent", result.SkippedRecent,
+			"skipped_empty", result.SkippedEmpty,
+			"skipped_automation", result.SkippedAutomation,
+			"complete", result.Complete,
+		)
+	}
+	return result, nil
+}
+
+func (b *ContactDossierBackfill) runContactPage(
+	ctx context.Context,
+	state *contactDossierBackfillState,
+	result *ContactDossierBackfillResult,
+	limit int,
+) error {
+	page, hasMore, err := b.listContacts(state.Cutoff, state.ContactCursor, limit)
+	if err != nil {
+		return fmt.Errorf("page active contacts: %w", err)
+	}
+	for _, contact := range page {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if contact == nil {
+			return fmt.Errorf("page active contacts: nil contact")
+		}
+		id := contact.ID.String()
+		result.Scanned++
+		if err := b.enqueueSubject(ctx, "contact:"+id, "contact", id,
+			"Active contact seeded for one-time dossier backfill.", result); err != nil {
+			return err
+		}
+		state.ContactCursor = id
+	}
+	if !hasMore {
+		state.Phase = backfillPhaseSessions
+	}
+	return nil
+}
+
+func (b *ContactDossierBackfill) runSessionPage(
+	ctx context.Context,
+	state *contactDossierBackfillState,
+	result *ContactDossierBackfillResult,
+	limit int,
+) error {
+	page, hasMore, err := b.listSessions(state.Cutoff, state.SessionCursor, limit)
+	if err != nil {
+		return fmt.Errorf("page closed sessions: %w", err)
+	}
+	for _, session := range page {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if session == nil {
+			return fmt.Errorf("page closed sessions: nil session")
+		}
+		result.Scanned++
+		switch {
+		case session.MessageCount == 0:
+			result.SkippedEmpty++
+		case !IsArchivableSession(session.ConversationID):
+			result.SkippedAutomation++
+		default:
+			if err := b.enqueueSubject(ctx, "session:"+session.ID, "session", session.ID,
+				"Historical closed session seeded for one-time contact dossier backfill.", result); err != nil {
+				return err
+			}
+		}
+		state.SessionCursor = session.ID
+	}
+	if !hasMore {
+		state.Phase = backfillPhaseComplete
+		state.Complete = true
+	}
+	return nil
+}
+
+func (b *ContactDossierBackfill) enqueueSubject(
+	ctx context.Context,
+	key, eventType, id, summary string,
+	result *ContactDossierBackfillResult,
+) error {
+	seen, err := b.hasRecent(ctx, DefinitionName, key)
+	if err != nil {
+		return fmt.Errorf("inspect archivist queue key %s: %w", key, err)
+	}
+	if seen {
+		result.SkippedRecent++
+		return nil
+	}
+
+	payload := messages.LoopNotifyPayload{
+		Events: []messages.LoopEventPayload{{
+			Source:     "contact_dossier_backfill",
+			Type:       eventType,
+			ID:         id,
+			Summary:    summary,
+			ObservedAt: b.now().UTC(),
+		}},
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal archivist queue key %s: %w", key, err)
+	}
+	if err := b.enqueue(ctx, DefinitionName, key, contactBackfillPriority, raw); err != nil {
+		return fmt.Errorf("enqueue archivist queue key %s: %w", key, err)
+	}
+	result.Enqueued++
+	return nil
+}
+
+func (b *ContactDossierBackfill) loadState() (contactDossierBackfillState, bool, error) {
+	raw, err := b.getState(contactBackfillNamespace, contactBackfillStateKey)
+	if err != nil {
+		return contactDossierBackfillState{}, false, fmt.Errorf("load contact dossier backfill state: %w", err)
+	}
+	if strings.TrimSpace(raw) == "" {
+		return contactDossierBackfillState{
+			Version: contactBackfillVersion,
+			Cutoff:  b.now().UTC(),
+			Phase:   backfillPhaseContacts,
+		}, true, nil
+	}
+
+	var state contactDossierBackfillState
+	if err := json.Unmarshal([]byte(raw), &state); err != nil {
+		return contactDossierBackfillState{}, false, fmt.Errorf("decode contact dossier backfill state: %w", err)
+	}
+	if state.Version != contactBackfillVersion {
+		return contactDossierBackfillState{}, false, fmt.Errorf("unsupported contact dossier backfill state version %d", state.Version)
+	}
+	if state.Cutoff.IsZero() {
+		return contactDossierBackfillState{}, false, fmt.Errorf("contact dossier backfill state is missing cutoff")
+	}
+	if state.Complete {
+		state.Phase = backfillPhaseComplete
+	}
+	return state, false, nil
+}
+
+func (b *ContactDossierBackfill) saveState(state contactDossierBackfillState) error {
+	raw, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("encode contact dossier backfill state: %w", err)
+	}
+	if err := b.setState(contactBackfillNamespace, contactBackfillStateKey, string(raw)); err != nil {
+		return fmt.Errorf("save contact dossier backfill state: %w", err)
+	}
+	return nil
+}
+
+// IsArchivableSession reports whether a closed session is worth folding into
+// dossiers based on its deterministic conversation origin. Automation and
+// auxiliary origins are skipped; unknown origins default to archivable so
+// potentially substantive evidence is not silently discarded.
+func IsArchivableSession(conversationID string) bool {
+	for _, prefix := range automationSessionOrigins {
+		if strings.HasPrefix(conversationID, prefix) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/runtime/archivist/contact_backfill_test.go
+++ b/internal/runtime/archivist/contact_backfill_test.go
@@ -1,0 +1,216 @@
+package archivist
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/nugget/thane-ai-agent/internal/channels/messages"
+	"github.com/nugget/thane-ai-agent/internal/state/contacts"
+	"github.com/nugget/thane-ai-agent/internal/state/memory"
+)
+
+type fakeContactBackfillSource struct {
+	contacts []*contacts.Contact
+	limits   []int
+}
+
+func (f *fakeContactBackfillSource) ListActivePage(_ time.Time, afterID string, limit int) ([]*contacts.Contact, bool, error) {
+	f.limits = append(f.limits, limit)
+	var page []*contacts.Contact
+	for _, contact := range f.contacts {
+		if contact.ID.String() > afterID {
+			page = append(page, contact)
+		}
+	}
+	hasMore := len(page) > limit
+	if hasMore {
+		page = page[:limit]
+	}
+	return page, hasMore, nil
+}
+
+type fakeSessionBackfillSource struct {
+	sessions []*memory.Session
+	limits   []int
+}
+
+func (f *fakeSessionBackfillSource) ListClosedSessionsPage(_ time.Time, afterID string, limit int) ([]*memory.Session, bool, error) {
+	f.limits = append(f.limits, limit)
+	var page []*memory.Session
+	for _, session := range f.sessions {
+		if session.ID > afterID {
+			page = append(page, session)
+		}
+	}
+	hasMore := len(page) > limit
+	if hasMore {
+		page = page[:limit]
+	}
+	return page, hasMore, nil
+}
+
+type fakeBackfillEnqueue struct {
+	consumer string
+	key      string
+	priority int
+	payload  []byte
+}
+
+type fakeContactBackfillQueue struct {
+	seen     map[string]bool
+	enqueues []fakeBackfillEnqueue
+}
+
+func (f *fakeContactBackfillQueue) HasRecentWork(_ context.Context, consumerLoop, dedupKey string) (bool, error) {
+	return f.seen[consumerLoop+"/"+dedupKey], nil
+}
+
+func (f *fakeContactBackfillQueue) Enqueue(_ context.Context, consumerLoop, dedupKey string, priority int, payload []byte) error {
+	f.enqueues = append(f.enqueues, fakeBackfillEnqueue{
+		consumer: consumerLoop,
+		key:      dedupKey,
+		priority: priority,
+		payload:  append([]byte(nil), payload...),
+	})
+	f.seen[consumerLoop+"/"+dedupKey] = true
+	return nil
+}
+
+type fakeContactBackfillState struct {
+	value    string
+	setCalls int
+	failOn   int
+}
+
+func (f *fakeContactBackfillState) Get(_, _ string) (string, error) {
+	return f.value, nil
+}
+
+func (f *fakeContactBackfillState) Set(_, _, value string) error {
+	f.setCalls++
+	if f.failOn == f.setCalls {
+		return errors.New("state unavailable")
+	}
+	f.value = value
+	return nil
+}
+
+func TestContactDossierBackfill_BoundedPhasesAndDurableCompletion(t *testing.T) {
+	fixedNow := time.Date(2026, 8, 31, 16, 0, 0, 0, time.UTC)
+	contactA := uuid.MustParse("019c0000-0000-7000-8000-000000000001")
+	contactB := uuid.MustParse("019c0000-0000-7000-8000-000000000002")
+	contactsSource := &fakeContactBackfillSource{contacts: []*contacts.Contact{
+		{ID: contactA},
+		{ID: contactB},
+	}}
+	sessionsSource := &fakeSessionBackfillSource{sessions: []*memory.Session{
+		{ID: "019d0000-0000-7000-8000-000000000001", ConversationID: "signal-contact", MessageCount: 3},
+		{ID: "019d0000-0000-7000-8000-000000000002", ConversationID: "signal-empty", MessageCount: 0},
+		{ID: "019d0000-0000-7000-8000-000000000003", ConversationID: "loop-archivist-1", MessageCount: 5},
+	}}
+	queue := &fakeContactBackfillQueue{seen: map[string]bool{
+		DefinitionName + "/contact:" + contactB.String(): true,
+	}}
+	state := &fakeContactBackfillState{}
+	backfill := newFakeContactDossierBackfill(contactsSource, sessionsSource, queue, state)
+	backfill.now = func() time.Time { return fixedNow }
+
+	first, err := backfill.Run(t.Context(), 2)
+	if err != nil {
+		t.Fatalf("contact page: %v", err)
+	}
+	if first.Phase != backfillPhaseContacts || first.NextPhase != backfillPhaseSessions {
+		t.Fatalf("contact page phases = %q -> %q", first.Phase, first.NextPhase)
+	}
+	if first.Scanned != 2 || first.Enqueued != 1 || first.SkippedRecent != 1 || first.Complete {
+		t.Fatalf("contact page result = %+v", first)
+	}
+	if !first.Cutoff.Equal(fixedNow) {
+		t.Fatalf("cutoff = %v, want %v", first.Cutoff, fixedNow)
+	}
+
+	second, err := backfill.Run(t.Context(), 2000)
+	if err != nil {
+		t.Fatalf("session page: %v", err)
+	}
+	if second.Phase != backfillPhaseSessions || second.NextPhase != backfillPhaseComplete || !second.Complete {
+		t.Fatalf("session page phases = %q -> %q, complete=%v", second.Phase, second.NextPhase, second.Complete)
+	}
+	if second.Scanned != 3 || second.Enqueued != 1 || second.SkippedEmpty != 1 || second.SkippedAutomation != 1 {
+		t.Fatalf("session page result = %+v", second)
+	}
+	if len(sessionsSource.limits) != 1 || sessionsSource.limits[0] != MaxContactBackfillLimit {
+		t.Fatalf("session limits = %v, want [%d]", sessionsSource.limits, MaxContactBackfillLimit)
+	}
+
+	third, err := backfill.Run(t.Context(), 10)
+	if err != nil {
+		t.Fatalf("completed no-op: %v", err)
+	}
+	if !third.Complete || third.Phase != backfillPhaseComplete || third.Scanned != 0 || third.Enqueued != 0 {
+		t.Fatalf("completed result = %+v", third)
+	}
+	if len(queue.enqueues) != 2 {
+		t.Fatalf("enqueues = %d, want 2", len(queue.enqueues))
+	}
+	for _, enqueue := range queue.enqueues {
+		if enqueue.consumer != DefinitionName || enqueue.priority != contactBackfillPriority {
+			t.Errorf("enqueue = %+v", enqueue)
+		}
+		var payload messages.LoopNotifyPayload
+		if err := json.Unmarshal(enqueue.payload, &payload); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		if len(payload.Events) != 1 || payload.Events[0].Source != "contact_dossier_backfill" {
+			t.Errorf("payload = %+v", payload)
+		}
+	}
+}
+
+func TestContactDossierBackfill_StateFailureRetriesWithoutDuplicate(t *testing.T) {
+	contactID := uuid.MustParse("019c0000-0000-7000-8000-000000000001")
+	contactsSource := &fakeContactBackfillSource{contacts: []*contacts.Contact{{ID: contactID}}}
+	queue := &fakeContactBackfillQueue{seen: make(map[string]bool)}
+	state := &fakeContactBackfillState{failOn: 2}
+	backfill := newFakeContactDossierBackfill(contactsSource, &fakeSessionBackfillSource{}, queue, state)
+
+	if _, err := backfill.Run(t.Context(), 10); err == nil || !strings.Contains(err.Error(), "state unavailable") {
+		t.Fatalf("first Run error = %v, want state failure", err)
+	}
+	if len(queue.enqueues) != 1 {
+		t.Fatalf("first Run enqueues = %d, want 1", len(queue.enqueues))
+	}
+
+	retry, err := backfill.Run(t.Context(), 10)
+	if err != nil {
+		t.Fatalf("retry Run: %v", err)
+	}
+	if retry.Enqueued != 0 || retry.SkippedRecent != 1 {
+		t.Fatalf("retry result = %+v", retry)
+	}
+	if len(queue.enqueues) != 1 {
+		t.Fatalf("retry duplicated enqueue: got %d total", len(queue.enqueues))
+	}
+}
+
+func newFakeContactDossierBackfill(
+	contactSource *fakeContactBackfillSource,
+	sessionSource *fakeSessionBackfillSource,
+	queue *fakeContactBackfillQueue,
+	state *fakeContactBackfillState,
+) *ContactDossierBackfill {
+	return &ContactDossierBackfill{
+		listContacts: contactSource.ListActivePage,
+		listSessions: sessionSource.ListClosedSessionsPage,
+		hasRecent:    queue.HasRecentWork,
+		enqueue:      queue.Enqueue,
+		getState:     state.Get,
+		setState:     state.Set,
+		now:          time.Now,
+	}
+}

--- a/internal/runtime/archivist/contact_backfill_test.go
+++ b/internal/runtime/archivist/contact_backfill_test.go
@@ -166,8 +166,14 @@ func TestContactDossierBackfill_BoundedPhasesAndDurableCompletion(t *testing.T) 
 		if err := json.Unmarshal(enqueue.payload, &payload); err != nil {
 			t.Fatalf("decode payload: %v", err)
 		}
-		if len(payload.Events) != 1 || payload.Events[0].Source != "contact_dossier_backfill" {
-			t.Errorf("payload = %+v", payload)
+		if len(payload.Events) != 1 {
+			t.Fatalf("payload events = %+v, want one", payload.Events)
+		}
+		if payload.Events[0].Source != "contact_dossier_backfill" {
+			t.Errorf("payload source = %q, want contact_dossier_backfill", payload.Events[0].Source)
+		}
+		if !payload.Events[0].ObservedAt.IsZero() {
+			t.Errorf("payload observed_at = %v, want omitted", payload.Events[0].ObservedAt)
 		}
 	}
 }

--- a/internal/server/api/contact_dossier_backfill_test.go
+++ b/internal/server/api/contact_dossier_backfill_test.go
@@ -1,0 +1,79 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/runtime/archivist"
+)
+
+func TestHandleContactDossierBackfill(t *testing.T) {
+	t.Run("not configured", func(t *testing.T) {
+		server := &Server{logger: testAPILogger()}
+		recorder := httptest.NewRecorder()
+		server.handleContactDossierBackfill(recorder, httptest.NewRequest(http.MethodPost,
+			"/v1/archive/contact-dossier-backfill", nil))
+		if recorder.Code != http.StatusServiceUnavailable {
+			t.Fatalf("status = %d, want %d", recorder.Code, http.StatusServiceUnavailable)
+		}
+	})
+
+	t.Run("invalid limit", func(t *testing.T) {
+		server := &Server{logger: testAPILogger()}
+		server.ConfigureContactDossierBackfill(func(_ context.Context, _ int) (archivist.ContactDossierBackfillResult, error) {
+			return archivist.ContactDossierBackfillResult{}, nil
+		})
+		recorder := httptest.NewRecorder()
+		server.handleContactDossierBackfill(recorder, httptest.NewRequest(http.MethodPost,
+			"/v1/archive/contact-dossier-backfill?limit=201", nil))
+		if recorder.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
+		}
+	})
+
+	t.Run("advances one batch", func(t *testing.T) {
+		server := &Server{logger: testAPILogger()}
+		var gotLimit int
+		want := archivist.ContactDossierBackfillResult{
+			Phase:     "contacts",
+			NextPhase: "sessions",
+			Cutoff:    time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC),
+			Scanned:   2,
+			Enqueued:  2,
+		}
+		server.ConfigureContactDossierBackfill(func(_ context.Context, limit int) (archivist.ContactDossierBackfillResult, error) {
+			gotLimit = limit
+			return want, nil
+		})
+		recorder := httptest.NewRecorder()
+		server.handleContactDossierBackfill(recorder, httptest.NewRequest(http.MethodPost,
+			"/v1/archive/contact-dossier-backfill?limit=2", nil))
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("status = %d, body=%s", recorder.Code, recorder.Body.String())
+		}
+		if gotLimit != 2 {
+			t.Fatalf("limit = %d, want 2", gotLimit)
+		}
+		if got := recorder.Body.String(); !strings.Contains(got, `"next_phase":"sessions"`) {
+			t.Fatalf("body = %s", got)
+		}
+	})
+
+	t.Run("reports advancement failure", func(t *testing.T) {
+		server := &Server{logger: testAPILogger()}
+		server.ConfigureContactDossierBackfill(func(_ context.Context, _ int) (archivist.ContactDossierBackfillResult, error) {
+			return archivist.ContactDossierBackfillResult{}, errors.New("queue offline")
+		})
+		recorder := httptest.NewRecorder()
+		server.handleContactDossierBackfill(recorder, httptest.NewRequest(http.MethodPost,
+			"/v1/archive/contact-dossier-backfill", nil))
+		if recorder.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want %d", recorder.Code, http.StatusInternalServerError)
+		}
+	})
+}

--- a/internal/server/api/server.go
+++ b/internal/server/api/server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/logging"
 	"github.com/nugget/thane-ai-agent/internal/platform/usage"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agent"
+	"github.com/nugget/thane-ai-agent/internal/runtime/archivist"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/server/legacyroute"
 	"github.com/nugget/thane-ai-agent/internal/server/openapi"
@@ -109,6 +110,7 @@ type Server struct {
 	reconcileLoopDefinition            func(context.Context, string) error
 	launchLoopDefinition               func(context.Context, string, looppkg.Launch) (looppkg.LaunchResult, error)
 	launchChatLoop                     func(context.Context, looppkg.Launch) (looppkg.LaunchResult, error)
+	runContactDossierBackfill          func(context.Context, int) (archivist.ContactDossierBackfillResult, error)
 	anthropicRateLimitSnapshot         func() *fleet.AnthropicRateLimitSnapshot
 	logger                             *slog.Logger
 	server                             *http.Server
@@ -449,6 +451,14 @@ func (s *Server) SetArchiveStore(as *memory.ArchiveStore) {
 	s.archiveStore = as
 }
 
+// ConfigureContactDossierBackfill configures the explicit operator path that
+// advances the archivist's one-time historical contact-dossier traversal.
+func (s *Server) ConfigureContactDossierBackfill(
+	run func(context.Context, int) (archivist.ContactDossierBackfillResult, error),
+) {
+	s.runContactDossierBackfill = run
+}
+
 // Start begins serving HTTP requests.
 func (s *Server) Start(ctx context.Context) error {
 	mux := http.NewServeMux()
@@ -538,6 +548,7 @@ func (s *Server) Start(ctx context.Context) error {
 	mux.HandleFunc("GET /v1/archive/search", s.handleArchiveSearch)
 	mux.HandleFunc("GET /v1/archive/messages", s.handleArchiveMessages)
 	mux.HandleFunc("GET /v1/archive/stats", s.handleArchiveStats)
+	mux.HandleFunc("POST /v1/archive/contact-dossier-backfill", s.handleContactDossierBackfill)
 
 	// First-party realtime WebSocket. /v1/realtime/ws is the canonical
 	// path (per native.yaml); the legacy aliases for existing
@@ -1859,6 +1870,33 @@ func (s *Server) handleArchiveStats(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	writeJSON(w, stats, s.logger)
+}
+
+func (s *Server) handleContactDossierBackfill(w http.ResponseWriter, r *http.Request) {
+	if s.runContactDossierBackfill == nil {
+		s.errorResponse(w, http.StatusServiceUnavailable, "contact dossier backfill is not configured")
+		return
+	}
+
+	limit := archivist.DefaultContactBackfillLimit
+	if raw := strings.TrimSpace(r.URL.Query().Get("limit")); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed < 1 || parsed > archivist.MaxContactBackfillLimit {
+			s.errorResponse(w, http.StatusBadRequest,
+				fmt.Sprintf("limit must be an integer from 1 through %d", archivist.MaxContactBackfillLimit))
+			return
+		}
+		limit = parsed
+	}
+
+	result, err := s.runContactDossierBackfill(r.Context(), limit)
+	if err != nil {
+		s.errorResponse(w, http.StatusInternalServerError, "advance contact dossier backfill: "+err.Error())
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	writeJSON(w, result, s.logger)
 }
 
 func parseIntParam(r *http.Request, name string, defaultVal int) int {

--- a/internal/server/openapi/native.yaml
+++ b/internal/server/openapi/native.yaml
@@ -28,12 +28,13 @@ info:
     - **AuthZ scopes** are `resource:action`:
       `loops:read`, `definitions:read`, `definitions:write`, `requests:read`,
       `schedules:read`, `conversations:read`, `sessions:read`, `sessions:write`,
-      `archive:read`,
+      `archive:read`, `archive:write`,
       `checkpoints:read`, `checkpoints:write`, `models:read`, `models:admin`,
       `telemetry:read`, `contacts:read`, `contacts:write`, `identity:read`,
       `system:read`, `companion:write`.
     - **Roles** bundle scopes: `observer` (all `:read`), `operator`
-      (observer + `definitions:write`, `sessions:write`, `checkpoints:write`),
+      (observer + `definitions:write`, `sessions:write`, `archive:write`,
+      `checkpoints:write`),
       `admin` (everything, incl. `models:admin`, `contacts:write`).
 
     CORS is a per-surface concern: the native API allowlists the UI origins
@@ -853,6 +854,50 @@ paths:
           content:
             application/json:
               schema: { $ref: "#/components/schemas/ArchiveStats" }
+  /v1/archive/contact-dossier-backfill:
+    post:
+      tags: [Archive]
+      operationId: advanceContactDossierBackfill
+      summary: Advance the one-time historical contact-dossier backfill
+      description: |
+        Operator-only catch-up path. Each call advances one bounded page of a
+        durable traversal: active contact subjects first, then closed
+        substantive sessions. A frozen cutoff and persisted keyset cursors
+        make retries and process restarts idempotent; queue keys that are
+        already pending or present in the retained completion journal are not
+        enqueued again. Historical items enter below fresh session-close work
+        and do not wake the self-paced archivist.
+
+        Repeat calls until `complete` is true. Once complete, later calls are
+        durable no-ops; this endpoint never turns into a recurring full-archive
+        scan.
+      x-thane-scope: archive:write
+      parameters:
+        - name: limit
+          in: query
+          description: Maximum source records scanned in this call.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+            default: 50
+      responses:
+        "200":
+          description: One bounded page advanced, or the already-complete no-op state.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ContactDossierBackfillResult" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "500":
+          description: The source page, queue write, or durable cursor update failed.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "503":
+          description: The archivist or its backfill dependencies are not configured.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   # ------------------------------------------------------------ Checkpoints
   /v1/checkpoints:
@@ -4029,6 +4074,67 @@ components:
         by_status:
           active: 12044
           archived: 306160
+
+    ContactDossierBackfillResult:
+      type: object
+      description: >-
+        Per-call progress for the durable one-time contact-dossier backfill.
+        Counts cover this bounded request, not the lifetime traversal.
+      required:
+        - phase
+        - cutoff
+        - scanned
+        - enqueued
+        - skipped_recent
+        - skipped_empty
+        - skipped_automation
+        - complete
+      properties:
+        phase:
+          type: string
+          enum: [contacts, sessions, complete]
+          description: Source phase processed by this call, or complete for a durable no-op.
+        next_phase:
+          type: string
+          enum: [contacts, sessions, complete]
+          description: Durable phase the next call will process.
+        cutoff:
+          type: string
+          format: date-time
+          description: Frozen upper time bound shared by the complete traversal.
+        scanned:
+          type: integer
+          minimum: 0
+          description: Source records examined in this call.
+        enqueued:
+          type: integer
+          minimum: 0
+          description: New low-priority archivist subjects enqueued in this call.
+        skipped_recent:
+          type: integer
+          minimum: 0
+          description: Subjects already pending or present in the retained completion journal.
+        skipped_empty:
+          type: integer
+          minimum: 0
+          description: Closed sessions skipped because they contain no messages.
+        skipped_automation:
+          type: integer
+          minimum: 0
+          description: Closed sessions skipped because their origin is automation or auxiliary traffic.
+        complete:
+          type: boolean
+          description: Whether the durable one-time traversal is finished.
+      example:
+        phase: sessions
+        next_phase: sessions
+        cutoff: "2026-08-31T16:00:00Z"
+        scanned: 50
+        enqueued: 43
+        skipped_recent: 2
+        skipped_empty: 3
+        skipped_automation: 2
+        complete: false
 
     ArchivedSessionList:
       type: object

--- a/internal/state/contacts/store.go
+++ b/internal/state/contacts/store.go
@@ -440,6 +440,44 @@ func (s *Store) ListAllLimit(limit int) ([]*Contact, error) {
 	return s.scanContacts(rows)
 }
 
+// ListActivePage returns one stable, ID-keyset page of active contacts that
+// existed at cutoff. Results are ordered by canonical UUID, and hasMore says
+// whether another page remains after the last returned contact. The cutoff
+// freezes a one-time traversal so contacts created while it runs are left to
+// steady-state processing rather than shifting the page boundary.
+func (s *Store) ListActivePage(cutoff time.Time, afterID string, limit int) ([]*Contact, bool, error) {
+	if cutoff.IsZero() {
+		return nil, false, fmt.Errorf("contact page cutoff is required")
+	}
+	if limit <= 0 {
+		limit = 50
+	}
+
+	rows, err := s.db.Query(`
+		SELECT `+contactColumns+`
+		FROM contacts
+		WHERE `+activeFilter+`
+		  AND datetime(created_at) <= datetime(?)
+		  AND id > ?
+		ORDER BY id ASC
+		LIMIT ?
+	`, cutoff.UTC().Format(time.RFC3339Nano), strings.TrimSpace(afterID), limit+1)
+	if err != nil {
+		return nil, false, fmt.Errorf("query active contact page: %w", err)
+	}
+	defer rows.Close()
+
+	contacts, err := s.scanContacts(rows)
+	if err != nil {
+		return nil, false, err
+	}
+	hasMore := len(contacts) > limit
+	if hasMore {
+		contacts = contacts[:limit]
+	}
+	return contacts, hasMore, nil
+}
+
 // ListAllWithProperties returns all active contacts with their
 // Properties slices populated.  Unlike [ListAll], there is no row
 // limit — this is intended for full-sync use cases like CardDAV.

--- a/internal/state/contacts/store_test.go
+++ b/internal/state/contacts/store_test.go
@@ -73,6 +73,45 @@ func TestCreateAndGet(t *testing.T) {
 	}
 }
 
+func TestListActivePage_KeysetAndCutoff(t *testing.T) {
+	store := newTestStore(t)
+	cutoff := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+	rows := []struct {
+		id        string
+		name      string
+		createdAt time.Time
+	}{
+		{"019c0000-0000-7000-8000-000000000001", "Alpha", cutoff.Add(-time.Hour)},
+		{"019c0000-0000-7000-8000-000000000002", "Bravo", cutoff},
+		{"019c0000-0000-7000-8000-000000000003", "Future", cutoff.Add(time.Hour)},
+	}
+	for _, row := range rows {
+		stamp := row.createdAt.Format(time.RFC3339Nano)
+		if _, err := store.db.Exec(`
+			INSERT INTO contacts (id, formatted_name, rev, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?)
+		`, row.id, row.name, stamp, stamp, stamp); err != nil {
+			t.Fatalf("insert %s: %v", row.name, err)
+		}
+	}
+
+	first, hasMore, err := store.ListActivePage(cutoff, "", 1)
+	if err != nil {
+		t.Fatalf("first page: %v", err)
+	}
+	if len(first) != 1 || first[0].FormattedName != "Alpha" || !hasMore {
+		t.Fatalf("first page = %#v, hasMore=%v", first, hasMore)
+	}
+
+	second, hasMore, err := store.ListActivePage(cutoff, first[0].ID.String(), 1)
+	if err != nil {
+		t.Fatalf("second page: %v", err)
+	}
+	if len(second) != 1 || second[0].FormattedName != "Bravo" || hasMore {
+		t.Fatalf("second page = %#v, hasMore=%v", second, hasMore)
+	}
+}
+
 func TestUpsertByName(t *testing.T) {
 	store := newTestStore(t)
 

--- a/internal/state/loopqueue/queue_schema.go
+++ b/internal/state/loopqueue/queue_schema.go
@@ -70,5 +70,12 @@ var queueSchema = database.Schema{
 			SQL: `CREATE INDEX IF NOT EXISTS idx_loop_queue_completions_acked
 				ON loop_queue_completions (acked_at)`,
 		},
+		database.IndexCreate{
+			Name: "idx_loop_queue_completions_key",
+			// Supports producer overlap checks before admitting a historical
+			// backfill key that the consumer recently completed.
+			SQL: `CREATE INDEX IF NOT EXISTS idx_loop_queue_completions_key
+				ON loop_queue_completions (consumer_loop, dedup_key)`,
+		},
 	},
 }

--- a/internal/state/loopqueue/queue_store.go
+++ b/internal/state/loopqueue/queue_store.go
@@ -377,6 +377,34 @@ func (s *Store) Ack(ctx context.Context, consumerLoop, dedupKey string) error {
 	return nil
 }
 
+// HasRecentWork reports whether a key is pending or appears in the retained
+// completion journal for consumerLoop. Completion rows are intentionally
+// time-bounded by [Store.PruneCompletions], so this is a recent-overlap guard,
+// not permanent domain state. A durable producer cursor should remain the
+// authority for whether an older source has already been traversed.
+func (s *Store) HasRecentWork(ctx context.Context, consumerLoop, dedupKey string) (bool, error) {
+	consumerLoop = strings.TrimSpace(consumerLoop)
+	dedupKey = strings.TrimSpace(dedupKey)
+	if consumerLoop == "" || dedupKey == "" {
+		return false, fmt.Errorf("loopqueue: consumer_loop and dedup_key are required")
+	}
+
+	var found bool
+	err := s.db.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM loop_queue
+			WHERE consumer_loop = ? AND dedup_key = ?
+			UNION ALL
+			SELECT 1 FROM loop_queue_completions
+			WHERE consumer_loop = ? AND dedup_key = ?
+		)
+	`, consumerLoop, dedupKey, consumerLoop, dedupKey).Scan(&found)
+	if err != nil {
+		return false, fmt.Errorf("loopqueue: inspect recent work %s/%s: %w", consumerLoop, dedupKey, err)
+	}
+	return found, nil
+}
+
 // Consumers returns the distinct consumer partitions that currently
 // hold pending work, optionally filtered to names beginning with
 // prefix (empty prefix = all). Used by boot-time recovery sweeps:

--- a/internal/state/loopqueue/queue_store_test.go
+++ b/internal/state/loopqueue/queue_store_test.go
@@ -62,6 +62,26 @@ func TestStore_EnqueuePeekAck(t *testing.T) {
 	}
 }
 
+func TestStore_HasRecentWorkIncludesPendingAndCompletions(t *testing.T) {
+	s := newTestStore(t)
+
+	if found, err := s.HasRecentWork(t.Context(), "archivist", "session:missing"); err != nil || found {
+		t.Fatalf("missing found=%v err=%v", found, err)
+	}
+	if err := s.Enqueue(t.Context(), "archivist", "session:abc", 0, nil); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	if found, err := s.HasRecentWork(t.Context(), "archivist", "session:abc"); err != nil || !found {
+		t.Fatalf("pending found=%v err=%v", found, err)
+	}
+	if err := s.Ack(t.Context(), "archivist", "session:abc"); err != nil {
+		t.Fatalf("ack: %v", err)
+	}
+	if found, err := s.HasRecentWork(t.Context(), "archivist", "session:abc"); err != nil || !found {
+		t.Fatalf("completed found=%v err=%v", found, err)
+	}
+}
+
 func TestStore_AppendKeepsDuplicateItems(t *testing.T) {
 	s := newTestStore(t)
 

--- a/internal/state/memory/archive.go
+++ b/internal/state/memory/archive.go
@@ -541,9 +541,9 @@ func (s *ArchiveStore) countSessionMessages(sessionID string) int {
 
 // populateMessageCounts fills the MessageCount field on a slice of sessions
 // using a single grouped query to avoid the N+1 query pattern.
-func (s *ArchiveStore) populateMessageCounts(sessions []*Session) {
+func (s *ArchiveStore) populateMessageCounts(sessions []*Session) error {
 	if len(sessions) == 0 {
-		return
+		return nil
 	}
 
 	ids := make([]string, 0, len(sessions))
@@ -553,7 +553,7 @@ func (s *ArchiveStore) populateMessageCounts(sessions []*Session) {
 		}
 	}
 	if len(ids) == 0 {
-		return
+		return nil
 	}
 
 	placeholders, args := database.InList(ids)
@@ -566,7 +566,7 @@ func (s *ArchiveStore) populateMessageCounts(sessions []*Session) {
 
 	rows, err := s.msgDB().Query(query, args...)
 	if err != nil {
-		return
+		return fmt.Errorf("query session message counts: %w", err)
 	}
 	defer rows.Close()
 
@@ -575,9 +575,12 @@ func (s *ArchiveStore) populateMessageCounts(sessions []*Session) {
 		var sessionID string
 		var count int
 		if err := rows.Scan(&sessionID, &count); err != nil {
-			return
+			return fmt.Errorf("scan session message count: %w", err)
 		}
 		counts[sessionID] = count
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate session message counts: %w", err)
 	}
 
 	for _, sess := range sessions {
@@ -588,6 +591,7 @@ func (s *ArchiveStore) populateMessageCounts(sessions []*Session) {
 			sess.MessageCount = c
 		}
 	}
+	return nil
 }
 
 func (s *ArchiveStore) migrate() error {
@@ -2271,7 +2275,9 @@ func (s *ArchiveStore) ListSessions(conversationID string, limit int) ([]*Sessio
 		return nil, err
 	}
 
-	s.populateMessageCounts(sessions)
+	if err := s.populateMessageCounts(sessions); err != nil {
+		return nil, fmt.Errorf("populate message counts: %w", err)
+	}
 	return sessions, nil
 }
 
@@ -2324,7 +2330,9 @@ func (s *ArchiveStore) ListClosedSessionsPage(cutoff time.Time, afterID string, 
 	if hasMore {
 		sessions = sessions[:limit]
 	}
-	s.populateMessageCounts(sessions)
+	if err := s.populateMessageCounts(sessions); err != nil {
+		return nil, false, fmt.Errorf("populate message counts: %w", err)
+	}
 	return sessions, hasMore, nil
 }
 
@@ -2371,7 +2379,9 @@ func (s *ArchiveStore) ListClosedSessionsEndedBefore(conversationID string, cuto
 		return nil, err
 	}
 
-	s.populateMessageCounts(sessions)
+	if err := s.populateMessageCounts(sessions); err != nil {
+		return nil, fmt.Errorf("populate message counts: %w", err)
+	}
 	return sessions, nil
 }
 
@@ -2403,7 +2413,9 @@ func (s *ArchiveStore) ListChildSessions(parentSessionID string) ([]*Session, er
 		return nil, err
 	}
 
-	s.populateMessageCounts(sessions)
+	if err := s.populateMessageCounts(sessions); err != nil {
+		return nil, fmt.Errorf("populate message counts: %w", err)
+	}
 	return sessions, nil
 }
 
@@ -2457,7 +2469,9 @@ func (s *ArchiveStore) UnsummarizedSessions(limit int) ([]*Session, error) {
 	// Populate MessageCount so the worker (and any other caller)
 	// sees accurate counts on returned sessions, even though the
 	// query no longer gates on them.
-	s.populateMessageCounts(sessions)
+	if err := s.populateMessageCounts(sessions); err != nil {
+		return nil, fmt.Errorf("populate message counts: %w", err)
+	}
 	return sessions, nil
 }
 

--- a/internal/state/memory/archive.go
+++ b/internal/state/memory/archive.go
@@ -2275,6 +2275,59 @@ func (s *ArchiveStore) ListSessions(conversationID string, limit int) ([]*Sessio
 	return sessions, nil
 }
 
+// ListClosedSessionsPage returns one stable, ID-keyset page of closed sessions
+// that ended no later than cutoff. Results are ordered by session ID, and
+// hasMore says whether another page remains after the last returned session.
+// The cutoff freezes a one-time traversal while the normal session-close path
+// continues to handle sessions that finish after it began.
+//
+// Session IDs are the cursor rather than ended_at because historical rows mix
+// timestamp encodings. SQLite datetime() is used only for the inclusive cutoff;
+// pagination itself stays exact and index-backed through the primary key.
+func (s *ArchiveStore) ListClosedSessionsPage(cutoff time.Time, afterID string, limit int) ([]*Session, bool, error) {
+	if cutoff.IsZero() {
+		return nil, false, fmt.Errorf("closed session page cutoff is required")
+	}
+	if limit <= 0 {
+		limit = 50
+	}
+
+	rows, err := s.db.Query(`
+		SELECT id, conversation_id, started_at, ended_at, end_reason,
+		       0 AS message_count,
+		       summary, title, tags, metadata, parent_session_id, parent_tool_call_id
+		FROM sessions
+		WHERE ended_at IS NOT NULL
+		  AND datetime(ended_at) <= datetime(?)
+		  AND id > ?
+		ORDER BY id ASC
+		LIMIT ?
+	`, cutoff.UTC().Format(time.RFC3339Nano), strings.TrimSpace(afterID), limit+1)
+	if err != nil {
+		return nil, false, fmt.Errorf("list closed session page: %w", err)
+	}
+	defer rows.Close()
+
+	var sessions []*Session
+	for rows.Next() {
+		sess, err := s.scanSessionRow(rows)
+		if err != nil {
+			return nil, false, err
+		}
+		sessions = append(sessions, sess)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, false, err
+	}
+
+	hasMore := len(sessions) > limit
+	if hasMore {
+		sessions = sessions[:limit]
+	}
+	s.populateMessageCounts(sessions)
+	return sessions, hasMore, nil
+}
+
 // ListClosedSessionsEndedBefore returns closed sessions on the given
 // conversation whose ended_at is strictly before cutoff, most recently
 // ended first, with message counts populated. Paginated by limit and

--- a/internal/state/memory/archive_test.go
+++ b/internal/state/memory/archive_test.go
@@ -71,6 +71,62 @@ func TestArchiveMessages_BasicInsert(t *testing.T) {
 	}
 }
 
+func TestListClosedSessionsPage_KeysetCutoffAndMessageCount(t *testing.T) {
+	store := newTestArchiveStore(t)
+	cutoff := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+	rows := []struct {
+		id      string
+		endedAt *time.Time
+	}{
+		{"019c0000-0000-7000-8000-000000000001", timePointer(cutoff.Add(-time.Hour))},
+		{"019c0000-0000-7000-8000-000000000002", timePointer(cutoff)},
+		{"019c0000-0000-7000-8000-000000000003", timePointer(cutoff.Add(time.Hour))},
+		{"019c0000-0000-7000-8000-000000000004", nil},
+	}
+	for _, row := range rows {
+		var endedAt any
+		if row.endedAt != nil {
+			endedAt = row.endedAt.Format(time.RFC3339Nano)
+		}
+		if _, err := store.db.Exec(`
+			INSERT INTO sessions (id, conversation_id, started_at, ended_at)
+			VALUES (?, 'signal-test', ?, ?)
+		`, row.id, cutoff.Add(-2*time.Hour).Format(time.RFC3339Nano), endedAt); err != nil {
+			t.Fatalf("insert session %s: %v", row.id, err)
+		}
+	}
+	if err := store.ArchiveMessages([]Message{{
+		ID:             "message-1",
+		ConversationID: "signal-test",
+		SessionID:      rows[0].id,
+		Role:           "user",
+		Content:        "hello",
+		Timestamp:      cutoff.Add(-90 * time.Minute),
+	}}); err != nil {
+		t.Fatalf("archive message: %v", err)
+	}
+
+	first, hasMore, err := store.ListClosedSessionsPage(cutoff, "", 1)
+	if err != nil {
+		t.Fatalf("first page: %v", err)
+	}
+	if len(first) != 1 || first[0].ID != rows[0].id || first[0].MessageCount != 1 || !hasMore {
+		t.Fatalf("first page = %#v, hasMore=%v", first, hasMore)
+	}
+
+	second, hasMore, err := store.ListClosedSessionsPage(cutoff, first[0].ID, 1)
+	if err != nil {
+		t.Fatalf("second page: %v", err)
+	}
+	if len(second) != 1 || second[0].ID != rows[1].id || hasMore {
+		t.Fatalf("second page = %#v, hasMore=%v", second, hasMore)
+	}
+}
+
+func timePointer(value time.Time) *time.Time {
+	return &value
+}
+
 func TestArchiveMessages_Deduplication(t *testing.T) {
 	store := newTestArchiveStore(t)
 

--- a/internal/state/memory/archive_test.go
+++ b/internal/state/memory/archive_test.go
@@ -2,10 +2,12 @@ package memory
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
 )
 
 func newTestArchiveStore(t *testing.T) *ArchiveStore {
@@ -120,6 +122,30 @@ func TestListClosedSessionsPage_KeysetCutoffAndMessageCount(t *testing.T) {
 	}
 	if len(second) != 1 || second[0].ID != rows[1].id || hasMore {
 		t.Fatalf("second page = %#v, hasMore=%v", second, hasMore)
+	}
+}
+
+func TestListClosedSessionsPage_MessageCountFailure(t *testing.T) {
+	store := newTestArchiveStore(t)
+	cutoff := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+	if _, err := store.db.Exec(`
+		INSERT INTO sessions (id, conversation_id, started_at, ended_at)
+		VALUES ('019c0000-0000-7000-8000-000000000001', 'signal-test', ?, ?)
+	`, cutoff.Add(-time.Hour).Format(time.RFC3339Nano), cutoff.Format(time.RFC3339Nano)); err != nil {
+		t.Fatalf("insert session: %v", err)
+	}
+
+	brokenMessages, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("open broken message database: %v", err)
+	}
+	t.Cleanup(func() { brokenMessages.Close() })
+	store.messagesDB = brokenMessages
+	store.msgTableName = "messages"
+
+	_, _, err = store.ListClosedSessionsPage(cutoff, "", 1)
+	if err == nil || !strings.Contains(err.Error(), "populate message counts") {
+		t.Fatalf("ListClosedSessionsPage error = %v, want message count failure", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add an explicit `POST /v1/archive/contact-dossier-backfill` operator path that advances one bounded, durable page per request
- seed active `contact:<uuid>` subjects first, then closed substantive `session:<uuid>` evidence, below fresh session-close work
- document rename, forget, merge, explicit archival, and production backfill behavior

## Why

The steady-state archivist path now keeps canonical contact dossiers current, but an existing installation still needs a deliberate way to introduce its historical corpus without teaching the model or autonomous loop to rescan the full archive. The traversal freezes its cutoff before queue mutation, persists ID-keyset cursors in opstate, and becomes a durable no-op after completion.

The queue admission guard skips subjects that are already pending or present in the retained completion journal. Cursor persistence remains the permanent traversal authority, so retries after a failed state write can safely revisit a page without duplicating pending work.

Structured-property provenance and post-authority-write refresh signaling are split into #1482.

## User impact

Operators can call the endpoint repeatedly with `?limit=1..200` until `complete` is true. Each response reports the processed phase and per-call scanned, enqueued, recent, empty, and automation counts. Historical entries use priority `-10`, so live session-close evidence at priority `0` continues to drain first, and the endpoint never wakes the self-paced archivist.

The native API contract declares the new `archive:write` operator scope. Existing contact dossier history remains UUID-stable across renames and is retained across forget or merge unless an operator explicitly moves or deletes the document.

## Test plan

- [x] `just ci`
- [x] race coverage for contact and session keyset pages
- [x] retry coverage when queue mutation succeeds but cursor persistence fails
- [x] queue overlap coverage for pending and completed work
- [x] native handler, route parity, OpenAPI lint, and architecture baseline coverage

Refs #1463.