### PR TITLE
feat: establish signed dossiers document root

### DIFF
--- a/cmd/thane/init.go
+++ b/cmd/thane/init.go
@@ -301,7 +301,11 @@ func runInit(w io.Writer, dir string, opts initOptions) error {
 	if err != nil {
 		return fmt.Errorf("bootstrap core identity: %w", err)
 	}
-	dossierConfigured, dossierCreated, err := bootstrapContactDossierRoot(ctx, coreConfigPath, absDir, slog.Default())
+	contactDossiersConfigured, contactDossiersCreated, err := bootstrapContactDossierRoot(ctx, coreConfigPath, absDir, slog.Default())
+	if err != nil {
+		return err
+	}
+	subjectDossiersConfigured, subjectDossiersCreated, err := bootstrapSubjectDossierRoot(ctx, coreConfigPath, absDir, slog.Default())
 	if err != nil {
 		return err
 	}
@@ -324,11 +328,18 @@ func runInit(w io.Writer, dir string, opts initOptions) error {
 	} else {
 		fmt.Fprintf(w, "  · %s (core identity exists, skipping)\n", result.CoreDir)
 	}
-	if dossierConfigured {
-		if dossierCreated {
+	if contactDossiersConfigured {
+		if contactDossiersCreated {
 			fmt.Fprintf(w, "  ✓ %s (signed contact dossier root)\n", filepath.Join(absDir, platformconfig.ContactsRootName))
 		} else {
 			fmt.Fprintf(w, "  · %s (contact dossier root exists, skipping)\n", filepath.Join(absDir, platformconfig.ContactsRootName))
+		}
+	}
+	if subjectDossiersConfigured {
+		if subjectDossiersCreated {
+			fmt.Fprintf(w, "  ✓ %s (signed dossier root)\n", filepath.Join(absDir, platformconfig.DossiersRootName))
+		} else {
+			fmt.Fprintf(w, "  · %s (dossier root exists, skipping)\n", filepath.Join(absDir, platformconfig.DossiersRootName))
 		}
 	}
 	if contactBootstrap != nil {

--- a/cmd/thane/init_contact_dossiers.go
+++ b/cmd/thane/init_contact_dossiers.go
@@ -16,43 +16,56 @@ import (
 )
 
 func bootstrapContactDossierRoot(ctx context.Context, configPath, workspace string, logger *slog.Logger) (bool, bool, error) {
+	return bootstrapDossierRoot(ctx, configPath, workspace, platformconfig.ContactsRootName, logger)
+}
+
+func bootstrapSubjectDossierRoot(ctx context.Context, configPath, workspace string, logger *slog.Logger) (bool, bool, error) {
+	return bootstrapDossierRoot(ctx, configPath, workspace, platformconfig.DossiersRootName, logger)
+}
+
+func bootstrapDossierRoot(ctx context.Context, configPath, workspace, rootName string, logger *slog.Logger) (bool, bool, error) {
 	cfg, err := platformconfig.LoadWithWorkspace(configPath, workspace)
 	if err != nil {
-		return false, false, fmt.Errorf("load core config for contact dossier root: %w", err)
+		return false, false, fmt.Errorf("load core config for %s root: %w", rootName, err)
 	}
-	entry, found := cfg.DocRoots[platformconfig.ContactsRootName]
+	entry, found := cfg.DocRoots[rootName]
 	if !found {
 		return false, false, nil
 	}
 	if !entry.Git.Enabled || !entry.Git.SignCommits {
-		return true, false, fmt.Errorf("roots.%s must enable signed commits so thane init can establish its dossier history", platformconfig.ContactsRootName)
+		return true, false, fmt.Errorf("roots.%s must enable signed commits so thane init can establish its dossier history", rootName)
 	}
 	if len(entry.SeedSigners) == 0 {
-		return true, false, fmt.Errorf("roots.%s must declare seed_signers before thane init can establish it", platformconfig.ContactsRootName)
+		return true, false, fmt.Errorf("roots.%s must declare seed_signers before thane init can establish it", rootName)
+	}
+	rootPath, err := dossierRootPath(cfg, rootName)
+	if err != nil {
+		return true, false, err
 	}
 
-	rootPaths := make(map[string]string, len(cfg.Paths)+3)
+	rootPaths := make(map[string]string, len(cfg.Paths)+4)
 	for name, path := range cfg.Paths {
 		rootPaths[name] = path
 	}
 	rootPaths[platformconfig.CoreRootName] = cfg.CoreRoot()
 	rootPaths[platformconfig.SelfRootName] = cfg.SelfRoot()
 	rootPaths[platformconfig.ContactsRootName] = cfg.ContactsRoot()
+	rootPaths[platformconfig.DossiersRootName] = cfg.DossiersRoot()
 	resolver := paths.New(rootPaths)
 
 	signingKey, err := resolver.Resolve(entry.Git.SigningKey)
 	if err != nil {
-		return true, false, fmt.Errorf("resolve roots.%s.git.signing_key: %w", platformconfig.ContactsRootName, err)
+		return true, false, fmt.Errorf("resolve roots.%s.git.signing_key: %w", rootName, err)
 	}
 	repoPath := strings.TrimSpace(entry.Git.RepoPath)
 	if repoPath == "" {
-		repoPath = cfg.ContactsRoot()
+		repoPath = rootPath
 	} else if repoPath, err = resolver.Resolve(repoPath); err != nil {
-		return true, false, fmt.Errorf("resolve roots.%s.git.repo_path: %w", platformconfig.ContactsRootName, err)
+		return true, false, fmt.Errorf("resolve roots.%s.git.repo_path: %w", rootName, err)
 	}
-	resolvedRoot, err := checkout.ResolveRoot(repoPath, cfg.ContactsRoot())
+	resolvedRoot, err := checkout.ResolveRoot(repoPath, rootPath)
 	if err != nil {
-		return true, false, fmt.Errorf("resolve roots.%s.git.repo_path: %w", platformconfig.ContactsRootName, err)
+		return true, false, fmt.Errorf("resolve roots.%s.git.repo_path: %w", rootName, err)
 	}
 	seeds := make([]provenance.TrustedSigner, 0, len(entry.SeedSigners))
 	for _, seed := range entry.SeedSigners {
@@ -68,10 +81,10 @@ func bootstrapContactDossierRoot(ctx context.Context, configPath, workspace stri
 	_, statErr := os.Stat(filepath.Join(resolvedRoot.RepoPath, ".git"))
 	created := errors.Is(statErr, os.ErrNotExist)
 	if statErr != nil && !created {
-		return true, false, fmt.Errorf("stat contact dossier repository: %w", statErr)
+		return true, false, fmt.Errorf("stat %s repository: %w", rootName, statErr)
 	}
 	signed, err := checkout.OpenSigned(ctx, checkout.SignedSpec{
-		Name:           "contacts.dossiers",
+		Name:           rootName,
 		WorktreePath:   resolvedRoot.WorktreePath,
 		RepoPath:       resolvedRoot.RepoPath,
 		SigningKeyPath: signingKey,
@@ -79,13 +92,24 @@ func bootstrapContactDossierRoot(ctx context.Context, configPath, workspace stri
 		Logger:         logger,
 	})
 	if err != nil {
-		return true, false, fmt.Errorf("bootstrap contact dossier root: %w", err)
+		return true, false, fmt.Errorf("bootstrap %s root: %w", rootName, err)
 	}
 	if err := signed.VerifyHead(ctx); err != nil {
-		return true, false, fmt.Errorf("verify contact dossier root birth: %w", err)
+		return true, false, fmt.Errorf("verify %s root birth: %w", rootName, err)
 	}
 	if _, err := provenance.VerifyAdmission(ctx, resolvedRoot.RepoPath, seeds); err != nil {
-		return true, false, fmt.Errorf("verify contact dossier root admission: %w", err)
+		return true, false, fmt.Errorf("verify %s root admission: %w", rootName, err)
 	}
 	return true, created, nil
+}
+
+func dossierRootPath(cfg *platformconfig.Config, rootName string) (string, error) {
+	switch rootName {
+	case platformconfig.ContactsRootName:
+		return cfg.ContactsRoot(), nil
+	case platformconfig.DossiersRootName:
+		return cfg.DossiersRoot(), nil
+	default:
+		return "", fmt.Errorf("%q is not a dossier root", rootName)
+	}
 }

--- a/cmd/thane/init_test.go
+++ b/cmd/thane/init_test.go
@@ -46,7 +46,7 @@ func TestRunInit_FreshDirectory(t *testing.T) {
 	out := buf.String()
 
 	// Verify directory structure.
-	for _, sub := range []string{"core", "contacts", "db", filepath.Join("core", "talents")} {
+	for _, sub := range []string{"core", "contacts", "dossiers", "db", filepath.Join("core", "talents")} {
 		info, err := os.Stat(filepath.Join(dir, sub))
 		if err != nil {
 			t.Errorf("expected directory %s: %v", sub, err)
@@ -176,22 +176,31 @@ func TestRunInit_FreshDirectory(t *testing.T) {
 	if !contactsRoot.Git.Enabled || !contactsRoot.Git.SignCommits || contactsRoot.Git.VerifySignatures != "required" {
 		t.Fatalf("generated contacts git policy = %#v", contactsRoot.Git)
 	}
-	contactsDir := filepath.Join(dir, platformconfig.ContactsRootName)
-	for _, args := range [][]string{
-		{"rev-list", "--count", "HEAD"},
-		{"status", "--short", "--untracked-files=all"},
-		{"verify-commit", "HEAD"},
-	} {
-		cmd := exec.Command("git", append([]string{"-C", contactsDir}, args...)...)
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			t.Fatalf("git %s in contacts root: %v\n%s", strings.Join(args, " "), err, out)
-		}
-		if args[0] == "rev-list" && strings.TrimSpace(string(out)) != "1" {
-			t.Fatalf("contacts root commit count = %q, want 1", strings.TrimSpace(string(out)))
-		}
-		if args[0] == "status" && strings.TrimSpace(string(out)) != "" {
-			t.Fatalf("contacts root status = %q, want clean", strings.TrimSpace(string(out)))
+	dossiersRoot, ok := generated.Roots[platformconfig.DossiersRootName]
+	if !ok || dossiersRoot.Authoring != "managed" || dossiersRoot.Context.Advertise != "" {
+		t.Fatalf("generated dossiers root = %#v, want managed non-contact dossier policy", dossiersRoot)
+	}
+	if !dossiersRoot.Git.Enabled || !dossiersRoot.Git.SignCommits || dossiersRoot.Git.VerifySignatures != "required" {
+		t.Fatalf("generated dossiers git policy = %#v", dossiersRoot.Git)
+	}
+	for _, root := range []string{platformconfig.ContactsRootName, platformconfig.DossiersRootName} {
+		rootDir := filepath.Join(dir, root)
+		for _, args := range [][]string{
+			{"rev-list", "--count", "HEAD"},
+			{"status", "--short", "--untracked-files=all"},
+			{"verify-commit", "HEAD"},
+		} {
+			cmd := exec.Command("git", append([]string{"-C", rootDir}, args...)...)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("git %s in %s root: %v\n%s", strings.Join(args, " "), root, err, out)
+			}
+			if args[0] == "rev-list" && strings.TrimSpace(string(out)) != "1" {
+				t.Fatalf("%s root commit count = %q, want 1", root, strings.TrimSpace(string(out)))
+			}
+			if args[0] == "status" && strings.TrimSpace(string(out)) != "" {
+				t.Fatalf("%s root status = %q, want clean", root, strings.TrimSpace(string(out)))
+			}
 		}
 	}
 

--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -279,6 +279,10 @@ roots:
       signing_key: ~/.ssh/id_ed25519
   dossiers:
     authoring: managed
+    seed_signers:
+      - principal: thane@provenance.local
+        key: "ssh-ed25519 AAAA..." # public half of git.signing_key
+        label: agent
     git:
       enabled: true
       sign_commits: true
@@ -304,7 +308,9 @@ roots:
 `core`, `self`, `contacts`, and `dossiers` are reserved roots whose paths
 are derived from `workspace.path`. Declare `contacts` or `dossiers` with policy
 to enable it, but do not give either a path. They resolve to
-`{workspace}/contacts` and `{workspace}/dossiers` respectively.
+`{workspace}/contacts` and `{workspace}/dossiers` respectively. An explicit
+`dossiers` path is rejected with a migration recipe instead of being silently
+discarded.
 
 > **Deprecated:** the older `paths:` / `doc_roots:` split — one block to
 > name the path, a second to attach policy — is still parsed but emits a

--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -278,8 +278,12 @@ roots:
       verify_signatures: warn
       signing_key: ~/.ssh/id_ed25519
   dossiers:
-    path: ~/Vaults/private-dossiers
-    authoring: read_only
+    authoring: managed
+    git:
+      enabled: true
+      sign_commits: true
+      verify_signatures: required
+      signing_key: core:identity/signing_ed25519
   scratchpad:
     path: ~/Thane/scratchpad
     indexing: false
@@ -296,6 +300,11 @@ string when it needs no policy beyond its path:
 roots:
   kb: ~/Thane/knowledge
 ```
+
+`core`, `self`, `contacts`, and `dossiers` are reserved roots whose paths
+are derived from `workspace.path`. Declare `contacts` or `dossiers` with policy
+to enable it, but do not give either a path. They resolve to
+`{workspace}/contacts` and `{workspace}/dossiers` respectively.
 
 > **Deprecated:** the older `paths:` / `doc_roots:` split — one block to
 > name the path, a second to attach policy — is still parsed but emits a
@@ -354,7 +363,7 @@ Good uses for custom roots:
 - knowledge bases
 - scratch work you want to revisit
 - generated reports
-- dossiers
+- custom private note collections
 - imported research notes
 
 See [Document Roots](../understanding/document-roots.md) for the fuller

--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -460,9 +460,12 @@ policy in one subsystem.
 
 Four root names are reserved: `core`, `self`, `contacts`, and `dossiers`. Their
 paths come from the workspace, and none takes a path from `roots:`. You may name
-them there to set policy; a path given alongside policy is ignored. `core` and
-`self` are always registered. `contacts` and `dossiers` are opt-in and are
-registered only when their policy is declared.
+them there to set policy. Paths on `core`, `self`, and `contacts` are ignored
+for compatibility. An explicit `dossiers` path is rejected with instructions
+to move or clone the corpus to `{workspace}/dossiers`, preventing an upgrade
+from silently redirecting an existing custom root. `core` and `self` are always
+registered. `contacts` and `dossiers` are opt-in and are registered only when
+their policy is declared.
 
 `core` and `self` are separate roots because they answer to different
 authorities, and that difference is the whole point of their split.

--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -10,7 +10,8 @@ tell Thane which local collections matter.
 roots:
   kb: ./knowledge
   scratchpad: ./scratchpad
-  dossiers: ~/Vaults/private-dossiers
+  dossiers:
+    authoring: managed
 ```
 
 > The legacy `paths:` / `doc_roots:` split is still parsed with a
@@ -20,7 +21,9 @@ roots:
 Each entry gives a directory a stable identity. Instead of treating your
 files as one anonymous pile, Thane can understand that some notes live
 in a knowledge base, some are scratch work, and some belong to a more
-private long-form collection.
+private long-form collection. Most roots declare their path. The reserved
+`dossiers` root above takes its path from the workspace and is enabled by
+declaring its policy.
 
 ## Why This Helps
 
@@ -75,7 +78,7 @@ Example:
 roots:
   kb: ~/Thane/knowledge
   scratchpad: ~/Thane/scratchpad
-  dossiers: ~/Vaults/private-dossiers
+  private_notes: ~/Vaults/private-notes
   research: ~/Work/research-notes
 ```
 
@@ -455,11 +458,11 @@ policy in one subsystem.
 
 ## Special Case: the Derived Roots
 
-Three root names are reserved: `core`, `self`, and `contacts`. Their paths come
-from the workspace, and none takes a path from `roots:`. You may name them
-there to set policy; a path given alongside policy is ignored. `core` and
-`self` are always registered. `contacts` is opt-in and is registered only when
-its policy is declared.
+Four root names are reserved: `core`, `self`, `contacts`, and `dossiers`. Their
+paths come from the workspace, and none takes a path from `roots:`. You may name
+them there to set policy; a path given alongside policy is ignored. `core` and
+`self` are always registered. `contacts` and `dossiers` are opt-in and are
+registered only when their policy is declared.
 
 `core` and `self` are separate roots because they answer to different
 authorities, and that difference is the whole point of their split.
@@ -494,6 +497,13 @@ Both are always registered because the core service loops write `self` on
 every install. A root an operator had to remember to declare would leave a
 fresh install with nowhere for those documents to land.
 
+`contacts` and `dossiers` are opt-in because not every instance enables the
+archivist's longitudinal documents. When declared, their fixed sibling paths
+are `{workspace}/contacts` and `{workspace}/dossiers`. A fresh `thane init`
+declares and establishes both as managed, signed roots. Existing instances can
+adopt either independently by adding its policy and restoring or initializing
+the repository at that derived path.
+
 ### Contact dossiers
 
 `contacts` is the optional longitudinal document side of the structured
@@ -521,10 +531,12 @@ should not author dossier structure through them.
 The archivist uses the same contract-owned door. Contact-shaped queue subjects
 and contact evidence discovered in closed sessions are resolved through the
 structured directory, reconciled with the existing canonical dossier, and
-republished through `contact_dossier_write`. The generic `kb:dossiers/`
-namespace remains the home for entities, areas, routines, and themes; it is
-never a fallback location for a contact, because that would split one person's
-history across two document roots. Before replacement, the archivist checks
+republished through `contact_dossier_write`. The separate `dossiers:` root is
+the home for entities, areas, routines, and themes; it is never a fallback
+location for a contact, because that would split one person's history across
+two document roots. The legacy `kb:dossiers/` namespace is retired once its
+documents have moved to `dossiers:` and must not remain indexed alongside the
+new root. Before replacement, the archivist checks
 whether `doc_read` truncated the current dossier and walks its outline and
 sections when necessary. An unreadable remainder or unavailable canonical
 writer defers the durable queue item behind ready work rather than losing it or

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -239,14 +239,16 @@ workspace:
 # Typical names: kb (curated knowledge), generated (model-produced
 # durable outputs), and scratchpad (low-integrity work area). The core,
 # self, contacts, and dossiers names are reserved and derived from
-# workspace.path; declaring them under roots: sets policy, while any path
-# is ignored.
+# workspace.path; declaring them under roots: sets policy. Paths on core,
+# self, and contacts are ignored for compatibility; an explicit dossiers
+# path is rejected with its migration recipe.
 roots:
   generated:
     # Path is the directory the root resolves to. Supports ~ expansion at
-    # resolver construction time. For reserved derived roots (core, self,
-    # contacts, and dossiers) this is ignored; their paths come from
-    # workspace.path.
+    # resolver construction time. Reserved derived roots take their paths from
+    # workspace.path. Paths on core, self, and contacts are ignored for
+    # compatibility; an explicit dossiers path is rejected with its migration
+    # recipe.
     path: ./generated
     # Indexing controls whether markdown files in this root are
     # scanned into the document index. Omit to keep indexing enabled.
@@ -360,9 +362,10 @@ roots:
     seed_signers: []
   kb:
     # Path is the directory the root resolves to. Supports ~ expansion at
-    # resolver construction time. For reserved derived roots (core, self,
-    # contacts, and dossiers) this is ignored; their paths come from
-    # workspace.path.
+    # resolver construction time. Reserved derived roots take their paths from
+    # workspace.path. Paths on core, self, and contacts are ignored for
+    # compatibility; an explicit dossiers path is rejected with its migration
+    # recipe.
     path: ./knowledge
     # Indexing controls whether markdown files in this root are
     # scanned into the document index. Omit to keep indexing enabled.
@@ -549,9 +552,10 @@ roots:
         valid_before: ""
   scratchpad:
     # Path is the directory the root resolves to. Supports ~ expansion at
-    # resolver construction time. For reserved derived roots (core, self,
-    # contacts, and dossiers) this is ignored; their paths come from
-    # workspace.path.
+    # resolver construction time. Reserved derived roots take their paths from
+    # workspace.path. Paths on core, self, and contacts are ignored for
+    # compatibility; an explicit dossiers path is rejected with its migration
+    # recipe.
     path: ./scratchpad
     # Indexing controls whether markdown files in this root are
     # scanned into the document index. Omit to keep indexing enabled.

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -204,8 +204,9 @@ embeddings:
 # Workspace configures the agent's sandboxed file system access.
 # The workspace root also anchors Thane's derived document roots.
 # {workspace.path}/core holds what the operator declares Thane to be;
-# {workspace.path}/self holds what Thane has made of that; and the
-# optional {workspace.path}/contacts holds contact dossiers.
+# {workspace.path}/self holds what Thane has made of that; the optional
+# {workspace.path}/contacts holds contact dossiers; and the optional
+# {workspace.path}/dossiers holds dossiers for non-contact subjects.
 workspace:
   # ReadOnlyDirs are additional directories the agent can read from
   # but not write to. Useful for compatibility or reference roots that
@@ -237,13 +238,15 @@ workspace:
 # 
 # Typical names: kb (curated knowledge), generated (model-produced
 # durable outputs), and scratchpad (low-integrity work area). The core,
-# self, and contacts names are reserved and derived from workspace.path;
-# declaring them under roots: sets policy, while any path is ignored.
+# self, contacts, and dossiers names are reserved and derived from
+# workspace.path; declaring them under roots: sets policy, while any path
+# is ignored.
 roots:
   generated:
     # Path is the directory the root resolves to. Supports ~ expansion at
     # resolver construction time. For reserved derived roots (core, self,
-    # and contacts) this is ignored; their paths come from workspace.path.
+    # contacts, and dossiers) this is ignored; their paths come from
+    # workspace.path.
     path: ./generated
     # Indexing controls whether markdown files in this root are
     # scanned into the document index. Omit to keep indexing enabled.
@@ -358,7 +361,8 @@ roots:
   kb:
     # Path is the directory the root resolves to. Supports ~ expansion at
     # resolver construction time. For reserved derived roots (core, self,
-    # and contacts) this is ignored; their paths come from workspace.path.
+    # contacts, and dossiers) this is ignored; their paths come from
+    # workspace.path.
     path: ./knowledge
     # Indexing controls whether markdown files in this root are
     # scanned into the document index. Omit to keep indexing enabled.
@@ -546,7 +550,8 @@ roots:
   scratchpad:
     # Path is the directory the root resolves to. Supports ~ expansion at
     # resolver construction time. For reserved derived roots (core, self,
-    # and contacts) this is ignored; their paths come from workspace.path.
+    # contacts, and dossiers) this is ignored; their paths come from
+    # workspace.path.
     path: ./scratchpad
     # Indexing controls whether markdown files in this root are
     # scanned into the document index. Omit to keep indexing enabled.

--- a/internal/app/coreloop_docs_parity_test.go
+++ b/internal/app/coreloop_docs_parity_test.go
@@ -147,7 +147,9 @@ func TestArchivistUsesCanonicalContactDossiers(t *testing.T) {
 	for _, want := range []string{
 		"contacts:<uuid>.md",
 		"contact_dossier_write",
-		"Never create or maintain a contact dossier under `kb:dossiers/`",
+		"Never create or maintain a contact dossier under `dossiers:`",
+		"`dossiers:entity-binary_sensor-game_room_door.md`",
+		"retired `kb:dossiers/` namespace",
 		"complete status-line, teaser, digest, and full projections",
 		"archive:session:<full-session-uuid>",
 		"never an 8-character prefix",

--- a/internal/app/document_root_admission.go
+++ b/internal/app/document_root_admission.go
@@ -45,12 +45,13 @@ func resolveRootPaths(root, rootPath string, gitCfg config.DocumentRootGitConfig
 
 // documentRootPaths returns the path prefixes for this instance's document
 // roots, with reserved derived roots forced to locations beneath
-// workspace.path. Core and self are always present; contacts is present when
-// its policy is explicitly declared.
+// workspace.path. Core and self are always present; contacts and dossiers are
+// present when their policy is explicitly declared.
 //
 // The derived roots are what make this worth centralizing. They carry
-// policy under roots.core / roots.self / roots.contacts but never a path, so they are
-// simply absent from cfg.Paths as loaded and appear only once derived.
+// policy under roots.core / roots.self / roots.contacts / roots.dossiers but
+// never a path, so they are simply absent from cfg.Paths as loaded and appear
+// only once derived.
 // Any caller that enumerates roots without this step silently omits them
 // — which for a per-root check means reporting on every root except the
 // one holding the config that decides what the instance trusts. Boot
@@ -61,7 +62,7 @@ func resolveRootPaths(root, rootPath string, gitCfg config.DocumentRootGitConfig
 // The returned map is a copy. Creating the directories is left to the
 // caller, so read-only callers stay read-only.
 func documentRootPaths(cfg *config.Config, logger *slog.Logger) map[string]string {
-	out := make(map[string]string, len(cfg.Paths)+3)
+	out := make(map[string]string, len(cfg.Paths)+4)
 	for name, path := range cfg.Paths {
 		out[name] = path
 	}
@@ -79,8 +80,10 @@ func documentRootPaths(cfg *config.Config, logger *slog.Logger) map[string]strin
 		{config.CoreRootName, cfg.CoreRoot()},
 		{config.SelfRootName, cfg.SelfRoot()},
 		{config.ContactsRootName, cfg.ContactsRoot()},
+		{config.DossiersRootName, cfg.DossiersRoot()},
 	} {
-		if derivedRoot.name == config.ContactsRootName && !declaresDocumentRoot(cfg.DocRoots, config.ContactsRootName) {
+		if (derivedRoot.name == config.ContactsRootName || derivedRoot.name == config.DossiersRootName) &&
+			!declaresDocumentRoot(cfg.DocRoots, derivedRoot.name) {
 			continue
 		}
 		rootName, derived := derivedRoot.name, derivedRoot.path
@@ -149,6 +152,8 @@ func missingDerivedRoot(cfg *config.Config, root string, mode documents.Verifica
 		path = cfg.SelfRoot()
 	case config.ContactsRootName:
 		path = cfg.ContactsRoot()
+	case config.DossiersRootName:
+		path = cfg.DossiersRoot()
 	}
 	// RepoPath stays empty: it reports the repository admission judged, and
 	// admission never ran here. Naming a directory that does not exist would

--- a/internal/app/document_root_admission.go
+++ b/internal/app/document_root_admission.go
@@ -82,14 +82,7 @@ func documentRootPaths(cfg *config.Config, logger *slog.Logger) map[string]strin
 		{config.ContactsRootName, cfg.ContactsRoot()},
 		{config.DossiersRootName, cfg.DossiersRoot()},
 	} {
-		if (derivedRoot.name == config.ContactsRootName || derivedRoot.name == config.DossiersRootName) &&
-			!declaresDocumentRoot(cfg.DocRoots, derivedRoot.name) {
-			continue
-		}
 		rootName, derived := derivedRoot.name, derivedRoot.path
-		if derived == "" {
-			continue
-		}
 		for name, path := range out {
 			if strings.TrimSuffix(name, ":") != rootName {
 				continue
@@ -103,6 +96,13 @@ func documentRootPaths(cfg *config.Config, logger *slog.Logger) map[string]strin
 				)
 			}
 			delete(out, name)
+		}
+		if (derivedRoot.name == config.ContactsRootName || derivedRoot.name == config.DossiersRootName) &&
+			!declaresDocumentRoot(cfg.DocRoots, derivedRoot.name) {
+			continue
+		}
+		if derived == "" {
+			continue
 		}
 		out[rootName] = derived
 	}

--- a/internal/app/document_root_admission_test.go
+++ b/internal/app/document_root_admission_test.go
@@ -289,9 +289,14 @@ func TestContactsRootIsDerivedOnlyWhenDeclared(t *testing.T) {
 
 func TestDossiersRootIsDerivedOnlyWhenDeclared(t *testing.T) {
 	workspace := t.TempDir()
-	cfg := &config.Config{Workspace: config.WorkspaceConfig{Path: workspace}}
+	cfg := &config.Config{
+		Workspace: config.WorkspaceConfig{Path: workspace},
+		Paths: map[string]string{
+			config.DossiersRootName: "/legacy/private-dossiers",
+		},
+	}
 	if _, ok := documentRootPaths(cfg, nil)[config.DossiersRootName]; ok {
-		t.Fatal("dossiers root was registered without an explicit policy declaration")
+		t.Fatal("legacy dossiers path was registered without an explicit policy declaration")
 	}
 
 	cfg.DocRoots = map[string]config.DocumentRootConfig{

--- a/internal/app/document_root_admission_test.go
+++ b/internal/app/document_root_admission_test.go
@@ -286,3 +286,19 @@ func TestContactsRootIsDerivedOnlyWhenDeclared(t *testing.T) {
 		t.Fatalf("contacts root = %q, want derived %q", got, want)
 	}
 }
+
+func TestDossiersRootIsDerivedOnlyWhenDeclared(t *testing.T) {
+	workspace := t.TempDir()
+	cfg := &config.Config{Workspace: config.WorkspaceConfig{Path: workspace}}
+	if _, ok := documentRootPaths(cfg, nil)[config.DossiersRootName]; ok {
+		t.Fatal("dossiers root was registered without an explicit policy declaration")
+	}
+
+	cfg.DocRoots = map[string]config.DocumentRootConfig{
+		config.DossiersRootName: {Authoring: "managed"},
+	}
+	paths := documentRootPaths(cfg, nil)
+	if got, want := paths[config.DossiersRootName], filepath.Join(workspace, config.DossiersRootName); got != want {
+		t.Fatalf("dossiers root = %q, want derived %q", got, want)
+	}
+}

--- a/internal/app/document_root_missing_test.go
+++ b/internal/app/document_root_missing_test.go
@@ -38,6 +38,7 @@ func TestCheckRootAdmissionReportsMissingDerivedRoots(t *testing.T) {
 			config.CoreRootName:     signedRoot(),
 			config.SelfRootName:     signedRoot(),
 			config.ContactsRootName: signedRoot(),
+			config.DossiersRootName: signedRoot(),
 		},
 	}
 
@@ -48,7 +49,7 @@ func TestCheckRootAdmissionReportsMissingDerivedRoots(t *testing.T) {
 		byRoot[r.Root] = r
 	}
 
-	for _, root := range []string{config.CoreRootName, config.SelfRootName, config.ContactsRootName} {
+	for _, root := range []string{config.CoreRootName, config.SelfRootName, config.ContactsRootName, config.DossiersRootName} {
 		t.Run(root, func(t *testing.T) {
 			got, ok := byRoot[root]
 			if !ok {

--- a/internal/app/new_agent.go
+++ b/internal/app/new_agent.go
@@ -33,11 +33,11 @@ func (a *App) initAgentLoop(s *newState) error {
 	// LoopOptions instead of post-construction setters.
 	if cfg.Workspace.Path != "" {
 		cfg.Paths = documentRootPaths(cfg, logger)
-		// Core and self are created on every install; contacts joins them
-		// when its canonical dossier policy is declared. Creating derived
+		// Core and self are created on every install; contacts and dossiers
+		// join them when their dossier policies are declared. Creating derived
 		// roots before resolver construction keeps policy and filesystem
 		// identity from depending on which subsystem happens to write first.
-		for _, root := range []string{config.CoreRootName, config.SelfRootName, config.ContactsRootName} {
+		for _, root := range []string{config.CoreRootName, config.SelfRootName, config.ContactsRootName, config.DossiersRootName} {
 			path := cfg.Paths[root]
 			if strings.TrimSpace(path) == "" {
 				continue

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -56,13 +56,15 @@ const DefaultWorkspace = "~/Thane"
 // ConfigFileName is the fixed name of the runtime config inside core.
 const ConfigFileName = "config.yaml"
 
-// CoreRootName, SelfRootName, and ContactsRootName are document roots whose
-// paths are derived from the workspace rather than declared. They may be
-// named in roots: to set policy, and none takes a path from there.
+// CoreRootName, SelfRootName, ContactsRootName, and DossiersRootName are
+// document roots whose paths are derived from the workspace rather than
+// declared. They may be named in roots: to set policy, and none takes a path
+// from there.
 const (
 	CoreRootName     = "core"
 	SelfRootName     = "self"
 	ContactsRootName = "contacts"
+	DossiersRootName = "dossiers"
 )
 
 // legacyConfigLocations are the paths Thane searched before the config
@@ -247,8 +249,9 @@ type Config struct {
 	// Workspace configures the agent's sandboxed file system access.
 	// The workspace root also anchors Thane's derived document roots.
 	// {workspace.path}/core holds what the operator declares Thane to be;
-	// {workspace.path}/self holds what Thane has made of that; and the
-	// optional {workspace.path}/contacts holds contact dossiers.
+	// {workspace.path}/self holds what Thane has made of that; the optional
+	// {workspace.path}/contacts holds contact dossiers; and the optional
+	// {workspace.path}/dossiers holds dossiers for non-contact subjects.
 	Workspace WorkspaceConfig `yaml:"workspace"`
 
 	// Roots is the unified document-root config. Each entry names one
@@ -276,8 +279,9 @@ type Config struct {
 	//
 	// Typical names: kb (curated knowledge), generated (model-produced
 	// durable outputs), and scratchpad (low-integrity work area). The core,
-	// self, and contacts names are reserved and derived from workspace.path;
-	// declaring them under roots: sets policy, while any path is ignored.
+	// self, contacts, and dossiers names are reserved and derived from
+	// workspace.path; declaring them under roots: sets policy, while any path
+	// is ignored.
 	Roots map[string]RootEntry `yaml:"roots,omitempty"`
 
 	// Paths is the legacy directory-mapping block. Replaced by roots:.
@@ -1006,7 +1010,8 @@ type AllowedSigner struct {
 type RootEntry struct {
 	// Path is the directory the root resolves to. Supports ~ expansion at
 	// resolver construction time. For reserved derived roots (core, self,
-	// and contacts) this is ignored; their paths come from workspace.path.
+	// contacts, and dossiers) this is ignored; their paths come from
+	// workspace.path.
 	Path string `yaml:"path"`
 
 	// Indexing controls whether markdown files in this root are
@@ -2805,7 +2810,7 @@ func (c *Config) normalizeRoots() error {
 				}
 			} else {
 				if pathValue == "" {
-					return fmt.Errorf("config: roots.%s.path must be set; only the derived roots (%s, %s, %s) take their path from workspace.path", trimmed, CoreRootName, SelfRootName, ContactsRootName)
+					return fmt.Errorf("config: roots.%s.path must be set; only the derived roots (%s, %s, %s, %s) take their path from workspace.path", trimmed, CoreRootName, SelfRootName, ContactsRootName, DossiersRootName)
 				}
 				c.Paths[trimmed] = entry.Path
 			}
@@ -3755,7 +3760,7 @@ func (c *Config) CoreRoot() string {
 // need to treat "this root is missing" as a problem rather than a preference
 // use this to distinguish them.
 func IsDerivedRootName(name string) bool {
-	return name == CoreRootName || name == SelfRootName || name == ContactsRootName
+	return name == CoreRootName || name == SelfRootName || name == ContactsRootName || name == DossiersRootName
 }
 
 // SelfRoot returns the fixed document root holding what Thane writes
@@ -3791,6 +3796,18 @@ func (c *Config) ContactsRoot() string {
 		return ""
 	}
 	return filepath.Join(c.Workspace.Path, ContactsRootName)
+}
+
+// DossiersRoot returns the fixed document root holding dossiers for
+// non-contact subjects, derived from [Workspace.Path] exactly as [CoreRoot]
+// is. The root is opt-in: callers only register it when dossiers is explicitly
+// declared under roots:. When workspace.path is unset, DossiersRoot returns
+// the empty string.
+func (c *Config) DossiersRoot() string {
+	if strings.TrimSpace(c.Workspace.Path) == "" {
+		return ""
+	}
+	return filepath.Join(c.Workspace.Path, DossiersRootName)
 }
 
 // CoreFile returns the absolute-or-relative path to a named file in the

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -280,8 +280,9 @@ type Config struct {
 	// Typical names: kb (curated knowledge), generated (model-produced
 	// durable outputs), and scratchpad (low-integrity work area). The core,
 	// self, contacts, and dossiers names are reserved and derived from
-	// workspace.path; declaring them under roots: sets policy, while any path
-	// is ignored.
+	// workspace.path; declaring them under roots: sets policy. Paths on core,
+	// self, and contacts are ignored for compatibility; an explicit dossiers
+	// path is rejected with its migration recipe.
 	Roots map[string]RootEntry `yaml:"roots,omitempty"`
 
 	// Paths is the legacy directory-mapping block. Replaced by roots:.
@@ -1009,9 +1010,10 @@ type AllowedSigner struct {
 // mapping with explicit path: and policy fields.
 type RootEntry struct {
 	// Path is the directory the root resolves to. Supports ~ expansion at
-	// resolver construction time. For reserved derived roots (core, self,
-	// contacts, and dossiers) this is ignored; their paths come from
-	// workspace.path.
+	// resolver construction time. Reserved derived roots take their paths from
+	// workspace.path. Paths on core, self, and contacts are ignored for
+	// compatibility; an explicit dossiers path is rejected with its migration
+	// recipe.
 	Path string `yaml:"path"`
 
 	// Indexing controls whether markdown files in this root are
@@ -2800,9 +2802,13 @@ func (c *Config) normalizeRoots() error {
 			}
 			seen[trimmed] = name
 			pathValue := strings.TrimSpace(entry.Path)
-			// Derived roots are reserved — their paths are always
-			// derived from workspace.path. Allow declaring either in
-			// roots: solely to set policy; ignore any path provided.
+			if trimmed == DossiersRootName && pathValue != "" {
+				return dossiersPathMigrationError("roots.dossiers.path", entry.Path)
+			}
+			// Derived roots are reserved — their paths are always derived
+			// from workspace.path. Dossiers rejects an explicit path above so
+			// upgrades cannot silently redirect a prior custom root. The older
+			// derived roots retain their path-ignoring compatibility behavior.
 			if IsDerivedRootName(trimmed) {
 				if pathValue != "" && !entryHasPolicy(entry) {
 					slog.Default().Warn("config: derived root path is ignored (it comes from workspace.path); declare this root only when setting policy",
@@ -2831,9 +2837,18 @@ func (c *Config) normalizeRoots() error {
 	}
 
 	if len(c.Paths) > 0 || len(c.DocRoots) > 0 {
+		for name, path := range c.Paths {
+			if strings.TrimSuffix(strings.TrimSpace(name), ":") == DossiersRootName && strings.TrimSpace(path) != "" {
+				return dossiersPathMigrationError("paths.dossiers", path)
+			}
+		}
 		slog.Default().Warn("config: paths: and doc_roots: are deprecated in favor of the unified roots: block; see docs/understanding/document-roots.md for the new shape")
 	}
 	return nil
+}
+
+func dossiersPathMigrationError(field, configuredPath string) error {
+	return fmt.Errorf("config: %s %q is no longer accepted because dossiers is now a workspace-derived root: move or clone that corpus to {workspace.path}/dossiers, remove the explicit path, and retain its policy under roots.dossiers", field, configuredPath)
 }
 
 // entryHasPolicy reports whether a root entry has any policy fields

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -1623,6 +1623,55 @@ func TestNormalizeRoots_DossiersReservedAcceptsPolicyOnly(t *testing.T) {
 	}
 }
 
+func TestNormalizeRoots_DossiersPathRequiresMigration(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name  string
+		entry RootEntry
+	}{
+		{name: "path only", entry: RootEntry{Path: "/legacy/private-dossiers"}},
+		{name: "path and policy", entry: RootEntry{Path: "/legacy/private-dossiers", Authoring: "managed"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{
+				Roots: map[string]RootEntry{
+					DossiersRootName: tc.entry,
+				},
+			}
+			err := cfg.normalizeRoots()
+			if err == nil {
+				t.Fatal("normalizeRoots should reject an explicit dossiers path")
+			}
+			for _, want := range []string{"roots.dossiers.path", "/legacy/private-dossiers", "{workspace.path}/dossiers", "remove the explicit path"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error = %q, want migration detail %q", err, want)
+				}
+			}
+		})
+	}
+}
+
+func TestNormalizeRoots_LegacyDossiersPathRequiresMigration(t *testing.T) {
+	t.Parallel()
+	cfg := &Config{
+		Paths: map[string]string{
+			DossiersRootName: "/legacy/private-dossiers",
+		},
+		DocRoots: map[string]DocumentRootConfig{
+			DossiersRootName: {Authoring: "managed"},
+		},
+	}
+	err := cfg.normalizeRoots()
+	if err == nil {
+		t.Fatal("normalizeRoots should reject a legacy dossiers path")
+	}
+	for _, want := range []string{"paths.dossiers", "/legacy/private-dossiers", "{workspace.path}/dossiers", "roots.dossiers"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %q, want migration detail %q", err, want)
+		}
+	}
+}
+
 // --- Ego loop validation ---
 
 // egoBaseConfig returns a Config with the ego loop enabled and a workspace

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -1605,6 +1605,24 @@ func TestNormalizeRoots_ContactsReservedAcceptsPolicyOnly(t *testing.T) {
 	}
 }
 
+func TestNormalizeRoots_DossiersReservedAcceptsPolicyOnly(t *testing.T) {
+	t.Parallel()
+	cfg := &Config{
+		Roots: map[string]RootEntry{
+			DossiersRootName: {Authoring: "managed"},
+		},
+	}
+	if err := cfg.normalizeRoots(); err != nil {
+		t.Fatalf("normalizeRoots: %v", err)
+	}
+	if _, ok := cfg.Paths[DossiersRootName]; ok {
+		t.Errorf("dossiers path must be derived; Paths = %#v", cfg.Paths)
+	}
+	if got := cfg.DocRoots[DossiersRootName].Authoring; got != "managed" {
+		t.Errorf("dossiers authoring policy = %q, want managed", got)
+	}
+}
+
 // --- Ego loop validation ---
 
 // egoBaseConfig returns a Config with the ego loop enabled and a workspace

--- a/internal/platform/identity/bootstrap.go
+++ b/internal/platform/identity/bootstrap.go
@@ -335,9 +335,9 @@ type channelPolicy struct {
 }
 
 // coreRootPolicy carries one generated document-root declaration. Core emits
-// only seed_signers; contacts also emits its managed authoring, exact-subject
-// context, and signed-history policy so a fresh instance has a complete
-// dossier root without post-init path surgery.
+// only seed_signers; the dossier roots also emit their managed authoring and
+// signed-history policy so a fresh instance has complete roots without
+// post-init path surgery. Contacts additionally advertises exact subjects.
 type coreRootPolicy struct {
 	Authoring   string                `yaml:"authoring,omitempty"`
 	Context     coreRootContextPolicy `yaml:"context,omitempty"`
@@ -384,11 +384,20 @@ func coreSeedDeclaration(signing *SigningKeyPair, operator *OperatorSigner) core
 }
 
 func contactsRootDeclaration(signing *SigningKeyPair) coreRootPolicy {
+	policy := managedDossierRootDeclaration(signing)
+	policy.Context = coreRootContextPolicy{
+		Advertise: "exact_subject",
+	}
+	return policy
+}
+
+func dossiersRootDeclaration(signing *SigningKeyPair) coreRootPolicy {
+	return managedDossierRootDeclaration(signing)
+}
+
+func managedDossierRootDeclaration(signing *SigningKeyPair) coreRootPolicy {
 	return coreRootPolicy{
 		Authoring: "managed",
-		Context: coreRootContextPolicy{
-			Advertise: "exact_subject",
-		},
 		SeedSigners: []coreSeedSigner{{
 			Principal: provenance.AgentPrincipal,
 			Key:       strings.TrimSpace(signing.Public),
@@ -408,6 +417,7 @@ func renderCoreConfig(instanceName string, generatedAt time.Time, signing *Signi
 		Roots: map[string]coreRootPolicy{
 			"core":     coreSeedDeclaration(signing, operator),
 			"contacts": contactsRootDeclaration(signing),
+			"dossiers": dossiersRootDeclaration(signing),
 		},
 		Version:     1,
 		GeneratedAt: generatedAt.Format(time.RFC3339),

--- a/internal/platform/identity/bootstrap_test.go
+++ b/internal/platform/identity/bootstrap_test.go
@@ -100,6 +100,19 @@ func TestBootstrapCoreCreatesSignedBirthCommit(t *testing.T) {
 	if len(contactsRoot.SeedSigners) != 1 || contactsRoot.SeedSigners[0].Principal != "thane@provenance.local" {
 		t.Fatalf("generated contacts seed signers = %#v", contactsRoot.SeedSigners)
 	}
+	dossiersRoot, ok := cfg.Roots["dossiers"]
+	if !ok {
+		t.Fatal("generated config is missing roots.dossiers")
+	}
+	if dossiersRoot.Authoring != "managed" || dossiersRoot.Context.Advertise != "" {
+		t.Fatalf("generated dossiers root policy = %#v", dossiersRoot)
+	}
+	if !dossiersRoot.Git.Enabled || !dossiersRoot.Git.SignCommits || dossiersRoot.Git.VerifySignatures != "required" || dossiersRoot.Git.SigningKey != "core:"+SigningPrivateKeyFile {
+		t.Fatalf("generated dossiers git policy = %#v", dossiersRoot.Git)
+	}
+	if len(dossiersRoot.SeedSigners) != 1 || dossiersRoot.SeedSigners[0].Principal != "thane@provenance.local" {
+		t.Fatalf("generated dossiers seed signers = %#v", dossiersRoot.SeedSigners)
+	}
 	if cfg.Identity.SigningKey.Fingerprint != result.SigningKeyFingerprint {
 		t.Fatalf("signing fingerprint = %q, want %q", cfg.Identity.SigningKey.Fingerprint, result.SigningKeyFingerprint)
 	}

--- a/loops/archivist.md
+++ b/loops/archivist.md
@@ -161,14 +161,16 @@ durable queue holds that).
      Do not copy trust zone, title, organization, phone, or other structured
      directory fields as identity boilerplate; include such a fact only when it
      materially supports the relationship synthesis. Never create or maintain a
-     contact dossier under `kb:dossiers/`; that would fork one person's history
-     across two sources. If the canonical contact root or writer is unavailable,
-     record that outcome in archivist.md and call `queue_defer`; do not
-     acknowledge unpublished evidence or create a fallback document.
+     contact dossier under `dossiers:` or the retired `kb:dossiers/` namespace;
+     that would fork one person's history across two sources. If the canonical
+     contact root or writer is unavailable, record that outcome in archivist.md
+     and call `queue_defer`; do not acknowledge unpublished evidence or create a
+     fallback document.
    - Every non-contact subject remains an ordinary managed document under the
-     `kb:dossiers/` namespace. Use canonical `root:path` refs — for the game
-     room door, `kb:dossiers/entity-binary_sensor-game_room_door.md`, never a
-     bare `dossiers/...` path. Read the existing document before replacing it.
+     `dossiers:` root. Use canonical `root:path` refs — for the game room door,
+     `dossiers:entity-binary_sensor-game_room_door.md`, never a bare
+     `dossiers/...` path or the retired `kb:dossiers/` namespace. Read the
+     existing document before replacing it.
 4. **Ack every item you handle** — Call `queue_ack` with each item's
    subject only after every warranted dossier write succeeded, or after an
    evidence-based decision that the complete source changes nothing. Correct a
@@ -226,7 +228,7 @@ subject benefits from reading just this paragraph.
 ## Connections
 
 - Related subjects: `area:game_room`, `zone:smoke_break`
-- Dossiers that reference this one: `kb:dossiers/<other-subject>.md`, …
+- Dossiers that reference this one: `dossiers:<other-subject>.md`, …
 ```
 
 Every claim line carries citations. If you cannot back a claim with specific


### PR DESCRIPTION
## Summary

- reserve `dossiers` as an opt-in workspace-derived root at `{workspace}/dossiers`
- bootstrap and verify its signed Git history during `thane init`, alongside contact dossiers
- steer the archivist to `dossiers:` for non-contact subjects and retire `kb:dossiers/`
- update operator documentation and generated configuration guidance

## Why

Production already has a reconstructed, signed dossiers repository at `{workspace}/dossiers`, but Thane still treats ordinary dossiers as a legacy directory nested under `kb:`. Giving dossiers the same derived-root lifecycle as contacts makes its location stable, applies admission and signature policy consistently, and prevents the archivist from continuing to fork new work into the unsigned legacy namespace.

## User impact

Operators can declare `roots.dossiers` without a path. Thane resolves it to `{workspace}/dossiers`, registers it only when declared, and `thane init` establishes or verifies the signed repository. Fresh initializations generate both contact and ordinary dossier root policies. The archivist now reads and writes ordinary dossiers through canonical `dossiers:<path>` refs.

## Test plan

- [x] `just test`
- [x] `just ci`
- [x] fresh init creates one clean, verified birth commit in both `contacts` and `dossiers`
- [x] derived-root tests cover opt-in registration and missing-root admission
- [x] generated config and embedded archivist defaults are current

Refs #986.