### PR TITLE
feat: deepen contact provenance and dossier reads

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -54,9 +54,9 @@ filesystem paths, signer principals, or the contents of `.allowed_signers`.
 | `PUT` | `/v1/models/registry/resource-policy` | Set a resource policy. |
 | `DELETE` | `/v1/models/registry/resource-policy?resource=...` | Clear a resource policy. |
 | `GET` | `/v1/contacts` | List or search contacts. Supports `query`, `kind`, `trust_zone`, `property`, `value`, `exact=true`, and `limit` (default 100, max 500). |
-| `GET` | `/v1/contacts/{id}` | Get one contact with structured properties. |
-| `POST` | `/v1/contacts` | Create a contact with optional vCard-style `properties`. |
-| `PUT` | `/v1/contacts/{id}` | Replace a contact and its structured properties. |
+| `GET` | `/v1/contacts/{id}` | Get one contact with structured properties; property objects include model-turn provenance when known and `null` for legacy or non-model authorship. |
+| `POST` | `/v1/contacts` | Create a contact with optional vCard-style `properties`; API-authored properties retain unknown provenance. |
+| `PUT` | `/v1/contacts/{id}` | Replace a contact and its structured properties; API-authored properties retain unknown provenance. |
 | `DELETE` | `/v1/contacts/{id}` | Soft-delete a contact. |
 | `GET` | `/v1/loops` | Running loop status snapshots. Optional `?state=` filter (`pending`, `sleeping`, `waiting`, `processing`, `error`, `stopped`). |
 | `GET` | `/v1/loops/{id}` | One running loop's status. |

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -274,7 +274,7 @@ being reimplemented in each loop prompt.
 
 | Tool | Description |
 |------|-------------|
-| `contact_save` | Create or update a contact with vCard properties. Model-authored property rows retain turn provenance, and a committed change coalesces one canonical contact refresh for the archivist. |
+| `contact_save` | Create or update a contact with vCard properties. Model-authored property rows retain turn provenance. When an archivist refresh consumer is enabled, a committed change coalesces one canonical contact refresh; identical no-ops never enqueue one. |
 | `contact_lookup` | Search by name, query, kind, or property. Exact rich results include the canonical UUID and configured `contact_dossier_read` trailhead. |
 | `contact_dossier_read` | Read or probe the canonical dossier for an active contact UUID. Go derives the ref and tracks revision state. Every success exposes `dossier.exists`, `dossier.ref`, and `dossier.document`; an absent dossier is a successful result with a null document and the exact create action. |
 | `contact_dossier_write` | Create or replace a canonical contact dossier from four structured projections; Go owns its ref, private tag, frontmatter, and section layout, and requires full canonical UUIDs in archive-session citations. Available only for a managed-writable `contacts` root. |

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -276,7 +276,7 @@ being reimplemented in each loop prompt.
 |------|-------------|
 | `contact_save` | Create or update a contact with vCard properties. Model-authored property rows retain turn provenance, and a committed change coalesces one canonical contact refresh for the archivist. |
 | `contact_lookup` | Search by name, query, kind, or property. Exact rich results include the canonical UUID and configured `contact_dossier_read` trailhead. |
-| `contact_dossier_read` | Read or probe the canonical dossier for an active contact UUID. Go derives the ref and tracks revision state; an absent dossier is a successful result with the exact create action. |
+| `contact_dossier_read` | Read or probe the canonical dossier for an active contact UUID. Go derives the ref and tracks revision state. Every success exposes `dossier.exists`, `dossier.ref`, and `dossier.document`; an absent dossier is a successful result with a null document and the exact create action. |
 | `contact_dossier_write` | Create or replace a canonical contact dossier from four structured projections; Go owns its ref, private tag, frontmatter, and section layout, and requires full canonical UUIDs in archive-session citations. Available only for a managed-writable `contacts` root. |
 | `contact_whereabouts` | Fuse a contact's room, HA zone, and bound-device location sources with provenance, freshness, and explicit room conflicts. |
 | `contact_forget` | Delete a contact. |

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -274,8 +274,9 @@ being reimplemented in each loop prompt.
 
 | Tool | Description |
 |------|-------------|
-| `contact_save` | Create or update a contact with vCard properties. |
-| `contact_lookup` | Search by name, query, kind, or property. Exact rich results include the canonical UUID and configured contact-dossier ref. |
+| `contact_save` | Create or update a contact with vCard properties. Model-authored property rows retain turn provenance, and a committed change coalesces one canonical contact refresh for the archivist. |
+| `contact_lookup` | Search by name, query, kind, or property. Exact rich results include the canonical UUID and configured `contact_dossier_read` trailhead. |
+| `contact_dossier_read` | Read or probe the canonical dossier for an active contact UUID. Go derives the ref and tracks revision state; an absent dossier is a successful result with the exact create action. |
 | `contact_dossier_write` | Create or replace a canonical contact dossier from four structured projections; Go owns its ref, private tag, frontmatter, and section layout, and requires full canonical UUIDs in archive-session citations. Available only for a managed-writable `contacts` root. |
 | `contact_whereabouts` | Fuse a contact's room, HA zone, and bound-device location sources with provenance, freshness, and explicit room conflicts. |
 | `contact_forget` | Delete a contact. |
@@ -289,7 +290,8 @@ being reimplemented in each loop prompt.
 
 | Tool | Description |
 |------|-------------|
-| `contact_owner` | Return the runtime operator contact, canonical UUID, configured dossier ref, and active operator channels. Protected tag; name retained for compatibility. |
+| `contact_owner` | Return the runtime operator contact, canonical UUID, configured dossier trailhead, and active operator channels. Protected tag; name retained for compatibility. |
+| `contact_dossier_read` | Read or probe the operator's canonical dossier when the managed `contacts` root is available; also exposed through the `contacts` capability. |
 | `contact_dossier_write` | Write a canonical dossier from an operator-origin turn when the managed `contacts` root is available; also exposed through the `contacts` capability. |
 
 Operator channel activity recency is reported with delta fields such as

--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -522,7 +522,12 @@ The boundary is strict: SQLite contacts remain authoritative for UUIDs,
 structured identity, communication properties, trust zones, Home Assistant
 bindings, and companion attribution. Dossier prose is relationship synthesis,
 not a way to mutate those fields. `contact_lookup` and `contact_owner` expose a
-bounded dossier ref; `doc_read` opens it when the prose is useful.
+bounded `contact_dossier_read` trailhead. That tool accepts the active contact
+UUID, derives the canonical ref in Go, and either returns the dossier with a
+revision receipt or returns a successful structured absence with the exact
+create action. This keeps a missing dossier from becoming a retry loop over
+manually transcribed refs.
+
 `contact_dossier_write` is the canonical mutation door on a managed-writable
 root. It accepts the contact UUID plus status-line, teaser, digest, and full
 content, then derives the ref, exact private tag, frontmatter, and section
@@ -534,16 +539,17 @@ should not author dossier structure through them.
 The archivist uses the same contract-owned door. Contact-shaped queue subjects
 and contact evidence discovered in closed sessions are resolved through the
 structured directory, reconciled with the existing canonical dossier, and
-republished through `contact_dossier_write`. The separate `dossiers:` root is
+read through `contact_dossier_read` before being republished through
+`contact_dossier_write`. The separate `dossiers:` root is
 the home for entities, areas, routines, and themes; it is never a fallback
 location for a contact, because that would split one person's history across
 two document roots. The legacy `kb:dossiers/` namespace is retired once its
 documents have moved to `dossiers:` and must not remain indexed alongside the
-new root. Before replacement, the archivist checks
-whether `doc_read` truncated the current dossier and walks its outline and
-sections when necessary. An unreadable remainder or unavailable canonical
-writer defers the durable queue item behind ready work rather than losing it or
-letting it block the queue.
+new root. Before replacement, the archivist checks whether the canonical read
+truncated the current dossier and walks its outline and sections when
+necessary. An absent read proceeds directly to one create attempt; an unreadable
+remainder or unavailable canonical writer defers the durable queue item behind
+ready work rather than losing it or letting it block the queue.
 
 Archive evidence in a contact dossier uses
 `archive:session:<full-session-uuid>`. Archive tools accept short prefixes as

--- a/internal/app/adapters_test.go
+++ b/internal/app/adapters_test.go
@@ -297,7 +297,7 @@ func TestContactChannelBindingResolverCachesLegacyConfiguredContactName(t *testi
 		t.Fatalf("NewStore: %v", err)
 	}
 
-	tools := contacts.NewTools(store)
+	tools := contacts.NewTools(store, nil)
 	if _, err := tools.SaveContact(`{"name":"Aimee","kind":"individual","facts":{"email":"aimee@example.com"}}`); err != nil {
 		t.Fatalf("SaveContact: %v", err)
 	}

--- a/internal/app/archivist_contact_refresh.go
+++ b/internal/app/archivist_contact_refresh.go
@@ -62,7 +62,12 @@ func (a *App) enqueueContactDossierRefresh(ctx context.Context, mutation contact
 	if err != nil {
 		return fmt.Errorf("marshal contact dossier refresh: %w", err)
 	}
-	if err := a.loopQueue.Enqueue(ctx, archivist.DefinitionName, "contact:"+mutation.ContactID.String(), 0, raw); err != nil {
+	// The structured contact is already committed when this handoff runs.
+	// Detach request cancellation so a disconnect cannot erase the durable
+	// refresh, while retaining the shared bounded delivery window.
+	deliveryCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), queueWakeDeliveryTimeout)
+	defer cancel()
+	if err := a.loopQueue.Enqueue(deliveryCtx, archivist.DefinitionName, "contact:"+mutation.ContactID.String(), 0, raw); err != nil {
 		return fmt.Errorf("enqueue contact dossier refresh: %w", err)
 	}
 	return nil

--- a/internal/app/archivist_contact_refresh.go
+++ b/internal/app/archivist_contact_refresh.go
@@ -1,0 +1,75 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/nugget/thane-ai-agent/internal/channels/messages"
+	"github.com/nugget/thane-ai-agent/internal/runtime/archivist"
+	"github.com/nugget/thane-ai-agent/internal/state/contacts"
+)
+
+// enqueueContactDossierRefresh records one committed structured-contact
+// mutation as frontier work for the archivist. The contact UUID is the dedup
+// identity, so repeated writes coalesce into the latest authoritative field
+// set without waking the self-paced consumer.
+func (a *App) enqueueContactDossierRefresh(ctx context.Context, mutation contacts.ContactMutation) error {
+	if a == nil || a.loopQueue == nil {
+		return fmt.Errorf("loop queue not configured")
+	}
+	if mutation.ContactID == uuid.Nil {
+		return fmt.Errorf("empty contact_id")
+	}
+
+	metadata := map[string]string{
+		"contact_id":   mutation.ContactID.String(),
+		"contact_name": strings.TrimSpace(mutation.ContactName),
+		"created":      strconv.FormatBool(mutation.Created),
+		"fields":       strings.Join(mutation.Fields, ","),
+	}
+	if provenance := mutation.Provenance; provenance != nil {
+		addContactRefreshMetadata(metadata, "source", provenance.Source)
+		addContactRefreshMetadata(metadata, "model", provenance.Model)
+		addContactRefreshMetadata(metadata, "loop_id", provenance.LoopID)
+		addContactRefreshMetadata(metadata, "conversation_id", provenance.ConversationID)
+		addContactRefreshMetadata(metadata, "session_id", provenance.SessionID)
+		addContactRefreshMetadata(metadata, "request_id", provenance.RequestID)
+		addContactRefreshMetadata(metadata, "tool_call_id", provenance.ToolCallID)
+		if provenance.Iteration != nil {
+			metadata["iteration"] = strconv.Itoa(*provenance.Iteration)
+		}
+	}
+
+	payload := messages.LoopNotifyPayload{
+		Events: []messages.LoopEventPayload{{
+			Source: "contact_save",
+			Type:   "structured_contact_changed",
+			ID:     mutation.ContactID.String(),
+			Title:  mutation.ContactName,
+			Summary: fmt.Sprintf(
+				"Authoritative structured contact fields changed for %q (%s). Resolve the current contact by this exact name, read its canonical dossier, and refresh the dossier only when the longitudinal synthesis materially changes; do not copy structured identity boilerplate into dossier prose.",
+				mutation.ContactName,
+				strings.Join(mutation.Fields, ", "),
+			),
+			Metadata: metadata,
+		}},
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal contact dossier refresh: %w", err)
+	}
+	if err := a.loopQueue.Enqueue(ctx, archivist.DefinitionName, "contact:"+mutation.ContactID.String(), 0, raw); err != nil {
+		return fmt.Errorf("enqueue contact dossier refresh: %w", err)
+	}
+	return nil
+}
+
+func addContactRefreshMetadata(metadata map[string]string, key, value string) {
+	if value = strings.TrimSpace(value); value != "" {
+		metadata[key] = value
+	}
+}

--- a/internal/app/archivist_session_close_wake_test.go
+++ b/internal/app/archivist_session_close_wake_test.go
@@ -212,6 +212,25 @@ func TestEnqueueContactDossierRefreshCoalescesByContact(t *testing.T) {
 	}
 }
 
+func TestEnqueueContactDossierRefreshSurvivesRequestCancellation(t *testing.T) {
+	a, store := newQueueTestApp(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	id := uuid.MustParse("019c76e4-2ff1-7918-8d6f-6c2488f5098d")
+	err := a.enqueueContactDossierRefresh(ctx, contacts.ContactMutation{
+		ContactID:   id,
+		ContactName: "Canceled Request Contact",
+		Fields:      []string{"note"},
+	})
+	if err != nil {
+		t.Fatalf("detached contact refresh enqueue: %v", err)
+	}
+	items, err := store.Peek(context.Background(), archivist.DefinitionName, 1)
+	if err != nil || len(items) != 1 || items[0].DedupKey != "contact:"+id.String() {
+		t.Fatalf("durable refresh after cancellation: items=%#v err=%v", items, err)
+	}
+}
+
 // TestEnqueueSessionCloseWork_SkipsAutomationOrigins verifies the archival
 // policy (issue #1024): sessions from autonomous/automation/auxiliary origins
 // are not enqueued for the archivist, so it isn't drowned in service-loop and

--- a/internal/app/archivist_session_close_wake_test.go
+++ b/internal/app/archivist_session_close_wake_test.go
@@ -2,12 +2,17 @@ package app
 
 import (
 	"context"
+	"encoding/json"
+	"strings"
 	"testing"
 
+	"github.com/google/uuid"
+	"github.com/nugget/thane-ai-agent/internal/channels/messages"
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 	"github.com/nugget/thane-ai-agent/internal/runtime/archivist"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/state/contacts"
 	"github.com/nugget/thane-ai-agent/internal/state/loopqueue"
 
 	_ "modernc.org/sqlite"
@@ -126,6 +131,84 @@ func TestEnqueueSessionCloseWork_EmptySessionID(t *testing.T) {
 	a, _ := newQueueTestApp(t)
 	if err := a.enqueueSessionCloseWork(context.Background(), "", "signal-x", "x"); err == nil {
 		t.Fatal("enqueueSessionCloseWork with empty session_id should error")
+	}
+}
+
+func TestEnqueueContactDossierRefreshCoalescesByContact(t *testing.T) {
+	a, store := newQueueTestApp(t)
+	id := uuid.MustParse("019c76e4-2ff1-7918-8d6f-6c2488f5098d")
+	iteration := 4
+	mutation := contacts.ContactMutation{
+		ContactID:   id,
+		ContactName: "Contact Person",
+		Created:     false,
+		Fields:      []string{"ai_summary", "property:EMAIL"},
+		Provenance: &contacts.PropertyProvenance{
+			Source:         "contact_save",
+			Model:          "test-model",
+			LoopID:         "loop-1",
+			ConversationID: "conversation-1",
+			SessionID:      "session-1",
+			RequestID:      "request-1",
+			ToolCallID:     "tool-call-1",
+			Iteration:      &iteration,
+		},
+	}
+	if err := a.enqueueContactDossierRefresh(context.Background(), mutation); err != nil {
+		t.Fatalf("enqueueContactDossierRefresh: %v", err)
+	}
+
+	items, err := store.Peek(context.Background(), archivist.DefinitionName, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 1 || items[0].DedupKey != "contact:"+id.String() {
+		t.Fatalf("queue items = %#v, want one contact-keyed item", items)
+	}
+	var payload messages.LoopNotifyPayload
+	if err := json.Unmarshal(items[0].Payload, &payload); err != nil {
+		t.Fatalf("decode queue payload: %v", err)
+	}
+	if len(payload.Events) != 1 {
+		t.Fatalf("events = %#v, want 1", payload.Events)
+	}
+	event := payload.Events[0]
+	if event.Source != "contact_save" || event.Type != "structured_contact_changed" || event.ID != id.String() {
+		t.Errorf("event identity = %#v", event)
+	}
+	for _, want := range []string{`"Contact Person"`, "ai_summary, property:EMAIL", "exact name"} {
+		if !strings.Contains(event.Summary, want) {
+			t.Errorf("event summary = %q, want %q", event.Summary, want)
+		}
+	}
+	if !event.ObservedAt.IsZero() {
+		t.Errorf("contact refresh exposed scan time as observed_at: %v", event.ObservedAt)
+	}
+	for key, want := range map[string]string{
+		"contact_id": id.String(), "contact_name": "Contact Person",
+		"created": "false", "fields": "ai_summary,property:EMAIL",
+		"source": "contact_save", "model": "test-model", "loop_id": "loop-1",
+		"conversation_id": "conversation-1", "session_id": "session-1",
+		"request_id": "request-1", "tool_call_id": "tool-call-1", "iteration": "4",
+	} {
+		if got := event.Metadata[key]; got != want {
+			t.Errorf("metadata[%q] = %q, want %q", key, got, want)
+		}
+	}
+
+	mutation.Fields = []string{"note"}
+	if err := a.enqueueContactDossierRefresh(context.Background(), mutation); err != nil {
+		t.Fatalf("re-enqueue contact refresh: %v", err)
+	}
+	if n, _ := store.PendingCount(context.Background(), archivist.DefinitionName); n != 1 {
+		t.Fatalf("pending contact refreshes = %d, want 1 coalesced item", n)
+	}
+	items, err = store.Peek(context.Background(), archivist.DefinitionName, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, summary := projectQueuePayload(items[0].Payload); summary == "" {
+		t.Error("coalesced contact refresh lost its model-facing summary")
 	}
 }
 

--- a/internal/app/coreloop_docs_parity_test.go
+++ b/internal/app/coreloop_docs_parity_test.go
@@ -128,8 +128,9 @@ func TestEmbeddedDocumentsMatchTheRepoSources(t *testing.T) {
 
 // TestArchivistUsesCanonicalContactDossiers pins the model-facing routing
 // contract that keeps one person's history out of the generic dossier root.
-// A configured runtime exposes contact_dossier_write through the archivist's
-// contacts tag; the shipped task must teach the loop to choose it.
+// A configured runtime exposes the canonical contact dossier read/write pair
+// through the archivist's contacts tag; the shipped task must teach the loop
+// to choose them.
 func TestArchivistUsesCanonicalContactDossiers(t *testing.T) {
 	spec, err := decodeCoreLoopDefinition(filepath.Join("..", "..", "loops", "archivist.md"))
 	if err != nil {
@@ -140,12 +141,17 @@ func TestArchivistUsesCanonicalContactDossiers(t *testing.T) {
 			t.Errorf("archivist tags = %#v, want %q so the canonical dossier tools are reachable", spec.Tags, tag)
 		}
 	}
-	if slices.Contains(spec.ExcludeTools, "contact_dossier_write") {
-		t.Error("archivist excludes contact_dossier_write despite teaching it as the canonical contact door")
+	for _, tool := range []string{"contact_dossier_read", "contact_dossier_write"} {
+		if slices.Contains(spec.ExcludeTools, tool) {
+			t.Errorf("archivist excludes %s despite teaching it as a canonical contact door", tool)
+		}
 	}
 	normalizedTask := strings.Join(strings.Fields(spec.Task), " ")
 	for _, want := range []string{
 		"contacts:<uuid>.md",
+		"contact_dossier_read",
+		"An absent dossier is a successful, actionable result",
+		"A `contact:<uuid>` item from `contact_save` names the exact current contact",
 		"contact_dossier_write",
 		"Never create or maintain a contact dossier under `dossiers:`",
 		"`dossiers:entity-binary_sensor-game_room_door.md`",
@@ -154,7 +160,7 @@ func TestArchivistUsesCanonicalContactDossiers(t *testing.T) {
 		"archive:session:<full-session-uuid>",
 		"never an 8-character prefix",
 		"response's `truncated` marker",
-		"call `doc_outline`, verify that outline is not truncated",
+		"use the returned canonical ref with `doc_outline`, verify that outline is not truncated",
 		"recover every top-level section with `doc_section`",
 		"call `queue_defer`",
 	} {

--- a/internal/app/coreloop_docs_parity_test.go
+++ b/internal/app/coreloop_docs_parity_test.go
@@ -159,10 +159,11 @@ func TestArchivistUsesCanonicalContactDossiers(t *testing.T) {
 		"complete status-line, teaser, digest, and full projections",
 		"archive:session:<full-session-uuid>",
 		"never an 8-character prefix",
-		"response's `truncated` marker",
+		"`dossier.document.truncated`",
 		"use the returned canonical ref with `doc_outline`, verify that outline is not truncated",
 		"recover every top-level section with `doc_section`",
 		"call `queue_defer`",
+		"a stale ack returns `retained_newer`",
 	} {
 		if !strings.Contains(normalizedTask, want) {
 			t.Errorf("archivist task does not teach %q", want)

--- a/internal/app/document_roots_test.go
+++ b/internal/app/document_roots_test.go
@@ -151,7 +151,7 @@ func TestBuildDocumentStoreOptionsWiresContactDossierValidator(t *testing.T) {
 	if err != nil {
 		t.Fatalf("contacts.NewStore: %v", err)
 	}
-	contactTools := contacts.NewTools(contactStore)
+	contactTools := contacts.NewTools(contactStore, nil)
 	if _, err := contactTools.SaveContact(`{"name":"Dossier Person","kind":"individual"}`); err != nil {
 		t.Fatalf("SaveContact: %v", err)
 	}

--- a/internal/app/loop_queue_tools.go
+++ b/internal/app/loop_queue_tools.go
@@ -68,7 +68,7 @@ func buildLoopQueueTools(store *loopqueue.Store, loopName string) []looppkg.Runt
 				now := time.Now().UTC()
 				views := make([]queueItemView, 0, len(items))
 				for _, it := range items {
-					receipts.remember(it.DedupKey, it.Generation)
+					receipts.remember(it.DedupKey, it.Receipt)
 					source, summary := projectQueuePayload(it.Payload)
 					views = append(views, queueItemView{
 						Subject:  it.DedupKey,
@@ -83,8 +83,8 @@ func buildLoopQueueTools(store *loopqueue.Store, loopName string) []looppkg.Runt
 		},
 		{
 			Name: "queue_ack",
-			Description: "Mark a queue item done and remove the exact generation returned by queue_pull. Pass only its subject; Go retains the hidden generation receipt. " +
-				"If newer evidence arrived while you worked, that newer generation remains queued and the result tells you to pull it later. Acking a subject that is no longer queued is harmless. Ack only after its evidence is durably folded or you made an evidence-based no-change decision; use queue_defer when an external prerequisite blocks completion.",
+			Description: "Mark a queue item done and remove the exact item returned by queue_pull. Pass only its subject; Go retains a hidden one-shot receipt and discards it after acknowledgement. " +
+				"If newer evidence arrived while you worked, that newer item remains queued and the result tells you to pull it later. Ack only after its evidence is durably folded or you made an evidence-based no-change decision; use queue_defer when an external prerequisite blocks completion.",
 			SkipContentResolve: true,
 			Parameters: map[string]any{
 				"type": "object",
@@ -101,24 +101,22 @@ func buildLoopQueueTools(store *loopqueue.Store, loopName string) []looppkg.Runt
 				if subject == "" {
 					return "", fmt.Errorf("subject is required")
 				}
-				generation, ok := receipts.generation(subject)
+				receipt, ok := receipts.receipt(subject)
 				if !ok {
 					return "", fmt.Errorf("subject %q has no receipt from queue_pull in this loop run; call queue_pull before queue_ack", subject)
 				}
-				outcome, err := store.Ack(ctx, loopName, subject, generation)
+				outcome, err := store.Ack(ctx, loopName, subject, receipt)
 				if err != nil {
 					return "", err
 				}
+				receipts.forget(subject, receipt)
 				switch outcome {
 				case loopqueue.Acked:
-					receipts.complete(subject, generation)
 					return fmt.Sprintf(`{"status":"ok","subject":%q}`, subject), nil
 				case loopqueue.AckMissing:
-					receipts.complete(subject, generation)
 					return fmt.Sprintf(`{"status":"already_acknowledged","subject":%q}`, subject), nil
 				case loopqueue.AckSuperseded:
-					receipts.forget(subject, generation)
-					return fmt.Sprintf(`{"status":"retained_newer","subject":%q,"instruction":"Newer evidence arrived while this generation was being processed. The newer item remains queued; call queue_pull before handling it."}`, subject), nil
+					return fmt.Sprintf(`{"status":"retained_newer","subject":%q,"instruction":"Newer evidence arrived while this item was being processed. The newer item remains queued; call queue_pull before handling it."}`, subject), nil
 				default:
 					return "", fmt.Errorf("unexpected queue acknowledgement outcome %q", outcome)
 				}
@@ -206,50 +204,35 @@ func buildLoopQueueTools(store *loopqueue.Store, loopName string) []looppkg.Runt
 	}
 }
 
-type queueReceipt struct {
-	generation int64
-	complete   bool
-}
-
 type queueReceipts struct {
 	mu        sync.Mutex
-	bySubject map[string]queueReceipt
+	bySubject map[string]string
 }
 
 func newQueueReceipts() *queueReceipts {
-	return &queueReceipts{bySubject: make(map[string]queueReceipt)}
+	return &queueReceipts{bySubject: make(map[string]string)}
 }
 
-func (r *queueReceipts) remember(subject string, generation int64) {
+func (r *queueReceipts) remember(subject, receipt string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	current, ok := r.bySubject[subject]
-	if ok && !current.complete {
+	if _, ok := r.bySubject[subject]; ok {
 		return
 	}
-	r.bySubject[subject] = queueReceipt{generation: generation}
+	r.bySubject[subject] = receipt
 }
 
-func (r *queueReceipts) generation(subject string) (int64, bool) {
+func (r *queueReceipts) receipt(subject string) (string, bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	receipt, ok := r.bySubject[subject]
-	return receipt.generation, ok
+	return receipt, ok
 }
 
-func (r *queueReceipts) complete(subject string, generation int64) {
+func (r *queueReceipts) forget(subject, expectedReceipt string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if receipt, ok := r.bySubject[subject]; ok && receipt.generation == generation {
-		receipt.complete = true
-		r.bySubject[subject] = receipt
-	}
-}
-
-func (r *queueReceipts) forget(subject string, generation int64) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if receipt, ok := r.bySubject[subject]; ok && receipt.generation == generation {
+	if receipt, ok := r.bySubject[subject]; ok && receipt == expectedReceipt {
 		delete(r.bySubject, subject)
 	}
 }

--- a/internal/app/loop_queue_tools.go
+++ b/internal/app/loop_queue_tools.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/channels/messages"
@@ -32,6 +33,7 @@ const (
 // Trigger rate (producers calling Enqueue) is fully decoupled from work
 // rate (this loop's sleep cadence).
 func buildLoopQueueTools(store *loopqueue.Store, loopName string) []looppkg.RuntimeTool {
+	receipts := newQueueReceipts()
 	return []looppkg.RuntimeTool{
 		{
 			Name: "queue_pull",
@@ -66,6 +68,7 @@ func buildLoopQueueTools(store *loopqueue.Store, loopName string) []looppkg.Runt
 				now := time.Now().UTC()
 				views := make([]queueItemView, 0, len(items))
 				for _, it := range items {
+					receipts.remember(it.DedupKey, it.Generation)
 					source, summary := projectQueuePayload(it.Payload)
 					views = append(views, queueItemView{
 						Subject:  it.DedupKey,
@@ -80,8 +83,8 @@ func buildLoopQueueTools(store *loopqueue.Store, loopName string) []looppkg.Runt
 		},
 		{
 			Name: "queue_ack",
-			Description: "Mark a queue item done and remove it from your queue. Pass the subject you got from queue_pull. " +
-				"Idempotent: acking a subject that is no longer queued is a harmless no-op. Ack only after its evidence is durably folded or you made an evidence-based no-change decision; use queue_defer when an external prerequisite blocks completion.",
+			Description: "Mark a queue item done and remove the exact generation returned by queue_pull. Pass only its subject; Go retains the hidden generation receipt. " +
+				"If newer evidence arrived while you worked, that newer generation remains queued and the result tells you to pull it later. Acking a subject that is no longer queued is harmless. Ack only after its evidence is durably folded or you made an evidence-based no-change decision; use queue_defer when an external prerequisite blocks completion.",
 			SkipContentResolve: true,
 			Parameters: map[string]any{
 				"type": "object",
@@ -98,10 +101,27 @@ func buildLoopQueueTools(store *loopqueue.Store, loopName string) []looppkg.Runt
 				if subject == "" {
 					return "", fmt.Errorf("subject is required")
 				}
-				if err := store.Ack(ctx, loopName, subject); err != nil {
+				generation, ok := receipts.generation(subject)
+				if !ok {
+					return "", fmt.Errorf("subject %q has no receipt from queue_pull in this loop run; call queue_pull before queue_ack", subject)
+				}
+				outcome, err := store.Ack(ctx, loopName, subject, generation)
+				if err != nil {
 					return "", err
 				}
-				return fmt.Sprintf(`{"status":"ok","subject":%q}`, subject), nil
+				switch outcome {
+				case loopqueue.Acked:
+					receipts.complete(subject, generation)
+					return fmt.Sprintf(`{"status":"ok","subject":%q}`, subject), nil
+				case loopqueue.AckMissing:
+					receipts.complete(subject, generation)
+					return fmt.Sprintf(`{"status":"already_acknowledged","subject":%q}`, subject), nil
+				case loopqueue.AckSuperseded:
+					receipts.forget(subject, generation)
+					return fmt.Sprintf(`{"status":"retained_newer","subject":%q,"instruction":"Newer evidence arrived while this generation was being processed. The newer item remains queued; call queue_pull before handling it."}`, subject), nil
+				default:
+					return "", fmt.Errorf("unexpected queue acknowledgement outcome %q", outcome)
+				}
 			},
 		},
 		{
@@ -127,6 +147,7 @@ func buildLoopQueueTools(store *loopqueue.Store, loopName string) []looppkg.Runt
 				if err := store.Defer(ctx, loopName, subject); err != nil {
 					return "", err
 				}
+				receipts.forgetSubject(subject)
 				return fmt.Sprintf(`{"status":"deferred","subject":%q}`, subject), nil
 			},
 		},
@@ -183,6 +204,60 @@ func buildLoopQueueTools(store *loopqueue.Store, loopName string) []looppkg.Runt
 			},
 		},
 	}
+}
+
+type queueReceipt struct {
+	generation int64
+	complete   bool
+}
+
+type queueReceipts struct {
+	mu        sync.Mutex
+	bySubject map[string]queueReceipt
+}
+
+func newQueueReceipts() *queueReceipts {
+	return &queueReceipts{bySubject: make(map[string]queueReceipt)}
+}
+
+func (r *queueReceipts) remember(subject string, generation int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	current, ok := r.bySubject[subject]
+	if ok && !current.complete {
+		return
+	}
+	r.bySubject[subject] = queueReceipt{generation: generation}
+}
+
+func (r *queueReceipts) generation(subject string) (int64, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	receipt, ok := r.bySubject[subject]
+	return receipt.generation, ok
+}
+
+func (r *queueReceipts) complete(subject string, generation int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if receipt, ok := r.bySubject[subject]; ok && receipt.generation == generation {
+		receipt.complete = true
+		r.bySubject[subject] = receipt
+	}
+}
+
+func (r *queueReceipts) forget(subject string, generation int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if receipt, ok := r.bySubject[subject]; ok && receipt.generation == generation {
+		delete(r.bySubject, subject)
+	}
+}
+
+func (r *queueReceipts) forgetSubject(subject string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.bySubject, subject)
 }
 
 type queueItemView struct {

--- a/internal/app/loop_queue_tools_test.go
+++ b/internal/app/loop_queue_tools_test.go
@@ -60,3 +60,54 @@ func TestQueueDeferToolRetainsWorkAndMovesItBehindThePartition(t *testing.T) {
 		t.Fatalf("deferred payload = %q", got)
 	}
 }
+
+func TestQueueAckToolRetainsNewerCoalescedGeneration(t *testing.T) {
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store, err := loopqueue.NewStore(db, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const subject = "contact:changing"
+	if err := store.Enqueue(t.Context(), "archivist", subject, 0, []byte(`{"v":1}`)); err != nil {
+		t.Fatal(err)
+	}
+
+	tools := buildLoopQueueTools(store, "archivist")
+	var pull, ack func(context.Context, map[string]any) (string, error)
+	for _, tool := range tools {
+		switch tool.Name {
+		case "queue_pull":
+			pull = tool.Handler
+		case "queue_ack":
+			ack = tool.Handler
+		}
+	}
+	if pull == nil || ack == nil {
+		t.Fatal("queue pull/ack tools not generated")
+	}
+	if _, err := pull(t.Context(), map[string]any{"limit": 1}); err != nil {
+		t.Fatalf("queue_pull: %v", err)
+	}
+	if err := store.Enqueue(t.Context(), "archivist", subject, 0, []byte(`{"v":2}`)); err != nil {
+		t.Fatal(err)
+	}
+	result, err := ack(t.Context(), map[string]any{"subject": subject})
+	if err != nil {
+		t.Fatalf("queue_ack: %v", err)
+	}
+	var response map[string]string
+	if err := json.Unmarshal([]byte(result), &response); err != nil {
+		t.Fatal(err)
+	}
+	if response["status"] != "retained_newer" {
+		t.Fatalf("queue_ack response = %v, want retained_newer", response)
+	}
+	items, err := store.Peek(t.Context(), "archivist", 1)
+	if err != nil || len(items) != 1 || string(items[0].Payload) != `{"v":2}` {
+		t.Fatalf("newer item was not retained: items=%#v err=%v", items, err)
+	}
+}

--- a/internal/app/loop_queue_tools_test.go
+++ b/internal/app/loop_queue_tools_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
@@ -61,7 +62,7 @@ func TestQueueDeferToolRetainsWorkAndMovesItBehindThePartition(t *testing.T) {
 	}
 }
 
-func TestQueueAckToolRetainsNewerCoalescedGeneration(t *testing.T) {
+func TestQueueAckToolRetainsNewerCoalescedItem(t *testing.T) {
 	db, err := database.OpenMemory()
 	if err != nil {
 		t.Fatal(err)
@@ -109,5 +110,51 @@ func TestQueueAckToolRetainsNewerCoalescedGeneration(t *testing.T) {
 	items, err := store.Peek(t.Context(), "archivist", 1)
 	if err != nil || len(items) != 1 || string(items[0].Payload) != `{"v":2}` {
 		t.Fatalf("newer item was not retained: items=%#v err=%v", items, err)
+	}
+}
+
+func TestQueueAckToolDiscardsCompletedReceiptBeforeKeyRecreation(t *testing.T) {
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store, err := loopqueue.NewStore(db, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const subject = "contact:recreated"
+	if err := store.Enqueue(t.Context(), "archivist", subject, 0, []byte(`{"v":1}`)); err != nil {
+		t.Fatal(err)
+	}
+
+	tools := buildLoopQueueTools(store, "archivist")
+	var pull, ack func(context.Context, map[string]any) (string, error)
+	for _, tool := range tools {
+		switch tool.Name {
+		case "queue_pull":
+			pull = tool.Handler
+		case "queue_ack":
+			ack = tool.Handler
+		}
+	}
+	if _, err := pull(t.Context(), map[string]any{"limit": 1}); err != nil {
+		t.Fatal(err)
+	}
+	if result, err := ack(t.Context(), map[string]any{"subject": subject}); err != nil || !strings.Contains(result, `"status":"ok"`) {
+		t.Fatalf("first ack result=%q err=%v", result, err)
+	}
+	if _, err := ack(t.Context(), map[string]any{"subject": subject}); err == nil || !strings.Contains(err.Error(), "no receipt from queue_pull") {
+		t.Fatalf("repeated ack error = %v, want discarded receipt", err)
+	}
+	if err := store.Enqueue(t.Context(), "archivist", subject, 0, []byte(`{"v":2}`)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ack(t.Context(), map[string]any{"subject": subject}); err == nil || !strings.Contains(err.Error(), "no receipt from queue_pull") {
+		t.Fatalf("delayed ack after recreation error = %v, want no receipt", err)
+	}
+	items, err := store.Peek(t.Context(), "archivist", 1)
+	if err != nil || len(items) != 1 || string(items[0].Payload) != `{"v":2}` {
+		t.Fatalf("recreated item was not retained: items=%#v err=%v", items, err)
 	}
 }

--- a/internal/app/new_channels.go
+++ b/internal/app/new_channels.go
@@ -154,7 +154,11 @@ func (a *App) initChannels(s *newState) error {
 		return nil
 	})
 
-	contactTools := contacts.NewTools(contactStore)
+	var contactMutationSink func(context.Context, contacts.ContactMutation) error
+	if a.loopQueue != nil && a.archivistDefinitionEnabled() {
+		contactMutationSink = a.enqueueContactDossierRefresh
+	}
+	contactTools := contacts.NewTools(contactStore, contactMutationSink)
 	dossierRoot, dossiersEnabled := declaredDocumentRoot(a.cfg.DocRoots, contacts.DossierRootName)
 	dossiersWritable := dossiersEnabled && documentRootPolicyFromConfig(dossierRoot).Authoring == documents.AuthoringManaged
 	contactTools.ConfigureDossierRoot(dossiersEnabled, dossiersWritable)
@@ -424,7 +428,7 @@ func (a *App) initChannels(s *newState) error {
 		}
 	}
 	if a.documentTools != nil {
-		contactTools.ConfigureDossierDocuments(a.documentTools.Write)
+		contactTools.ConfigureDossierDocuments(a.documentTools.Read, a.documentTools.Write)
 	}
 	a.loop.Tools().SetContactTools(contactTools)
 

--- a/internal/app/queue_wake_dispatch.go
+++ b/internal/app/queue_wake_dispatch.go
@@ -189,8 +189,16 @@ func (d *queuedWakeDispatcher) drain(partition string) {
 // deliver replays one queued record onto the message bus, then acks it.
 func (d *queuedWakeDispatcher) deliver(partition string, item loopqueue.Item) {
 	ack := func() {
-		if err := d.queue.Ack(context.Background(), partition, item.DedupKey); err != nil {
+		outcome, err := d.queue.Ack(context.Background(), partition, item.DedupKey, item.Generation)
+		if err != nil {
 			d.logger.Warn("queued wake ack failed", "partition", partition, "dedup_key", item.DedupKey, "error", err)
+			return
+		}
+		if outcome == loopqueue.AckSuperseded {
+			d.logger.Debug("queued wake retained newer coalesced generation",
+				"partition", partition,
+				"dedup_key", item.DedupKey,
+			)
 		}
 	}
 

--- a/internal/app/queue_wake_dispatch.go
+++ b/internal/app/queue_wake_dispatch.go
@@ -189,13 +189,13 @@ func (d *queuedWakeDispatcher) drain(partition string) {
 // deliver replays one queued record onto the message bus, then acks it.
 func (d *queuedWakeDispatcher) deliver(partition string, item loopqueue.Item) {
 	ack := func() {
-		outcome, err := d.queue.Ack(context.Background(), partition, item.DedupKey, item.Generation)
+		outcome, err := d.queue.Ack(context.Background(), partition, item.DedupKey, item.Receipt)
 		if err != nil {
 			d.logger.Warn("queued wake ack failed", "partition", partition, "dedup_key", item.DedupKey, "error", err)
 			return
 		}
 		if outcome == loopqueue.AckSuperseded {
-			d.logger.Debug("queued wake retained newer coalesced generation",
+			d.logger.Debug("queued wake retained newer coalesced item",
 				"partition", partition,
 				"dedup_key", item.DedupKey,
 			)

--- a/internal/model/toolcatalog/catalog.go
+++ b/internal/model/toolcatalog/catalog.go
@@ -194,6 +194,7 @@ var builtinToolSpecs = map[string]BuiltinToolSpec{
 	"contact_export_all_vcf":        {CanonicalID: "native:contact_export_all_vcf", Source: NativeToolSource, Tags: []string{"contacts"}},
 	"contact_export_vcf":            {CanonicalID: "native:contact_export_vcf", Source: NativeToolSource, Tags: []string{"contacts"}},
 	"contact_export_vcf_qr":         {CanonicalID: "native:contact_export_vcf_qr", Source: NativeToolSource, Tags: []string{"contacts"}},
+	"contact_dossier_read":          {CanonicalID: "native:contact_dossier_read", Source: NativeToolSource, Tags: []string{"contacts", "owner"}},
 	"contact_dossier_write":         {CanonicalID: "native:contact_dossier_write", Source: NativeToolSource, Tags: []string{"contacts", "owner"}},
 	"file_edit":                     {CanonicalID: "native:file_edit", Source: NativeToolSource, Tags: []string{"files"}},
 	"file_grep":                     {CanonicalID: "native:file_grep", Source: NativeToolSource, Tags: []string{"files"}},

--- a/internal/runtime/loop/mailbox.go
+++ b/internal/runtime/loop/mailbox.go
@@ -29,6 +29,9 @@ type MailboxItem struct {
 	ID         string
 	Payload    []byte
 	EnqueuedAt time.Time
+	// Generation is the runtime-only queue receipt retained across delivery
+	// and acknowledgement; mailbox payloads never expose it to the model.
+	Generation int64 `json:"-"`
 }
 
 // MailboxReceipt summarizes the effect of enqueuing a mailbox item.
@@ -186,7 +189,7 @@ func (m *Mailbox) Enqueue(ctx context.Context, loopName, keyPrefix string, paylo
 	if err != nil {
 		return MailboxItem{}, err
 	}
-	return MailboxItem{ID: key, Payload: append([]byte(nil), payload...), EnqueuedAt: time.Now().UTC()}, nil
+	return MailboxItem{ID: key, Payload: append([]byte(nil), payload...), EnqueuedAt: time.Now().UTC(), Generation: 1}, nil
 }
 
 func (m *Mailbox) drain(ctx context.Context, loopName string, limit int) ([]MailboxItem, error) {
@@ -220,6 +223,7 @@ func (m *Mailbox) Peek(ctx context.Context, loopName string, limit int) ([]Mailb
 			ID:         it.DedupKey,
 			Payload:    append([]byte(nil), it.Payload...),
 			EnqueuedAt: it.EnqueuedAt,
+			Generation: it.Generation,
 		})
 	}
 	return items, nil
@@ -230,8 +234,12 @@ func (m *Mailbox) ack(ctx context.Context, loopName string, items []MailboxItem)
 		return nil
 	}
 	for _, item := range items {
-		if err := m.store.Ack(ctx, loopName, item.ID); err != nil {
+		outcome, err := m.store.Ack(ctx, loopName, item.ID, item.Generation)
+		if err != nil {
 			return err
+		}
+		if outcome == loopqueue.AckSuperseded {
+			return fmt.Errorf("loop mailbox item %s advanced while being handled", item.ID)
 		}
 	}
 	return nil

--- a/internal/runtime/loop/mailbox.go
+++ b/internal/runtime/loop/mailbox.go
@@ -29,9 +29,9 @@ type MailboxItem struct {
 	ID         string
 	Payload    []byte
 	EnqueuedAt time.Time
-	// Generation is the runtime-only queue receipt retained across delivery
+	// Receipt is the runtime-only queue receipt retained across delivery
 	// and acknowledgement; mailbox payloads never expose it to the model.
-	Generation int64 `json:"-"`
+	Receipt string `json:"-"`
 }
 
 // MailboxReceipt summarizes the effect of enqueuing a mailbox item.
@@ -189,7 +189,7 @@ func (m *Mailbox) Enqueue(ctx context.Context, loopName, keyPrefix string, paylo
 	if err != nil {
 		return MailboxItem{}, err
 	}
-	return MailboxItem{ID: key, Payload: append([]byte(nil), payload...), EnqueuedAt: time.Now().UTC(), Generation: 1}, nil
+	return MailboxItem{ID: key, Payload: append([]byte(nil), payload...), EnqueuedAt: time.Now().UTC(), Receipt: key}, nil
 }
 
 func (m *Mailbox) drain(ctx context.Context, loopName string, limit int) ([]MailboxItem, error) {
@@ -223,7 +223,7 @@ func (m *Mailbox) Peek(ctx context.Context, loopName string, limit int) ([]Mailb
 			ID:         it.DedupKey,
 			Payload:    append([]byte(nil), it.Payload...),
 			EnqueuedAt: it.EnqueuedAt,
-			Generation: it.Generation,
+			Receipt:    it.Receipt,
 		})
 	}
 	return items, nil
@@ -234,7 +234,7 @@ func (m *Mailbox) ack(ctx context.Context, loopName string, items []MailboxItem)
 		return nil
 	}
 	for _, item := range items {
-		outcome, err := m.store.Ack(ctx, loopName, item.ID, item.Generation)
+		outcome, err := m.store.Ack(ctx, loopName, item.ID, item.Receipt)
 		if err != nil {
 			return err
 		}

--- a/internal/state/contacts/dossier.go
+++ b/internal/state/contacts/dossier.go
@@ -3,6 +3,7 @@ package contacts
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"regexp"
@@ -45,14 +46,33 @@ type DossierWriteArgs struct {
 	ReceiptScope string `json:"-"`
 }
 
+// DossierReadArgs identifies one canonical contact dossier without exposing
+// its derived document ref to the model.
+type DossierReadArgs struct {
+	ContactID string `json:"contact_id"`
+	// ReceiptScope is runtime-owned concurrency state and is never exposed to
+	// the model.
+	ReceiptScope string `json:"-"`
+}
+
 // ConfigureDossierDocuments installs the managed document surface used by
-// [Tools.WriteDossier]. Configure it only after the document store has been
-// initialized so an advertised mutation tool is always callable.
-func (t *Tools) ConfigureDossierDocuments(write func(context.Context, documents.WriteArgs) (string, error)) {
+// [Tools.ReadDossier] and [Tools.WriteDossier]. Configure it only after the
+// document store has been initialized so every advertised tool is callable.
+func (t *Tools) ConfigureDossierDocuments(
+	read func(context.Context, documents.RefArgs) (string, error),
+	write func(context.Context, documents.WriteArgs) (string, error),
+) {
 	if t == nil {
 		return
 	}
+	t.dossierRead = read
 	t.dossierWrite = write
+}
+
+// DossierReadsEnabled reports whether the configured canonical dossier root
+// has a live managed document read surface.
+func (t *Tools) DossierReadsEnabled() bool {
+	return t != nil && t.dossiersEnabled && t.dossierRead != nil
 }
 
 // DossierWritesEnabled reports whether the configured contact tools have a
@@ -65,6 +85,35 @@ func (t *Tools) DossierWritesEnabled() bool {
 // document order. Callers receive a copy and may safely enrich descriptions.
 func DossierFacetFields() []looppkg.FacetField {
 	return dossierOutputContract.FacetFields()
+}
+
+// ReadDossier reads the canonical dossier for one active structured contact.
+// An absent dossier is a successful, structured result that names the write
+// door; retrying an unchanged document read cannot make an absent file appear.
+func (t *Tools) ReadDossier(ctx context.Context, args DossierReadArgs) (string, error) {
+	if t == nil || t.store == nil {
+		return "", fmt.Errorf("contact directory not configured")
+	}
+	if !t.dossiersEnabled {
+		return "", fmt.Errorf("contact dossiers are not configured")
+	}
+	if t.dossierRead == nil {
+		return "", fmt.Errorf("contact dossier document reader is not configured")
+	}
+
+	contact, id, err := t.resolveDossierContact(args.ContactID)
+	if err != nil {
+		return "", err
+	}
+	ref := DossierRef(id)
+	result, err := t.dossierRead(ctx, documents.RefArgs{Ref: ref, ReceiptScope: args.ReceiptScope})
+	if documents.IsNotFound(err) {
+		return marshalDossierAbsence(contact, ref, t.DossierWritesEnabled())
+	}
+	if err != nil {
+		return "", fmt.Errorf("read contact dossier %s: %w", id, err)
+	}
+	return result, nil
 }
 
 // WriteDossier creates or replaces one contact's canonical longitudinal
@@ -85,17 +134,9 @@ func (t *Tools) WriteDossier(ctx context.Context, args DossierWriteArgs) (string
 		return "", fmt.Errorf("contact dossier document tools are not configured")
 	}
 
-	rawID := strings.TrimSpace(args.ContactID)
-	id, err := uuid.Parse(rawID)
-	if err != nil || id == uuid.Nil || id.String() != rawID {
-		return "", fmt.Errorf("contact_id must be a canonical non-zero UUID from contact_lookup or contact_owner; got %q", args.ContactID)
-	}
-	contact, err := t.store.Get(id)
-	if errors.Is(err, sql.ErrNoRows) {
-		return "", fmt.Errorf("contact_id %s is not an active structured contact; use contact_lookup to resolve the intended contact before writing a dossier", id)
-	}
+	contact, id, err := t.resolveDossierContact(args.ContactID)
 	if err != nil {
-		return "", fmt.Errorf("load structured contact %s: %w", id, err)
+		return "", err
 	}
 
 	payload := looppkg.FacetPayload{
@@ -128,6 +169,50 @@ func (t *Tools) WriteDossier(ctx context.Context, args DossierWriteArgs) (string
 		Body:         &body,
 		ReceiptScope: args.ReceiptScope,
 	})
+}
+
+func (t *Tools) resolveDossierContact(rawID string) (*Contact, uuid.UUID, error) {
+	rawID = strings.TrimSpace(rawID)
+	id, err := uuid.Parse(rawID)
+	if err != nil || id == uuid.Nil || id.String() != rawID {
+		return nil, uuid.Nil, fmt.Errorf("contact_id must be a canonical non-zero UUID from contact_lookup or contact_owner; got %q", rawID)
+	}
+	contact, err := t.store.Get(id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, uuid.Nil, fmt.Errorf("contact_id %s is not an active structured contact; call contact_lookup to resolve the intended contact instead of retrying this UUID", id)
+	}
+	if err != nil {
+		return nil, uuid.Nil, fmt.Errorf("load structured contact %s: %w", id, err)
+	}
+	return contact, id, nil
+}
+
+func marshalDossierAbsence(contact *Contact, ref string, writable bool) (string, error) {
+	result := map[string]any{
+		"contact_id":   contact.ID.String(),
+		"contact_name": contact.FormattedName,
+		"dossier": map[string]any{
+			"exists": false,
+			"ref":    ref,
+		},
+	}
+	if writable {
+		result["next_action"] = map[string]any{
+			"tool":       "contact_dossier_write",
+			"contact_id": contact.ID.String(),
+			"instruction": "Create the dossier with all four projections; do not retry " +
+				"contact_dossier_read until a write succeeds.",
+		}
+	} else {
+		result["next_action"] = map[string]any{
+			"instruction": "No canonical dossier exists and this contact root is read-only; do not retry the read.",
+		}
+	}
+	raw, err := json.Marshal(result)
+	if err != nil {
+		return "", fmt.Errorf("encode absent contact dossier result: %w", err)
+	}
+	return string(raw), nil
 }
 
 // DossierRef returns the stable document ref for a contact UUID.

--- a/internal/state/contacts/dossier.go
+++ b/internal/state/contacts/dossier.go
@@ -113,7 +113,7 @@ func (t *Tools) ReadDossier(ctx context.Context, args DossierReadArgs) (string, 
 	if err != nil {
 		return "", fmt.Errorf("read contact dossier %s: %w", id, err)
 	}
-	return result, nil
+	return marshalDossierPresence(contact, ref, result)
 }
 
 // WriteDossier creates or replaces one contact's canonical longitudinal
@@ -187,30 +187,69 @@ func (t *Tools) resolveDossierContact(rawID string) (*Contact, uuid.UUID, error)
 	return contact, id, nil
 }
 
+type dossierReadResult struct {
+	ContactID   string             `json:"contact_id"`
+	ContactName string             `json:"contact_name"`
+	Dossier     dossierReadState   `json:"dossier"`
+	NextAction  *dossierNextAction `json:"next_action"`
+}
+
+type dossierReadState struct {
+	Exists   bool            `json:"exists"`
+	Ref      string          `json:"ref"`
+	Document json.RawMessage `json:"document"`
+}
+
+type dossierNextAction struct {
+	Tool        string `json:"tool,omitempty"`
+	ContactID   string `json:"contact_id,omitempty"`
+	Instruction string `json:"instruction"`
+}
+
+func marshalDossierPresence(contact *Contact, ref, document string) (string, error) {
+	raw := json.RawMessage(document)
+	if !json.Valid(raw) {
+		return "", fmt.Errorf("contact dossier reader returned invalid JSON for %s", contact.ID)
+	}
+	return marshalDossierReadResult(dossierReadResult{
+		ContactID:   contact.ID.String(),
+		ContactName: contact.FormattedName,
+		Dossier: dossierReadState{
+			Exists:   true,
+			Ref:      ref,
+			Document: raw,
+		},
+	})
+}
+
 func marshalDossierAbsence(contact *Contact, ref string, writable bool) (string, error) {
-	result := map[string]any{
-		"contact_id":   contact.ID.String(),
-		"contact_name": contact.FormattedName,
-		"dossier": map[string]any{
-			"exists": false,
-			"ref":    ref,
+	result := dossierReadResult{
+		ContactID:   contact.ID.String(),
+		ContactName: contact.FormattedName,
+		Dossier: dossierReadState{
+			Exists: false,
+			Ref:    ref,
 		},
 	}
 	if writable {
-		result["next_action"] = map[string]any{
-			"tool":       "contact_dossier_write",
-			"contact_id": contact.ID.String(),
-			"instruction": "Create the dossier with all four projections; do not retry " +
+		result.NextAction = &dossierNextAction{
+			Tool:      "contact_dossier_write",
+			ContactID: contact.ID.String(),
+			Instruction: "Create the dossier with all four projections; do not retry " +
 				"contact_dossier_read until a write succeeds.",
 		}
 	} else {
-		result["next_action"] = map[string]any{
-			"instruction": "No canonical dossier exists and this contact root is read-only; do not retry the read.",
+		result.NextAction = &dossierNextAction{
+			Instruction: "No canonical dossier exists and this contact root is read-only; do not retry the read.",
 		}
 	}
+	return marshalDossierReadResult(result)
+}
+
+func marshalDossierReadResult(result dossierReadResult) (string, error) {
 	raw, err := json.Marshal(result)
 	if err != nil {
-		return "", fmt.Errorf("encode absent contact dossier result: %w", err)
+		return "", fmt.Errorf("encode contact dossier result: %w", err)
 	}
 	return string(raw), nil
 }

--- a/internal/state/contacts/dossier_test.go
+++ b/internal/state/contacts/dossier_test.go
@@ -217,7 +217,7 @@ func TestWriteDossierRejectsSubjectUUIDInEveryProjection(t *testing.T) {
 	}
 	writer := &recordingDossierWriter{}
 	tools.ConfigureDossierRoot(true, true)
-	tools.ConfigureDossierDocuments(writer.Write)
+	tools.ConfigureDossierDocuments(nil, writer.Write)
 
 	id := contact.ID.String()
 	_, err = tools.WriteDossier(context.Background(), DossierWriteArgs{
@@ -256,7 +256,7 @@ func TestWriteDossierRejectsSubjectNameInCompactProjections(t *testing.T) {
 	}
 	writer := &recordingDossierWriter{}
 	tools.ConfigureDossierRoot(true, true)
-	tools.ConfigureDossierDocuments(writer.Write)
+	tools.ConfigureDossierDocuments(nil, writer.Write)
 
 	_, err = tools.WriteDossier(context.Background(), DossierWriteArgs{
 		ContactID:  contact.ID.String(),
@@ -295,7 +295,7 @@ func TestWriteDossierAllowsSubjectNameInStandaloneProjections(t *testing.T) {
 	}
 	writer := &recordingDossierWriter{}
 	tools.ConfigureDossierRoot(true, true)
-	tools.ConfigureDossierDocuments(writer.Write)
+	tools.ConfigureDossierDocuments(nil, writer.Write)
 
 	_, err = tools.WriteDossier(context.Background(), DossierWriteArgs{
 		ContactID:  contact.ID.String(),
@@ -344,7 +344,7 @@ func TestWriteDossierRejectsEveryAmbiguousArchiveSessionCitation(t *testing.T) {
 	}
 	writer := &recordingDossierWriter{}
 	tools.ConfigureDossierRoot(true, true)
-	tools.ConfigureDossierDocuments(writer.Write)
+	tools.ConfigureDossierDocuments(nil, writer.Write)
 
 	_, err = tools.WriteDossier(context.Background(), DossierWriteArgs{
 		ContactID:  contact.ID.String(),
@@ -428,7 +428,7 @@ func TestWriteDossierOwnsDocumentIdentityAndStructure(t *testing.T) {
 	}
 	writer := &recordingDossierWriter{}
 	tools.ConfigureDossierRoot(true, true)
-	tools.ConfigureDossierDocuments(writer.Write)
+	tools.ConfigureDossierDocuments(nil, writer.Write)
 
 	args := DossierWriteArgs{
 		ContactID:    contact.ID.String(),
@@ -481,7 +481,7 @@ func TestWriteDossierReportsAllProjectionViolationsBeforeWriting(t *testing.T) {
 	}
 	writer := &recordingDossierWriter{}
 	tools.ConfigureDossierRoot(true, true)
-	tools.ConfigureDossierDocuments(writer.Write)
+	tools.ConfigureDossierDocuments(nil, writer.Write)
 
 	_, err = tools.WriteDossier(context.Background(), DossierWriteArgs{
 		ContactID:  contact.ID.String(),
@@ -513,7 +513,7 @@ func TestWriteDossierRequiresCanonicalActiveContact(t *testing.T) {
 	tools := newTestTools(t)
 	writer := &recordingDossierWriter{}
 	tools.ConfigureDossierRoot(true, true)
-	tools.ConfigureDossierDocuments(writer.Write)
+	tools.ConfigureDossierDocuments(nil, writer.Write)
 	validPayload := DossierWriteArgs{
 		StatusLine: "Current.",
 		Teaser:     "Useful hook.",

--- a/internal/state/contacts/schema.go
+++ b/internal/state/contacts/schema.go
@@ -75,6 +75,11 @@ var schema = database.Schema{
 				updated_at TEXT NOT NULL
 			)`,
 		},
+		// Model-authored property rows carry their turn provenance as a
+		// compact JSON object. NULL is the deliberate legacy/unknown posture:
+		// migration must never invent an author for existing rows or for
+		// CardDAV/vCard writes whose caller supplied no provenance.
+		database.ColumnAdd{Table: "contact_properties", Column: "provenance", Typedef: "TEXT"},
 		database.IndexCreate{Name: "idx_cp_contact", SQL: `CREATE INDEX IF NOT EXISTS idx_cp_contact ON contact_properties(contact_id)`},
 		database.IndexCreate{Name: "idx_cp_property", SQL: `CREATE INDEX IF NOT EXISTS idx_cp_property ON contact_properties(property)`},
 		database.IndexCreate{Name: "idx_cp_property_value", SQL: `CREATE INDEX IF NOT EXISTS idx_cp_property_value ON contact_properties(property, value)`},

--- a/internal/state/contacts/store.go
+++ b/internal/state/contacts/store.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 	"time"
 
@@ -40,6 +41,9 @@ const (
 		note, photo_uri, trust_zone, ai_summary, rev, etag,
 		embedding, last_interaction, last_interaction_meta,
 		created_at, updated_at`
+
+	propertyColumns = `id, contact_id, property, value, type, pref, label,
+		mediatype, verified, provenance, created_at, updated_at`
 
 	activeFilter = "deleted_at IS NULL"
 )
@@ -89,17 +93,32 @@ type Contact struct {
 // KEY, CATEGORIES, RELATED, MEMBER, etc.) are stored here rather than
 // on the Contact struct directly.
 type Property struct {
-	ID        int64     `json:"id"`
-	ContactID uuid.UUID `json:"contact_id"`
-	Property  string    `json:"property"` // EMAIL, TEL, ADR, IMPP, URL, KEY, etc.
-	Value     string    `json:"value"`
-	Type      string    `json:"type,omitempty"`      // TYPE param: work, home, cell, etc.
-	Pref      int       `json:"pref,omitempty"`      // PREF param: 1-100, 0 = unset
-	Label     string    `json:"label,omitempty"`     // LABEL param
-	MediaType string    `json:"mediatype,omitempty"` // MEDIATYPE param
-	Verified  bool      `json:"verified,omitempty"`  // has Thane verified traffic from this?
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	ID         int64               `json:"id"`
+	ContactID  uuid.UUID           `json:"contact_id"`
+	Property   string              `json:"property"` // EMAIL, TEL, ADR, IMPP, URL, KEY, etc.
+	Value      string              `json:"value"`
+	Type       string              `json:"type,omitempty"`      // TYPE param: work, home, cell, etc.
+	Pref       int                 `json:"pref,omitempty"`      // PREF param: 1-100, 0 = unset
+	Label      string              `json:"label,omitempty"`     // LABEL param
+	MediaType  string              `json:"mediatype,omitempty"` // MEDIATYPE param
+	Verified   bool                `json:"verified,omitempty"`  // has Thane verified traffic from this?
+	Provenance *PropertyProvenance `json:"provenance"`
+	CreatedAt  time.Time           `json:"created_at"`
+	UpdatedAt  time.Time           `json:"updated_at"`
+}
+
+// PropertyProvenance identifies the model-facing turn that authored a
+// structured contact property. A nil Property.Provenance means legacy or
+// otherwise unknown authorship; it never grants authority to the value.
+type PropertyProvenance struct {
+	Source         string `json:"source"`
+	Model          string `json:"model,omitempty"`
+	LoopID         string `json:"loop_id,omitempty"`
+	ConversationID string `json:"conversation_id,omitempty"`
+	SessionID      string `json:"session_id,omitempty"`
+	RequestID      string `json:"request_id,omitempty"`
+	ToolCallID     string `json:"tool_call_id,omitempty"`
+	Iteration      *int   `json:"iteration,omitempty"`
 }
 
 // InteractionMeta holds structured metadata about a contact's most
@@ -502,7 +521,7 @@ func (s *Store) ListAllWithProperties() ([]*Contact, error) {
 
 	// Batch-load all properties in one query.
 	propRows, err := s.db.Query(`
-		SELECT id, contact_id, property, value, type, pref, label, mediatype, verified, created_at, updated_at
+		SELECT ` + propertyColumns + `
 		FROM contact_properties
 		WHERE contact_id IN (SELECT id FROM contacts WHERE ` + activeFilter + `)
 		ORDER BY contact_id, property, pref NULLS LAST, id
@@ -580,6 +599,14 @@ func (s *Store) UpsertWithPropertiesAndHAPerson(c *Contact, props []Property, ha
 }
 
 func (s *Store) upsertWithPropertiesBinding(c *Contact, props []Property, haPersonEntity *string) (*Contact, error) {
+	// Full-record writers (CardDAV, vCard import, and the native contacts API)
+	// do not execute inside a model turn. Ignore any caller-supplied JSON here
+	// so those surfaces cannot fabricate model provenance; their authored rows
+	// deliberately retain the nil/unknown posture.
+	props = append([]Property(nil), props...)
+	for i := range props {
+		props[i].Provenance = nil
+	}
 	tx, err := s.db.Begin()
 	if err != nil {
 		return nil, fmt.Errorf("begin tx: %w", err)
@@ -587,35 +614,68 @@ func (s *Store) upsertWithPropertiesBinding(c *Contact, props []Property, haPers
 	defer tx.Rollback() //nolint:errcheck // best-effort on defer
 
 	now := time.Now().UTC()
+	// Full-record replacement historically stamps the stored representation
+	// at write time. Existing rows retain their database created_at through
+	// ON CONFLICT, while a client-selected new UUID cannot inject one.
+	c.CreatedAt = now
+	if err := upsertContactTx(tx, c, now); err != nil {
+		return nil, err
+	}
 
+	// Replace all properties.
+	if _, err := tx.Exec(
+		`DELETE FROM contact_properties WHERE contact_id = ?`,
+		c.ID.String()); err != nil {
+		return nil, fmt.Errorf("clear properties: %w", err)
+	}
+	for _, p := range props {
+		if err := insertPropertyTx(tx, c.ID, p, now); err != nil {
+			return nil, err
+		}
+	}
+
+	if haPersonEntity != nil {
+		if err := applyHAPersonEntity(tx, c.ID, *haPersonEntity); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit: %w", err)
+	}
+
+	s.rebuildFTS()
+	return c, nil
+}
+
+func upsertContactTx(tx *sql.Tx, c *Contact, now time.Time) error {
 	if c.Kind == "" {
 		c.Kind = "individual"
 	}
 	if !ValidKinds[c.Kind] {
-		return nil, fmt.Errorf("invalid kind %q (valid: individual, group, org, location)", c.Kind)
+		return fmt.Errorf("invalid kind %q (valid: individual, group, org, location)", c.Kind)
 	}
 	if c.TrustZone == "" {
 		c.TrustZone = ZoneKnown
 	}
 	if !ValidTrustZones[c.TrustZone] {
-		return nil, fmt.Errorf("invalid trust zone %q (valid: admin, household, trusted, known)", c.TrustZone)
+		return fmt.Errorf("invalid trust zone %q (valid: admin, household, trusted, known)", c.TrustZone)
 	}
-
-	c.Rev = now.Format(time.RFC3339)
-	c.UpdatedAt = now
-
 	if c.ID == uuid.Nil {
-		id, idErr := uuid.NewV7()
-		if idErr != nil {
-			return nil, fmt.Errorf("generate id: %w", idErr)
+		id, err := uuid.NewV7()
+		if err != nil {
+			return fmt.Errorf("generate id: %w", err)
 		}
 		c.ID = id
 	}
+	if c.CreatedAt.IsZero() {
+		c.CreatedAt = now
+	}
+	c.Rev = now.Format(time.RFC3339)
+	c.UpdatedAt = now
 
-	// INSERT or UPDATE via ON CONFLICT so both new and existing IDs
-	// work correctly.
-	c.CreatedAt = now
-	_, err = tx.Exec(`
+	// INSERT or UPDATE via ON CONFLICT so both new and existing IDs work.
+	_, err := tx.Exec(`
 		INSERT INTO contacts (id, kind, formatted_name, family_name, given_name,
 			additional_names, name_prefix, name_suffix, nickname,
 			birthday, anniversary, gender, org, title, role,
@@ -655,41 +715,109 @@ func (s *Store) upsertWithPropertiesBinding(c *Contact, props []Property, haPers
 		nullStr(c.Note), nullStr(c.PhotoURI),
 		c.TrustZone, nullStr(c.AISummary), c.Rev, nullStr(c.ETag),
 		nullTime(c.LastInteraction), nullInteractionMeta(c.LastInteractionMeta),
-		now.Format(time.RFC3339), now.Format(time.RFC3339))
+		c.CreatedAt.Format(time.RFC3339), now.Format(time.RFC3339))
 	if err != nil {
-		return nil, fmt.Errorf("upsert contact: %w", err)
+		return fmt.Errorf("upsert contact: %w", err)
 	}
+	return nil
+}
 
-	// Replace all properties.
-	if _, err := tx.Exec(
-		`DELETE FROM contact_properties WHERE contact_id = ?`,
-		c.ID.String()); err != nil {
-		return nil, fmt.Errorf("clear properties: %w", err)
+func insertPropertyTx(tx *sql.Tx, contactID uuid.UUID, p Property, now time.Time) error {
+	provenance, err := marshalPropertyProvenance(p.Provenance)
+	if err != nil {
+		return fmt.Errorf("encode property %s provenance: %w", p.Property, err)
 	}
-	for _, p := range props {
-		propNow := now.Format(time.RFC3339)
-		if _, err := tx.Exec(`
-			INSERT INTO contact_properties (contact_id, property, value, type, pref, label, mediatype, verified, created_at, updated_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-		`, c.ID.String(), p.Property, p.Value,
-			nullStr(p.Type), nullInt(p.Pref), nullStr(p.Label), nullStr(p.MediaType),
-			boolToInt(p.Verified), propNow, propNow); err != nil {
-			return nil, fmt.Errorf("add property %s: %w", p.Property, err)
+	_, err = tx.Exec(`
+		INSERT INTO contact_properties (contact_id, property, value, type, pref, label, mediatype, verified, provenance, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, contactID.String(), p.Property, p.Value,
+		nullStr(p.Type), nullInt(p.Pref), nullStr(p.Label), nullStr(p.MediaType),
+		boolToInt(p.Verified), provenance, now.Format(time.RFC3339), now.Format(time.RFC3339))
+	if err != nil {
+		return fmt.Errorf("add property %s: %w", p.Property, err)
+	}
+	return nil
+}
+
+// applyContactSave atomically applies the model-facing contact_save merge.
+// The caller has already decided which scalar fields differ and which
+// replace-style property families changed; additive properties are rechecked
+// inside the transaction so a concurrent identical insert remains a true
+// no-op. The returned changed bit is therefore safe to use as the archivist
+// refresh gate.
+func (s *Store) applyContactSave(
+	c *Contact,
+	contactChanged bool,
+	additions []Property,
+	replacements map[string][]Property,
+) (*Contact, bool, error) {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, false, fmt.Errorf("begin contact save: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // best-effort on defer
+
+	now := time.Now().UTC()
+	isNew := c.ID == uuid.Nil
+	if isNew {
+		if err := upsertContactTx(tx, c, now); err != nil {
+			return nil, false, err
 		}
 	}
 
-	if haPersonEntity != nil {
-		if err := applyHAPersonEntity(tx, c.ID, *haPersonEntity); err != nil {
-			return nil, err
+	propertyChanged := false
+	replacementNames := make([]string, 0, len(replacements))
+	for property := range replacements {
+		replacementNames = append(replacementNames, property)
+	}
+	sort.Strings(replacementNames)
+	for _, property := range replacementNames {
+		if _, err := tx.Exec(
+			`DELETE FROM contact_properties WHERE contact_id = ? AND property = ?`,
+			c.ID.String(), property); err != nil {
+			return nil, false, fmt.Errorf("replace contact property %s: %w", property, err)
 		}
+		for _, p := range replacements[property] {
+			if err := insertPropertyTx(tx, c.ID, p, now); err != nil {
+				return nil, false, err
+			}
+		}
+		propertyChanged = true
 	}
 
+	for _, p := range additions {
+		var exists int
+		if err := tx.QueryRow(`
+			SELECT COUNT(*) FROM contact_properties
+			WHERE contact_id = ? AND property = ? AND LOWER(value) = LOWER(?)
+		`, c.ID.String(), p.Property, p.Value).Scan(&exists); err != nil {
+			return nil, false, fmt.Errorf("check existing property %s: %w", p.Property, err)
+		}
+		if exists > 0 {
+			continue
+		}
+		if err := insertPropertyTx(tx, c.ID, p, now); err != nil {
+			return nil, false, err
+		}
+		propertyChanged = true
+	}
+
+	changed := isNew || contactChanged || propertyChanged
+	if !changed {
+		return c, false, nil
+	}
+	if !isNew {
+		// A property mutation advances the parent contact revision and CTag
+		// just as the pre-provenance contact_save path did.
+		if err := upsertContactTx(tx, c, now); err != nil {
+			return nil, false, err
+		}
+	}
 	if err := tx.Commit(); err != nil {
-		return nil, fmt.Errorf("commit: %w", err)
+		return nil, false, fmt.Errorf("commit contact save: %w", err)
 	}
-
 	s.rebuildFTS()
-	return c, nil
+	return c, true, nil
 }
 
 // Delete soft-deletes a contact by ID.
@@ -773,12 +901,16 @@ func (s *Store) AddProperty(contactID uuid.UUID, p *Property) error {
 
 	now := time.Now().UTC().Format(time.RFC3339)
 
+	provenance, err := marshalPropertyProvenance(p.Provenance)
+	if err != nil {
+		return fmt.Errorf("encode property provenance: %w", err)
+	}
 	result, err := s.db.Exec(`
-		INSERT INTO contact_properties (contact_id, property, value, type, pref, label, mediatype, verified, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO contact_properties (contact_id, property, value, type, pref, label, mediatype, verified, provenance, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, contactID.String(), p.Property, p.Value,
 		nullStr(p.Type), nullInt(p.Pref), nullStr(p.Label), nullStr(p.MediaType),
-		boolToInt(p.Verified), now, now)
+		boolToInt(p.Verified), provenance, now, now)
 	if err != nil {
 		return fmt.Errorf("add property: %w", err)
 	}
@@ -793,7 +925,7 @@ func (s *Store) AddProperty(contactID uuid.UUID, p *Property) error {
 // property name then preference.
 func (s *Store) GetProperties(contactID uuid.UUID) ([]Property, error) {
 	rows, err := s.db.Query(`
-		SELECT id, contact_id, property, value, type, pref, label, mediatype, verified, created_at, updated_at
+		SELECT `+propertyColumns+`
 		FROM contact_properties
 		WHERE contact_id = ?
 		ORDER BY property, pref NULLS LAST, id
@@ -830,7 +962,7 @@ func (s *Store) GetPropertiesForContacts(contactIDs []uuid.UUID) (map[uuid.UUID]
 	}
 
 	rows, err := s.db.Query(`
-		SELECT id, contact_id, property, value, type, pref, label, mediatype, verified, created_at, updated_at
+		SELECT `+propertyColumns+`
 		FROM contact_properties
 		WHERE contact_id IN (`+placeholders+`)
 		ORDER BY contact_id, property, pref NULLS LAST, id
@@ -1237,14 +1369,14 @@ func (s *Store) scanContacts(rows *sql.Rows) ([]*Contact, error) {
 func scanProperty(rows *sql.Rows) (Property, error) {
 	var p Property
 	var contactIDStr string
-	var typ, label, mediatype sql.NullString
+	var typ, label, mediatype, provenance sql.NullString
 	var pref sql.NullInt64
 	var verified int
 	var createdStr, updatedStr string
 
 	err := rows.Scan(&p.ID, &contactIDStr, &p.Property, &p.Value,
 		&typ, &pref, &label, &mediatype, &verified,
-		&createdStr, &updatedStr)
+		&provenance, &createdStr, &updatedStr)
 	if err != nil {
 		return Property{}, fmt.Errorf("scan property: %w", err)
 	}
@@ -1260,6 +1392,13 @@ func scanProperty(rows *sql.Rows) (Property, error) {
 	p.Label = label.String
 	p.MediaType = mediatype.String
 	p.Verified = verified != 0
+	if provenance.Valid && strings.TrimSpace(provenance.String) != "" {
+		var parsed PropertyProvenance
+		if err := json.Unmarshal([]byte(provenance.String), &parsed); err != nil {
+			return Property{}, fmt.Errorf("decode property provenance: %w", err)
+		}
+		p.Provenance = &parsed
+	}
 	p.CreatedAt, err = database.ParseTimestamp(createdStr)
 	if err != nil {
 		return Property{}, fmt.Errorf("parse property created_at: %w", err)
@@ -1270,6 +1409,17 @@ func scanProperty(rows *sql.Rows) (Property, error) {
 	}
 
 	return p, nil
+}
+
+func marshalPropertyProvenance(provenance *PropertyProvenance) (sql.NullString, error) {
+	if provenance == nil {
+		return sql.NullString{}, nil
+	}
+	raw, err := json.Marshal(provenance)
+	if err != nil {
+		return sql.NullString{}, err
+	}
+	return sql.NullString{String: string(raw), Valid: true}, nil
 }
 
 // --- FTS helpers ---

--- a/internal/state/contacts/store.go
+++ b/internal/state/contacts/store.go
@@ -786,14 +786,11 @@ func (s *Store) applyContactSave(
 	}
 
 	for _, p := range additions {
-		var exists int
-		if err := tx.QueryRow(`
-			SELECT COUNT(*) FROM contact_properties
-			WHERE contact_id = ? AND property = ? AND LOWER(value) = LOWER(?)
-		`, c.ID.String(), p.Property, p.Value).Scan(&exists); err != nil {
+		exists, err := propertyExistsTx(tx, c.ID, p.Property, p.Value)
+		if err != nil {
 			return nil, false, fmt.Errorf("check existing property %s: %w", p.Property, err)
 		}
-		if exists > 0 {
+		if exists {
 			continue
 		}
 		if err := insertPropertyTx(tx, c.ID, p, now); err != nil {
@@ -818,6 +815,31 @@ func (s *Store) applyContactSave(
 	}
 	s.rebuildFTS()
 	return c, true, nil
+}
+
+func propertyExistsTx(tx *sql.Tx, contactID uuid.UUID, property, value string) (bool, error) {
+	rows, err := tx.Query(`
+		SELECT value FROM contact_properties
+		WHERE contact_id = ? AND property = ?
+	`, contactID.String(), property)
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var candidate string
+		if err := rows.Scan(&candidate); err != nil {
+			return false, err
+		}
+		if propertyValueEqual(property, candidate, value) {
+			return true, nil
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return false, err
+	}
+	return false, nil
 }
 
 // Delete soft-deletes a contact by ID.

--- a/internal/state/contacts/store_test.go
+++ b/internal/state/contacts/store_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"log/slog"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -1414,5 +1415,108 @@ func TestForeignKeysEnabled(t *testing.T) {
 	err = store.AddProperty(bogusID, &Property{Property: "EMAIL", Value: "nobody@example.com"})
 	if err == nil {
 		t.Error("expected foreign key violation for bogus contact_id")
+	}
+}
+
+func TestPropertyProvenanceRoundTrip(t *testing.T) {
+	store := newTestStore(t)
+	contact, err := store.Upsert(&Contact{FormattedName: "Provenance", Kind: "individual"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	iteration := 4
+	want := &PropertyProvenance{
+		Source:         "contact_save",
+		Model:          "model-a",
+		LoopID:         "loop-a",
+		ConversationID: "conversation-a",
+		SessionID:      "session-a",
+		RequestID:      "request-a",
+		ToolCallID:     "tool-a",
+		Iteration:      &iteration,
+	}
+	if err := store.AddProperty(contact.ID, &Property{
+		Property: "EMAIL", Value: "person@example.com", Provenance: want,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	properties, err := store.GetProperties(contact.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(properties) != 1 || !reflect.DeepEqual(properties[0].Provenance, want) {
+		t.Fatalf("property provenance = %#v, want %#v", properties, want)
+	}
+}
+
+func TestUpsertWithPropertiesDoesNotAcceptCallerSuppliedProvenance(t *testing.T) {
+	store := newTestStore(t)
+	contact, err := store.UpsertWithProperties(&Contact{
+		FormattedName: "API Authored",
+		Kind:          "individual",
+	}, []Property{{
+		Property: "EMAIL",
+		Value:    "api@example.com",
+		Provenance: &PropertyProvenance{
+			Source:    "forged-model-write",
+			RequestID: "r_forged",
+		},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	properties, err := store.GetProperties(contact.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(properties) != 1 || properties[0].Provenance != nil {
+		t.Fatalf("full-record write accepted caller provenance: %#v", properties)
+	}
+}
+
+func TestPropertyProvenanceMigrationKeepsLegacyRowsUnknown(t *testing.T) {
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(`
+		CREATE TABLE contact_properties (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			contact_id TEXT NOT NULL,
+			property TEXT NOT NULL,
+			value TEXT NOT NULL,
+			type TEXT,
+			pref INTEGER,
+			label TEXT,
+			mediatype TEXT,
+			verified INTEGER NOT NULL DEFAULT 0,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		)
+	`); err != nil {
+		t.Fatal(err)
+	}
+	id := uuid.MustParse("019c76e4-2ff1-7918-8d6f-6c2488f5098d")
+	stamp := time.Now().UTC().Format(time.RFC3339)
+	if _, err := db.Exec(`
+		INSERT INTO contact_properties (contact_id, property, value, created_at, updated_at)
+		VALUES (?, 'EMAIL', 'legacy@example.com', ?, ?)
+	`, id.String(), stamp, stamp); err != nil {
+		t.Fatal(err)
+	}
+	store, err := NewStore(db, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	properties, err := store.GetProperties(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(properties) != 1 {
+		t.Fatalf("legacy properties = %d, want 1", len(properties))
+	}
+	if properties[0].Provenance != nil {
+		t.Fatalf("legacy row fabricated provenance: %#v", properties[0].Provenance)
 	}
 }

--- a/internal/state/contacts/tools.go
+++ b/internal/state/contacts/tools.go
@@ -72,6 +72,12 @@ func NewTools(store *Store, mutationSink func(context.Context, ContactMutation) 
 	return &Tools{store: store, mutationSink: mutationSink}
 }
 
+// ContactRefreshesEnabled reports whether committed model-authored changes
+// have a configured downstream dossier-refresh consumer.
+func (t *Tools) ContactRefreshesEnabled() bool {
+	return t != nil && t.mutationSink != nil
+}
+
 // SetEmbeddingClient sets the embedding client for semantic search.
 func (t *Tools) SetEmbeddingClient(client EmbeddingClient) {
 	t.embeddings = client
@@ -327,7 +333,7 @@ func (t *Tools) saveContact(
 		if provided == nil {
 			return
 		}
-		values := cleanOriginValues(provided)
+		values := cleanReplacementValues(property, provided)
 		if propertyValuesEqual(contact.Properties, property, values) {
 			return
 		}
@@ -478,6 +484,27 @@ func propertyValuesEqual(properties []Property, property string, want []string) 
 		}
 	}
 	return true
+}
+
+func cleanReplacementValues(property string, values []string) []string {
+	cleaned := cleanOriginValues(values)
+	if len(cleaned) < 2 {
+		return cleaned
+	}
+	deduplicated := make([]string, 0, len(cleaned))
+	for _, value := range cleaned {
+		duplicate := false
+		for _, existing := range deduplicated {
+			if propertyValueEqual(property, existing, value) {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			deduplicated = append(deduplicated, value)
+		}
+	}
+	return deduplicated
 }
 
 // propertyValueEqual is the single equality contract for model-authored

--- a/internal/state/contacts/tools.go
+++ b/internal/state/contacts/tools.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -353,7 +352,6 @@ func (t *Tools) saveContact(
 		return fmt.Sprintf("Contact unchanged: **%s** (%s); no dossier refresh was queued", saved.FormattedName, saved.Kind), nil
 	}
 
-	t.generateEmbedding(saved)
 	fields := sortedKeys(changedFields)
 	if notify && t.mutationSink != nil {
 		mutation := ContactMutation{
@@ -367,6 +365,9 @@ func (t *Tools) saveContact(
 			return "", fmt.Errorf("contact write committed for %s but dossier refresh enqueue failed; do not repeat contact_save: %w", saved.ID, err)
 		}
 	}
+	// The durable refresh is part of the authoritative-write contract;
+	// optional embedding maintenance must never delay or prevent it.
+	t.generateEmbedding(saved)
 
 	if created {
 		return fmt.Sprintf("Saved new contact: **%s** (%s)", saved.FormattedName, saved.Kind), nil
@@ -445,7 +446,7 @@ func additiveProperties(facts map[string]string, existing []Property, provenance
 
 func hasProperty(properties []Property, property, value string) bool {
 	for _, candidate := range properties {
-		if candidate.Property == property && strings.EqualFold(candidate.Value, value) {
+		if candidate.Property == property && propertyValueEqual(property, candidate.Value, value) {
 			return true
 		}
 	}
@@ -459,7 +460,36 @@ func propertyValuesEqual(properties []Property, property string, want []string) 
 			got = append(got, candidate.Value)
 		}
 	}
-	return slices.Equal(got, want)
+	if len(got) != len(want) {
+		return false
+	}
+	matched := make([]bool, len(want))
+	for _, actual := range got {
+		found := false
+		for i, expected := range want {
+			if !matched[i] && propertyValueEqual(property, actual, expected) {
+				matched[i] = true
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+// propertyValueEqual is the single equality contract for model-authored
+// properties, whether they arrive through additive facts or replace-style
+// origin fields. Existing additive contact facts are case-insensitive;
+// document refs remain byte-exact because case can select a different path on
+// a case-sensitive root.
+func propertyValueEqual(property, left, right string) bool {
+	if property == PropertyOriginContextRef {
+		return left == right
+	}
+	return strings.EqualFold(left, right)
 }
 
 func sortedKeys(values map[string]struct{}) []string {

--- a/internal/state/contacts/tools.go
+++ b/internal/state/contacts/tools.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -49,12 +50,27 @@ type Tools struct {
 	ownerActivity     func() []OwnerChannelActivity
 	dossiersEnabled   bool
 	dossiersWritable  bool
+	dossierRead       func(context.Context, documents.RefArgs) (string, error)
 	dossierWrite      func(context.Context, documents.WriteArgs) (string, error)
+	mutationSink      func(context.Context, ContactMutation) error
 }
 
-// NewTools creates contact tools using the given store.
-func NewTools(store *Store) *Tools {
-	return &Tools{store: store}
+// ContactMutation describes one committed contact_save change for downstream
+// consumers such as the archivist queue. Fields names the structured scalar
+// or property keys whose authority changed.
+type ContactMutation struct {
+	ContactID   uuid.UUID           `json:"contact_id"`
+	ContactName string              `json:"contact_name"`
+	Created     bool                `json:"created"`
+	Fields      []string            `json:"fields"`
+	Provenance  *PropertyProvenance `json:"provenance"`
+}
+
+// NewTools creates contact tools using the given store and optional committed
+// mutation sink. The sink is a construction dependency so a live tool surface
+// cannot race with post-startup rewiring.
+func NewTools(store *Store, mutationSink func(context.Context, ContactMutation) error) *Tools {
+	return &Tools{store: store, mutationSink: mutationSink}
 }
 
 // SetEmbeddingClient sets the embedding client for semantic search.
@@ -208,6 +224,21 @@ var saveContactKnownFields = map[string]bool{
 // (e.g., "email", "phone") are automatically rescued into the Facts
 // map or contact_properties, since models frequently flatten them.
 func (t *Tools) SaveContact(argsJSON string) (string, error) {
+	return t.saveContact(context.Background(), argsJSON, nil, false)
+}
+
+// SaveContactFromModel applies contact_save with the current model turn's
+// provenance and emits the configured post-commit mutation signal.
+func (t *Tools) SaveContactFromModel(ctx context.Context, argsJSON string, provenance *PropertyProvenance) (string, error) {
+	return t.saveContact(ctx, argsJSON, provenance, true)
+}
+
+func (t *Tools) saveContact(
+	ctx context.Context,
+	argsJSON string,
+	provenance *PropertyProvenance,
+	notify bool,
+) (string, error) {
 	var args SaveContactArgs
 	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
 		return "", fmt.Errorf("parse args: %w", err)
@@ -258,139 +289,186 @@ func (t *Tools) SaveContact(argsJSON string) (string, error) {
 		return "", fmt.Errorf("find contact: %w", err)
 	}
 
-	if existing != nil {
-		// Update existing contact — only non-empty fields overwrite.
-		if args.Kind != "" {
-			existing.Kind = args.Kind
+	created := existing == nil
+	var contact *Contact
+	if created {
+		contact = &Contact{
+			FormattedName: args.Name,
+			Kind:          args.Kind,
+			GivenName:     args.GivenName,
+			FamilyName:    args.FamilyName,
+			Nickname:      args.Nickname,
+			Org:           args.Org,
+			Title:         args.Title,
+			Role:          args.Role,
+			Note:          args.Note,
+			AISummary:     args.AISummary,
 		}
-		if args.GivenName != "" {
-			existing.GivenName = args.GivenName
-		}
-		if args.FamilyName != "" {
-			existing.FamilyName = args.FamilyName
-		}
-		if args.Nickname != "" {
-			existing.Nickname = args.Nickname
-		}
-		if args.Org != "" {
-			existing.Org = args.Org
-		}
-		if args.Title != "" {
-			existing.Title = args.Title
-		}
-		if args.Role != "" {
-			existing.Role = args.Role
-		}
-		if args.Note != "" {
-			existing.Note = args.Note
-		}
-		if args.AISummary != "" {
-			existing.AISummary = args.AISummary
-		}
-
-		updated, err := t.store.Upsert(existing)
+	} else {
+		contact, err = t.store.GetWithProperties(existing.ID)
 		if err != nil {
-			return "", fmt.Errorf("update contact: %w", err)
+			return "", fmt.Errorf("load contact for update: %w", err)
 		}
-
-		if err := t.saveProperties(updated.ID, args.Facts); err != nil {
-			return "", err
-		}
-		if err := t.saveOriginPolicyProperties(updated.ID, args.OriginTags, args.OriginContextRefs); err != nil {
-			return "", err
-		}
-
-		t.generateEmbedding(updated)
-
-		return fmt.Sprintf("Updated contact: **%s** (%s)", updated.FormattedName, updated.Kind), nil
 	}
 
-	// Create new contact.
-	c := &Contact{
-		FormattedName: args.Name,
-		Kind:          args.Kind,
-		GivenName:     args.GivenName,
-		FamilyName:    args.FamilyName,
-		Nickname:      args.Nickname,
-		Org:           args.Org,
-		Title:         args.Title,
-		Role:          args.Role,
-		Note:          args.Note,
-		AISummary:     args.AISummary,
+	changedFields := make(map[string]struct{})
+	contactChanged := created
+	if created {
+		markCreatedContactFields(args, changedFields)
+	} else {
+		contactChanged = applyContactScalarUpdates(contact, args, changedFields)
 	}
 
-	created, err := t.store.Upsert(c)
+	additions := additiveProperties(args.Facts, contact.Properties, provenance)
+	for _, property := range additions {
+		changedFields["property:"+property.Property] = struct{}{}
+	}
+	replacements := make(map[string][]Property)
+	collectReplacement := func(property string, provided []string) {
+		if provided == nil {
+			return
+		}
+		values := cleanOriginValues(provided)
+		if propertyValuesEqual(contact.Properties, property, values) {
+			return
+		}
+		props := make([]Property, 0, len(values))
+		for _, value := range values {
+			props = append(props, Property{Property: property, Value: value, Provenance: provenance})
+		}
+		replacements[property] = props
+		changedFields["property:"+property] = struct{}{}
+	}
+	collectReplacement(PropertyOriginTag, args.OriginTags)
+	collectReplacement(PropertyOriginContextRef, args.OriginContextRefs)
+
+	saved, changed, err := t.store.applyContactSave(contact, contactChanged, additions, replacements)
 	if err != nil {
-		return "", fmt.Errorf("create contact: %w", err)
+		if created {
+			return "", fmt.Errorf("create contact: %w", err)
+		}
+		return "", fmt.Errorf("update contact: %w", err)
+	}
+	if !changed {
+		return fmt.Sprintf("Contact unchanged: **%s** (%s); no dossier refresh was queued", saved.FormattedName, saved.Kind), nil
 	}
 
-	if err := t.saveProperties(created.ID, args.Facts); err != nil {
-		return "", err
-	}
-	if err := t.saveOriginPolicyProperties(created.ID, args.OriginTags, args.OriginContextRefs); err != nil {
-		return "", err
+	t.generateEmbedding(saved)
+	fields := sortedKeys(changedFields)
+	if notify && t.mutationSink != nil {
+		mutation := ContactMutation{
+			ContactID:   saved.ID,
+			ContactName: saved.FormattedName,
+			Created:     created,
+			Fields:      fields,
+			Provenance:  provenance,
+		}
+		if err := t.mutationSink(ctx, mutation); err != nil {
+			return "", fmt.Errorf("contact write committed for %s but dossier refresh enqueue failed; do not repeat contact_save: %w", saved.ID, err)
+		}
 	}
 
-	t.generateEmbedding(created)
-
-	return fmt.Sprintf("Saved new contact: **%s** (%s)", created.FormattedName, created.Kind), nil
+	if created {
+		return fmt.Sprintf("Saved new contact: **%s** (%s)", saved.FormattedName, saved.Kind), nil
+	}
+	return fmt.Sprintf("Updated contact: **%s** (%s)", saved.FormattedName, saved.Kind), nil
 }
 
-func (t *Tools) saveOriginPolicyProperties(contactID uuid.UUID, tags, refs []string) error {
-	if tags != nil {
-		if err := t.store.DeleteContactProperties(contactID, PropertyOriginTag); err != nil {
-			return err
-		}
-		for _, tag := range cleanOriginValues(tags) {
-			if err := t.store.AddProperty(contactID, &Property{
-				Property: PropertyOriginTag,
-				Value:    tag,
-			}); err != nil {
-				return fmt.Errorf("add origin tag: %w", err)
-			}
-		}
-	}
-	if refs != nil {
-		if err := t.store.DeleteContactProperties(contactID, PropertyOriginContextRef); err != nil {
-			return err
-		}
-		for _, ref := range cleanOriginValues(refs) {
-			if err := t.store.AddProperty(contactID, &Property{
-				Property: PropertyOriginContextRef,
-				Value:    ref,
-			}); err != nil {
-				return fmt.Errorf("add origin context ref: %w", err)
-			}
+func markCreatedContactFields(args SaveContactArgs, changed map[string]struct{}) {
+	changed["formatted_name"] = struct{}{}
+	changed["kind"] = struct{}{}
+	for field, value := range map[string]string{
+		"given_name":  args.GivenName,
+		"family_name": args.FamilyName,
+		"nickname":    args.Nickname,
+		"org":         args.Org,
+		"title":       args.Title,
+		"role":        args.Role,
+		"note":        args.Note,
+		"ai_summary":  args.AISummary,
+	} {
+		if value != "" {
+			changed[field] = struct{}{}
 		}
 	}
-	return nil
 }
 
-// saveProperties stores all fact entries as contact_properties. Known
-// vCard keys (email, phone, signal, matrix) are mapped to their
-// standard property names (EMAIL, TEL, IMPP); all others are stored
-// with their original key as the property name.
-func (t *Tools) saveProperties(contactID uuid.UUID, facts map[string]string) error {
-	for k, v := range facts {
-		propName, isVCard := propertyKeys[k]
-		if !isVCard {
-			propName = k
+func applyContactScalarUpdates(contact *Contact, args SaveContactArgs, changed map[string]struct{}) bool {
+	updated := false
+	set := func(field string, target *string, value string) {
+		if value == "" || *target == value {
+			return
 		}
-		value := v
-		// For IMPP properties, prefix with the protocol scheme if not
-		// already present.  Use HasPrefix rather than Contains so that
-		// Matrix IDs like @user:server.com still get the scheme prepended.
-		if propName == "IMPP" && !strings.HasPrefix(v, k+":") {
-			value = k + ":" + v
+		*target = value
+		changed[field] = struct{}{}
+		updated = true
+	}
+	set("kind", &contact.Kind, args.Kind)
+	set("given_name", &contact.GivenName, args.GivenName)
+	set("family_name", &contact.FamilyName, args.FamilyName)
+	set("nickname", &contact.Nickname, args.Nickname)
+	set("org", &contact.Org, args.Org)
+	set("title", &contact.Title, args.Title)
+	set("role", &contact.Role, args.Role)
+	set("note", &contact.Note, args.Note)
+	set("ai_summary", &contact.AISummary, args.AISummary)
+	return updated
+}
+
+func additiveProperties(facts map[string]string, existing []Property, provenance *PropertyProvenance) []Property {
+	keys := make([]string, 0, len(facts))
+	for key := range facts {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	properties := make([]Property, 0, len(keys))
+	for _, key := range keys {
+		property := propertyKeys[key]
+		if property == "" {
+			property = key
 		}
-		if err := t.store.AddProperty(contactID, &Property{
-			Property: propName,
-			Value:    value,
-		}); err != nil {
-			return fmt.Errorf("add property %s: %w", propName, err)
+		value := facts[key]
+		if property == "IMPP" && !strings.HasPrefix(value, key+":") {
+			value = key + ":" + value
+		}
+		if hasProperty(existing, property, value) {
+			continue
+		}
+		properties = append(properties, Property{
+			Property:   property,
+			Value:      value,
+			Provenance: provenance,
+		})
+	}
+	return properties
+}
+
+func hasProperty(properties []Property, property, value string) bool {
+	for _, candidate := range properties {
+		if candidate.Property == property && strings.EqualFold(candidate.Value, value) {
+			return true
 		}
 	}
-	return nil
+	return false
+}
+
+func propertyValuesEqual(properties []Property, property string, want []string) bool {
+	got := make([]string, 0, len(want))
+	for _, candidate := range properties {
+		if candidate.Property == property {
+			got = append(got, candidate.Value)
+		}
+	}
+	return slices.Equal(got, want)
+}
+
+func sortedKeys(values map[string]struct{}) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // LookupContactArgs are arguments for the contact_lookup tool.
@@ -1056,11 +1134,14 @@ func (t *Tools) formatContact(c *Contact) string {
 	if t == nil || !t.dossiersEnabled || c == nil || c.ID == uuid.Nil {
 		return formatted
 	}
-	trailhead := "doc_read"
+	if t.DossierReadsEnabled() {
+		return fmt.Sprintf("%s\nContact ID: %s\nDossier access: contact_dossier_read(contact_id=%q)", formatted, c.ID, c.ID.String())
+	}
+	trailhead := "may be absent; probe once with doc_read"
 	if t.DossierWritesEnabled() {
 		trailhead += "; create or replace with contact_dossier_write"
 	}
-	return fmt.Sprintf("%s\nContact ID: %s\nDossier: %s (%s)", formatted, c.ID, DossierRef(c.ID), trailhead)
+	return fmt.Sprintf("%s\nContact ID: %s\nDossier target: %s (%s)", formatted, c.ID, DossierRef(c.ID), trailhead)
 }
 
 func (t *Tools) formatOwnerActivitySummary() string {

--- a/internal/state/contacts/tools_test.go
+++ b/internal/state/contacts/tools_test.go
@@ -21,6 +21,15 @@ type fakeEmbedder struct {
 	err       error
 }
 
+type callbackEmbedder struct {
+	generate func()
+}
+
+func (e *callbackEmbedder) Generate(_ context.Context, _ string) ([]float32, error) {
+	e.generate()
+	return []float32{0.25}, nil
+}
+
 func (f *fakeEmbedder) Generate(_ context.Context, _ string) ([]float32, error) {
 	return f.embedding, f.err
 }
@@ -145,7 +154,8 @@ func TestSaveContactFromModelRecordsPropertyProvenanceAndSignalsOnce(t *testing.
 	result, err := tools.SaveContactFromModel(context.Background(), `{
 		"name":"Provenance Person",
 		"kind":"individual",
-		"facts":{"email":"person@example.com","timezone":"America/Chicago"}
+		"facts":{"email":"person@example.com","timezone":"America/Chicago"},
+		"origin_tags":["signal","projects"]
 	}`, provenance)
 	if err != nil {
 		t.Fatalf("SaveContactFromModel() error = %v", err)
@@ -156,7 +166,7 @@ func TestSaveContactFromModelRecordsPropertyProvenanceAndSignalsOnce(t *testing.
 	if len(mutations) != 1 {
 		t.Fatalf("mutation calls = %d, want 1", len(mutations))
 	}
-	wantFields := []string{"formatted_name", "kind", "property:EMAIL", "property:timezone"}
+	wantFields := []string{"formatted_name", "kind", "property:EMAIL", "property:X-THANE-ORIGIN-TAG", "property:timezone"}
 	if !reflect.DeepEqual(mutations[0].Fields, wantFields) {
 		t.Errorf("mutation fields = %#v, want %#v", mutations[0].Fields, wantFields)
 	}
@@ -172,8 +182,8 @@ func TestSaveContactFromModelRecordsPropertyProvenanceAndSignalsOnce(t *testing.
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(properties) != 2 {
-		t.Fatalf("properties = %#v, want 2", properties)
+	if len(properties) != 4 {
+		t.Fatalf("properties = %#v, want 4", properties)
 	}
 	for _, property := range properties {
 		if !reflect.DeepEqual(property.Provenance, provenance) {
@@ -185,7 +195,8 @@ func TestSaveContactFromModelRecordsPropertyProvenanceAndSignalsOnce(t *testing.
 	result, err = tools.SaveContactFromModel(context.Background(), `{
 		"name":"Provenance Person",
 		"kind":"individual",
-		"facts":{"email":"person@example.com","timezone":"America/Chicago"}
+		"facts":{"email":"PERSON@example.com","timezone":"america/chicago"},
+		"origin_tags":["PROJECTS","SIGNAL"]
 	}`, newer)
 	if err != nil {
 		t.Fatalf("repeated SaveContactFromModel() error = %v", err)
@@ -531,6 +542,24 @@ func TestSaveContact_WithEmbedding(t *testing.T) {
 	}
 	if len(contacts) != 1 || contacts[0].ID != c.ID {
 		t.Error("expected semantic search to find the contact with embedding")
+	}
+}
+
+func TestSaveContactFromModelQueuesRefreshBeforeEmbedding(t *testing.T) {
+	var order []string
+	tools := NewTools(newTestStore(t), func(context.Context, ContactMutation) error {
+		order = append(order, "refresh")
+		return nil
+	})
+	tools.SetEmbeddingClient(&callbackEmbedder{generate: func() {
+		order = append(order, "embedding")
+	}})
+
+	if _, err := tools.SaveContactFromModel(t.Context(), `{"name":"Ordered Contact","kind":"individual"}`, &PropertyProvenance{Source: "contact_save"}); err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"refresh", "embedding"}; !reflect.DeepEqual(order, want) {
+		t.Fatalf("post-commit order = %#v, want %#v", order, want)
 	}
 }
 

--- a/internal/state/contacts/tools_test.go
+++ b/internal/state/contacts/tools_test.go
@@ -155,7 +155,7 @@ func TestSaveContactFromModelRecordsPropertyProvenanceAndSignalsOnce(t *testing.
 		"name":"Provenance Person",
 		"kind":"individual",
 		"facts":{"email":"person@example.com","timezone":"America/Chicago"},
-		"origin_tags":["signal","projects"]
+		"origin_tags":["signal","SIGNAL","projects"]
 	}`, provenance)
 	if err != nil {
 		t.Fatalf("SaveContactFromModel() error = %v", err)

--- a/internal/state/contacts/tools_test.go
+++ b/internal/state/contacts/tools_test.go
@@ -2,13 +2,17 @@ package contacts
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/state/documents"
 )
 
 // fakeEmbedder returns a fixed embedding for any text.
@@ -24,7 +28,7 @@ func (f *fakeEmbedder) Generate(_ context.Context, _ string) ([]float32, error) 
 func newTestTools(t *testing.T) *Tools {
 	t.Helper()
 	store := newTestStore(t)
-	return NewTools(store)
+	return NewTools(store, nil)
 }
 
 func TestSaveContact_New(t *testing.T) {
@@ -116,6 +120,130 @@ func TestSaveContact_WithFacts(t *testing.T) {
 	}
 	if !foundTZ {
 		t.Error("expected timezone property for America/Chicago")
+	}
+}
+
+func TestSaveContactFromModelRecordsPropertyProvenanceAndSignalsOnce(t *testing.T) {
+	iteration := 3
+	provenance := &PropertyProvenance{
+		Source:         "contact_save",
+		Model:          "test-model",
+		LoopID:         "loop-archivist-1",
+		ConversationID: "loop-archivist-1-123",
+		SessionID:      "019c52f0-9ce8-7708-867f-35da2e6b4777",
+		RequestID:      "r_contact",
+		ToolCallID:     "call_contact",
+		Iteration:      &iteration,
+	}
+	var mutations []ContactMutation
+	store := newTestStore(t)
+	tools := NewTools(store, func(_ context.Context, mutation ContactMutation) error {
+		mutations = append(mutations, mutation)
+		return nil
+	})
+
+	result, err := tools.SaveContactFromModel(context.Background(), `{
+		"name":"Provenance Person",
+		"kind":"individual",
+		"facts":{"email":"person@example.com","timezone":"America/Chicago"}
+	}`, provenance)
+	if err != nil {
+		t.Fatalf("SaveContactFromModel() error = %v", err)
+	}
+	if !strings.Contains(result, "Saved new contact") {
+		t.Fatalf("result = %q, want new-contact result", result)
+	}
+	if len(mutations) != 1 {
+		t.Fatalf("mutation calls = %d, want 1", len(mutations))
+	}
+	wantFields := []string{"formatted_name", "kind", "property:EMAIL", "property:timezone"}
+	if !reflect.DeepEqual(mutations[0].Fields, wantFields) {
+		t.Errorf("mutation fields = %#v, want %#v", mutations[0].Fields, wantFields)
+	}
+	if mutations[0].Provenance != provenance {
+		t.Error("mutation did not preserve the model-turn provenance")
+	}
+
+	contact, err := tools.store.FindByName("Provenance Person")
+	if err != nil {
+		t.Fatal(err)
+	}
+	properties, err := tools.store.GetProperties(contact.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(properties) != 2 {
+		t.Fatalf("properties = %#v, want 2", properties)
+	}
+	for _, property := range properties {
+		if !reflect.DeepEqual(property.Provenance, provenance) {
+			t.Errorf("property %s provenance = %#v, want %#v", property.Property, property.Provenance, provenance)
+		}
+	}
+
+	newer := &PropertyProvenance{Source: "contact_save", RequestID: "r_retry"}
+	result, err = tools.SaveContactFromModel(context.Background(), `{
+		"name":"Provenance Person",
+		"kind":"individual",
+		"facts":{"email":"person@example.com","timezone":"America/Chicago"}
+	}`, newer)
+	if err != nil {
+		t.Fatalf("repeated SaveContactFromModel() error = %v", err)
+	}
+	if !strings.Contains(result, "Contact unchanged") || !strings.Contains(result, "no dossier refresh") {
+		t.Fatalf("no-op result = %q, want explicit unchanged result", result)
+	}
+	if len(mutations) != 1 {
+		t.Fatalf("no-op mutation calls = %d, want 1 total", len(mutations))
+	}
+	properties, err = tools.store.GetProperties(contact.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, property := range properties {
+		if !reflect.DeepEqual(property.Provenance, provenance) {
+			t.Errorf("no-op rewrote property %s provenance to %#v", property.Property, property.Provenance)
+		}
+	}
+}
+
+func TestSaveContactFromModelDoesNotSignalRejectedOrRolledBackWrites(t *testing.T) {
+	calls := 0
+	store := newTestStore(t)
+	tools := NewTools(store, func(context.Context, ContactMutation) error {
+		calls++
+		return nil
+	})
+	provenance := &PropertyProvenance{Source: "contact_save", RequestID: "r_rejected"}
+
+	if _, err := tools.SaveContactFromModel(context.Background(), `{
+		"name":"Custody Rejection",
+		"kind":"individual",
+		"trust_zone":"admin"
+	}`, provenance); err == nil || !strings.Contains(err.Error(), "operator-custodied") {
+		t.Fatalf("trust-zone rejection error = %v", err)
+	}
+	if _, err := tools.store.db.Exec(`
+		CREATE TRIGGER fail_model_property
+		BEFORE INSERT ON contact_properties
+		BEGIN
+			SELECT RAISE(ABORT, 'forced property rollback');
+		END
+	`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tools.SaveContactFromModel(context.Background(), `{
+		"name":"Rollback Rejection",
+		"kind":"individual",
+		"facts":{"email":"nobody@example.com"}
+	}`, provenance); err == nil || !strings.Contains(err.Error(), "forced property rollback") {
+		t.Fatalf("property rollback error = %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("rejected/rolled-back writes signaled %d mutations, want 0", calls)
+	}
+	if _, err := tools.store.FindByName("Rollback Rejection"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("rolled-back contact lookup error = %v, want sql.ErrNoRows", err)
 	}
 }
 
@@ -729,7 +857,7 @@ func TestLookupContactIncludesConfiguredDossierTrailhead(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{"Contact ID: " + contact.ID.String(), "Dossier: " + DossierRef(contact.ID)} {
+	for _, want := range []string{"Contact ID: " + contact.ID.String(), "Dossier target: " + DossierRef(contact.ID), "may be absent"} {
 		if !strings.Contains(with, want) {
 			t.Fatalf("configured result = %q, want %q", with, want)
 		}
@@ -739,13 +867,19 @@ func TestLookupContactIncludesConfiguredDossierTrailhead(t *testing.T) {
 	}
 
 	tools.ConfigureDossierRoot(true, true)
-	tools.ConfigureDossierDocuments((&recordingDossierWriter{}).Write)
+	tools.ConfigureDossierDocuments(func(_ context.Context, args documents.RefArgs) (string, error) {
+		return args.Ref, nil
+	}, (&recordingDossierWriter{}).Write)
 	writable, err := tools.LookupContact(`{"name":"Dossier Person"}`)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(writable, "create or replace with contact_dossier_write") {
-		t.Fatalf("managed dossier trailhead omitted the structured write door: %s", writable)
+	wantCall := `Dossier access: contact_dossier_read(contact_id="` + contact.ID.String() + `")`
+	if !strings.Contains(writable, wantCall) {
+		t.Fatalf("managed dossier trailhead = %q, want exact read call %q", writable, wantCall)
+	}
+	if strings.Contains(writable, DossierRef(contact.ID)) || strings.Contains(writable, "doc_read") {
+		t.Fatalf("managed dossier trailhead exposed the error-prone raw ref path: %s", writable)
 	}
 }
 

--- a/internal/state/introspection/tool_provider_test.go
+++ b/internal/state/introspection/tool_provider_test.go
@@ -161,7 +161,7 @@ func TestQueueStatusToolReportsAuditView(t *testing.T) {
 	if err != nil || len(items) != 1 {
 		t.Fatalf("peek queue item: items=%#v err=%v", items, err)
 	}
-	if outcome, err := queue.Ack(ctx, "archivist", "session:done", items[0].Generation); err != nil || outcome != loopqueue.Acked {
+	if outcome, err := queue.Ack(ctx, "archivist", "session:done", items[0].Receipt); err != nil || outcome != loopqueue.Acked {
 		t.Fatalf("ack queue item outcome=%q err=%v", outcome, err)
 	}
 	if err := queue.Enqueue(ctx, "archivist", "session:waiting", 0, nil); err != nil {

--- a/internal/state/introspection/tool_provider_test.go
+++ b/internal/state/introspection/tool_provider_test.go
@@ -157,8 +157,12 @@ func TestQueueStatusToolReportsAuditView(t *testing.T) {
 	if err := queue.Enqueue(ctx, "archivist", "session:done", 0, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := queue.Ack(ctx, "archivist", "session:done"); err != nil {
-		t.Fatal(err)
+	items, err := queue.Peek(ctx, "archivist", 1)
+	if err != nil || len(items) != 1 {
+		t.Fatalf("peek queue item: items=%#v err=%v", items, err)
+	}
+	if outcome, err := queue.Ack(ctx, "archivist", "session:done", items[0].Generation); err != nil || outcome != loopqueue.Acked {
+		t.Fatalf("ack queue item outcome=%q err=%v", outcome, err)
 	}
 	if err := queue.Enqueue(ctx, "archivist", "session:waiting", 0, nil); err != nil {
 		t.Fatal(err)

--- a/internal/state/loopqueue/queue_schema.go
+++ b/internal/state/loopqueue/queue_schema.go
@@ -24,11 +24,21 @@ var queueSchema = database.Schema{
 				PRIMARY KEY (consumer_loop, dedup_key)
 			)`,
 		},
-		// generation is the queue's hidden read receipt. Every coalescing
-		// Enqueue advances it so a consumer can acknowledge only the exact
-		// payload generation it actually processed; legacy pending rows begin
-		// at generation 1.
-		database.ColumnAdd{Table: "loop_queue", Column: "generation", Typedef: "INTEGER NOT NULL DEFAULT 1"},
+		// receipt is the queue's hidden read receipt. Every Enqueue writes a
+		// new opaque value, including an insert after an earlier row with the
+		// same key was acknowledged and deleted, so delayed acknowledgements
+		// can never match later work.
+		database.ColumnAdd{Table: "loop_queue", Column: "receipt", Typedef: "TEXT NOT NULL DEFAULT ''"},
+		database.Raw{
+			Description: "seed receipts for legacy pending loop queue rows",
+			SQL: `UPDATE loop_queue
+				SET receipt = lower(hex(randomblob(16)))
+				WHERE receipt = ''`,
+		},
+		database.IndexCreate{
+			Name: "idx_loop_queue_receipt_unique",
+			SQL:  `CREATE UNIQUE INDEX IF NOT EXISTS idx_loop_queue_receipt_unique ON loop_queue(receipt)`,
+		},
 		database.IndexCreate{
 			Name: "idx_loop_queue_drain",
 			// Supports the per-partition drain query: pending items for

--- a/internal/state/loopqueue/queue_schema.go
+++ b/internal/state/loopqueue/queue_schema.go
@@ -24,6 +24,11 @@ var queueSchema = database.Schema{
 				PRIMARY KEY (consumer_loop, dedup_key)
 			)`,
 		},
+		// generation is the queue's hidden read receipt. Every coalescing
+		// Enqueue advances it so a consumer can acknowledge only the exact
+		// payload generation it actually processed; legacy pending rows begin
+		// at generation 1.
+		database.ColumnAdd{Table: "loop_queue", Column: "generation", Typedef: "INTEGER NOT NULL DEFAULT 1"},
 		database.IndexCreate{
 			Name: "idx_loop_queue_drain",
 			// Supports the per-partition drain query: pending items for

--- a/internal/state/loopqueue/queue_stats_test.go
+++ b/internal/state/loopqueue/queue_stats_test.go
@@ -28,17 +28,15 @@ func TestAckJournalsExactlyOnce(t *testing.T) {
 	if err := s.Enqueue(ctx, "archivist", "session:a", 3, []byte(`{}`)); err != nil {
 		t.Fatalf("enqueue: %v", err)
 	}
-	if err := s.Ack(ctx, "archivist", "session:a"); err != nil {
-		t.Fatalf("ack: %v", err)
-	}
+	generation := ackPending(t, s, "archivist", "session:a")
 	if got := completionCount(t, s, "archivist"); got != 1 {
 		t.Fatalf("completions after ack = %d, want 1", got)
 	}
 
 	// Re-acking the same key is idempotent for the queue AND for the
 	// journal: no phantom completion rows, no double-counted throughput.
-	if err := s.Ack(ctx, "archivist", "session:a"); err != nil {
-		t.Fatalf("re-ack: %v", err)
+	if outcome, err := s.Ack(ctx, "archivist", "session:a", generation); err != nil || outcome != AckMissing {
+		t.Fatalf("re-ack outcome=%q err=%v", outcome, err)
 	}
 	if got := completionCount(t, s, "archivist"); got != 1 {
 		t.Errorf("completions after re-ack = %d, want 1", got)
@@ -133,9 +131,7 @@ func TestCompletionStatsAggregatesPerConsumer(t *testing.T) {
 		if err := s.Enqueue(ctx, "archivist", key, 0, nil); err != nil {
 			t.Fatal(err)
 		}
-		if err := s.Ack(ctx, "archivist", key); err != nil {
-			t.Fatal(err)
-		}
+		ackPending(t, s, "archivist", key)
 	}
 
 	stats, err := s.CompletionStatsSince(ctx, time.Now().Add(-time.Hour))
@@ -169,9 +165,7 @@ func TestPruneCompletionsIsAgeBased(t *testing.T) {
 	if err := s.Enqueue(ctx, "archivist", "session:old", 0, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.Ack(ctx, "archivist", "session:old"); err != nil {
-		t.Fatal(err)
-	}
+	ackPending(t, s, "archivist", "session:old")
 	// Backdate the journal row two days so a one-day retention removes it.
 	if _, err := s.db.ExecContext(ctx,
 		`UPDATE loop_queue_completions SET acked_at = ? WHERE dedup_key = 'session:old'`,

--- a/internal/state/loopqueue/queue_stats_test.go
+++ b/internal/state/loopqueue/queue_stats_test.go
@@ -28,14 +28,14 @@ func TestAckJournalsExactlyOnce(t *testing.T) {
 	if err := s.Enqueue(ctx, "archivist", "session:a", 3, []byte(`{}`)); err != nil {
 		t.Fatalf("enqueue: %v", err)
 	}
-	generation := ackPending(t, s, "archivist", "session:a")
+	receipt := ackPending(t, s, "archivist", "session:a")
 	if got := completionCount(t, s, "archivist"); got != 1 {
 		t.Fatalf("completions after ack = %d, want 1", got)
 	}
 
 	// Re-acking the same key is idempotent for the queue AND for the
 	// journal: no phantom completion rows, no double-counted throughput.
-	if outcome, err := s.Ack(ctx, "archivist", "session:a", generation); err != nil || outcome != AckMissing {
+	if outcome, err := s.Ack(ctx, "archivist", "session:a", receipt); err != nil || outcome != AckMissing {
 		t.Fatalf("re-ack outcome=%q err=%v", outcome, err)
 	}
 	if got := completionCount(t, s, "archivist"); got != 1 {

--- a/internal/state/loopqueue/queue_store.go
+++ b/internal/state/loopqueue/queue_store.go
@@ -33,13 +33,13 @@ import (
 const StatusPending = "pending"
 
 // AckOutcome reports whether a receipt-guarded acknowledgement removed its
-// exact queue generation, found newer work, or found no pending item.
+// exact queue item, found newer work, or found no pending item.
 type AckOutcome string
 
 const (
-	// Acked means the exact generation was removed and journaled.
+	// Acked means the exact receipt was removed and journaled.
 	Acked AckOutcome = "acked"
-	// AckSuperseded means a newer coalesced generation remains pending.
+	// AckSuperseded means a newer coalesced item remains pending.
 	AckSuperseded AckOutcome = "superseded"
 	// AckMissing means no item with that consumer and key remains pending.
 	AckMissing AckOutcome = "missing"
@@ -49,7 +49,7 @@ const (
 // opaque JSON the producer enqueued; the queue does not interpret it.
 type Item struct {
 	DedupKey   string
-	Generation int64
+	Receipt    string
 	Priority   int
 	EnqueuedAt time.Time
 	Payload    []byte
@@ -98,16 +98,20 @@ func (s *Store) Enqueue(ctx context.Context, consumerLoop, dedupKey string, prio
 	if len(payload) == 0 {
 		payload = []byte("{}")
 	}
-	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO loop_queue (consumer_loop, dedup_key, priority, status, attempts, payload, enqueued_at, updated_at, generation)
-		VALUES (?, ?, ?, 'pending', 0, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 1)
+	receipt, err := newReceipt()
+	if err != nil {
+		return fmt.Errorf("loopqueue: enqueue %s/%s: %w", consumerLoop, dedupKey, err)
+	}
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO loop_queue (consumer_loop, dedup_key, priority, status, attempts, payload, enqueued_at, updated_at, receipt)
+		VALUES (?, ?, ?, 'pending', 0, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, ?)
 		ON CONFLICT(consumer_loop, dedup_key) DO UPDATE SET
 			priority   = MAX(loop_queue.priority, excluded.priority),
 			status     = 'pending',
 			payload    = excluded.payload,
 			updated_at = CURRENT_TIMESTAMP,
-			generation = loop_queue.generation + 1
-	`, consumerLoop, dedupKey, priority, string(payload))
+			receipt    = excluded.receipt
+	`, consumerLoop, dedupKey, priority, string(payload), receipt)
 	if err != nil {
 		return fmt.Errorf("loopqueue: enqueue %s/%s: %w", consumerLoop, dedupKey, err)
 	}
@@ -141,9 +145,9 @@ func (s *Store) Append(ctx context.Context, consumerLoop, keyPrefix string, prio
 	}
 	dedupKey := keyPrefix + ":" + id.String()
 	_, err = s.db.ExecContext(ctx, `
-		INSERT INTO loop_queue (consumer_loop, dedup_key, priority, status, attempts, payload, enqueued_at, updated_at, generation)
-		VALUES (?, ?, ?, 'pending', 0, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 1)
-	`, consumerLoop, dedupKey, priority, string(payload))
+		INSERT INTO loop_queue (consumer_loop, dedup_key, priority, status, attempts, payload, enqueued_at, updated_at, receipt)
+		VALUES (?, ?, ?, 'pending', 0, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, ?)
+	`, consumerLoop, dedupKey, priority, string(payload), dedupKey)
 	if err != nil {
 		return "", fmt.Errorf("loopqueue: append %s/%s: %w", consumerLoop, dedupKey, err)
 	}
@@ -212,7 +216,7 @@ func (s *Store) peek(ctx context.Context, consumerLoop string, limit int) ([]Ite
 		return nil, fmt.Errorf("loopqueue: consumer_loop is required")
 	}
 	query := `
-		SELECT dedup_key, generation, priority, payload, enqueued_at
+		SELECT dedup_key, receipt, priority, payload, enqueued_at
 		FROM loop_queue
 		WHERE consumer_loop = ? AND status = ?
 		ORDER BY priority DESC, enqueued_at ASC, dedup_key ASC`
@@ -234,7 +238,7 @@ func (s *Store) peek(ctx context.Context, consumerLoop string, limit int) ([]Ite
 			payload     string
 			enqueuedRaw any
 		)
-		if err := rows.Scan(&it.DedupKey, &it.Generation, &it.Priority, &payload, &enqueuedRaw); err != nil {
+		if err := rows.Scan(&it.DedupKey, &it.Receipt, &it.Priority, &payload, &enqueuedRaw); err != nil {
 			return nil, err
 		}
 		it.Payload = []byte(payload)
@@ -332,19 +336,19 @@ func (s *Store) MoveConsumer(ctx context.Context, from, to string) error {
 	return nil
 }
 
-// Ack removes a completed item only when expectedGeneration matches the
-// generation returned by [Store.Peek]. A coalescing Enqueue that lands while
+// Ack removes a completed item only when expectedReceipt matches the receipt
+// returned by [Store.Peek]. A coalescing Enqueue that lands while
 // the consumer is working therefore survives the stale acknowledgement.
 // Successful removal and completion journaling share one transaction. A
 // missing item is idempotent and journals nothing.
-func (s *Store) Ack(ctx context.Context, consumerLoop, dedupKey string, expectedGeneration int64) (AckOutcome, error) {
+func (s *Store) Ack(ctx context.Context, consumerLoop, dedupKey, expectedReceipt string) (AckOutcome, error) {
 	consumerLoop = strings.TrimSpace(consumerLoop)
 	dedupKey = strings.TrimSpace(dedupKey)
 	if consumerLoop == "" || dedupKey == "" {
 		return "", fmt.Errorf("loopqueue: consumer_loop and dedup_key are required")
 	}
-	if expectedGeneration <= 0 {
-		return "", fmt.Errorf("loopqueue: expected generation must be positive")
+	if strings.TrimSpace(expectedReceipt) == "" {
+		return "", fmt.Errorf("loopqueue: expected receipt is required")
 	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -353,25 +357,25 @@ func (s *Store) Ack(ctx context.Context, consumerLoop, dedupKey string, expected
 	defer tx.Rollback() //nolint:errcheck // no-op after commit
 
 	var (
-		enqueuedRaw      any
-		actualGeneration int64
+		enqueuedRaw   any
+		actualReceipt string
 	)
 	err = tx.QueryRowContext(ctx,
-		`SELECT enqueued_at, generation FROM loop_queue WHERE consumer_loop = ? AND dedup_key = ?`,
+		`SELECT enqueued_at, receipt FROM loop_queue WHERE consumer_loop = ? AND dedup_key = ?`,
 		consumerLoop, dedupKey,
-	).Scan(&enqueuedRaw, &actualGeneration)
+	).Scan(&enqueuedRaw, &actualReceipt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return AckMissing, nil
 	}
 	if err != nil {
 		return "", fmt.Errorf("loopqueue: ack %s/%s: %w", consumerLoop, dedupKey, err)
 	}
-	if actualGeneration != expectedGeneration {
+	if actualReceipt != expectedReceipt {
 		return AckSuperseded, nil
 	}
 	res, err := tx.ExecContext(ctx,
-		`DELETE FROM loop_queue WHERE consumer_loop = ? AND dedup_key = ? AND generation = ?`,
-		consumerLoop, dedupKey, expectedGeneration,
+		`DELETE FROM loop_queue WHERE consumer_loop = ? AND dedup_key = ? AND receipt = ?`,
+		consumerLoop, dedupKey, expectedReceipt,
 	)
 	if err != nil {
 		return "", fmt.Errorf("loopqueue: ack %s/%s: %w", consumerLoop, dedupKey, err)
@@ -397,6 +401,14 @@ func (s *Store) Ack(ctx context.Context, consumerLoop, dedupKey string, expected
 		return "", fmt.Errorf("loopqueue: ack %s/%s: %w", consumerLoop, dedupKey, err)
 	}
 	return Acked, nil
+}
+
+func newReceipt() (string, error) {
+	id, err := uuid.NewV7()
+	if err != nil {
+		return "", fmt.Errorf("generate receipt: %w", err)
+	}
+	return id.String(), nil
 }
 
 // HasRecentWork reports whether a key is pending or appears in the retained

--- a/internal/state/loopqueue/queue_store.go
+++ b/internal/state/loopqueue/queue_store.go
@@ -32,10 +32,24 @@ import (
 // migration.
 const StatusPending = "pending"
 
+// AckOutcome reports whether a receipt-guarded acknowledgement removed its
+// exact queue generation, found newer work, or found no pending item.
+type AckOutcome string
+
+const (
+	// Acked means the exact generation was removed and journaled.
+	Acked AckOutcome = "acked"
+	// AckSuperseded means a newer coalesced generation remains pending.
+	AckSuperseded AckOutcome = "superseded"
+	// AckMissing means no item with that consumer and key remains pending.
+	AckMissing AckOutcome = "missing"
+)
+
 // Item is one pending unit of work for a consumer loop. Payload is the
 // opaque JSON the producer enqueued; the queue does not interpret it.
 type Item struct {
 	DedupKey   string
+	Generation int64
 	Priority   int
 	EnqueuedAt time.Time
 	Payload    []byte
@@ -85,13 +99,14 @@ func (s *Store) Enqueue(ctx context.Context, consumerLoop, dedupKey string, prio
 		payload = []byte("{}")
 	}
 	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO loop_queue (consumer_loop, dedup_key, priority, status, attempts, payload, enqueued_at, updated_at)
-		VALUES (?, ?, ?, 'pending', 0, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+		INSERT INTO loop_queue (consumer_loop, dedup_key, priority, status, attempts, payload, enqueued_at, updated_at, generation)
+		VALUES (?, ?, ?, 'pending', 0, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 1)
 		ON CONFLICT(consumer_loop, dedup_key) DO UPDATE SET
 			priority   = MAX(loop_queue.priority, excluded.priority),
 			status     = 'pending',
 			payload    = excluded.payload,
-			updated_at = CURRENT_TIMESTAMP
+			updated_at = CURRENT_TIMESTAMP,
+			generation = loop_queue.generation + 1
 	`, consumerLoop, dedupKey, priority, string(payload))
 	if err != nil {
 		return fmt.Errorf("loopqueue: enqueue %s/%s: %w", consumerLoop, dedupKey, err)
@@ -126,8 +141,8 @@ func (s *Store) Append(ctx context.Context, consumerLoop, keyPrefix string, prio
 	}
 	dedupKey := keyPrefix + ":" + id.String()
 	_, err = s.db.ExecContext(ctx, `
-		INSERT INTO loop_queue (consumer_loop, dedup_key, priority, status, attempts, payload, enqueued_at, updated_at)
-		VALUES (?, ?, ?, 'pending', 0, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+		INSERT INTO loop_queue (consumer_loop, dedup_key, priority, status, attempts, payload, enqueued_at, updated_at, generation)
+		VALUES (?, ?, ?, 'pending', 0, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 1)
 	`, consumerLoop, dedupKey, priority, string(payload))
 	if err != nil {
 		return "", fmt.Errorf("loopqueue: append %s/%s: %w", consumerLoop, dedupKey, err)
@@ -197,7 +212,7 @@ func (s *Store) peek(ctx context.Context, consumerLoop string, limit int) ([]Ite
 		return nil, fmt.Errorf("loopqueue: consumer_loop is required")
 	}
 	query := `
-		SELECT dedup_key, priority, payload, enqueued_at
+		SELECT dedup_key, generation, priority, payload, enqueued_at
 		FROM loop_queue
 		WHERE consumer_loop = ? AND status = ?
 		ORDER BY priority DESC, enqueued_at ASC, dedup_key ASC`
@@ -219,7 +234,7 @@ func (s *Store) peek(ctx context.Context, consumerLoop string, limit int) ([]Ite
 			payload     string
 			enqueuedRaw any
 		)
-		if err := rows.Scan(&it.DedupKey, &it.Priority, &payload, &enqueuedRaw); err != nil {
+		if err := rows.Scan(&it.DedupKey, &it.Generation, &it.Priority, &payload, &enqueuedRaw); err != nil {
 			return nil, err
 		}
 		it.Payload = []byte(payload)
@@ -317,42 +332,49 @@ func (s *Store) MoveConsumer(ctx context.Context, from, to string) error {
 	return nil
 }
 
-// Ack removes a completed item from consumerLoop's partition and
-// journals the completion — consumer, key, and the enqueued→acked
-// span — in the same transaction as the DELETE, so the record is exact
-// and a crash can never leave a phantom completion. A missing
-// (consumerLoop, dedupKey) is a no-op (idempotent) and journals
-// nothing: re-acking an already-acked item must not double-count
-// throughput.
-func (s *Store) Ack(ctx context.Context, consumerLoop, dedupKey string) error {
+// Ack removes a completed item only when expectedGeneration matches the
+// generation returned by [Store.Peek]. A coalescing Enqueue that lands while
+// the consumer is working therefore survives the stale acknowledgement.
+// Successful removal and completion journaling share one transaction. A
+// missing item is idempotent and journals nothing.
+func (s *Store) Ack(ctx context.Context, consumerLoop, dedupKey string, expectedGeneration int64) (AckOutcome, error) {
 	consumerLoop = strings.TrimSpace(consumerLoop)
 	dedupKey = strings.TrimSpace(dedupKey)
 	if consumerLoop == "" || dedupKey == "" {
-		return fmt.Errorf("loopqueue: consumer_loop and dedup_key are required")
+		return "", fmt.Errorf("loopqueue: consumer_loop and dedup_key are required")
+	}
+	if expectedGeneration <= 0 {
+		return "", fmt.Errorf("loopqueue: expected generation must be positive")
 	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("loopqueue: ack %s/%s: %w", consumerLoop, dedupKey, err)
+		return "", fmt.Errorf("loopqueue: ack %s/%s: %w", consumerLoop, dedupKey, err)
 	}
 	defer tx.Rollback() //nolint:errcheck // no-op after commit
 
-	var enqueuedRaw any
+	var (
+		enqueuedRaw      any
+		actualGeneration int64
+	)
 	err = tx.QueryRowContext(ctx,
-		`SELECT enqueued_at FROM loop_queue WHERE consumer_loop = ? AND dedup_key = ?`,
+		`SELECT enqueued_at, generation FROM loop_queue WHERE consumer_loop = ? AND dedup_key = ?`,
 		consumerLoop, dedupKey,
-	).Scan(&enqueuedRaw)
+	).Scan(&enqueuedRaw, &actualGeneration)
 	if errors.Is(err, sql.ErrNoRows) {
-		return nil
+		return AckMissing, nil
 	}
 	if err != nil {
-		return fmt.Errorf("loopqueue: ack %s/%s: %w", consumerLoop, dedupKey, err)
+		return "", fmt.Errorf("loopqueue: ack %s/%s: %w", consumerLoop, dedupKey, err)
+	}
+	if actualGeneration != expectedGeneration {
+		return AckSuperseded, nil
 	}
 	res, err := tx.ExecContext(ctx,
-		`DELETE FROM loop_queue WHERE consumer_loop = ? AND dedup_key = ?`,
-		consumerLoop, dedupKey,
+		`DELETE FROM loop_queue WHERE consumer_loop = ? AND dedup_key = ? AND generation = ?`,
+		consumerLoop, dedupKey, expectedGeneration,
 	)
 	if err != nil {
-		return fmt.Errorf("loopqueue: ack %s/%s: %w", consumerLoop, dedupKey, err)
+		return "", fmt.Errorf("loopqueue: ack %s/%s: %w", consumerLoop, dedupKey, err)
 	}
 	// Journal only when this transaction actually removed the row. Two
 	// concurrent Acks of the same key can both pass the SELECT before
@@ -360,21 +382,21 @@ func (s *Store) Ack(ctx context.Context, consumerLoop, dedupKey string) error {
 	// and journaling it anyway would double-count throughput.
 	deleted, err := res.RowsAffected()
 	if err != nil {
-		return fmt.Errorf("loopqueue: ack %s/%s: %w", consumerLoop, dedupKey, err)
+		return "", fmt.Errorf("loopqueue: ack %s/%s: %w", consumerLoop, dedupKey, err)
 	}
 	if deleted == 0 {
-		return nil
+		return AckSuperseded, nil
 	}
 	if _, err := tx.ExecContext(ctx, `
 		INSERT INTO loop_queue_completions (consumer_loop, dedup_key, enqueued_at, acked_at)
 		VALUES (?, ?, ?, CURRENT_TIMESTAMP)
 	`, consumerLoop, dedupKey, enqueuedRaw); err != nil {
-		return fmt.Errorf("loopqueue: journal completion %s/%s: %w", consumerLoop, dedupKey, err)
+		return "", fmt.Errorf("loopqueue: journal completion %s/%s: %w", consumerLoop, dedupKey, err)
 	}
 	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("loopqueue: ack %s/%s: %w", consumerLoop, dedupKey, err)
+		return "", fmt.Errorf("loopqueue: ack %s/%s: %w", consumerLoop, dedupKey, err)
 	}
-	return nil
+	return Acked, nil
 }
 
 // HasRecentWork reports whether a key is pending or appears in the retained

--- a/internal/state/loopqueue/queue_store_test.go
+++ b/internal/state/loopqueue/queue_store_test.go
@@ -27,6 +27,26 @@ func newTestStore(t *testing.T) *Store {
 	return store
 }
 
+func ackPending(t *testing.T, store *Store, consumer, key string) int64 {
+	t.Helper()
+	items, err := store.PeekAll(t.Context(), consumer)
+	if err != nil {
+		t.Fatalf("peek before ack: %v", err)
+	}
+	for _, item := range items {
+		if item.DedupKey != key {
+			continue
+		}
+		outcome, err := store.Ack(t.Context(), consumer, key, item.Generation)
+		if err != nil || outcome != Acked {
+			t.Fatalf("ack %s/%s outcome=%q err=%v", consumer, key, outcome, err)
+		}
+		return item.Generation
+	}
+	t.Fatalf("pending item %s/%s not found", consumer, key)
+	return 0
+}
+
 func TestStore_EnqueuePeekAck(t *testing.T) {
 	s := newTestStore(t)
 
@@ -50,15 +70,52 @@ func TestStore_EnqueuePeekAck(t *testing.T) {
 		t.Errorf("enqueued_at not parsed")
 	}
 
-	if err := s.Ack(t.Context(), "archivist", "session:abc"); err != nil {
+	outcome, err := s.Ack(t.Context(), "archivist", "session:abc", items[0].Generation)
+	if err != nil || outcome != Acked {
 		t.Fatalf("ack: %v", err)
 	}
 	if n, _ := s.PendingCount(t.Context(), "archivist"); n != 0 {
 		t.Errorf("pending after ack = %d, want 0", n)
 	}
 	// Ack of a missing key is a no-op, not an error.
-	if err := s.Ack(t.Context(), "archivist", "session:gone"); err != nil {
+	if outcome, err := s.Ack(t.Context(), "archivist", "session:gone", 1); err != nil || outcome != AckMissing {
 		t.Errorf("ack missing: %v", err)
+	}
+}
+
+func TestStore_MigratesPendingRowsWithInitialGeneration(t *testing.T) {
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(`
+		CREATE TABLE loop_queue (
+			consumer_loop TEXT NOT NULL,
+			dedup_key TEXT NOT NULL,
+			priority INTEGER NOT NULL DEFAULT 0,
+			status TEXT NOT NULL DEFAULT 'pending',
+			attempts INTEGER NOT NULL DEFAULT 0,
+			payload TEXT NOT NULL DEFAULT '{}',
+			enqueued_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (consumer_loop, dedup_key)
+		);
+		INSERT INTO loop_queue (consumer_loop, dedup_key, payload)
+		VALUES ('archivist', 'contact:legacy', '{"legacy":true}')
+	`); err != nil {
+		t.Fatal(err)
+	}
+	store, err := NewStore(db, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	items, err := store.Peek(t.Context(), "archivist", 1)
+	if err != nil || len(items) != 1 {
+		t.Fatalf("peek migrated row: items=%#v err=%v", items, err)
+	}
+	if items[0].Generation != 1 {
+		t.Fatalf("legacy generation = %d, want 1", items[0].Generation)
 	}
 }
 
@@ -74,7 +131,11 @@ func TestStore_HasRecentWorkIncludesPendingAndCompletions(t *testing.T) {
 	if found, err := s.HasRecentWork(t.Context(), "archivist", "session:abc"); err != nil || !found {
 		t.Fatalf("pending found=%v err=%v", found, err)
 	}
-	if err := s.Ack(t.Context(), "archivist", "session:abc"); err != nil {
+	items, err := s.Peek(t.Context(), "archivist", 1)
+	if err != nil || len(items) != 1 {
+		t.Fatalf("peek before ack: items=%#v err=%v", items, err)
+	}
+	if outcome, err := s.Ack(t.Context(), "archivist", "session:abc", items[0].Generation); err != nil || outcome != Acked {
 		t.Fatalf("ack: %v", err)
 	}
 	if found, err := s.HasRecentWork(t.Context(), "archivist", "session:abc"); err != nil || !found {
@@ -190,6 +251,38 @@ func TestStore_CoalesceOnDedupKey(t *testing.T) {
 	}
 	if string(items[0].Payload) != `{"v":3}` {
 		t.Errorf("payload = %q, want latest {\"v\":3}", items[0].Payload)
+	}
+	if items[0].Generation != 3 {
+		t.Errorf("generation = %d, want 3", items[0].Generation)
+	}
+}
+
+func TestStore_StaleAckRetainsCoalescedGeneration(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	if err := s.Enqueue(ctx, "archivist", "contact:abc", 0, []byte(`{"v":1}`)); err != nil {
+		t.Fatal(err)
+	}
+	first, err := s.Peek(ctx, "archivist", 1)
+	if err != nil || len(first) != 1 {
+		t.Fatalf("first peek: items=%#v err=%v", first, err)
+	}
+	if err := s.Enqueue(ctx, "archivist", "contact:abc", 0, []byte(`{"v":2}`)); err != nil {
+		t.Fatal(err)
+	}
+	outcome, err := s.Ack(ctx, "archivist", "contact:abc", first[0].Generation)
+	if err != nil || outcome != AckSuperseded {
+		t.Fatalf("stale ack outcome=%q err=%v, want superseded", outcome, err)
+	}
+	current, err := s.Peek(ctx, "archivist", 1)
+	if err != nil || len(current) != 1 {
+		t.Fatalf("current peek: items=%#v err=%v", current, err)
+	}
+	if got := string(current[0].Payload); got != `{"v":2}` {
+		t.Fatalf("retained payload = %q, want latest", got)
+	}
+	if current[0].Generation == first[0].Generation {
+		t.Fatalf("generation did not advance: first=%d current=%d", first[0].Generation, current[0].Generation)
 	}
 }
 

--- a/internal/state/loopqueue/queue_store_test.go
+++ b/internal/state/loopqueue/queue_store_test.go
@@ -27,7 +27,7 @@ func newTestStore(t *testing.T) *Store {
 	return store
 }
 
-func ackPending(t *testing.T, store *Store, consumer, key string) int64 {
+func ackPending(t *testing.T, store *Store, consumer, key string) string {
 	t.Helper()
 	items, err := store.PeekAll(t.Context(), consumer)
 	if err != nil {
@@ -37,14 +37,14 @@ func ackPending(t *testing.T, store *Store, consumer, key string) int64 {
 		if item.DedupKey != key {
 			continue
 		}
-		outcome, err := store.Ack(t.Context(), consumer, key, item.Generation)
+		outcome, err := store.Ack(t.Context(), consumer, key, item.Receipt)
 		if err != nil || outcome != Acked {
 			t.Fatalf("ack %s/%s outcome=%q err=%v", consumer, key, outcome, err)
 		}
-		return item.Generation
+		return item.Receipt
 	}
 	t.Fatalf("pending item %s/%s not found", consumer, key)
-	return 0
+	return ""
 }
 
 func TestStore_EnqueuePeekAck(t *testing.T) {
@@ -70,7 +70,7 @@ func TestStore_EnqueuePeekAck(t *testing.T) {
 		t.Errorf("enqueued_at not parsed")
 	}
 
-	outcome, err := s.Ack(t.Context(), "archivist", "session:abc", items[0].Generation)
+	outcome, err := s.Ack(t.Context(), "archivist", "session:abc", items[0].Receipt)
 	if err != nil || outcome != Acked {
 		t.Fatalf("ack: %v", err)
 	}
@@ -78,12 +78,12 @@ func TestStore_EnqueuePeekAck(t *testing.T) {
 		t.Errorf("pending after ack = %d, want 0", n)
 	}
 	// Ack of a missing key is a no-op, not an error.
-	if outcome, err := s.Ack(t.Context(), "archivist", "session:gone", 1); err != nil || outcome != AckMissing {
+	if outcome, err := s.Ack(t.Context(), "archivist", "session:gone", "unused-receipt"); err != nil || outcome != AckMissing {
 		t.Errorf("ack missing: %v", err)
 	}
 }
 
-func TestStore_MigratesPendingRowsWithInitialGeneration(t *testing.T) {
+func TestStore_MigratesPendingRowsWithUniqueReceipts(t *testing.T) {
 	db, err := database.OpenMemory()
 	if err != nil {
 		t.Fatal(err)
@@ -114,8 +114,8 @@ func TestStore_MigratesPendingRowsWithInitialGeneration(t *testing.T) {
 	if err != nil || len(items) != 1 {
 		t.Fatalf("peek migrated row: items=%#v err=%v", items, err)
 	}
-	if items[0].Generation != 1 {
-		t.Fatalf("legacy generation = %d, want 1", items[0].Generation)
+	if items[0].Receipt == "" {
+		t.Fatal("legacy pending row did not receive a receipt")
 	}
 }
 
@@ -135,7 +135,7 @@ func TestStore_HasRecentWorkIncludesPendingAndCompletions(t *testing.T) {
 	if err != nil || len(items) != 1 {
 		t.Fatalf("peek before ack: items=%#v err=%v", items, err)
 	}
-	if outcome, err := s.Ack(t.Context(), "archivist", "session:abc", items[0].Generation); err != nil || outcome != Acked {
+	if outcome, err := s.Ack(t.Context(), "archivist", "session:abc", items[0].Receipt); err != nil || outcome != Acked {
 		t.Fatalf("ack: %v", err)
 	}
 	if found, err := s.HasRecentWork(t.Context(), "archivist", "session:abc"); err != nil || !found {
@@ -252,12 +252,12 @@ func TestStore_CoalesceOnDedupKey(t *testing.T) {
 	if string(items[0].Payload) != `{"v":3}` {
 		t.Errorf("payload = %q, want latest {\"v\":3}", items[0].Payload)
 	}
-	if items[0].Generation != 3 {
-		t.Errorf("generation = %d, want 3", items[0].Generation)
+	if items[0].Receipt == "" {
+		t.Error("coalesced item has an empty receipt")
 	}
 }
 
-func TestStore_StaleAckRetainsCoalescedGeneration(t *testing.T) {
+func TestStore_StaleAckRetainsCoalescedItem(t *testing.T) {
 	s := newTestStore(t)
 	ctx := t.Context()
 	if err := s.Enqueue(ctx, "archivist", "contact:abc", 0, []byte(`{"v":1}`)); err != nil {
@@ -270,7 +270,7 @@ func TestStore_StaleAckRetainsCoalescedGeneration(t *testing.T) {
 	if err := s.Enqueue(ctx, "archivist", "contact:abc", 0, []byte(`{"v":2}`)); err != nil {
 		t.Fatal(err)
 	}
-	outcome, err := s.Ack(ctx, "archivist", "contact:abc", first[0].Generation)
+	outcome, err := s.Ack(ctx, "archivist", "contact:abc", first[0].Receipt)
 	if err != nil || outcome != AckSuperseded {
 		t.Fatalf("stale ack outcome=%q err=%v, want superseded", outcome, err)
 	}
@@ -281,8 +281,37 @@ func TestStore_StaleAckRetainsCoalescedGeneration(t *testing.T) {
 	if got := string(current[0].Payload); got != `{"v":2}` {
 		t.Fatalf("retained payload = %q, want latest", got)
 	}
-	if current[0].Generation == first[0].Generation {
-		t.Fatalf("generation did not advance: first=%d current=%d", first[0].Generation, current[0].Generation)
+	if current[0].Receipt == first[0].Receipt {
+		t.Fatalf("receipt did not advance: %q", current[0].Receipt)
+	}
+}
+
+func TestStore_StaleAckCannotDeleteRecreatedKey(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	const key = "contact:recreated"
+	if err := s.Enqueue(ctx, "archivist", key, 0, []byte(`{"v":1}`)); err != nil {
+		t.Fatal(err)
+	}
+	first, err := s.Peek(ctx, "archivist", 1)
+	if err != nil || len(first) != 1 {
+		t.Fatalf("first peek: items=%#v err=%v", first, err)
+	}
+	if outcome, err := s.Ack(ctx, "archivist", key, first[0].Receipt); err != nil || outcome != Acked {
+		t.Fatalf("first ack outcome=%q err=%v", outcome, err)
+	}
+	if err := s.Enqueue(ctx, "archivist", key, 0, []byte(`{"v":2}`)); err != nil {
+		t.Fatal(err)
+	}
+	if outcome, err := s.Ack(ctx, "archivist", key, first[0].Receipt); err != nil || outcome != AckSuperseded {
+		t.Fatalf("delayed ack outcome=%q err=%v, want superseded", outcome, err)
+	}
+	current, err := s.Peek(ctx, "archivist", 1)
+	if err != nil || len(current) != 1 || string(current[0].Payload) != `{"v":2}` {
+		t.Fatalf("recreated item was not retained: items=%#v err=%v", current, err)
+	}
+	if current[0].Receipt == first[0].Receipt {
+		t.Fatalf("recreated key reused receipt %q", current[0].Receipt)
 	}
 }
 

--- a/internal/tools/contact_dossier_tool_test.go
+++ b/internal/tools/contact_dossier_tool_test.go
@@ -75,10 +75,12 @@ func TestContactDossierReadToolOwnsRefAndMakesAbsenceActionable(t *testing.T) {
 		t.Errorf("receipt scope = %q, want %q", got, want)
 	}
 	var decoded struct {
-		ContactID string `json:"contact_id"`
-		Dossier   struct {
-			Exists bool   `json:"exists"`
-			Ref    string `json:"ref"`
+		ContactID   string `json:"contact_id"`
+		ContactName string `json:"contact_name"`
+		Dossier     struct {
+			Exists   bool            `json:"exists"`
+			Ref      string          `json:"ref"`
+			Document json.RawMessage `json:"document"`
 		} `json:"dossier"`
 		NextAction struct {
 			Tool        string `json:"tool"`
@@ -91,6 +93,9 @@ func TestContactDossierReadToolOwnsRefAndMakesAbsenceActionable(t *testing.T) {
 	}
 	if decoded.ContactID != contact.ID.String() || decoded.Dossier.Exists || decoded.Dossier.Ref != contacts.DossierRef(contact.ID) {
 		t.Errorf("absence result = %#v", decoded)
+	}
+	if decoded.ContactName != contact.FormattedName || string(decoded.Dossier.Document) != "null" {
+		t.Errorf("absence envelope = %#v, want stable identity and null document", decoded)
 	}
 	if decoded.NextAction.Tool != "contact_dossier_write" || decoded.NextAction.ContactID != contact.ID.String() {
 		t.Errorf("next action = %#v, want exact dossier write", decoded.NextAction)
@@ -151,7 +156,7 @@ func TestContactDossierReadToolReturnsExistingDocumentPayload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	reader := &contactDossierReaderRecorder{result: `{"ref":"contacts:existing.md","content":"current"}`}
+	reader := &contactDossierReaderRecorder{result: `{"ref":"contacts:existing.md","body":"current","word_count":1}`}
 	contactTools := contacts.NewTools(store, nil)
 	contactTools.ConfigureDossierRoot(true, false)
 	contactTools.ConfigureDossierDocuments(reader.Read, nil)
@@ -164,8 +169,24 @@ func TestContactDossierReadToolReturnsExistingDocumentPayload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result != reader.result {
-		t.Fatalf("existing dossier result = %q, want %q", result, reader.result)
+	var decoded struct {
+		ContactID   string `json:"contact_id"`
+		ContactName string `json:"contact_name"`
+		Dossier     struct {
+			Exists   bool            `json:"exists"`
+			Ref      string          `json:"ref"`
+			Document json.RawMessage `json:"document"`
+		} `json:"dossier"`
+		NextAction json.RawMessage `json:"next_action"`
+	}
+	if err := json.Unmarshal([]byte(result), &decoded); err != nil {
+		t.Fatalf("decode existing result: %v", err)
+	}
+	if decoded.ContactID != contact.ID.String() || decoded.ContactName != contact.FormattedName || !decoded.Dossier.Exists || decoded.Dossier.Ref != contacts.DossierRef(contact.ID) {
+		t.Fatalf("existing dossier envelope = %#v", decoded)
+	}
+	if string(decoded.Dossier.Document) != reader.result || string(decoded.NextAction) != "null" {
+		t.Fatalf("existing dossier payload = %s next_action=%s", decoded.Dossier.Document, decoded.NextAction)
 	}
 }
 

--- a/internal/tools/contact_dossier_tool_test.go
+++ b/internal/tools/contact_dossier_tool_test.go
@@ -2,6 +2,8 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -15,9 +17,156 @@ type contactDossierWriterRecorder struct {
 	args documents.WriteArgs
 }
 
+type contactDossierReaderRecorder struct {
+	args   documents.RefArgs
+	result string
+	err    error
+}
+
+func (r *contactDossierReaderRecorder) Read(_ context.Context, args documents.RefArgs) (string, error) {
+	r.args = args
+	return r.result, r.err
+}
+
 func (w *contactDossierWriterRecorder) Write(_ context.Context, args documents.WriteArgs) (string, error) {
 	w.args = args
 	return `{"action":"doc_write","applied":true}`, nil
+}
+
+func TestContactDossierReadToolOwnsRefAndMakesAbsenceActionable(t *testing.T) {
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store, err := contacts.NewStore(db, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contact, err := store.Upsert(&contacts.Contact{FormattedName: "Dossier Person", Kind: "individual"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reader := &contactDossierReaderRecorder{err: fmt.Errorf("document not found: absent")}
+	writer := &contactDossierWriterRecorder{}
+	contactTools := contacts.NewTools(store, nil)
+	contactTools.ConfigureDossierRoot(true, true)
+	contactTools.ConfigureDossierDocuments(reader.Read, writer.Write)
+	registry := NewEmptyRegistry()
+	registry.SetContactTools(contactTools)
+
+	tool := registry.Get("contact_dossier_read")
+	if tool == nil {
+		t.Fatal("contact_dossier_read not registered for a managed dossier root")
+	}
+	if got, want := tool.Tags, []string{"contacts", "owner"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("tool tags = %#v, want %#v", got, want)
+	}
+	ctx := WithConversationID(WithLoopID(context.Background(), "archivist-1"), "loop-archivist-1-123")
+	result, err := tool.Handler(ctx, map[string]any{"contact_id": contact.ID.String()})
+	if err != nil {
+		t.Fatalf("absent contact_dossier_read returned an error: %v", err)
+	}
+	if got, want := reader.args.Ref, contacts.DossierRef(contact.ID); got != want {
+		t.Errorf("read ref = %q, want %q", got, want)
+	}
+	if got, want := reader.args.ReceiptScope, "loop:archivist-1/conversation:loop-archivist-1-123"; got != want {
+		t.Errorf("receipt scope = %q, want %q", got, want)
+	}
+	var decoded struct {
+		ContactID string `json:"contact_id"`
+		Dossier   struct {
+			Exists bool   `json:"exists"`
+			Ref    string `json:"ref"`
+		} `json:"dossier"`
+		NextAction struct {
+			Tool        string `json:"tool"`
+			ContactID   string `json:"contact_id"`
+			Instruction string `json:"instruction"`
+		} `json:"next_action"`
+	}
+	if err := json.Unmarshal([]byte(result), &decoded); err != nil {
+		t.Fatalf("decode absence result: %v", err)
+	}
+	if decoded.ContactID != contact.ID.String() || decoded.Dossier.Exists || decoded.Dossier.Ref != contacts.DossierRef(contact.ID) {
+		t.Errorf("absence result = %#v", decoded)
+	}
+	if decoded.NextAction.Tool != "contact_dossier_write" || decoded.NextAction.ContactID != contact.ID.String() {
+		t.Errorf("next action = %#v, want exact dossier write", decoded.NextAction)
+	}
+	if !strings.Contains(decoded.NextAction.Instruction, "do not retry") {
+		t.Errorf("next action instruction = %q, want retry guard", decoded.NextAction.Instruction)
+	}
+}
+
+func TestContactDossierReadToolRejectsMistypedContactBeforeDocumentRead(t *testing.T) {
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store, err := contacts.NewStore(db, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader := &contactDossierReaderRecorder{}
+	contactTools := contacts.NewTools(store, nil)
+	contactTools.ConfigureDossierRoot(true, false)
+	contactTools.ConfigureDossierDocuments(reader.Read, nil)
+	registry := NewEmptyRegistry()
+	registry.SetContactTools(contactTools)
+
+	tool := registry.Get("contact_dossier_read")
+	if tool == nil {
+		t.Fatal("read-only contact root did not advertise contact_dossier_read")
+	}
+	_, err = tool.Handler(context.Background(), map[string]any{
+		"contact_id": "019c76e4-2ff1-7918-8d6f-6c2488f5098d",
+	})
+	if err == nil {
+		t.Fatal("missing contact unexpectedly read a dossier")
+	}
+	for _, want := range []string{"not an active structured contact", "call contact_lookup", "instead of retrying"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("missing-contact error = %v, want %q", err, want)
+		}
+	}
+	if reader.args.Ref != "" {
+		t.Fatalf("missing contact reached document reader with %#v", reader.args)
+	}
+}
+
+func TestContactDossierReadToolReturnsExistingDocumentPayload(t *testing.T) {
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store, err := contacts.NewStore(db, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contact, err := store.Upsert(&contacts.Contact{FormattedName: "Existing Dossier", Kind: "individual"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader := &contactDossierReaderRecorder{result: `{"ref":"contacts:existing.md","content":"current"}`}
+	contactTools := contacts.NewTools(store, nil)
+	contactTools.ConfigureDossierRoot(true, false)
+	contactTools.ConfigureDossierDocuments(reader.Read, nil)
+	registry := NewEmptyRegistry()
+	registry.SetContactTools(contactTools)
+
+	result, err := registry.Get("contact_dossier_read").Handler(context.Background(), map[string]any{
+		"contact_id": contact.ID.String(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != reader.result {
+		t.Fatalf("existing dossier result = %q, want %q", result, reader.result)
+	}
 }
 
 func TestContactDossierWriteToolOwnsStructureAndRevisionScope(t *testing.T) {
@@ -36,9 +185,9 @@ func TestContactDossierWriteToolOwnsStructureAndRevisionScope(t *testing.T) {
 	}
 
 	writer := &contactDossierWriterRecorder{}
-	contactTools := contacts.NewTools(store)
+	contactTools := contacts.NewTools(store, nil)
 	contactTools.ConfigureDossierRoot(true, true)
-	contactTools.ConfigureDossierDocuments(writer.Write)
+	contactTools.ConfigureDossierDocuments(nil, writer.Write)
 	registry := NewEmptyRegistry()
 	registry.SetContactTools(contactTools)
 
@@ -103,9 +252,9 @@ func TestContactDossierWriteToolUnavailableWithoutManagedDocuments(t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
-	contactTools := contacts.NewTools(store)
+	contactTools := contacts.NewTools(store, nil)
 	contactTools.ConfigureDossierRoot(true, false)
-	contactTools.ConfigureDossierDocuments((&contactDossierWriterRecorder{}).Write)
+	contactTools.ConfigureDossierDocuments(nil, (&contactDossierWriterRecorder{}).Write)
 
 	registry := NewEmptyRegistry()
 	registry.SetContactTools(contactTools)
@@ -124,9 +273,9 @@ func TestContactDossierWriteToolRejectsEveryUnknownArgument(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	contactTools := contacts.NewTools(store)
+	contactTools := contacts.NewTools(store, nil)
 	contactTools.ConfigureDossierRoot(true, true)
-	contactTools.ConfigureDossierDocuments((&contactDossierWriterRecorder{}).Write)
+	contactTools.ConfigureDossierDocuments(nil, (&contactDossierWriterRecorder{}).Write)
 	registry := NewEmptyRegistry()
 	registry.SetContactTools(contactTools)
 

--- a/internal/tools/contact_save_provenance_test.go
+++ b/internal/tools/contact_save_provenance_test.go
@@ -1,0 +1,69 @@
+package tools
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
+	"github.com/nugget/thane-ai-agent/internal/state/contacts"
+)
+
+func TestContactSaveToolStampsCurrentTurnProvenance(t *testing.T) {
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store, err := contacts.NewStore(db, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var mutation contacts.ContactMutation
+	contactTools := contacts.NewTools(store, func(_ context.Context, got contacts.ContactMutation) error {
+		mutation = got
+		return nil
+	})
+	registry := NewEmptyRegistry()
+	registry.SetContactTools(contactTools)
+
+	ctx := context.Background()
+	ctx = WithModel(ctx, "test-model")
+	ctx = WithLoopID(ctx, "loop-archivist-1")
+	ctx = WithConversationID(ctx, "loop-archivist-1-123")
+	ctx = WithSessionID(ctx, "session-1")
+	ctx = WithRequestID(ctx, "request-1")
+	ctx = WithToolCallID(ctx, "tool-call-1")
+	ctx = WithIterationIndex(ctx, 2)
+	if _, err := registry.Get("contact_save").Handler(ctx, map[string]any{
+		"name": "Turn Provenance",
+		"kind": "individual",
+		"facts": map[string]any{
+			"email": "turn@example.com",
+		},
+	}); err != nil {
+		t.Fatalf("contact_save handler: %v", err)
+	}
+
+	iteration := 2
+	want := &contacts.PropertyProvenance{
+		Source:         "contact_save",
+		Model:          "test-model",
+		LoopID:         "loop-archivist-1",
+		ConversationID: "loop-archivist-1-123",
+		SessionID:      "session-1",
+		RequestID:      "request-1",
+		ToolCallID:     "tool-call-1",
+		Iteration:      &iteration,
+	}
+	if !reflect.DeepEqual(mutation.Provenance, want) {
+		t.Fatalf("mutation provenance = %#v, want %#v", mutation.Provenance, want)
+	}
+	properties, err := store.GetProperties(mutation.ContactID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(properties) != 1 || !reflect.DeepEqual(properties[0].Provenance, want) {
+		t.Fatalf("stored property provenance = %#v, want %#v", properties, want)
+	}
+}

--- a/internal/tools/contact_save_provenance_test.go
+++ b/internal/tools/contact_save_provenance_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
@@ -65,5 +66,29 @@ func TestContactSaveToolStampsCurrentTurnProvenance(t *testing.T) {
 	}
 	if len(properties) != 1 || !reflect.DeepEqual(properties[0].Provenance, want) {
 		t.Fatalf("stored property provenance = %#v, want %#v", properties, want)
+	}
+}
+
+func TestContactSaveDescriptionReflectsArchivistRefreshWiring(t *testing.T) {
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store, err := contacts.NewStore(db, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	withoutRefresh := NewEmptyRegistry()
+	withoutRefresh.SetContactTools(contacts.NewTools(store, nil))
+	if description := withoutRefresh.Get("contact_save").Description; !strings.Contains(description, "No archivist refresh consumer is enabled") || strings.Contains(description, "A committed change is queued once") {
+		t.Fatalf("unwired contact_save description = %q", description)
+	}
+
+	withRefresh := NewEmptyRegistry()
+	withRefresh.SetContactTools(contacts.NewTools(store, func(context.Context, contacts.ContactMutation) error { return nil }))
+	if description := withRefresh.Get("contact_save").Description; !strings.Contains(description, "A committed change is queued once") || strings.Contains(description, "No archivist refresh consumer is enabled") {
+		t.Fatalf("wired contact_save description = %q", description)
 	}
 }

--- a/internal/tools/contact_tools.go
+++ b/internal/tools/contact_tools.go
@@ -24,7 +24,7 @@ func (r *Registry) registerContactTools() {
 
 	r.Register(&Tool{
 		Name:        "contact_save",
-		Description: "Store or update structured identity for a person, organization, or group. Properties should be compact personal attributes such as communication coordinates, aliases, roles, and stable preferences. Standard contact info (email, phone) is mapped to vCard property names automatically. Use origin_tags and origin_context_refs only to shape future sessions when this contact is the runtime origin. Evolving person-specific relationship or collaboration synthesis belongs in contact_dossier_write when available; project knowledge, technical decisions, and other non-person knowledge belong in remember_fact or documents. When updating an existing contact, only non-empty scalar fields are overwritten; facts are additive. origin_tags and origin_context_refs are replaced when provided, and an empty array clears that origin policy field.",
+		Description: "Store or update structured identity for a person, organization, or group. Properties should be compact personal attributes such as communication coordinates, aliases, roles, and stable preferences. Standard contact info (email, phone) is mapped to vCard property names automatically. Use origin_tags and origin_context_refs only to shape future sessions when this contact is the runtime origin. Evolving person-specific relationship or collaboration synthesis belongs in contact_dossier_write when available; project knowledge, technical decisions, and other non-person knowledge belong in remember_fact or documents. When updating an existing contact, only non-empty scalar fields are overwritten; facts are additive. origin_tags and origin_context_refs are replaced when provided, and an empty array clears that origin policy field. A committed change is queued once for later archivist dossier reconsideration; an identical no-op is not, so do not duplicate structured identity into dossier prose.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -92,15 +92,16 @@ func (r *Registry) registerContactTools() {
 			if err != nil {
 				return "", fmt.Errorf("failed to serialize arguments: %w", err)
 			}
-			return r.contactTools.SaveContact(string(argsJSON))
+			return r.contactTools.SaveContactFromModel(ctx, string(argsJSON), contactPropertyProvenance(ctx))
 		},
 	})
 
+	registerContactDossierReadTool(r, r.contactTools)
 	registerContactDossierWriteTool(r, r.contactTools)
 
 	r.Register(&Tool{
 		Name:        "contact_lookup",
-		Description: "Look up contacts from the directory. Search by name, query, kind, or property key/value. An exact name result includes the canonical contact UUID and optional contacts:<uuid>.md dossier ref when the dossier root is configured; use doc_read to inspect the dossier and contact_dossier_write to create or replace it when that tool is available. Dossier prose is not structured identity authority. With no arguments, returns directory statistics.",
+		Description: "Look up contacts from the directory. Search by name, query, kind, or property key/value. An exact rich result includes the canonical contact UUID and, when configured, an exact contact_dossier_read call that safely probes the canonical dossier without constructing a document ref. Dossier prose is not structured identity authority. With no arguments, returns directory statistics.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -138,7 +139,7 @@ func (r *Registry) registerContactTools() {
 
 	r.Register(&Tool{
 		Name:        "contact_owner",
-		Description: "Return the primary operator contact record with rich details and contact properties, its canonical UUID and optional contacts:<uuid>.md dossier ref, plus a structured summary of currently active operator-scoped channels. Use doc_read to inspect the dossier and contact_dossier_write to create or replace it when available; its prose is longitudinal synthesis, while this contact record remains authoritative for structured identity and bindings. Uses identity.operator_contact_id when configured; otherwise supports the legacy name selector and finally the sole admin contact if exactly one exists.",
+		Description: "Return the primary operator contact record with rich details and contact properties, its canonical UUID and canonical dossier trailhead when configured, plus a structured summary of currently active operator-scoped channels. Use contact_dossier_read to inspect or discover an absent dossier; its prose is longitudinal synthesis, while this contact record remains authoritative for structured identity and bindings. Uses identity.operator_contact_id when configured; otherwise supports the legacy name selector and finally the sole admin contact if exactly one exists.",
 		Parameters: map[string]any{
 			"type":       "object",
 			"properties": map[string]any{},
@@ -320,6 +321,51 @@ func (r *Registry) registerContactTools() {
 	})
 }
 
+func contactPropertyProvenance(ctx context.Context) *contacts.PropertyProvenance {
+	provenance := &contacts.PropertyProvenance{
+		Source:         "contact_save",
+		Model:          strings.TrimSpace(ModelFromContext(ctx)),
+		LoopID:         strings.TrimSpace(LoopIDFromContext(ctx)),
+		ConversationID: strings.TrimSpace(ConversationIDFromContext(ctx)),
+		SessionID:      strings.TrimSpace(SessionIDFromContext(ctx)),
+		RequestID:      strings.TrimSpace(RequestIDFromContext(ctx)),
+		ToolCallID:     strings.TrimSpace(ToolCallIDFromContext(ctx)),
+	}
+	if provenance.ConversationID == "default" {
+		provenance.ConversationID = ""
+	}
+	if iteration, ok := IterationIndexFromContext(ctx); ok {
+		provenance.Iteration = &iteration
+	}
+	return provenance
+}
+
+func registerContactDossierReadTool(r *Registry, contactTools *contacts.Tools) {
+	if contactTools == nil || !contactTools.DossierReadsEnabled() {
+		return
+	}
+	r.Register(&Tool{
+		Name:        "contact_dossier_read",
+		Description: "Read or probe one contact's canonical longitudinal dossier. Pass only the canonical contact UUID returned by contact_lookup or contact_owner; Go derives and validates the document ref and records the revision receipt needed for a safe later contact_dossier_write. A contact with no dossier is a successful result that says exactly how to create it. Do not retry an absent dossier read until a write succeeds, and never manually construct contacts:<uuid>.md for doc_read.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"contact_id": map[string]any{
+					"type":        "string",
+					"description": "Canonical contact UUID returned by contact_lookup or contact_owner. Go derives the dossier ref.",
+				},
+			},
+			"required": []string{"contact_id"},
+		},
+		Handler: func(ctx context.Context, args map[string]any) (string, error) {
+			return contactTools.ReadDossier(ctx, contacts.DossierReadArgs{
+				ContactID:    stringArg(args, "contact_id"),
+				ReceiptScope: documentRevisionScope(ctx),
+			})
+		},
+	})
+}
+
 func registerContactDossierWriteTool(r *Registry, contactTools *contacts.Tools) {
 	if contactTools == nil || !contactTools.DossierWritesEnabled() {
 		return
@@ -356,7 +402,7 @@ func registerContactDossierWriteTool(r *Registry, contactTools *contacts.Tools) 
 
 	r.Register(&Tool{
 		Name:               "contact_dossier_write",
-		Description:        "Create or replace one contact's canonical longitudinal dossier. Pass the canonical contact UUID only as contact_id; do not repeat it or its derived contacts ref or contact tag in any content projection. Omit the contact's canonical name from status_line and teaser because the structured record and dossier title already identify the subject; digest and full may use it when standalone prose needs it. Go verifies the structured contact and owns the document ref, private contact tag, frontmatter, section headings, and ordering. Use this for evolving relationship context, preferences, recurring themes, and evidence synthesis—not structured identity, trust, Home Assistant bindings, or companion attribution. Archive-session evidence must cite the full canonical session UUID so every claim remains checkable. Every projection is validated together and every violation is returned in one error. Read an existing dossier with doc_read before replacing it so Thane can protect against intervening writes.",
+		Description:        "Create or replace one contact's canonical longitudinal dossier. Pass the canonical contact UUID only as contact_id; do not repeat it or its derived contacts ref or contact tag in any content projection. Omit the contact's canonical name from status_line and teaser because the structured record and dossier title already identify the subject; digest and full may use it when standalone prose needs it. Go verifies the structured contact and owns the document ref, private contact tag, frontmatter, section headings, and ordering. Use this for evolving relationship context, preferences, recurring themes, and evidence synthesis—not structured identity, trust, Home Assistant bindings, or companion attribution. Archive-session evidence must cite the full canonical session UUID so every claim remains checkable. Every projection is validated together and every violation is returned in one error. Call contact_dossier_read first: it reads an existing dossier with revision protection or returns a successful, actionable absence result.",
 		SkipContentResolve: true,
 		Parameters: map[string]any{
 			"type":       "object",

--- a/internal/tools/contact_tools.go
+++ b/internal/tools/contact_tools.go
@@ -21,10 +21,16 @@ func (r *Registry) registerContactTools() {
 	if r.contactTools == nil {
 		return
 	}
+	saveDescription := "Store or update structured identity for a person, organization, or group. Properties should be compact personal attributes such as communication coordinates, aliases, roles, and stable preferences. Standard contact info (email, phone) is mapped to vCard property names automatically. Use origin_tags and origin_context_refs only to shape future sessions when this contact is the runtime origin. Evolving person-specific relationship or collaboration synthesis belongs in contact_dossier_write when available; project knowledge, technical decisions, and other non-person knowledge belong in remember_fact or documents. When updating an existing contact, only non-empty scalar fields are overwritten; facts are additive. origin_tags and origin_context_refs are replaced when provided, and an empty array clears that origin policy field."
+	if r.contactTools.ContactRefreshesEnabled() {
+		saveDescription += " A committed change is queued once for later archivist dossier reconsideration; an identical no-op is not, so do not duplicate structured identity into dossier prose."
+	} else {
+		saveDescription += " No archivist refresh consumer is enabled in this runtime, so committed changes are not queued for dossier reconsideration; do not duplicate structured identity into dossier prose."
+	}
 
 	r.Register(&Tool{
 		Name:        "contact_save",
-		Description: "Store or update structured identity for a person, organization, or group. Properties should be compact personal attributes such as communication coordinates, aliases, roles, and stable preferences. Standard contact info (email, phone) is mapped to vCard property names automatically. Use origin_tags and origin_context_refs only to shape future sessions when this contact is the runtime origin. Evolving person-specific relationship or collaboration synthesis belongs in contact_dossier_write when available; project knowledge, technical decisions, and other non-person knowledge belong in remember_fact or documents. When updating an existing contact, only non-empty scalar fields are overwritten; facts are additive. origin_tags and origin_context_refs are replaced when provided, and an empty array clears that origin policy field. A committed change is queued once for later archivist dossier reconsideration; an identical no-op is not, so do not duplicate structured identity into dossier prose.",
+		Description: saveDescription,
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{

--- a/internal/tools/contact_tools.go
+++ b/internal/tools/contact_tools.go
@@ -346,7 +346,7 @@ func registerContactDossierReadTool(r *Registry, contactTools *contacts.Tools) {
 	}
 	r.Register(&Tool{
 		Name:        "contact_dossier_read",
-		Description: "Read or probe one contact's canonical longitudinal dossier. Pass only the canonical contact UUID returned by contact_lookup or contact_owner; Go derives and validates the document ref and records the revision receipt needed for a safe later contact_dossier_write. A contact with no dossier is a successful result that says exactly how to create it. Do not retry an absent dossier read until a write succeeds, and never manually construct contacts:<uuid>.md for doc_read.",
+		Description: "Read or probe one contact's canonical longitudinal dossier. Pass only the canonical contact UUID returned by contact_lookup or contact_owner; Go derives and validates the document ref and records the revision receipt needed for a safe later contact_dossier_write. Every success has the same envelope: dossier.exists is authoritative, dossier.ref is canonical, dossier.document contains the document payload or null, and next_action is null unless absence requires guidance. Do not retry an absent dossier read until a write succeeds, and never manually construct contacts:<uuid>.md for doc_read.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{

--- a/loops/archivist.md
+++ b/loops/archivist.md
@@ -148,8 +148,9 @@ durable queue holds that).
      that UUID; Go derives the canonical ref so never transcribe or construct
      `contacts:<uuid>.md` for `doc_read`. An absent dossier is a successful,
      actionable result: create it once with `contact_dossier_write` and do not
-     retry the unchanged read. For an existing dossier, inspect the response's
-     `truncated` marker. A truncated read is not the whole dossier: use the
+     retry the unchanged read. The response shape is stable in both cases:
+     trust `dossier.exists`, and for an existing dossier inspect
+     `dossier.document.truncated`. A truncated read is not the whole dossier: use the
      returned canonical ref with `doc_outline`, verify that outline is not
      truncated, then recover every top-level section with `doc_section`. If a
      section result is also truncated, descend through its child headings;
@@ -185,6 +186,9 @@ durable queue holds that).
    complete when it failed. When an external prerequisite or incomplete read
    blocks safe completion, call `queue_defer` instead: the item stays durable
    but moves behind all work currently ready to proceed.
+   Go retains the hidden generation receipt from `queue_pull`. If newer
+   evidence for the same subject arrives while you work, a stale ack returns
+   `retained_newer` and leaves that newer generation queued for a later pull.
    Acking means "I am done with this item," not "I created a dossier": a
    session with nothing worth folding is still acked. Unacked items return
    every iteration forever and starve the queue (an empty item at the head

--- a/loops/archivist.md
+++ b/loops/archivist.md
@@ -132,6 +132,10 @@ durable queue holds that).
      the documents tools to read any existing dossier and adjacent KB
      content. Record every alias you discover in the dossier's Aliases
      section so future passes don't re-derive them.
+     A `contact:<uuid>` item from `contact_save` names the exact current
+     contact and changed structured fields in its summary: resolve that exact
+     name with `contact_lookup`, use the UUID from the subject for
+     `contact_dossier_read`, and treat the fresh directory record as authority.
 3. **Write each dossier through its owning surface.** Every claim carries an
    evidence citation — an archive session ID, a fact category+key, a document
    ref, or a working-memory conversation ID — so a reader can check it.
@@ -140,15 +144,18 @@ durable queue holds that).
    can share a prefix, turning a shortened durable citation into an ambiguous
    one that cannot be checked later.
    - A contact is the contract-owned exception. Resolve an active structured
-     contact and use its exact canonical UUID. Read the current
-     `contacts:<uuid>.md` with `doc_read` when it exists and inspect the
-     response's `truncated` marker. A truncated read is not the whole dossier:
-     call `doc_outline`, verify that outline is not truncated, then recover
-     every top-level section with `doc_section`. If a section result is also
-     truncated, descend through its child headings; never replace the dossier
-     until every content-bearing leaf was returned without truncation. If the
-     outline or a leaf remains truncated, call `queue_defer` rather than
-     overwriting claims you could not read.
+     contact and use its exact canonical UUID. Call `contact_dossier_read` with
+     that UUID; Go derives the canonical ref so never transcribe or construct
+     `contacts:<uuid>.md` for `doc_read`. An absent dossier is a successful,
+     actionable result: create it once with `contact_dossier_write` and do not
+     retry the unchanged read. For an existing dossier, inspect the response's
+     `truncated` marker. A truncated read is not the whole dossier: use the
+     returned canonical ref with `doc_outline`, verify that outline is not
+     truncated, then recover every top-level section with `doc_section`. If a
+     section result is also truncated, descend through its child headings;
+     never replace the dossier until every content-bearing leaf was returned
+     without truncation. If the outline or a leaf remains truncated, call
+     `queue_defer` rather than overwriting claims you could not read.
      Reconcile the new evidence with the complete dossier, then call
      `contact_dossier_write` with the complete status-line, teaser, digest, and
      full projections. Go owns the ref, private subject tag, frontmatter,

--- a/loops/archivist.md
+++ b/loops/archivist.md
@@ -186,9 +186,9 @@ durable queue holds that).
    complete when it failed. When an external prerequisite or incomplete read
    blocks safe completion, call `queue_defer` instead: the item stays durable
    but moves behind all work currently ready to proceed.
-   Go retains the hidden generation receipt from `queue_pull`. If newer
-   evidence for the same subject arrives while you work, a stale ack returns
-   `retained_newer` and leaves that newer generation queued for a later pull.
+   Go retains a hidden one-shot receipt from `queue_pull`. If newer evidence
+   for the same subject arrives while you work, a stale ack returns
+   `retained_newer` and leaves that newer item queued for a later pull.
    Acking means "I am done with this item," not "I created a dossier": a
    session with nothing worth folding is still acked. Unacked items return
    every iteration forever and starve the queue (an empty item at the head

--- a/talents/contacts.md
+++ b/talents/contacts.md
@@ -26,7 +26,7 @@ often reaches for one when the right answer is another:
 | You want to store / find... | Surface |
 |---|---|
 | "Frank prefers Signal" / "Alice is Engineering Lead at X" / "Bob's home address" | `contacts` (`contact_save` with `facts` or `note`) — structured person data |
-| "How Frank and I work together" / evolving preferences, themes, or relationship synthesis | `contacts` (`contact_dossier_write`) — longitudinal dossier prose |
+| "How Frank and I work together" / evolving preferences, themes, or relationship synthesis | `contacts` (`contact_dossier_read`, then `contact_dossier_write`) — longitudinal dossier prose |
 | "Who operates this host" | `contacts` (`contact_owner`) — this leaf |
 | "Sump pump runs Tuesdays" / "Garage door takes 23s to close" — stable, compact, *non-person* facts | `memory` (`remember_fact`) — see [`memory.md`](memory.md) |
 | "The VLAN renumber plan landed on 2026-04-22" / a project decision / design rationale | `documents` (`kb:`, `core:`) or workspace files — NOT memory, NOT contacts |
@@ -49,9 +49,11 @@ ordinary documents instead.
   and is deliberately outside these everyday mutation tools.
 
 - **You're maintaining evolving relationship understanding** — use
-  `contact_dossier_write` when the managed `contacts` document root makes
-  it available. Resolve the contact first; the tool takes its canonical UUID
-  and the four content projections, while Go owns document identity and shape.
+  `contact_dossier_read`, then `contact_dossier_write` when the managed
+  `contacts` document root makes them available. Resolve the contact first;
+  both tools take its canonical UUID while Go owns document identity and shape.
+  A read of an absent dossier succeeds with the exact create action, so do not
+  retry the same read or guess a `contacts:` ref.
 
 - **You're exchanging vCard data** — activate `contacts_vcf`. Import
   from external sources, export records for sharing (with trust-zone-
@@ -81,6 +83,12 @@ ordinary documents instead.
   tombstone. Lookup before forgetting; the cost of removing the wrong
   record is real.
 
+- **A real save queues synthesis once.** A committed model-authored change
+  records turn provenance on the property rows it adds or replaces and
+  coalesces one `contact:<uuid>` archivist item. Rejected, rolled-back, and
+  identical no-op calls do neither. The later dossier pass is for synthesis,
+  not a reason to copy directory fields into prose during the save turn.
+
 - **The operator is a contact too.** The host's primary operator lives in
   the same table as everyone else, marked by the stable
   `identity.operator_contact_id` config, the legacy name selector, or
@@ -89,16 +97,17 @@ ordinary documents instead.
   rather than guessing from message senders or workspace metadata.
 
 - **Dossier prose is synthesis, never structured authority.** Read the
-  `contacts:<uuid>.md` trailhead with `doc_read`; create or replace it with
-  `contact_dossier_write`. Do not use generic document mutations for ordinary
-  dossier authoring. The ref and frontmatter already establish which contact the
-  document describes, so pass the UUID only as the contact ID argument: never
-  repeat the subject's UUID, derived ref, or private tag in the projections, and
-  do not add a `Subject` section that merely copies directory fields. Omit the
-  contact's canonical name from the status line and teaser because the dossier
-  title already supplies it; digest and full may use the name where standalone
-  prose needs it. Do not encode trust, Home Assistant bindings, or companion
-  attribution as if prose changed those sources of truth.
+  canonical dossier with `contact_dossier_read`; create or replace it with
+  `contact_dossier_write`. Do not construct `contacts:<uuid>.md` for `doc_read`
+  or use generic document mutations for ordinary dossier authoring. The ref and
+  frontmatter already establish which contact the document describes, so pass
+  the UUID only as the contact ID argument: never repeat the subject's UUID,
+  derived ref, or private tag in the projections, and do not add a `Subject`
+  section that merely copies directory fields. Omit the contact's canonical
+  name from the status line and teaser because the dossier title already
+  supplies it; digest and full may use the name where standalone prose needs
+  it. Do not encode trust, Home Assistant bindings, or companion attribution as
+  if prose changed those sources of truth.
 
 ## Cross-references
 
@@ -114,8 +123,9 @@ ordinary documents instead.
 - For "what did this person and I last discuss" beyond what's in the
   contact note, bounce to `archive_text` scoped to a conversation.
 - For a durable synthesis of how the relationship is evolving, resolve the
-  person here and call `contact_dossier_write`; use the archive as evidence,
-  not as the final home of the synthesis.
+  person here, call `contact_dossier_read`, and then call
+  `contact_dossier_write` when the synthesis changes; use the archive as
+  evidence, not as the final home of the synthesis.
 - For project knowledge, technical decisions, or persistent facts that
   aren't person-shaped, `memory` (`remember_fact`) is the right home;
   don't pollute contact notes with non-person content.
@@ -382,8 +392,9 @@ within the tool surface.
   is a person record," that's a smell that you actually want
   `memory` (`remember_fact`) instead.
 - For relationship patterns or evolving context that are genuinely about the
-  person, resolve the canonical UUID and use `contact_dossier_write` rather
-  than expanding `note`, `ai_summary`, or `facts` into a document.
+  person, resolve the canonical UUID and use `contact_dossier_read` followed by
+  `contact_dossier_write` rather than expanding `note`, `ai_summary`, or
+  `facts` into a document.
 
 ---
 name: contacts_vcf

--- a/talents/contacts.md
+++ b/talents/contacts.md
@@ -49,7 +49,8 @@ ordinary documents instead.
   and is deliberately outside these everyday mutation tools.
 
 - **You're maintaining evolving relationship understanding** — use
-  `contact_dossier_read`, then `contact_dossier_write` when the managed
+  `contact_dossier_read`, trust its stable `dossier.exists` field, then use
+  `contact_dossier_write` when the managed
   `contacts` document root makes them available. Resolve the contact first;
   both tools take its canonical UUID while Go owns document identity and shape.
   A read of an absent dossier succeeds with the exact create action, so do not

--- a/talents/documents.md
+++ b/talents/documents.md
@@ -318,7 +318,8 @@ Three tools, each owning a different mutation shape.
 The default way to make an ordinary document exist. A contract-owned document
 uses the structured tool that names it: `contact_dossier_write` for a contact
 dossier, or a generated `publish_output_*` / `replace_output_*` tool for a loop
-output. Probe a contact dossier with `contact_dossier_read` first; an absent
+output. Probe a contact dossier with `contact_dossier_read` first and branch on
+its stable `dossier.exists` field; an absent
 result is successful and names the exact create action, so never guess its ref
 for `doc_read`. For ordinary corpus knowledge, one `doc_create` call
 collision-checks related documents, title/tags/path normalization, and root

--- a/talents/documents.md
+++ b/talents/documents.md
@@ -318,9 +318,11 @@ Three tools, each owning a different mutation shape.
 The default way to make an ordinary document exist. A contract-owned document
 uses the structured tool that names it: `contact_dossier_write` for a contact
 dossier, or a generated `publish_output_*` / `replace_output_*` tool for a loop
-output. For ordinary corpus knowledge, one `doc_create` call collision-checks
-related documents, title/tags/path normalization, and root policy, then writes
-when placement is clean:
+output. Probe a contact dossier with `contact_dossier_read` first; an absent
+result is successful and names the exact create action, so never guess its ref
+for `doc_read`. For ordinary corpus knowledge, one `doc_create` call
+collision-checks related documents, title/tags/path normalization, and root
+policy, then writes when placement is clean:
 
 ```json
 {


### PR DESCRIPTION
## Summary

- Persist nullable model-turn provenance on structured contact properties, while keeping legacy, CardDAV, vCard, and native API authorship explicitly unknown.
- Make `contact_save` transactional and no-op aware, then enqueue one coalesced `contact:<uuid>` archivist refresh only after a committed authoritative change.
- Add `contact_dossier_read`, which derives the canonical ref in Go, preserves revision protection, and returns a successful exact next action when the dossier does not exist.
- Teach contact lookup, the archivist loop, talents, and reference docs to use the canonical read/write pair instead of manually transcribing dossier refs.

## Why

Issue #1482 needs structured contact properties to carry auditable model-turn authorship and successful authority writes to refresh longitudinal synthesis without waking the archivist.

Production request `r_b5f1892cbe3c5bce` exposed the adjacent ergonomics gap: lookup found the right contact, but an absent dossier and manually copied UUID/ref led the model through repeated failed `doc_read` calls. Absence should be an ordinary state with one clear create path.

## User impact

- Property authorship can be traced to its model, loop, conversation/session, request, tool call, and iteration when those identifiers are present.
- Rejected, rolled-back, and identical contact saves do not generate false dossier work; repeated real changes coalesce by contact.
- A contact with no dossier no longer looks like a broken document read, and mistyped or inactive UUIDs route the model back to contact lookup.
- Structured identity, trust zones, Home Assistant bindings, companion attribution, CardDAV, and vCard remain outside dossier prose and retain their existing authority boundaries.

## Test plan

- [x] `just ci`
- [x] Provenance round-trip and legacy-null migration coverage
- [x] Transaction rollback, rejected write, and no-op signal coverage
- [x] Deduplicated archivist queue coverage without `observed_at`
- [x] Existing, absent, and mistyped contact dossier read coverage
- [x] Existing CardDAV, vCard, API, tool-catalog, and shipped-loop parity suites

Closes #1482