### PR TITLE
feat: unify faceted document publishing

### DIFF
--- a/docs/model-facing-tools.md
+++ b/docs/model-facing-tools.md
@@ -200,6 +200,28 @@ When writing back to upstream systems:
 This keeps the model-friendly layer separate from the machine-authority
 layer.
 
+### Structured document owners stay explicit
+
+Faceted documents are a content shape, not a root-specific feature. A document
+read or search result must name both the projections it offers and the exact
+`write_tool` that owns its next mutation. Models should not infer ownership
+from a root, path, or familiar heading.
+
+`doc_write` is the normal logical writer for a managed document without a
+narrower domain owner. It takes status-line, optional teaser/digest, and full
+content as separate fields, validates the complete projection set, and renders
+the private Markdown codec in Go. Once a projection exists, later writes require
+it so a compact view cannot silently remain stale. A narrower tool such as
+`contact_dossier_write` or `publish_output_<name>` stamps its own ownership;
+generic writers and body-only mutators must reject that target and name the
+owning tool without changing content. `doc_body_write` is the explicit exception
+for a genuinely undifferentiated Markdown body; it is not a storage bypass.
+
+Keep the validation at the document-store boundary as well as the tool
+boundary. Tool routing makes the model experience smooth; the store backstop
+ensures another internal caller cannot write an over-budget or malformed facet
+envelope into any root.
+
 ### Runtime-scoped tools stay runtime-scoped
 
 Some tools exist only because a specific loop run declared a narrow
@@ -296,7 +318,8 @@ Bad:
 Better:
 
 - `file_read(path="/home/thane/config.yaml")`
-- `file_read(path="kb:reference/architecture.md")`
+- `doc_read(ref="kb:reference/architecture.md")` for an indexed managed root
+- `file_read(path="thanecode:README.md")` for a non-indexed repository root
 - `ha_automation_get(entity_id="automation.low_battery_warning")`
 
 ## Delegate-Specific Guidance

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -217,45 +217,50 @@ absolute timestamps. Timestamp filter inputs still accept RFC3339 values
 or signed deltas like `-604800s`.
 
 On writable git-backed roots, Thane retains a hidden read receipt for each
-loop/conversation and document ref. `doc_write`, `doc_edit`, and
-`doc_journal_update` use that receipt automatically; revision hashes are not
-part of their model-facing contract. If the document changed after the read,
-the mutation returns `applied: false` without replacing newer content and
-includes a bounded `changed_since_read` patch. The receipt then advances to the
-current document so a reconciled retry has the right comparison base. When a
-patch is unavailable or truncated, the result includes a bounded current
-excerpt instead. Replacing an existing whole body requires reading it first;
-structured edits can safely derive a fresh base as part of the operation.
+loop/conversation and document ref. `doc_write`, `doc_body_write`, `doc_edit`,
+and `doc_journal_update` use that receipt automatically;
+revision hashes are not part of their model-facing contract. If the document
+changed after the read, the mutation returns `applied: false` without replacing
+newer content and includes a bounded `changed_since_read` patch. The receipt
+then advances to the current document so a reconciled retry has the right
+comparison base. When a patch is unavailable or truncated, the result includes
+a bounded current excerpt instead. Replacing an existing whole body requires
+reading it first; structured edits can safely derive a fresh base as part of
+the operation.
 
 | Tool | Description |
 |------|-------------|
 | `doc_roots` | List configured document roots with policy, health, and counts. |
-| `doc_browse` | Walk a document root by folder. |
+| `doc_browse` | Walk a document root by folder; document rows include their exact `write_tool`. |
 | `doc_outline` | Emit the heading/section outline for a document. |
-| `doc_read` | Read a document by prefixed path; on writable git-backed roots, also retain a hidden comparison base for this loop/conversation. |
+| `doc_read` | Read a document by prefixed path, including faceting, available levels, and exact `write_tool`; on writable git-backed roots, also retain a hidden comparison base for this loop/conversation. |
 | `doc_section` | Retrieve a named section from a document. |
-| `doc_search` | Full-text and tagged search across roots. |
+| `doc_search` | Full-text and tagged search across roots; hits advertise facets and exact `write_tool`. |
 | `doc_links` | List inbound/outbound links for a document. |
 | `doc_values` | List frontmatter values (tags, statuses, etc.) across a root. |
-| `doc_create` | Create a new ordinary document safely: corpus collision check + normalized placement + write in one call; contract-owned documents use their dedicated structured tool. |
+| `doc_create` | Create a normal faceted document safely: corpus collision check + normalized placement + logical write in one call. |
 | `doc_intake` | Analyze proposed knowledge against the existing corpus before writing it (the deliberate two-step form of `doc_create`). |
-| `doc_commit` | Commit an approved `doc_intake`/declined `doc_create` result through managed mutations. |
-| `doc_write` | Replace an ordinary document's content with automatic stale-write protection (contract-owned documents use their dedicated structured tool). |
-| `doc_edit` | Targeted edit within an ordinary document, with automatic stale-write protection; contract-owned documents use their dedicated structured tool. |
+| `doc_commit` | Commit an approved `doc_intake`/declined `doc_create` result through the normal logical document mutation. |
+| `doc_write` | Create, self-migrate, or update a normal managed document from status-line, optional teaser/digest, and full projections; Go validates and renders its private storage codec atomically. |
+| `doc_body_write` | Write one undifferentiated Markdown body for the unusual document that intentionally has no projection ladder. |
+| `doc_edit` | Targeted edit within an ordinary document, with automatic stale-write protection; faceted and contract-owned documents use their returned `write_tool`. |
 | `doc_copy` | Copy a document to another location. |
 | `doc_move` | Move or rename a document. |
 | `doc_delete` | Delete a document. |
-| `doc_copy_section` | Copy one named section into another document. |
-| `doc_move_section` | Move one named section into another document. |
-| `doc_journal_update` | Append or update a journal-style entry, with automatic stale-write protection. |
+| `doc_copy_section` | Copy one named section into an ordinary destination; faceted destinations reject partial mutation. |
+| `doc_move_section` | Move one named section between ordinary documents; faceted sources or destinations reject partial mutation. |
+| `doc_journal_update` | Append or update an ordinary journal-style entry, with automatic stale-write protection. |
 
-Loop-declared document output tools are request-scoped and do not appear
-in the global catalog above. When a loop declares an output, Thane
+`doc_write` is the normal logical writer for documents without a narrower
+domain owner. Loop-declared document output tools remain request-scoped and do
+not appear in the global catalog above. When a loop declares an output, Thane
 generates a tool such as `replace_output_metacognitive_state` or — for a
 maintained document that declares `facets` — `publish_output_office_status`,
-only for that loop run. These tools route through managed document roots, so
-root policy, indexing, and provenance remain centralized instead of
-being reimplemented in each loop prompt.
+only for that loop run. Those generated names are stamped as `managed_by`, and
+document reads return them as `write_tool`; `doc_write` will not bypass that
+narrower owner. Every structured publisher routes through managed document
+roots, so root policy, indexing, validation, and provenance remain centralized
+instead of being reimplemented in each loop prompt.
 
 ## `email` — inbox traffic
 
@@ -315,8 +320,11 @@ Operator channel activity recency is reported with delta fields such as
 | `repo_git_show` | Show one commit and its bounded patch from one named repository root. |
 | `repo_git_blame` | Read structured line attribution for one file in one named repository root. |
 
-File tools resolve configured roots such as `kb:` and dynamically registered
-repository roots such as `thanecode:` before applying workspace policy. A
+File tools resolve configured non-indexed roots and dynamically registered
+repository roots such as `thanecode:` before applying workspace policy.
+Indexed managed roots are deliberately unavailable through every `file_*`
+surface; use `doc_browse`, `doc_search`, `doc_read`, and the returned
+`write_tool` so the Markdown codec remains private. A
 forge subscription registers a repository root from its `repo_root` handle;
 the host checkout path is not model-facing. Repository roots are read-only.
 When a loop carries a `repo_root` binding, an unprefixed relative file path

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -450,7 +450,7 @@ structured envelopes over the message bus directly, and
 |------|-----------|-------------|
 | `thane_now` | sync | Synchronously delegate a bounded task and return the result inline. |
 | `thane_assign` | async one-shot | Assign a task to a sub-agent that runs in the background and reports back through the current conversation/channel when complete. |
-| `thane_loop_create` (`operation: service`) | recurring | Scaffold a declared output document in the exact shape its generated `publish_output_*` tool writes (optional `output.initial` seeds the first publish; working notes ride alongside) and launch a self-paced recurring loop that maintains it; `entities` surface HA subscriptions into the loop's context. |
+| `thane_loop_create` (`operation: service`) | recurring | Scaffold a declared output document in the exact shape its generated `publish_output_*` tool writes (optional `output.initial` seeds the first publish; after the old loop is stopped, `output.migration` explicitly supplies newly required projections when a replacement changes the contract; working notes ride alongside) and launch a self-paced recurring loop that maintains it; `entities` surface HA subscriptions into the loop's context. |
 | `thane_loop_create` (`operation: container`) | durable container | Create a non-executing loop container that groups descendant loops and provides inheritable tags. |
 
 `thane_now` and `thane_assign` accept `context_mode`. The default,

--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -313,8 +313,9 @@ target content is not cleanly covered by trusted signed git history:
 - Document store reads (`Read`, indexed browse and search surfaces)
 - Loop-declared output context
 - Tagged context articles
-- The model's `file_read` tool when the resolved path lies inside a
-  managed root
+- Internal non-document readers when the resolved path lies inside a managed
+  root. Model-facing file tools do not enter indexed roots at all; they route
+  the model to the logical document surface instead.
 - Inject-files each time they are read into the prompt, with startup
   fail-fast verification for initially configured files
 - Startup-time talents, loaded only after their source markdown files
@@ -323,11 +324,12 @@ target content is not cleanly covered by trusted signed git history:
 When verification is `warn`, Thane records and logs verification
 failures but still lets the content load.
 
-The raw `file_write` and `file_edit` tools are stricter than read
-verification. They cannot mutate read-only/restricted roots, and they
-cannot mutate roots with signed git provenance; those changes must go
-through managed document tools so root writers can preserve authoring
-policy, git history, and signatures.
+Model-facing `file_*` tools cannot read, search, enumerate, or mutate indexed
+managed roots. Direct access returns a document-tool redirect; a broader
+workspace walk skips those subtrees. Non-indexed repository roots remain file
+tool territory. Internal readers still apply signature verification, while all
+managed mutations go through document tools so root writers preserve logical
+projections, authoring policy, git history, and signatures.
 
 ### Concurrent writers
 
@@ -335,8 +337,9 @@ Git history makes a mistaken overwrite recoverable, but history alone does
 not stop a stale loop from replacing another writer's current work. On writable
 git-backed roots, a managed read therefore records the current file revision as
 a hidden receipt keyed by loop/conversation and document ref. The model never
-passes hashes between tools. A later `doc_write`, `doc_edit`, or
-`doc_journal_update` supplies that receipt to the root writer internally.
+passes hashes between tools. A later `doc_write`, `doc_body_write`, `doc_edit`,
+or `doc_journal_update` supplies that receipt to the root writer
+internally.
 Read-only history roots do not create mutation receipts.
 
 The root writer compares and commits managed mutations under the same lock, and
@@ -354,16 +357,10 @@ an editor that ignores this coordination can still save in the narrow window
 between the final worktree check and replacement. Git history remains the
 recovery boundary for that external race.
 
-Directory-walk surfaces (`file_list`, `file_tree`, `file_stat`,
-`file_search`, `file_grep`) intentionally do not consult the verifier.
-`file_list`, `file_tree`, `file_stat`, and `file_search` return only
-paths and metadata. **`file_grep` is different**: it returns short
-content excerpts that are
-*not* verified, so under `verify_signatures: required` it can surface
-snippets from files that would be blocked by `file_read`. If a result
-matters to you, re-read it through `file_read` — that path is gated
-and will fail if the underlying content is not covered by trusted
-signed history.
+Directory-walk surfaces (`file_list`, `file_tree`, `file_stat`, `file_search`,
+`file_grep`) share the same boundary. In particular, `file_grep` cannot leak
+the private frontmatter and section codec that logical `doc_read` deliberately
+hides.
 
 ## A Few Practical Guidelines
 
@@ -431,6 +428,44 @@ conversation IDs, Home Assistant entity IDs, attachment hashes, or feed
 IDs. Use `refresh_strategy` to distinguish one-shot immutable artifacts
 from generated files that are replaced, appended to, or maintained as a
 rolling window.
+
+## Faceted Documents and Write Ownership
+
+A faceted document publishes several views of one current state: a required
+one-line `status_line`, optional `teaser` and `digest`, and the always-present
+full detail. The reserved H2 headings are a private on-disk codec; the parser
+can discover this shape in any managed root without root-specific code, but
+model tools do not expose or accept that envelope. Reads and search/browse rows
+expose logical projections, available read levels, and a `write_tool` for the
+next mutation.
+
+Managed writes also canonicalize frontmatter: keys use normalized casing and a
+stable semantic/alphabetic order, set-valued fields are trimmed, deduplicated,
+and sorted, and scalars share one quoting form. Repeating an equivalent logical
+write therefore does not create ordering-only Git noise.
+
+`doc_write` is the normal logical mutation surface for a document with no
+narrower owner. It can create one at a deliberate ref, self-migrate a legacy or
+body-only document, or update an existing faceted document. The model supplies
+projections, not headings; Go applies the shared single-line and rune budgets,
+requires every already-present projection, renders the canonical section
+order, and stamps `managed_by: doc_write`. The document store independently
+rejects malformed or over-budget facet envelopes before any filesystem or Git
+mutation, regardless of which internal caller reached it.
+
+`doc_body_write` is the narrow exception for a document intentionally kept as
+one undifferentiated Markdown body. It still uses managed-root policy,
+provenance, indexing, and stale-write protection; it does not expose a raw file
+or bypass the document abstraction.
+
+Some domains own a narrower contract. A contact dossier stamps
+`managed_by: contact_dossier_write`; a declared loop output stamps its generated
+`publish_output_<name>` tool. Reads return that value as `write_tool`, and
+`doc_write`, `doc_body_write`, `doc_edit`, journal mutation, and partial section
+transfers reject the target with an actionable redirect. This prevents two
+write doors from disagreeing about structure or leaving compact projections
+describing an older state. Lifecycle and history operations remain
+root-agnostic; content-bearing reads project the logical document.
 
 ## Loop-Declared Outputs
 
@@ -533,8 +568,10 @@ root. It accepts the contact UUID plus status-line, teaser, digest, and full
 content, then derives the ref, exact private tag, frontmatter, and section
 layout in Go. Projection budgets are advertised in the schema, and one failed
 call reports every independently correctable projection violation together.
-The generic document tools remain available for operator recovery, but models
-should not author dossier structure through them.
+Generic document mutators reject the dossier and name
+`contact_dossier_write`; operator recovery remains available through Git
+history and direct repository administration rather than a second model-facing
+write door.
 
 The archivist uses the same contract-owned door. Contact-shaped queue subjects
 and contact evidence discovered in closed sessions are resolved through the

--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -491,6 +491,16 @@ of truth. The generated tools still write through document roots. That
 keeps path resolution, indexing, provenance, and root-level integrity
 policy in one subsystem.
 
+Replacing a loop definition preserves its output when the contract is
+unchanged. A contract change requires the old loop to be stopped and is
+explicit: `thane_loop_create` requires
+`output.migration`, preserves the existing full body and retained projections,
+and accepts values only for newly declared projections. An empty migration
+object authorizes a removal-only change, including a faceted output becoming
+body-only. The ownership transition between the same loop's
+`replace_output_*` and `publish_output_*` tools happens inside the document
+layer; it is not a general ownership override.
+
 ## Special Case: the Derived Roots
 
 Four root names are reserved: `core`, `self`, `contacts`, and `dossiers`. Their

--- a/internal/app/document_roots_test.go
+++ b/internal/app/document_roots_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
 	"github.com/nugget/thane-ai-agent/internal/state/contacts"
 	"github.com/nugget/thane-ai-agent/internal/state/documents"
+	documentfacets "github.com/nugget/thane-ai-agent/internal/state/documents/facets"
 )
 
 // writeTestSigningKey generates a fresh ed25519 SSH signing key,
@@ -159,10 +160,16 @@ func TestBuildDocumentStoreOptionsWiresContactDossierValidator(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FindByName: %v", err)
 	}
+	frontmatter := (documentfacets.Manifest{
+		Schema:    documentfacets.SchemaV1,
+		Contract:  documentfacets.DefaultContract(),
+		ManagedBy: contacts.DossierWriteToolName,
+	}).Frontmatter()
+	frontmatter["title"] = []string{"Dossier Person"}
 	candidate := documents.DocumentWriteCandidate{
 		Path:        contact.ID.String() + ".md",
 		Tags:        []string{contacts.DossierSubject(contact.ID)},
-		Frontmatter: map[string][]string{"title": {"Dossier Person"}},
+		Frontmatter: frontmatter,
 		Body: "## Status Line\n\nDossier Person is current.\n\n" +
 			"## Teaser\n\nOpen for current collaboration context.\n\n" +
 			"## Digest\n\nEnough standalone context to act.\n\n" +

--- a/internal/app/loop_output_publish.go
+++ b/internal/app/loop_output_publish.go
@@ -2,11 +2,14 @@ package app
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/state/documents"
+	documentfacets "github.com/nugget/thane-ai-agent/internal/state/documents/facets"
+	"github.com/nugget/thane-ai-agent/internal/tools"
 )
 
 // Frontmatter keys stamped on loop-managed documents. The contract
@@ -27,7 +30,7 @@ const (
 // notes is the loop's declared working-notes output when it has one.
 // Its presence adds the optional notes argument, so the argument exists
 // only when there is somewhere for the notes to land.
-func buildFacetPublishTool(store *documents.Store, output looppkg.OutputSpec, notes *looppkg.OutputSpec) looppkg.RuntimeTool {
+func buildFacetPublishTool(docTools *documents.Tools, output looppkg.OutputSpec, notes *looppkg.OutputSpec) looppkg.RuntimeTool {
 	fields := output.FacetFields()
 	properties := make(map[string]any, len(fields)+1)
 	required := make([]string, 0, len(fields))
@@ -63,22 +66,22 @@ func buildFacetPublishTool(store *documents.Store, output looppkg.OutputSpec, no
 			if err != nil {
 				return "", err
 			}
-			if err := output.ValidateFacetPayload(payload); err != nil {
-				return "", err
-			}
-			body := output.RenderFacetDocument(payload)
-			result, err := store.Write(ctx, documents.WriteArgs{
-				Ref:         output.Ref,
-				Body:        &body,
-				Frontmatter: loopOutputFrontmatter(output),
+			publishedResult, err := docTools.WriteFaceted(ctx, documents.FacetedWriteArgs{
+				Ref:          output.Ref,
+				Frontmatter:  loopOutputFrontmatter(output),
+				Contract:     documentfacets.Contract{Facets: append([]documentfacets.Spec(nil), output.Facets...)},
+				Payload:      documentfacets.Payload(payload),
+				WriteTool:    output.ToolName(),
+				ReceiptScope: tools.DocumentRevisionScope(ctx),
 			})
 			if err != nil {
 				return "", err
 			}
 
-			published := map[string]any{"published": result}
+			publishedJSON := json.RawMessage(publishedResult)
+			published := map[string]any{"published": publishedJSON}
 			if note, _ := args["notes"].(string); strings.TrimSpace(note) != "" && notes != nil {
-				noteResult, noteErr := writeLoopWorkingNotes(ctx, store, *notes, note)
+				noteResult, noteErr := writeLoopWorkingNotes(ctx, docTools, *notes, note)
 				switch {
 				case noteErr != nil:
 					// The document publish already succeeded, so this is
@@ -87,7 +90,7 @@ func buildFacetPublishTool(store *documents.Store, output looppkg.OutputSpec, no
 					// duplicate publish.
 					published["notes_error"] = fmt.Sprintf("%s was published, but the working notes were not updated: %v", output.Ref, noteErr)
 				default:
-					published["notes_written"] = noteResult
+					published["notes_written"] = json.RawMessage(noteResult)
 				}
 			}
 			return marshalLoopOutputToolResult(published)
@@ -116,14 +119,16 @@ func facetPublishDescription(output looppkg.OutputSpec, notes *looppkg.OutputSpe
 // writeLoopWorkingNotes replaces a working-notes body, stamping the
 // audience that keeps it out of consumer surfaces on every write —
 // notes hold a current view, so each one supersedes the last.
-func writeLoopWorkingNotes(ctx context.Context, store *documents.Store, notes looppkg.OutputSpec, body string) (*documents.MutationResult, error) {
+func writeLoopWorkingNotes(ctx context.Context, docTools *documents.Tools, notes looppkg.OutputSpec, body string) (string, error) {
 	if err := looppkg.ValidateOutputBodySize(body); err != nil {
-		return nil, fmt.Errorf("notes: %w", err)
+		return "", fmt.Errorf("notes: %w", err)
 	}
-	return store.Write(ctx, documents.WriteArgs{
-		Ref:         notes.Ref,
-		Body:        &body,
-		Frontmatter: loopOutputFrontmatter(notes),
+	return docTools.Write(ctx, documents.WriteArgs{
+		Ref:            notes.Ref,
+		Body:           &body,
+		Frontmatter:    loopOutputFrontmatter(notes),
+		ReceiptScope:   tools.DocumentRevisionScope(ctx),
+		StructuredTool: notes.ToolName(),
 	})
 }
 

--- a/internal/app/loop_output_publish_test.go
+++ b/internal/app/loop_output_publish_test.go
@@ -50,7 +50,7 @@ func TestFacetedOutputGeneratesPublishToolWithTypedProjections(t *testing.T) {
 	t.Parallel()
 
 	store, _ := newLoopOutputDocumentStore(t)
-	app := &App{documentStore: store}
+	app := &App{documentStore: store, documentTools: documents.NewTools(store)}
 
 	hydrated, err := app.hydrateLoopOutputs(facetedSpec())
 	if err != nil {
@@ -81,7 +81,7 @@ func TestPublishToolWithoutWorkingNotesOmitsNoteArgument(t *testing.T) {
 	t.Parallel()
 
 	store, _ := newLoopOutputDocumentStore(t)
-	app := &App{documentStore: store}
+	app := &App{documentStore: store, documentTools: documents.NewTools(store)}
 	spec := facetedSpec()
 	spec.Outputs = spec.Outputs[:1] // drop the working-notes declaration
 
@@ -100,7 +100,7 @@ func TestPublishToolRendersDocumentAndStampsFrontmatter(t *testing.T) {
 	t.Parallel()
 
 	store, coreDir := newLoopOutputDocumentStore(t)
-	app := &App{documentStore: store}
+	app := &App{documentStore: store, documentTools: documents.NewTools(store)}
 	hydrated, err := app.hydrateLoopOutputs(facetedSpec())
 	if err != nil {
 		t.Fatalf("hydrateLoopOutputs: %v", err)
@@ -156,7 +156,7 @@ func TestPublishToolRejectsOverBudgetWithoutWriting(t *testing.T) {
 	t.Parallel()
 
 	store, coreDir := newLoopOutputDocumentStore(t)
-	app := &App{documentStore: store}
+	app := &App{documentStore: store, documentTools: documents.NewTools(store)}
 	hydrated, err := app.hydrateLoopOutputs(facetedSpec())
 	if err != nil {
 		t.Fatalf("hydrateLoopOutputs: %v", err)
@@ -183,7 +183,7 @@ func TestPublishToolNotesReplaceInternalWorkingNotes(t *testing.T) {
 	t.Parallel()
 
 	store, coreDir := newLoopOutputDocumentStore(t)
-	app := &App{documentStore: store}
+	app := &App{documentStore: store, documentTools: documents.NewTools(store)}
 	hydrated, err := app.hydrateLoopOutputs(facetedSpec())
 	if err != nil {
 		t.Fatalf("hydrateLoopOutputs: %v", err)
@@ -235,7 +235,7 @@ func TestWorkingNotesToolStampsInternalAudience(t *testing.T) {
 	t.Parallel()
 
 	store, _ := newLoopOutputDocumentStore(t)
-	app := &App{documentStore: store}
+	app := &App{documentStore: store, documentTools: documents.NewTools(store)}
 	hydrated, err := app.hydrateLoopOutputs(facetedSpec())
 	if err != nil {
 		t.Fatalf("hydrateLoopOutputs: %v", err)
@@ -280,7 +280,7 @@ func TestFacetedOutputContextAdvertisesProjections(t *testing.T) {
 	t.Parallel()
 
 	store, _ := newLoopOutputDocumentStore(t)
-	app := &App{documentStore: store}
+	app := &App{documentStore: store, documentTools: documents.NewTools(store)}
 	hydrated, err := app.hydrateLoopOutputs(facetedSpec())
 	if err != nil {
 		t.Fatalf("hydrateLoopOutputs: %v", err)
@@ -306,7 +306,7 @@ func TestPublishToolRejectsNonStringProjection(t *testing.T) {
 	t.Parallel()
 
 	store, _ := newLoopOutputDocumentStore(t)
-	app := &App{documentStore: store}
+	app := &App{documentStore: store, documentTools: documents.NewTools(store)}
 	hydrated, err := app.hydrateLoopOutputs(facetedSpec())
 	if err != nil {
 		t.Fatalf("hydrateLoopOutputs: %v", err)
@@ -327,7 +327,7 @@ func TestFacetedOutputContextReportsPublishMode(t *testing.T) {
 	t.Parallel()
 
 	store, _ := newLoopOutputDocumentStore(t)
-	app := &App{documentStore: store}
+	app := &App{documentStore: store, documentTools: documents.NewTools(store)}
 	hydrated, err := app.hydrateLoopOutputs(facetedSpec())
 	if err != nil {
 		t.Fatalf("hydrateLoopOutputs: %v", err)
@@ -389,7 +389,7 @@ func TestWorkingNotesRewriteKeepsAudienceStamp(t *testing.T) {
 	t.Parallel()
 
 	store, _ := newLoopOutputDocumentStore(t)
-	app := &App{documentStore: store}
+	app := &App{documentStore: store, documentTools: documents.NewTools(store)}
 	hydrated, err := app.hydrateLoopOutputs(facetedSpec())
 	if err != nil {
 		t.Fatalf("hydrateLoopOutputs: %v", err)

--- a/internal/app/loop_outputs.go
+++ b/internal/app/loop_outputs.go
@@ -96,11 +96,11 @@ func (p orderedProjections) MarshalJSON() ([]byte, error) {
 // every spec the registry produces.
 func (a *App) hydrateLoopOutputs(spec looppkg.Spec) (looppkg.Spec, error) {
 	if len(spec.Outputs) > 0 {
-		if a == nil || a.documentStore == nil {
+		if a == nil || a.documentStore == nil || a.documentTools == nil {
 			return looppkg.Spec{}, fmt.Errorf("loop %q declares outputs but managed document roots are not configured", spec.Name)
 		}
 		outputs := cloneLoopOutputs(spec.Outputs)
-		spec.RuntimeTools = append(spec.RuntimeTools, buildLoopOutputTools(a.documentStore, outputs)...)
+		spec.RuntimeTools = append(spec.RuntimeTools, buildLoopOutputTools(a.documentTools, outputs)...)
 		spec.RuntimeTools = append(spec.RuntimeTools, a.ownOutputReadTools(outputs)...)
 		spec.OutputContextBuilder = func(ctx context.Context, _ []looppkg.OutputSpec) (string, error) {
 			return renderLoopOutputContextWithNow(ctx, a.documentStore, outputs, time.Now())
@@ -215,8 +215,8 @@ func reExposeNativeTools(registry *tools.Registry, names []string) []looppkg.Run
 	return out
 }
 
-func buildLoopOutputTools(store *documents.Store, outputs []looppkg.OutputSpec) []looppkg.RuntimeTool {
-	if store == nil || len(outputs) == 0 {
+func buildLoopOutputTools(docTools *documents.Tools, outputs []looppkg.OutputSpec) []looppkg.RuntimeTool {
+	if docTools == nil || len(outputs) == 0 {
 		return nil
 	}
 	out := make([]looppkg.RuntimeTool, 0, len(outputs))
@@ -226,7 +226,7 @@ func buildLoopOutputTools(store *documents.Store, outputs []looppkg.OutputSpec) 
 		if output.HasFacets() {
 			// A faceted output's interface is a set of typed projections,
 			// so it gets the publish tool instead of a body-blob replace.
-			out = append(out, buildFacetPublishTool(store, output, notes))
+			out = append(out, buildFacetPublishTool(docTools, output, notes))
 			continue
 		}
 		switch output.EffectiveMode() {
@@ -259,9 +259,11 @@ func buildLoopOutputTools(store *documents.Store, outputs []looppkg.OutputSpec) 
 					if err := looppkg.ValidateOutputBodySize(content); err != nil {
 						return "", err
 					}
-					result, err := store.Write(ctx, documents.WriteArgs{
-						Ref:  output.Ref,
-						Body: &content,
+					return docTools.Write(ctx, documents.WriteArgs{
+						Ref:            output.Ref,
+						Body:           &content,
+						ReceiptScope:   tools.DocumentRevisionScope(ctx),
+						StructuredTool: output.ToolName(),
 						// Stamped on every write, not only the first: the
 						// exclusion in search and tagged-guidance injection
 						// reads this key off the document, so a rewrite that
@@ -269,10 +271,6 @@ func buildLoopOutputTools(store *documents.Store, outputs []looppkg.OutputSpec) 
 						// thinking.
 						Frontmatter: loopOutputFrontmatter(output),
 					})
-					if err != nil {
-						return "", err
-					}
-					return marshalLoopOutputToolResult(result)
 				},
 			})
 		}
@@ -325,12 +323,12 @@ func renderLoopOutputContextWithNow(ctx context.Context, store *documents.Store,
 		entry.UpdatedDelta = loopOutputUpdatedDelta(doc, now)
 		switch output.Type {
 		case looppkg.OutputTypeMaintainedDocument:
-			if _, faceted := looppkg.ParseFacetSections(doc.Body); faceted && output.HasFacets() {
+			if len(doc.FacetContract.Facets) > 0 && output.HasFacets() {
 				// The loop's own context mirrors its publish tool's
 				// argument shape: each authored projection whole, the
 				// Details body under the byte budget. Same shape out
 				// as goes in, so a republish is mechanical.
-				payload := output.ParseFacetDocument(doc.Body)
+				payload := doc.FacetContract.Parse(doc.Body)
 				var projections orderedProjections
 				// Declared facets only — FacetFields() appends the
 				// always-published full field, and full is exactly what
@@ -340,7 +338,7 @@ func renderLoopOutputContextWithNow(ctx context.Context, store *documents.Store,
 				// this split exists to end.
 				for _, facet := range output.Facets {
 					key := string(facet.Name)
-					if value, ok := payload.FacetByKey(key); ok && strings.TrimSpace(value) != "" {
+					if value, ok := payload.ByKey(key); ok && strings.TrimSpace(value) != "" {
 						projections = append(projections, facetProjection{Key: key, Value: value})
 					}
 				}

--- a/internal/app/loop_outputs_test.go
+++ b/internal/app/loop_outputs_test.go
@@ -21,7 +21,7 @@ func TestHydrateLoopOutputsBuildsScopedToolsAndContext(t *testing.T) {
 	t.Parallel()
 
 	store, coreDir := newLoopOutputDocumentStore(t)
-	app := &App{documentStore: store}
+	app := &App{documentStore: store, documentTools: documents.NewTools(store)}
 	spec := looppkg.Spec{
 		Name:       "metacognitive",
 		Enabled:    true,
@@ -379,7 +379,7 @@ func TestReExposeNativeTools(t *testing.T) {
 // a launch dependency.
 func TestHydrateLoopOutputsWithoutAgentLoop(t *testing.T) {
 	store, _ := newLoopOutputDocumentStore(t)
-	app := &App{documentStore: store}
+	app := &App{documentStore: store, documentTools: documents.NewTools(store)}
 	spec := looppkg.Spec{
 		Name:      "reader",
 		Enabled:   true,
@@ -495,7 +495,7 @@ func TestWrapOwnOutputDocRead(t *testing.T) {
 // be able to write in the first place.
 func TestReplaceOutputRejectsOversizedBody(t *testing.T) {
 	store, _ := newLoopOutputDocumentStore(t)
-	runtimeTools := buildLoopOutputTools(store, []looppkg.OutputSpec{{
+	runtimeTools := buildLoopOutputTools(documents.NewTools(store), []looppkg.OutputSpec{{
 		Name: "state",
 		Type: looppkg.OutputTypeMaintainedDocument,
 		Ref:  "core:state.md",

--- a/internal/app/new_channels.go
+++ b/internal/app/new_channels.go
@@ -428,7 +428,7 @@ func (a *App) initChannels(s *newState) error {
 		}
 	}
 	if a.documentTools != nil {
-		contactTools.ConfigureDossierDocuments(a.documentTools.Read, a.documentTools.Write)
+		contactTools.ConfigureDossierDocuments(a.documentTools.Read, a.documentTools.WriteFaceted)
 	}
 	a.loop.Tools().SetContactTools(contactTools)
 

--- a/internal/model/toolcatalog/catalog.go
+++ b/internal/model/toolcatalog/catalog.go
@@ -182,6 +182,7 @@ var builtinToolSpecs = map[string]BuiltinToolSpec{
 	"doc_section":                   {CanonicalID: "native:doc_section", Source: NativeToolSource, Tags: []string{"documents"}},
 	"doc_values":                    {CanonicalID: "native:doc_values", Source: NativeToolSource, Tags: []string{"documents"}},
 	"doc_write":                     {CanonicalID: "native:doc_write", Source: NativeToolSource, Tags: []string{"documents"}},
+	"doc_body_write":                {CanonicalID: "native:doc_body_write", Source: NativeToolSource, Tags: []string{"documents"}},
 	"email_folders":                 {CanonicalID: "native:email_folders", Source: NativeToolSource, Tags: []string{"email"}},
 	"email_list":                    {CanonicalID: "native:email_list", Source: NativeToolSource, Tags: []string{"email"}},
 	"email_mark":                    {CanonicalID: "native:email_mark", Source: NativeToolSource, Tags: []string{"email"}},

--- a/internal/runtime/loop/facet_spec.go
+++ b/internal/runtime/loop/facet_spec.go
@@ -1,103 +1,23 @@
 package loop
 
-import (
-	"encoding/json"
-	"fmt"
-	"strings"
-)
+import documentfacets "github.com/nugget/thane-ai-agent/internal/state/documents/facets"
 
-// FacetFormat describes how a facet's value is encoded, which decides
-// what a surface can do with it.
-//
-// Format is a facet property rather than a binding one: it is part of
-// how the face is cut, not where it is mounted. A binding then checks
-// its own capacity against the facet's format and budget — an entity
-// state that holds 255 characters can carry a status_line and cannot
-// carry a digest — so a mismatch is refused where it is declared rather
-// than truncated where it is displayed.
-type FacetFormat string
+// FacetFormat describes how a projection value is encoded. The document layer
+// owns this vocabulary; the loop package keeps aliases for persisted output
+// specs and compatibility with callers that author loop definitions.
+type FacetFormat = documentfacets.Format
 
 const (
-	// FacetFormatMarkdown is prose with structure. The default, and what
-	// a document section wants.
-	FacetFormatMarkdown FacetFormat = "markdown"
-	// FacetFormatPlain is prose with no markup, safe to speak aloud or
-	// drop into a surface that renders nothing.
-	FacetFormatPlain FacetFormat = "plain"
-	// FacetFormatJSON is a structured value, for consumers that are code
-	// rather than readers.
-	FacetFormatJSON FacetFormat = "json"
+	FacetFormatMarkdown = documentfacets.FormatMarkdown
+	FacetFormatPlain    = documentfacets.FormatPlain
+	FacetFormatJSON     = documentfacets.FormatJSON
 )
 
-// FacetSpec declares one facet and how it is cut.
-//
-// It decodes from either a bare name or an object, because the common
-// case is a name and nothing else — `facets: [status_line, teaser]`
-// stays readable, and an author who needs an attribute reaches for the
-// longer form only on the facet that needs it.
-type FacetSpec struct {
-	// Name is which face this is: status_line, teaser, or digest.
-	Name OutputFacet `yaml:"name" json:"name"`
-	// Format is how the value is encoded. Empty means markdown.
-	Format FacetFormat `yaml:"format,omitempty" json:"format,omitempty"`
-}
+// FacetSpec declares one document projection and its encoding.
+type FacetSpec = documentfacets.Spec
 
-// EffectiveFormat resolves the declared format, defaulting to markdown.
-func (f FacetSpec) EffectiveFormat() FacetFormat {
-	if f.Format == "" {
-		return FacetFormatMarkdown
-	}
-	return f.Format
-}
-
-// UnmarshalJSON accepts either "status_line" or {"name":"status_line"}.
-func (f *FacetSpec) UnmarshalJSON(data []byte) error {
-	trimmed := strings.TrimSpace(string(data))
-	if strings.HasPrefix(trimmed, `"`) {
-		var name string
-		if err := json.Unmarshal(data, &name); err != nil {
-			return err
-		}
-		*f = FacetSpec{Name: OutputFacet(name)}
-		return nil
-	}
-	// A named type breaks the recursion into this method.
-	type facetSpecWire FacetSpec
-	var wire facetSpecWire
-	if err := json.Unmarshal(data, &wire); err != nil {
-		return fmt.Errorf("facet must be a name or an object with a name: %w", err)
-	}
-	*f = FacetSpec(wire)
-	return nil
-}
-
-// UnmarshalYAML mirrors UnmarshalJSON for config-authored specs.
-func (f *FacetSpec) UnmarshalYAML(unmarshal func(any) error) error {
-	var name string
-	if err := unmarshal(&name); err == nil {
-		*f = FacetSpec{Name: OutputFacet(name)}
-		return nil
-	}
-	type facetSpecWire FacetSpec
-	var wire facetSpecWire
-	if err := unmarshal(&wire); err != nil {
-		return fmt.Errorf("facet must be a name or a mapping with a name: %w", err)
-	}
-	*f = FacetSpec(wire)
-	return nil
-}
-
-// MarshalJSON writes the short form when nothing but the name is set, so
-// a round trip does not inflate every declaration into an object.
-func (f FacetSpec) MarshalJSON() ([]byte, error) {
-	if f.Format == "" {
-		return json.Marshal(string(f.Name))
-	}
-	type facetSpecWire FacetSpec
-	return json.Marshal(facetSpecWire(f))
-}
-
-// validFacetFormats gates the enum in one place.
 var validFacetFormats = map[FacetFormat]struct{}{
-	FacetFormatMarkdown: {}, FacetFormatPlain: {}, FacetFormatJSON: {},
+	FacetFormatMarkdown: {},
+	FacetFormatPlain:    {},
+	FacetFormatJSON:     {},
 }

--- a/internal/runtime/loop/output.go
+++ b/internal/runtime/loop/output.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 	"unicode"
+
+	documentfacets "github.com/nugget/thane-ai-agent/internal/state/documents/facets"
 )
 
 const maxOutputToolNameLength = 64
@@ -40,21 +42,20 @@ const (
 	OutputModeReplace OutputMode = "replace"
 )
 
-// OutputFacet names one face a maintained document publishes. The full
-// body is not a facet: it is the document itself, and the facets are
-// views of it.
-type OutputFacet string
+// OutputFacet names one projection a maintained document publishes. The
+// document package owns the vocabulary; this alias keeps loop specs stable.
+type OutputFacet = documentfacets.Name
 
 const (
 	// OutputFacetStatusLine is the ambient projection: current state in
 	// one standalone line, no markdown structure.
-	OutputFacetStatusLine OutputFacet = "status_line"
+	OutputFacetStatusLine = documentfacets.StatusLine
 	// OutputFacetTeaser is the interest hook: one short paragraph on why
 	// a reader would open the full document right now.
-	OutputFacetTeaser OutputFacet = "teaser"
+	OutputFacetTeaser = documentfacets.Teaser
 	// OutputFacetDigest is the standalone summary: enough detail to act
 	// on without opening the full document.
-	OutputFacetDigest OutputFacet = "digest"
+	OutputFacetDigest = documentfacets.Digest
 )
 
 // Frontmatter keys stamped on loop-managed documents wherever one is

--- a/internal/runtime/loop/output_facets.go
+++ b/internal/runtime/loop/output_facets.go
@@ -1,574 +1,105 @@
 package loop
 
 import (
-	"encoding/json"
-	"errors"
 	"fmt"
-	"strings"
-	"unicode/utf8"
 
-	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+	documentfacets "github.com/nugget/thane-ai-agent/internal/state/documents/facets"
 )
 
-// Rune budgets for the published projection facets. They are display
-// budgets, not storage limits: each one is the size at which that
-// projection still fits the surfaces that consume it — a fleet overview
-// row, a search snippet, a subscription digest. Overflow is rejected
-// rather than clipped, because a clipped projection is an unreadable
-// fragment with nothing to signal that anything was dropped.
-const (
-	statusLineMaxRunes = 120
-	teaserMaxRunes     = 500
-	digestMaxRunes     = 2048
-)
+// MaxOutputDocumentBytes is retained for loop-output callers. The document
+// layer owns the actual maintained-document readback invariant.
+const MaxOutputDocumentBytes = documentfacets.MaxDocumentBytes
 
-// MaxOutputDocumentBytes is the ceiling on a maintained document's
-// body, enforced at every owner write (publish, replace, notes, and
-// create-time seed). It exists to close an invariant with the owner's
-// privileged read budget (128 KiB in the app layer): anything the loop
-// can write, it can always read back whole in one call. The gap
-// between the two is serialization headroom — the read returns the
-// body JSON-escaped inside a payload with outline and frontmatter, so
-// the write ceiling sits a third below the read budget. Rejecting the
-// write is the honest failure: a document at this size has outgrown
-// single-document maintenance, and the loop should hear that at the
-// moment of writing, not discover it as a truncated read next cycle.
-const MaxOutputDocumentBytes = 96 * 1024
-
-// ValidateOutputBodySize checks a maintained document body against
-// [MaxOutputDocumentBytes]. The error teaches the restructure rather
-// than inviting a retry: no smaller attempt at the same content will
-// pass, so the correction is to the document's design.
+// ValidateOutputBodySize delegates the shared maintained-document ceiling to
+// the document layer.
 func ValidateOutputBodySize(body string) error {
-	if size := len(body); size > MaxOutputDocumentBytes {
-		return fmt.Errorf("the document body is %d bytes and a maintained document's ceiling is %d (96 KiB) — past this size the document has outgrown single-document maintenance; move detail into linked documents or trim the body. The ceiling is what guarantees you can always read back what you write in one call", size, MaxOutputDocumentBytes)
-	}
-	return nil
+	return documentfacets.ValidateBodySize(body)
 }
 
-// FacetPayload is one complete published projection set for a faceted
-// maintained document. Every publish carries the whole payload: a
-// rendered document shows exactly the last publish, so a partially
-// updated payload would leave one projection describing a state the
-// others have moved past.
-type FacetPayload struct {
-	StatusLine string
-	Teaser     string
-	Digest     string
-	Full       string
-}
+// FacetPayload is the loop-facing compatibility shape for a logical document
+// payload. Its semantics and codec are owned by the document layer.
+type FacetPayload documentfacets.Payload
 
-// FacetField describes one publishable field of a faceted output, as the
-// generated publish tool advertises it to the model.
-type FacetField struct {
-	// Key is the tool argument name.
-	Key string `json:"key"`
-	// MaxRunes is the display budget in runes; zero is unbounded.
-	MaxRunes int `json:"max_runes"`
-	// SingleLine marks a field that must not contain line breaks.
-	SingleLine bool `json:"single_line"`
-	// Guidance is the model-facing description of what this field is
-	// for and where it surfaces.
-	Guidance string `json:"guidance"`
-	// Format is how this facet's value is encoded. Empty on the full
-	// body, which is always markdown.
-	Format FacetFormat `json:"format,omitempty"`
-	// ContextRole describes how a consumer should treat this projection
-	// when it is offered as model context. It does not grant injection or
-	// choose a rank; the context discriminator owns those decisions.
-	ContextRole agentctx.ContextProjectionRole `json:"context_role"`
-}
+// FacetField describes one structured projection field.
+type FacetField = documentfacets.Field
 
-// facetSection binds one projection to its canonical document section and
-// its budget.
-type facetSection struct {
-	// Facet is the declared facet this section publishes, or empty for
-	// the always-present full projection.
-	Facet   OutputFacet
-	Field   FacetField
-	Heading string
-	// scaffoldHint is the short phrase rendered under this section's
-	// heading in a pre-first-publish scaffold — a compressed cue of what
-	// belongs there, sized for a placeholder rather than for teaching
-	// (the publish tool's Guidance carries the full contract).
-	scaffoldHint string
-	value        func(*FacetPayload) *string
-}
-
-// facetSections is the single source of truth for the publish tool's
-// schema, the payload validator, the document renderer, and the parser
-// that reads a rendered document back — so those four cannot drift
-// apart. Order is the canonical ladder order; declaration order in a
-// spec's facets list carries no meaning.
-var facetSections = []facetSection{
-	{
-		Facet:   OutputFacetStatusLine,
-		Heading: "Status Line",
-		Field: FacetField{
-			Key:         "status_line",
-			MaxRunes:    statusLineMaxRunes,
-			SingleLine:  true,
-			Guidance:    "The tight signal shape: one standalone line of current state, no line breaks. Reads as an ambient status: what is true right now. This is the only thing some surfaces show, so it must stand alone without the document around it.",
-			ContextRole: agentctx.ContextRoleSignal,
-		},
-		scaffoldHint: "one standalone line of what is true right now",
-		value:        func(p *FacetPayload) *string { return &p.StatusLine },
-	},
-	{
-		Facet:   OutputFacetTeaser,
-		Heading: "Teaser",
-		Field: FacetField{
-			Key:         "teaser",
-			MaxRunes:    teaserMaxRunes,
-			Guidance:    "The roomy signal shape: one short paragraph on why a reader would open this document right now. Surfaces as the snippet in search results and cross-references, so write the hook — the reason to look — rather than a compressed summary.",
-			ContextRole: agentctx.ContextRoleSignal,
-		},
-		scaffoldHint: "why a reader would open this document right now",
-		value:        func(p *FacetPayload) *string { return &p.Teaser },
-	},
-	{
-		Facet:   OutputFacetDigest,
-		Heading: "Digest",
-		Field: FacetField{
-			Key:         "digest",
-			MaxRunes:    digestMaxRunes,
-			Guidance:    "The context payload: a standalone summary carrying enough substance to act on without opening the full document. Surfaces in subscription rows and periodic digests.",
-			ContextRole: agentctx.ContextRoleContext,
-		},
-		scaffoldHint: "a summary with enough substance to act on",
-		value:        func(p *FacetPayload) *string { return &p.Digest },
-	},
-	{
-		Heading: "Details",
-		Field: FacetField{
-			Key:         "full",
-			Guidance:    "The detail payload: the complete current state in markdown. This is what a reader opens when the digest is not enough. Always required: it is the document's substance, and the other projections are views of it.",
-			ContextRole: agentctx.ContextRoleDetail,
-		},
-		scaffoldHint: "the complete current state",
-		value:        func(p *FacetPayload) *string { return &p.Full },
-	},
-}
-
-// FacetFields returns the fields a faceted output publishes, in canonical
-// ladder order: each declared facet, then the always-present full
-// projection. Every returned field is required at publish time —
-// optionality lives in the declaration (a spec may declare only
-// status_line), not in the write.
+// FacetFields returns the output's declared fields in canonical order.
 func (o OutputSpec) FacetFields() []FacetField {
 	if len(o.Facets) == 0 {
 		return nil
 	}
-	declared := make(map[OutputFacet]FacetSpec, len(o.Facets))
-	for _, facet := range o.Facets {
-		declared[facet.Name] = facet
-	}
-	fields := make([]FacetField, 0, len(o.Facets)+1)
-	for _, section := range facetSections {
-		// The full body is always published and is never declared, so it
-		// carries the contract's own format rather than a facet's.
-		if section.Facet == "" {
-			fields = append(fields, section.Field)
-			continue
-		}
-		if facet, ok := declared[section.Facet]; ok {
-			field := section.Field
-			field.Format = facet.EffectiveFormat()
-			fields = append(fields, field)
-		}
-	}
-	return fields
+	return o.facetContract().Fields()
 }
 
-// FacetFieldByKey returns the canonical metadata for one projection key.
-// Consumers that advertise faceted documents use this to share the same
-// role and size vocabulary as the generated publish tool.
+// FacetFieldByKey returns canonical metadata for one projection.
 func FacetFieldByKey(key string) (FacetField, bool) {
-	section, ok := facetSectionByKey(key)
-	if !ok {
-		return FacetField{}, false
-	}
-	return section.Field, true
+	return documentfacets.FieldByKey(key)
 }
 
-// HasFacets reports whether this output publishes through the faceted
-// projection contract rather than a whole-body replacement.
+// HasFacets reports whether this maintained output publishes projections.
 func (o OutputSpec) HasFacets() bool {
 	return o.Type == OutputTypeMaintainedDocument && len(o.Facets) > 0
 }
 
-// ValidateFacetPayload checks one payload against the output's declared
-// ladder. Its error names every independently correctable field violation so
-// the model can repair the whole payload in one retry without serially
-// rediscovering the contract.
+// ValidateFacetPayload validates a complete projection set through the shared
+// document contract.
 func (o OutputSpec) ValidateFacetPayload(payload FacetPayload) error {
 	if !o.HasFacets() {
 		return fmt.Errorf("output %q does not declare facets", o.Name)
 	}
-	var validationErrors []error
-	for _, field := range o.FacetFields() {
-		section, ok := facetSectionByKey(field.Key)
-		if !ok {
-			continue
-		}
-		value := strings.TrimSpace(*section.value(&payload))
-		if value == "" {
-			validationErrors = append(validationErrors, fmt.Errorf("%s is required; every declared projection is published together so they cannot describe different moments", field.Key))
-			continue
-		}
-		if err := validateFacetFormat(field, value); err != nil {
-			validationErrors = append(validationErrors, err)
-		}
-		if field.SingleLine && strings.ContainsAny(value, "\r\n") {
-			validationErrors = append(validationErrors, fmt.Errorf("%s must be a single line with no line breaks; it renders as one row on surfaces that show nothing else", field.Key))
-		}
-		if field.MaxRunes > 0 {
-			if runes := utf8.RuneCountInString(value); runes > field.MaxRunes {
-				validationErrors = append(validationErrors, fmt.Errorf("%s is %d characters and the limit is %d; tighten it rather than letting it be cut, because a clipped projection reads as a fragment with no sign that anything is missing", field.Key, runes, field.MaxRunes))
-			}
-		}
-		if heading, found := firstReservedFacetHeading(value); found {
-			validationErrors = append(validationErrors, fmt.Errorf("%s contains the reserved section heading %q; the facet headings are rendered automatically from the contract, so publish only the content beneath them", field.Key, heading))
-		}
-	}
-	// The full projection is the document's substance and the only
-	// unbudgeted field above, so it alone can push the document past
-	// the size the owner is guaranteed to read back whole. Checked
-	// first for the clean attribution, then the rendered document as a
-	// whole — the projections and their headings render into one body,
-	// and a full sitting exactly at the ceiling would put the composite
-	// over it.
-	fullTooLarge := false
-	if err := ValidateOutputBodySize(payload.Full); err != nil {
-		validationErrors = append(validationErrors, fmt.Errorf("full: %w", err))
-		fullTooLarge = true
-	}
-	if !fullTooLarge {
-		if err := ValidateOutputBodySize(o.RenderFacetDocument(payload)); err != nil {
-			validationErrors = append(validationErrors, fmt.Errorf("the rendered document (every projection plus its headings): %w — full is the lever; the other projections are already budget-capped", err))
-		}
-	}
-	if len(validationErrors) > 0 {
-		return errors.Join(validationErrors...)
-	}
-	return nil
+	return o.facetContract().Validate(documentfacets.Payload(payload))
 }
 
-// RenderFacetDocument renders a payload as the canonical document body:
-// one H2 section per published projection, in ladder order. Go owns this
-// structure so the model never authors the section convention and the
-// document stays parseable back into a payload.
+// RenderFacetDocument encodes projections with the shared Markdown codec.
 func (o OutputSpec) RenderFacetDocument(payload FacetPayload) string {
-	fields := o.FacetFields()
-	published := make(map[string]struct{}, len(fields))
-	for _, field := range fields {
-		published[field.Key] = struct{}{}
-	}
-	formats := make(map[string]FacetFormat, len(fields))
-	for _, field := range fields {
-		formats[field.Key] = field.Format
-	}
-
-	blocks := make([]string, 0, len(fields))
-	for _, section := range facetSections {
-		if _, ok := published[section.Field.Key]; !ok {
-			continue
-		}
-		value := strings.TrimSpace(*section.value(&payload))
-		if value == "" {
-			continue
-		}
-		if formats[section.Field.Key] == FacetFormatJSON {
-			value = jsonFence + "\n" + value + "\n" + fenceClose
-		}
-		blocks = append(blocks, "## "+section.Heading+"\n\n"+value)
-	}
-	return strings.Join(blocks, "\n\n")
+	return o.facetContract().Render(documentfacets.Payload(payload))
 }
 
-// RenderFacetScaffold renders the pre-first-publish body for a faceted
-// output: the same section skeleton [OutputSpec.RenderFacetDocument]
-// will produce, with an awaiting-first-cycle placeholder under each
-// heading. The first iteration sees this body in its Declared Durable
-// Outputs context, so the scaffold showing the exact shape a correct
-// publish produces is what stops that turn from inventing a structure
-// of its own. Rendering goes through the real renderer rather than a
-// copy so the scaffold cannot drift from the published form.
+// RenderFacetScaffold renders the output's first-cycle placeholder.
 func (o OutputSpec) RenderFacetScaffold() string {
-	var payload FacetPayload
-	for _, field := range o.FacetFields() {
-		section, ok := facetSectionByKey(field.Key)
-		if !ok {
-			continue
-		}
-		*section.value(&payload) = facetScaffoldPlaceholder(field, section.scaffoldHint)
-	}
-	return o.RenderFacetDocument(payload)
+	return o.facetContract().RenderScaffold()
 }
 
-// facetScaffoldPlaceholder builds one section's placeholder. A json
-// facet gets a valid-JSON placeholder because its section renders
-// inside a json fence, where prose reads as damage.
-func facetScaffoldPlaceholder(field FacetField, hint string) string {
-	if field.Format == FacetFormatJSON {
-		return `{"awaiting_first_cycle": true}`
-	}
-	if field.MaxRunes > 0 {
-		return fmt.Sprintf("_(awaiting first cycle — %s, ≤%d characters)_", hint, field.MaxRunes)
-	}
-	return fmt.Sprintf("_(awaiting first cycle — %s)_", hint)
-}
-
-// ParseFacetDocument reads a rendered document body back into a payload.
-// It is the inverse of [OutputSpec.RenderFacetDocument] and the reason
-// the document is the canonical store: any derived binding — an
-// ambient rail, a published entity, a remote display — can be re-seeded
-// from the document alone after a restart.
-//
-// A body with no recognized facet sections parses entirely into Full,
-// which is what lets an existing facetless maintained document be adopted
-// into the faceted contract without losing its content. Content ahead of
-// the first recognized heading is folded into Full for the same reason.
+// ParseFacetDocument decodes a document using this output's declared formats.
 func (o OutputSpec) ParseFacetDocument(body string) FacetPayload {
-	payload, _ := ParseFacetSections(body)
-	// Only a field this output declared as json is unfenced. A markdown
-	// facet whose content legitimately opens with a fenced JSON example
-	// would otherwise come back with that fence eaten — the parser cannot
-	// tell an example from an encoding without being told which is which,
-	// and only the spec knows.
-	for _, field := range o.FacetFields() {
-		if field.Format != FacetFormatJSON {
-			continue
-		}
-		section, ok := facetSectionByKey(field.Key)
-		if !ok {
-			continue
-		}
-		value := section.value(&payload)
-		*value = unfence(*value)
-	}
-	return payload
+	return FacetPayload(o.facetContract().Parse(body))
 }
 
-// ParseFacetSections splits a rendered body into its facets without a
-// spec, reporting whether the body carried any facet section at all.
-//
-// A reader consulting someone else's document has the body and not the
-// declaration behind it, and does not need it: the section headings are
-// fixed by the contract, so what a document *has* is answerable from the
-// document. Only the json unfencing needs the spec, which is why that
-// step lives in [OutputSpec.ParseFacetDocument] and this does not repeat
-// the split.
-//
-// A body with no recognized facet sections parses entirely into Full and
-// reports false, which is what lets an ordinary maintained document be
-// read through the same path and answer "no facets" rather than error.
-// Content ahead of the first recognized heading folds into Full for the
-// same reason.
+// ParseFacetSections recognizes the legacy and canonical section envelope
+// without a manifest. New document-layer consumers should prefer the durable
+// manifest when one is present.
 func ParseFacetSections(body string) (FacetPayload, bool) {
-	var payload FacetPayload
-	var preamble []string
-	current := ""
-	found := false
-	collected := make(map[string][]string, len(facetSections))
-
-	for _, line := range strings.Split(body, "\n") {
-		if heading, ok := reservedFacetHeadingOf(line); ok {
-			current = heading
-			found = true
-			continue
-		}
-		if current == "" {
-			preamble = append(preamble, line)
-			continue
-		}
-		collected[current] = append(collected[current], line)
-	}
-
-	for _, section := range facetSections {
-		lines, ok := collected[section.Heading]
-		if !ok {
-			continue
-		}
-		*section.value(&payload) = strings.TrimSpace(strings.Join(lines, "\n"))
-	}
-
-	if leading := strings.TrimSpace(strings.Join(preamble, "\n")); leading != "" {
-		if payload.Full == "" {
-			payload.Full = leading
-		} else {
-			payload.Full = leading + "\n\n" + payload.Full
-		}
-	}
-	return payload, found
+	payload, found := documentfacets.ParseLegacy(body)
+	return FacetPayload(payload), found
 }
 
-// FacetByKey returns one projection level's value from a payload by its
-// field key — "full" included — so a consumer can ask for the level it
-// wants without a switch of its own over the ladder.
+// FacetByKey returns one projection by its model-facing key.
 func (p FacetPayload) FacetByKey(key string) (string, bool) {
-	section, ok := facetSectionByKey(key)
-	if !ok {
-		return "", false
-	}
-	value := *section.value(&p)
-	return value, strings.TrimSpace(value) != ""
+	return documentfacets.Payload(p).ByKey(key)
 }
 
-// FacetKeys returns every facet key in canonical order, for a consumer
-// advertising the levels a document offers. It includes "full"
-// deliberately: the full body is not a declarable facet — it is the
-// document itself — but it is always a readable projection level, and a
-// consumer advertising levels needs the complete ladder.
+// FacetKeys returns the complete logical read ladder.
 func FacetKeys() []string {
-	keys := make([]string, 0, len(facetSections))
-	for _, section := range facetSections {
-		keys = append(keys, section.Field.Key)
-	}
-	return keys
+	return documentfacets.Keys()
 }
 
-// facetSectionByKey looks up the section table entry for a field key.
-func facetSectionByKey(key string) (facetSection, bool) {
-	for _, section := range facetSections {
-		if section.Field.Key == key {
-			return section, true
-		}
-	}
-	return facetSection{}, false
-}
-
-// reservedFacetHeadingOf reports the canonical heading a line declares,
-// if the line is exactly one of the contract's H2 section headings.
-// Deeper headings inside a projection are ordinary content.
-func reservedFacetHeadingOf(line string) (string, bool) {
-	trimmed := strings.TrimSpace(line)
-	if !strings.HasPrefix(trimmed, "## ") {
-		return "", false
-	}
-	text := strings.TrimSpace(strings.TrimPrefix(trimmed, "## "))
-	for _, section := range facetSections {
-		if strings.EqualFold(text, section.Heading) {
-			return section.Heading, true
-		}
-	}
-	return "", false
-}
-
-// firstReservedFacetHeading finds a reserved section heading inside
-// projection content. Such a line would be read back as a section
-// boundary, silently moving content between projections, so publishing
-// is refused instead.
-func firstReservedFacetHeading(value string) (string, bool) {
-	for _, line := range strings.Split(value, "\n") {
-		if heading, ok := reservedFacetHeadingOf(line); ok {
-			return "## " + heading, true
-		}
-	}
-	return "", false
-}
-
-// validateFacetFormat enforces what a declared format actually promises
-// a consumer.
-//
-// Only json is mechanically checkable, and it is the one worth checking:
-// a consumer that declared it is code, and code given prose fails at the
-// far end where nothing can explain why. plain is advisory — markdown is
-// a spectrum rather than a grammar, and rejecting a stray asterisk would
-// cost more than the surfaces gain — so it shapes the guidance a model
-// reads instead of the value it may send.
-func validateFacetFormat(field FacetField, value string) error {
-	if field.Format != FacetFormatJSON {
-		return nil
-	}
-	if !json.Valid([]byte(value)) {
-		return fmt.Errorf("%s declares format %q but the value is not valid JSON; a consumer that asked for json cannot read prose", field.Key, FacetFormatJSON)
-	}
-	return nil
-}
-
-// FormatGuidance returns the sentence appended to a facet's model-facing
-// description when its format is anything but the markdown default.
-//
-// A rule that is enforced but never explained is one the model learns by
-// failing, so the format that shapes validation also shapes the
-// description the model reads before it writes.
+// FormatGuidance returns model-facing guidance for non-default encodings.
 func FormatGuidance(format FacetFormat) string {
-	switch format {
-	case FacetFormatPlain:
-		return " Write plain text with no markdown: this is spoken aloud or shown somewhere that renders nothing, so asterisks and backticks are read out."
-	case FacetFormatJSON:
-		return " Emit valid JSON, not prose: this is read by code rather than a person, and a non-JSON value is rejected."
-	default:
-		return ""
-	}
+	return documentfacets.FormatGuidance(format)
 }
 
-const (
-	// jsonFence opens the block a json facet is rendered inside, and
-	// fenceClose closes it.
-	jsonFence  = "```json"
-	fenceClose = "```"
-)
-
-// unfence removes the code fence a json facet was rendered inside, so
-// the parse half of the round trip returns the value that was published
-// rather than the markdown it was published as.
-//
-// The fence earns its place by making the document readable rather than
-// by protecting the parser: a raw JSON value sitting under a heading
-// beside prose sections reads as damage, and the fence also marks the
-// section as machine-readable to anyone scanning the file. The parser
-// splits only on the four reserved headings, so an arbitrary "## " line
-// inside a value was never a hazard.
-func unfence(value string) string {
-	if !strings.HasPrefix(value, jsonFence) || !strings.HasSuffix(value, fenceClose) {
-		return value
-	}
-	inner := strings.TrimSuffix(strings.TrimPrefix(value, jsonFence), fenceClose)
-	// A value that merely opens and closes with fences is not one block:
-	// unwrapping it would splice unrelated content together.
-	if strings.Contains(inner, fenceClose) {
-		return value
-	}
-	return strings.TrimSpace(inner)
-}
-
-// FacetPayloadFromArgs reads publish-tool arguments into a payload.
-//
-// It lives with the contract rather than with the tool that calls it,
-// because reading those arguments is the same question as what a facet
-// accepts, and a second reading anywhere else would be a second answer.
-// Keeping it here is also what lets the talent gate check a taught
-// publish sample against the real path instead of a copy of it.
-//
-// A missing argument is left empty rather than rejected, so
-// [OutputSpec.ValidateFacetPayload] reports every omission at once
-// instead of one per attempt.
+// FacetPayloadFromArgs decodes structured tool arguments according to this
+// output's declared contract.
 func (o OutputSpec) FacetPayloadFromArgs(args map[string]any) (FacetPayload, error) {
-	var payload FacetPayload
-	for _, field := range o.FacetFields() {
-		section, ok := facetSectionByKey(field.Key)
-		if !ok {
-			continue
-		}
-		raw, present := args[field.Key]
-		if !present {
-			continue
-		}
-		value, ok := raw.(string)
-		if !ok {
-			return FacetPayload{}, fmt.Errorf("%s must be a string", field.Key)
-		}
-		*section.value(&payload) = value
-	}
-	return payload, nil
+	payload, err := o.facetContract().FromArgs(args)
+	return FacetPayload(payload), err
 }
 
-// IsFacetKey reports whether key names a facet in the contract, for a
-// consumer validating a caller-supplied level before using it. "full"
-// answers true: not a declarable facet, but always a readable level.
+// IsFacetKey reports whether key names a readable document projection.
 func IsFacetKey(key string) bool {
-	_, ok := facetSectionByKey(key)
-	return ok
+	return documentfacets.IsKey(key)
+}
+
+func (o OutputSpec) facetContract() documentfacets.Contract {
+	return documentfacets.Contract{Facets: append([]documentfacets.Spec(nil), o.Facets...)}
 }

--- a/internal/runtime/loop/output_facets_test.go
+++ b/internal/runtime/loop/output_facets_test.go
@@ -8,6 +8,17 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 )
 
+var (
+	statusLineMaxRunes = facetTestBudget(string(OutputFacetStatusLine))
+	teaserMaxRunes     = facetTestBudget(string(OutputFacetTeaser))
+	digestMaxRunes     = facetTestBudget(string(OutputFacetDigest))
+)
+
+func facetTestBudget(key string) int {
+	field, _ := FacetFieldByKey(key)
+	return field.MaxRunes
+}
+
 func facetedOutput(names ...OutputFacet) OutputSpec {
 	facets := make([]FacetSpec, 0, len(names))
 	for _, name := range names {

--- a/internal/state/contacts/dossier.go
+++ b/internal/state/contacts/dossier.go
@@ -12,23 +12,19 @@ import (
 	"unicode"
 
 	"github.com/google/uuid"
-	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/state/documents"
+	documentfacets "github.com/nugget/thane-ai-agent/internal/state/documents/facets"
 )
 
 // DossierRootName is the canonical managed document root for longitudinal
 // contact synthesis.
 const DossierRootName = "contacts"
 
-var dossierOutputContract = looppkg.OutputSpec{
-	Name: "contact_dossier",
-	Type: looppkg.OutputTypeMaintainedDocument,
-	Facets: []looppkg.FacetSpec{
-		{Name: looppkg.OutputFacetStatusLine},
-		{Name: looppkg.OutputFacetTeaser},
-		{Name: looppkg.OutputFacetDigest},
-	},
-}
+// DossierWriteToolName is the single structured mutation surface for
+// canonical contact dossiers.
+const DossierWriteToolName = "contact_dossier_write"
+
+var dossierOutputContract = documentfacets.DefaultContract()
 
 var archiveSessionCitationPattern = regexp.MustCompile(`archive:session([:-])([[:alnum:]-]*)`)
 
@@ -60,7 +56,7 @@ type DossierReadArgs struct {
 // document store has been initialized so every advertised tool is callable.
 func (t *Tools) ConfigureDossierDocuments(
 	read func(context.Context, documents.RefArgs) (string, error),
-	write func(context.Context, documents.WriteArgs) (string, error),
+	write func(context.Context, documents.FacetedWriteArgs) (string, error),
 ) {
 	if t == nil {
 		return
@@ -83,8 +79,8 @@ func (t *Tools) DossierWritesEnabled() bool {
 
 // DossierFacetFields returns the canonical model-facing projection fields in
 // document order. Callers receive a copy and may safely enrich descriptions.
-func DossierFacetFields() []looppkg.FacetField {
-	return dossierOutputContract.FacetFields()
+func DossierFacetFields() []documentfacets.Field {
+	return dossierOutputContract.Fields()
 }
 
 // ReadDossier reads the canonical dossier for one active structured contact.
@@ -139,14 +135,14 @@ func (t *Tools) WriteDossier(ctx context.Context, args DossierWriteArgs) (string
 		return "", err
 	}
 
-	payload := looppkg.FacetPayload{
+	payload := documentfacets.Payload{
 		StatusLine: args.StatusLine,
 		Teaser:     args.Teaser,
 		Digest:     args.Digest,
 		Full:       args.Full,
 	}
 	var validationErrs []error
-	if err := dossierOutputContract.ValidateFacetPayload(payload); err != nil {
+	if err := dossierOutputContract.Validate(payload); err != nil {
 		validationErrs = append(validationErrs, err)
 	}
 	if err := validateDossierSubjectIdentity(id, payload); err != nil {
@@ -161,12 +157,13 @@ func (t *Tools) WriteDossier(ctx context.Context, args DossierWriteArgs) (string
 	if len(validationErrs) > 0 {
 		return "", fmt.Errorf("contact dossier projections are invalid; correct every listed field and retry once: %w", errors.Join(validationErrs...))
 	}
-	body := dossierOutputContract.RenderFacetDocument(payload)
-	return t.dossierWrite(ctx, documents.WriteArgs{
+	return t.dossierWrite(ctx, documents.FacetedWriteArgs{
 		Ref:          DossierRef(id),
 		Title:        contact.FormattedName,
 		Tags:         []string{DossierSubject(id)},
-		Body:         &body,
+		Contract:     dossierOutputContract,
+		Payload:      payload,
+		WriteTool:    DossierWriteToolName,
 		ReceiptScope: args.ReceiptScope,
 	})
 }
@@ -233,7 +230,7 @@ func marshalDossierAbsence(contact *Contact, ref string, writable bool) (string,
 	}
 	if writable {
 		result.NextAction = &dossierNextAction{
-			Tool:      "contact_dossier_write",
+			Tool:      DossierWriteToolName,
 			ContactID: contact.ID.String(),
 			Instruction: "Create the dossier with all four projections; do not retry " +
 				"contact_dossier_read until a write succeeds.",
@@ -285,6 +282,9 @@ func validateDossierWrite(candidate documents.DocumentWriteCandidate, resolveCon
 	if len(candidate.Tags) != 1 || strings.TrimSpace(candidate.Tags[0]) != wantSubject {
 		return fmt.Errorf("dossier %s must carry exactly one frontmatter tag, %q, so no broader subject can advertise this private dossier; use contact_dossier_write to let Go derive dossier identity and structure", candidate.Path, wantSubject)
 	}
+	if managers := candidate.Frontmatter[documentfacets.ManagedByKey]; len(managers) != 1 || strings.TrimSpace(managers[0]) != DossierWriteToolName {
+		return fmt.Errorf("dossier %s must declare managed_by: %s so generic document tools can redirect mutations to its owning interface", candidate.Path, DossierWriteToolName)
+	}
 	if resolveContactName == nil {
 		return fmt.Errorf("dossier %s cannot validate identity because the structured contact resolver is not configured", candidate.Path)
 	}
@@ -297,12 +297,16 @@ func validateDossierWrite(candidate documents.DocumentWriteCandidate, resolveCon
 		return fmt.Errorf("dossier %s cannot validate identity because structured contact %s has no formatted name", candidate.Path, id)
 	}
 
-	payload, faceted := looppkg.ParseFacetSections(candidate.Body)
+	manifest, faceted, manifestErr := documentfacets.FromFrontmatter(candidate.Frontmatter)
+	if manifestErr != nil {
+		return fmt.Errorf("dossier %s has invalid facet manifest: %w", candidate.Path, manifestErr)
+	}
 	if !faceted {
 		return fmt.Errorf("dossier %s must use the status_line, teaser, digest, and full facet ladder", candidate.Path)
 	}
+	payload := manifest.Contract.Parse(candidate.Body)
 	var validationErrs []error
-	if err := dossierOutputContract.ValidateFacetPayload(payload); err != nil {
+	if err := dossierOutputContract.Validate(payload); err != nil {
 		validationErrs = append(validationErrs, fmt.Errorf("facet contract: %w", err))
 	}
 	if err := validateDossierSubjectIdentity(id, payload); err != nil {
@@ -320,7 +324,7 @@ func validateDossierWrite(candidate documents.DocumentWriteCandidate, resolveCon
 	if len(validationErrs) > 0 {
 		return fmt.Errorf("dossier %s projections are invalid; correct every listed field and retry once: %w", candidate.Path, errors.Join(validationErrs...))
 	}
-	if got, want := strings.TrimSpace(candidate.Body), dossierOutputContract.RenderFacetDocument(payload); got != want {
+	if got, want := strings.TrimSpace(candidate.Body), dossierOutputContract.Render(payload); got != want {
 		return fmt.Errorf("dossier %s must use the canonical facet section order with no text outside those sections", candidate.Path)
 	}
 	return nil
@@ -331,7 +335,7 @@ func validateDossierWrite(candidate documents.DocumentWriteCandidate, resolveCon
 // dossier's contact UUID; repeating it spends model attention and can drift
 // into a second, less reliable statement of the same identity. Other contact
 // UUIDs remain valid cross-references in relationship content.
-func validateDossierSubjectIdentity(id uuid.UUID, payload looppkg.FacetPayload) error {
+func validateDossierSubjectIdentity(id uuid.UUID, payload documentfacets.Payload) error {
 	fields := []struct {
 		name  string
 		value string
@@ -358,7 +362,7 @@ func validateDossierSubjectIdentity(id uuid.UUID, payload looppkg.FacetPayload) 
 // relationship signal. The structured contact and dossier title already name
 // the subject, while digest and full remain standalone prose where using the
 // name can improve clarity.
-func validateDossierSubjectName(name string, payload looppkg.FacetPayload) error {
+func validateDossierSubjectName(name string, payload documentfacets.Payload) error {
 	name = strings.TrimSpace(name)
 	if name == "" {
 		return nil
@@ -414,7 +418,7 @@ func isDossierNameRune(r rune) bool {
 // checkable. Archive tools accept short session prefixes for interactive
 // convenience, but imported sessions can share those prefixes; durable
 // citations therefore need the full canonical UUID.
-func validateDossierEvidenceCitations(payload looppkg.FacetPayload) error {
+func validateDossierEvidenceCitations(payload documentfacets.Payload) error {
 	fields := []struct {
 		name  string
 		value string

--- a/internal/state/contacts/dossier_test.go
+++ b/internal/state/contacts/dossier_test.go
@@ -6,34 +6,40 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/state/documents"
+	documentfacets "github.com/nugget/thane-ai-agent/internal/state/documents/facets"
 )
 
 type recordingDossierWriter struct {
-	args  documents.WriteArgs
+	args  documents.FacetedWriteArgs
 	calls int
 }
 
-func (w *recordingDossierWriter) Write(_ context.Context, args documents.WriteArgs) (string, error) {
+func (w *recordingDossierWriter) Write(_ context.Context, args documents.FacetedWriteArgs) (string, error) {
 	w.args = args
 	w.calls++
 	return `{"action":"doc_write","applied":true}`, nil
 }
 
 func validDossierCandidate(id uuid.UUID) documents.DocumentWriteCandidate {
-	payload := looppkg.FacetPayload{
+	payload := documentfacets.Payload{
 		StatusLine: "Relationship is current and steady.",
 		Teaser:     "Recent conversations clarified the operator's preferred collaboration style.",
 		Digest:     "The contact prefers direct technical collaboration and explicit source-of-truth boundaries.",
 		Full:       "# Relationship context\n\nCurrent synthesis — evidence: archive:session:019c52f0-9ce8-7708-867f-35da2e6b4777.",
 	}
-	return documents.DocumentWriteCandidate{
-		Path:        id.String() + ".md",
-		Tags:        []string{DossierSubject(id)},
-		Frontmatter: map[string][]string{"title": {"Dossier Person"}},
-		Body:        dossierOutputContract.RenderFacetDocument(payload),
+	candidate := documents.DocumentWriteCandidate{
+		Path: id.String() + ".md",
+		Tags: []string{DossierSubject(id)},
+		Frontmatter: map[string][]string{
+			"title": {"Dossier Person"},
+		},
+		Body: dossierOutputContract.Render(payload),
 	}
+	for key, values := range (documentfacets.Manifest{Contract: dossierOutputContract, ManagedBy: DossierWriteToolName}).Frontmatter() {
+		candidate.Frontmatter[key] = values
+	}
+	return candidate
 }
 
 func dossierValidatorForName(name string) documents.RootWriteValidator {
@@ -383,7 +389,7 @@ func TestWriteDossierRejectsEveryAmbiguousArchiveSessionCitation(t *testing.T) {
 func TestValidateDossierWriteReportsFacetAndEvidenceViolationsTogether(t *testing.T) {
 	id := uuid.MustParse("019c76e4-2ff1-7918-8d6f-6c2488f5098d")
 	candidate := validDossierCandidate(id)
-	candidate.Body = dossierOutputContract.RenderFacetDocument(looppkg.FacetPayload{
+	candidate.Body = dossierOutputContract.Render(documentfacets.Payload{
 		StatusLine: strings.Repeat("s", 121),
 		Teaser:     "Useful hook.",
 		Digest:     "Enough context to act.",
@@ -454,17 +460,24 @@ func TestWriteDossierOwnsDocumentIdentityAndStructure(t *testing.T) {
 	if len(writer.args.Tags) != 1 || writer.args.Tags[0] != DossierSubject(contact.ID) {
 		t.Errorf("write tags = %#v, want canonical private subject", writer.args.Tags)
 	}
-	if writer.args.Body == nil {
-		t.Fatal("write body is nil")
-	}
 	if got, want := writer.args.ReceiptScope, args.ReceiptScope; got != want {
 		t.Errorf("receipt scope = %q, want %q", got, want)
+	}
+	if got, want := writer.args.WriteTool, DossierWriteToolName; got != want {
+		t.Errorf("write tool = %q, want %q", got, want)
+	}
+	frontmatter := map[string][]string{"title": {writer.args.Title}}
+	for key, values := range writer.args.Frontmatter {
+		frontmatter[key] = append([]string(nil), values...)
+	}
+	for key, values := range (documentfacets.Manifest{Contract: writer.args.Contract, ManagedBy: writer.args.WriteTool}).Frontmatter() {
+		frontmatter[key] = values
 	}
 	if err := dossierValidatorForName(contact.FormattedName)(documents.DocumentWriteCandidate{
 		Path:        strings.TrimPrefix(writer.args.Ref, DossierRootName+":"),
 		Tags:        writer.args.Tags,
-		Frontmatter: map[string][]string{"title": {writer.args.Title}},
-		Body:        *writer.args.Body,
+		Frontmatter: frontmatter,
+		Body:        writer.args.Contract.Render(writer.args.Payload),
 	}); err != nil {
 		t.Fatalf("Go-authored dossier failed root validator: %v", err)
 	}

--- a/internal/state/contacts/tools.go
+++ b/internal/state/contacts/tools.go
@@ -50,7 +50,7 @@ type Tools struct {
 	dossiersEnabled   bool
 	dossiersWritable  bool
 	dossierRead       func(context.Context, documents.RefArgs) (string, error)
-	dossierWrite      func(context.Context, documents.WriteArgs) (string, error)
+	dossierWrite      func(context.Context, documents.FacetedWriteArgs) (string, error)
 	mutationSink      func(context.Context, ContactMutation) error
 }
 

--- a/internal/state/documents/advertise.go
+++ b/internal/state/documents/advertise.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
-	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	documentfacets "github.com/nugget/thane-ai-agent/internal/state/documents/facets"
 )
 
 // Frontmatter keys the loop-creation tooling stamps on curator task
@@ -42,8 +42,11 @@ type AdvertisableDocument struct {
 	// them without reading the file.
 	Facets     []string       `json:"facets,omitempty"`
 	FacetBytes map[string]int `json:"facet_bytes,omitempty"`
-	Tags       []string       `json:"tags,omitempty"`
-	ModifiedAt time.Time      `json:"modified_at"`
+	// FacetContract supplies durable formats to the advertiser. Legacy rows
+	// receive a default-format compatibility contract until their first write.
+	FacetContract documentfacets.Contract `json:"-"`
+	Tags          []string                `json:"tags,omitempty"`
+	ModifiedAt    time.Time               `json:"modified_at"`
 	// AbsPath and SizeBytes let a materializer read the file directly,
 	// off the store's locks — the same reason enumeration skips Refresh
 	// — and prove before rendering that the bytes on disk are still the
@@ -128,8 +131,15 @@ func (s *Store) AdvertisableDocuments(ctx context.Context) ([]AdvertisableDocume
 			return nil, fmt.Errorf("parse modified_at for %s: %w", doc.Ref, err)
 		}
 		doc.LoopDefinitionName = firstValue(frontmatter, loopDefinitionNameFrontmatterKey)
-		doc.ManagedBy = firstValue(frontmatter, looppkg.OutputManagedByFrontmatterKey)
+		doc.ManagedBy = firstValue(frontmatter, documentfacets.ManagedByKey)
 		doc.LoopIntent = firstValue(frontmatter, loopIntentFrontmatterKey)
+		if manifest, canonical, manifestErr := documentfacets.FromFrontmatter(frontmatter); canonical && manifestErr == nil {
+			doc.FacetContract = manifest.Contract
+		} else {
+			for _, name := range doc.Facets {
+				doc.FacetContract.Facets = append(doc.FacetContract.Facets, documentfacets.Spec{Name: documentfacets.Name(name)})
+			}
+		}
 		docs = append(docs, doc)
 	}
 	if err := rows.Err(); err != nil {

--- a/internal/state/documents/advertise.go
+++ b/internal/state/documents/advertise.go
@@ -133,7 +133,12 @@ func (s *Store) AdvertisableDocuments(ctx context.Context) ([]AdvertisableDocume
 		doc.LoopDefinitionName = firstValue(frontmatter, loopDefinitionNameFrontmatterKey)
 		doc.ManagedBy = firstValue(frontmatter, documentfacets.ManagedByKey)
 		doc.LoopIntent = firstValue(frontmatter, loopIntentFrontmatterKey)
-		if manifest, canonical, manifestErr := documentfacets.FromFrontmatter(frontmatter); canonical && manifestErr == nil {
+		if manifest, canonical, manifestErr := documentfacets.FromFrontmatter(frontmatter); canonical {
+			if manifestErr != nil {
+				// A malformed codec has no safe projection to offer. Direct reads
+				// return the bounded owner-directed repair error.
+				continue
+			}
 			doc.FacetContract = manifest.Contract
 		} else {
 			for _, name := range doc.Facets {

--- a/internal/state/documents/advertiser.go
+++ b/internal/state/documents/advertiser.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
-	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	documentfacets "github.com/nugget/thane-ai-agent/internal/state/documents/facets"
 	"github.com/nugget/thane-ai-agent/internal/state/knowledge"
 )
 
@@ -289,7 +289,8 @@ func (d *DocumentAdvertiser) MaterializeContextAdvertisement(ctx context.Context
 		return "", fmt.Errorf("document %s is audience-internal; refusing to materialize", ref)
 	}
 
-	payload, _ := looppkg.ParseFacetSections(body)
+	contract := parsedFacetContract(meta, body)
+	payload := contract.Parse(body)
 	content := facetContent(payload, selection.Projection.Name)
 	if strings.TrimSpace(content) == "" {
 		return "", fmt.Errorf("document %s no longer carries facet %s", ref, selection.Projection.Name)
@@ -330,17 +331,18 @@ func (d *DocumentAdvertiser) projectionsFor(row AdvertisableDocument, envelopeBy
 	var out []agentctx.ContextProjection
 	compact := false
 	for facet, size := range row.FacetBytes {
-		field, ok := looppkg.FacetFieldByKey(facet)
+		field, ok := documentfacets.FieldByKey(facet)
 		if !ok || size <= 0 {
 			continue
 		}
 		if field.ContextRole != agentctx.ContextRoleDetail {
 			compact = true
 		}
+		format := projectionMIMEType(row.FacetContract, facet)
 		out = append(out, agentctx.ContextProjection{
 			Name:           facet,
 			Role:           field.ContextRole,
-			Format:         "text/markdown",
+			Format:         format,
 			EstimatedBytes: size + envelopeBytes + advertiseEnvelopeSlackBytes,
 		})
 	}
@@ -460,17 +462,24 @@ func bestMatchKind(matches []agentctx.ContextMatchSignal) agentctx.ContextMatchK
 }
 
 // facetContent selects one projection's text from a parsed facet payload.
-func facetContent(payload looppkg.FacetPayload, name string) string {
-	switch name {
-	case string(looppkg.OutputFacetStatusLine):
-		return payload.StatusLine
-	case string(looppkg.OutputFacetTeaser):
-		return payload.Teaser
-	case string(looppkg.OutputFacetDigest):
-		return payload.Digest
-	case "full":
-		return payload.Full
-	default:
-		return ""
+func facetContent(payload documentfacets.Payload, name string) string {
+	value, _ := payload.ByKey(name)
+	return value
+}
+
+func projectionMIMEType(contract documentfacets.Contract, name string) string {
+	for _, field := range contract.Fields() {
+		if field.Key != name {
+			continue
+		}
+		switch field.Format {
+		case documentfacets.FormatJSON:
+			return "application/json"
+		case documentfacets.FormatPlain:
+			return "text/plain"
+		default:
+			return "text/markdown"
+		}
 	}
+	return "text/markdown"
 }

--- a/internal/state/documents/faceted_write.go
+++ b/internal/state/documents/faceted_write.go
@@ -52,6 +52,9 @@ type FacetedWriteArgs struct {
 	Validate         func(documentfacets.Payload) error `json:"-"`
 	ExpectedRevision string                             `json:"-"`
 	ReceiptScope     string                             `json:"-"`
+	// PreviousWriteTools permits a trusted adapter to rename its own write
+	// surface while atomically migrating the document contract.
+	PreviousWriteTools []string `json:"-"`
 }
 
 // StructuredDocumentMutationError redirects a mutation to the tool that owns
@@ -139,7 +142,7 @@ func (t *Tools) WriteFaceted(ctx context.Context, args FacetedWriteArgs) (string
 		return "", fmt.Errorf("inspect %s before %s: %w", args.Ref, args.WriteTool, err)
 	}
 	if current != nil {
-		if owner := strings.TrimSpace(current.ManagedBy); owner != "" && owner != args.WriteTool {
+		if owner := strings.TrimSpace(current.ManagedBy); owner != "" && owner != args.WriteTool && !containsWriteTool(args.PreviousWriteTools, owner) {
 			return "", &StructuredDocumentMutationError{Ref: args.Ref, Attempted: args.WriteTool, WriteTool: owner}
 		}
 	}
@@ -163,15 +166,16 @@ func (t *Tools) WriteFaceted(ctx context.Context, args FacetedWriteArgs) (string
 		frontmatter[key] = values
 	}
 	writeArgs := WriteArgs{
-		Ref:              args.Ref,
-		Title:            args.Title,
-		Description:      args.Description,
-		Tags:             append([]string(nil), args.Tags...),
-		Frontmatter:      frontmatter,
-		Body:             &body,
-		ExpectedRevision: args.ExpectedRevision,
-		ReceiptScope:     args.ReceiptScope,
-		StructuredTool:   args.WriteTool,
+		Ref:                args.Ref,
+		Title:              args.Title,
+		Description:        args.Description,
+		Tags:               append([]string(nil), args.Tags...),
+		Frontmatter:        frontmatter,
+		Body:               &body,
+		ExpectedRevision:   args.ExpectedRevision,
+		ReceiptScope:       args.ReceiptScope,
+		StructuredTool:     args.WriteTool,
+		PreviousWriteTools: append([]string(nil), args.PreviousWriteTools...),
 	}
 	t.prepareWriteReceipt(&writeArgs)
 	result, err := t.store.Write(ctx, writeArgs)
@@ -179,6 +183,16 @@ func (t *Tools) WriteFaceted(ctx context.Context, args FacetedWriteArgs) (string
 		result.Action = args.WriteTool
 	}
 	return t.marshalMutationResult(ctx, args.WriteTool, args.Ref, args.ReceiptScope, writeArgs.ExpectedRevision, result, err)
+}
+
+func containsWriteTool(tools []string, target string) bool {
+	target = strings.TrimSpace(target)
+	for _, tool := range tools {
+		if strings.TrimSpace(tool) == target {
+			return true
+		}
+	}
+	return false
 }
 
 func genericWriteContract(current *DocumentRecord, teaser, digest bool) documentfacets.Contract {
@@ -237,5 +251,19 @@ func structuredWriteTool(record *DocumentRecord) string {
 	if len(record.Facets) > 0 {
 		return DocumentWriteToolName
 	}
+	if record.InvalidFacetManifest != "" {
+		return DocumentWriteToolName
+	}
 	return ""
+}
+
+func invalidFacetManifestReadError(record *DocumentRecord) error {
+	if record == nil || strings.TrimSpace(record.InvalidFacetManifest) == "" {
+		return nil
+	}
+	owner := strings.TrimSpace(record.ManagedBy)
+	if owner == "" {
+		owner = DocumentWriteToolName
+	}
+	return fmt.Errorf("document %s has an invalid faceted manifest; no private storage envelope was returned. Repair it by calling %s with the complete logical projections, or correct the reserved frontmatter through repository administration: %s", record.Ref, owner, record.InvalidFacetManifest)
 }

--- a/internal/state/documents/faceted_write.go
+++ b/internal/state/documents/faceted_write.go
@@ -1,0 +1,241 @@
+package documents
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	documentfacets "github.com/nugget/thane-ai-agent/internal/state/documents/facets"
+)
+
+const (
+	// DocumentWriteToolName is the normal structured mutation surface for a
+	// faceted document without a narrower domain owner.
+	DocumentWriteToolName = "doc_write"
+	// DocumentBodyWriteToolName is the exceptional whole-body mutation surface
+	// for documents that intentionally have no projection contract.
+	DocumentBodyWriteToolName = "doc_body_write"
+)
+
+// PublishArgs carries one atomic logical document state for the generic
+// [DocumentWriteToolName] surface. Pointer compact projections distinguish an
+// omitted projection from an explicitly supplied empty value.
+type PublishArgs struct {
+	Ref              string              `json:"ref"`
+	Title            string              `json:"title,omitempty"`
+	Description      string              `json:"description,omitempty"`
+	Tags             []string            `json:"tags,omitempty"`
+	Frontmatter      map[string][]string `json:"frontmatter,omitempty"`
+	StatusLine       string              `json:"status_line"`
+	Teaser           *string             `json:"teaser,omitempty"`
+	Digest           *string             `json:"digest,omitempty"`
+	Full             string              `json:"full"`
+	ExpectedRevision string              `json:"-"`
+	ReceiptScope     string              `json:"-"`
+}
+
+// FacetedWriteArgs is the shared document-layer write primitive used by the
+// generic writer and narrower owners such as contact dossiers and loop
+// outputs. Domain validation is the only policy supplied by an adapter; the
+// contract, codec, manifest, ownership, receipts, CAS, and result shape remain
+// shared.
+type FacetedWriteArgs struct {
+	Ref              string                             `json:"ref"`
+	Title            string                             `json:"title,omitempty"`
+	Description      string                             `json:"description,omitempty"`
+	Tags             []string                           `json:"tags,omitempty"`
+	Frontmatter      map[string][]string                `json:"frontmatter,omitempty"`
+	Contract         documentfacets.Contract            `json:"contract"`
+	Payload          documentfacets.Payload             `json:"payload"`
+	WriteTool        string                             `json:"write_tool"`
+	Validate         func(documentfacets.Payload) error `json:"-"`
+	ExpectedRevision string                             `json:"-"`
+	ReceiptScope     string                             `json:"-"`
+}
+
+// StructuredDocumentMutationError redirects a mutation to the tool that owns
+// the target document's complete logical state.
+type StructuredDocumentMutationError struct {
+	Ref       string `json:"-"`
+	Attempted string `json:"-"`
+	WriteTool string `json:"-"`
+}
+
+// Error implements error with a one-retry recovery path for the model.
+func (e *StructuredDocumentMutationError) Error() string {
+	tool := strings.TrimSpace(e.WriteTool)
+	if tool == "" {
+		tool = DocumentWriteToolName
+	}
+	attempted := strings.TrimSpace(e.Attempted)
+	if attempted == "" {
+		attempted = "document mutation"
+	}
+	if tool == DocumentWriteToolName {
+		return fmt.Sprintf("%s cannot change %s because it is a faceted document; no change was made. Read it, then call %s with every published projection so all views move together", attempted, e.Ref, tool)
+	}
+	return fmt.Sprintf("%s cannot change %s because %s owns that document; no change was made. Use %s instead", attempted, e.Ref, tool, tool)
+}
+
+// Publish creates, adopts, or republishes a generic faceted document. Legacy
+// section envelopes and ordinary body-only documents acquire a durable
+// manifest on this first structured write.
+func (t *Tools) Publish(ctx context.Context, args PublishArgs) (string, error) {
+	if t == nil || t.store == nil {
+		return "", fmt.Errorf("document index not configured")
+	}
+	args.Ref = strings.TrimSpace(args.Ref)
+	if args.Ref == "" {
+		return "", fmt.Errorf("ref is required")
+	}
+
+	var current *DocumentRecord
+	record, err := t.store.Read(ctx, args.Ref)
+	switch {
+	case err == nil:
+		current = record
+	case IsNotFound(err):
+	default:
+		return "", fmt.Errorf("inspect %s before write: %w", args.Ref, err)
+	}
+	if current != nil {
+		if owner := strings.TrimSpace(current.ManagedBy); owner != "" && owner != DocumentWriteToolName {
+			return "", &StructuredDocumentMutationError{Ref: args.Ref, Attempted: DocumentWriteToolName, WriteTool: owner}
+		}
+	}
+
+	contract := genericWriteContract(current, args.Teaser != nil, args.Digest != nil)
+	return t.WriteFaceted(ctx, FacetedWriteArgs{
+		Ref:              args.Ref,
+		Title:            args.Title,
+		Description:      args.Description,
+		Tags:             append([]string(nil), args.Tags...),
+		Frontmatter:      cloneFrontmatter(args.Frontmatter),
+		Contract:         contract,
+		Payload:          documentfacets.Payload{StatusLine: args.StatusLine, Teaser: optionalProjection(args.Teaser), Digest: optionalProjection(args.Digest), Full: args.Full},
+		WriteTool:        DocumentWriteToolName,
+		ExpectedRevision: args.ExpectedRevision,
+		ReceiptScope:     args.ReceiptScope,
+	})
+}
+
+// WriteFaceted validates and atomically persists one complete logical
+// document state through the shared receipt/CAS path.
+func (t *Tools) WriteFaceted(ctx context.Context, args FacetedWriteArgs) (string, error) {
+	if t == nil || t.store == nil {
+		return "", fmt.Errorf("document index not configured")
+	}
+	args.Ref = strings.TrimSpace(args.Ref)
+	args.WriteTool = strings.TrimSpace(args.WriteTool)
+	if args.Ref == "" {
+		return "", fmt.Errorf("ref is required")
+	}
+	if args.WriteTool == "" {
+		return "", fmt.Errorf("write tool is required")
+	}
+	current, err := t.store.Read(ctx, args.Ref)
+	if err != nil && !IsNotFound(err) {
+		return "", fmt.Errorf("inspect %s before %s: %w", args.Ref, args.WriteTool, err)
+	}
+	if current != nil {
+		if owner := strings.TrimSpace(current.ManagedBy); owner != "" && owner != args.WriteTool {
+			return "", &StructuredDocumentMutationError{Ref: args.Ref, Attempted: args.WriteTool, WriteTool: owner}
+		}
+	}
+
+	var validationErrors []error
+	if err := args.Contract.Validate(args.Payload); err != nil {
+		validationErrors = append(validationErrors, err)
+	}
+	if args.Validate != nil {
+		if err := args.Validate(args.Payload); err != nil {
+			validationErrors = append(validationErrors, err)
+		}
+	}
+	if len(validationErrors) > 0 {
+		return "", fmt.Errorf("faceted document projections are invalid; correct every listed field and retry once: %w", errors.Join(validationErrors...))
+	}
+
+	body := args.Contract.Render(args.Payload)
+	frontmatter := cloneFrontmatter(args.Frontmatter)
+	for key, values := range (documentfacets.Manifest{Schema: documentfacets.SchemaV1, Contract: args.Contract, ManagedBy: args.WriteTool}).Frontmatter() {
+		frontmatter[key] = values
+	}
+	writeArgs := WriteArgs{
+		Ref:              args.Ref,
+		Title:            args.Title,
+		Description:      args.Description,
+		Tags:             append([]string(nil), args.Tags...),
+		Frontmatter:      frontmatter,
+		Body:             &body,
+		ExpectedRevision: args.ExpectedRevision,
+		ReceiptScope:     args.ReceiptScope,
+		StructuredTool:   args.WriteTool,
+	}
+	t.prepareWriteReceipt(&writeArgs)
+	result, err := t.store.Write(ctx, writeArgs)
+	if result != nil {
+		result.Action = args.WriteTool
+	}
+	return t.marshalMutationResult(ctx, args.WriteTool, args.Ref, args.ReceiptScope, writeArgs.ExpectedRevision, result, err)
+}
+
+func genericWriteContract(current *DocumentRecord, teaser, digest bool) documentfacets.Contract {
+	if current != nil && len(current.FacetContract.Facets) > 0 {
+		return current.FacetContract
+	}
+	contract := documentfacets.Contract{Facets: []documentfacets.Spec{{Name: documentfacets.StatusLine}}}
+	if teaser {
+		contract.Facets = append(contract.Facets, documentfacets.Spec{Name: documentfacets.Teaser})
+	}
+	if digest {
+		contract.Facets = append(contract.Facets, documentfacets.Spec{Name: documentfacets.Digest})
+	}
+	return contract
+}
+
+func optionalProjection(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func validateFacetedDocumentBody(body string, frontmatter map[string][]string) error {
+	manifest, canonical, err := documentfacets.FromFrontmatter(frontmatter)
+	if err != nil {
+		return err
+	}
+	if !canonical {
+		if _, legacy := documentfacets.ParseLegacy(body); legacy {
+			return fmt.Errorf("faceted documents require a durable %s manifest; write projections through their structured tool so the legacy envelope is migrated", documentfacets.SchemaKey)
+		}
+		return nil
+	}
+	payload := manifest.Contract.Parse(body)
+	var validationErrors []error
+	if err := manifest.Contract.Validate(payload); err != nil {
+		validationErrors = append(validationErrors, err)
+	}
+	if got, want := strings.TrimSpace(body), manifest.Contract.Render(payload); got != want {
+		validationErrors = append(validationErrors, fmt.Errorf("body does not match the canonical faceted document codec; write logical projections through %s", manifest.ManagedBy))
+	}
+	if len(validationErrors) > 0 {
+		return errors.Join(validationErrors...)
+	}
+	return nil
+}
+
+func structuredWriteTool(record *DocumentRecord) string {
+	if record == nil {
+		return ""
+	}
+	if managedBy := strings.TrimSpace(record.ManagedBy); managedBy != "" {
+		return managedBy
+	}
+	if len(record.Facets) > 0 {
+		return DocumentWriteToolName
+	}
+	return ""
+}

--- a/internal/state/documents/facets/codec.go
+++ b/internal/state/documents/facets/codec.go
@@ -1,0 +1,144 @@
+package facets
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	jsonFence  = "```json"
+	fenceClose = "```"
+)
+
+// Render encodes a logical payload into the canonical Markdown persistence
+// envelope. Callers must validate the payload before writing it.
+func (c Contract) Render(payload Payload) string {
+	fields := c.Fields()
+	published := make(map[string]Field, len(fields))
+	for _, field := range fields {
+		published[field.Key] = field
+	}
+	blocks := make([]string, 0, len(fields))
+	for _, item := range sections {
+		field, ok := published[item.field.Key]
+		if !ok {
+			continue
+		}
+		value := strings.TrimSpace(*item.value(&payload))
+		if value == "" {
+			continue
+		}
+		if field.Format == FormatJSON {
+			value = jsonFence + "\n" + value + "\n" + fenceClose
+		}
+		blocks = append(blocks, "## "+item.heading+"\n\n"+value)
+	}
+	return strings.Join(blocks, "\n\n")
+}
+
+// Parse decodes the canonical or legacy section envelope using the contract's
+// declared formats.
+func (c Contract) Parse(body string) Payload {
+	payload, _ := ParseLegacy(body)
+	for _, field := range c.Fields() {
+		if field.Format != FormatJSON {
+			continue
+		}
+		item, ok := sectionByKey(field.Key)
+		if !ok {
+			continue
+		}
+		value := item.value(&payload)
+		*value = unfence(*value)
+	}
+	return payload
+}
+
+// ParseLegacy recognizes the historical reserved-heading envelope without a
+// manifest. An ordinary body becomes Full and reports false, enabling lazy
+// adoption on its first structured write.
+func ParseLegacy(body string) (Payload, bool) {
+	var payload Payload
+	var preamble []string
+	current := ""
+	found := false
+	collected := make(map[string][]string, len(sections))
+	for _, line := range strings.Split(body, "\n") {
+		if heading, ok := reservedHeadingOf(line); ok {
+			current = heading
+			found = true
+			continue
+		}
+		if current == "" {
+			preamble = append(preamble, line)
+			continue
+		}
+		collected[current] = append(collected[current], line)
+	}
+	for _, item := range sections {
+		lines, ok := collected[item.heading]
+		if !ok {
+			continue
+		}
+		*item.value(&payload) = strings.TrimSpace(strings.Join(lines, "\n"))
+	}
+	if leading := strings.TrimSpace(strings.Join(preamble, "\n")); leading != "" {
+		if payload.Full == "" {
+			payload.Full = leading
+		} else {
+			payload.Full = leading + "\n\n" + payload.Full
+		}
+	}
+	return payload, found
+}
+
+// RenderScaffold produces the canonical pre-first-write placeholder.
+func (c Contract) RenderScaffold() string {
+	var payload Payload
+	for _, field := range c.Fields() {
+		item, _ := sectionByKey(field.Key)
+		placeholder := fmt.Sprintf("_(awaiting first cycle - %s)_", item.scaffoldHint)
+		if field.MaxRunes > 0 {
+			placeholder = fmt.Sprintf("_(awaiting first cycle - %s, <=%d characters)_", item.scaffoldHint, field.MaxRunes)
+		}
+		if field.Format == FormatJSON {
+			placeholder = `{"awaiting_first_cycle": true}`
+		}
+		*item.value(&payload) = placeholder
+	}
+	return c.Render(payload)
+}
+
+func reservedHeadingOf(line string) (string, bool) {
+	trimmed := strings.TrimSpace(line)
+	if !strings.HasPrefix(trimmed, "## ") {
+		return "", false
+	}
+	text := strings.TrimSpace(strings.TrimPrefix(trimmed, "## "))
+	for _, item := range sections {
+		if strings.EqualFold(text, item.heading) {
+			return item.heading, true
+		}
+	}
+	return "", false
+}
+
+func firstReservedHeading(value string) (string, bool) {
+	for _, line := range strings.Split(value, "\n") {
+		if heading, ok := reservedHeadingOf(line); ok {
+			return "## " + heading, true
+		}
+	}
+	return "", false
+}
+
+func unfence(value string) string {
+	if !strings.HasPrefix(value, jsonFence) || !strings.HasSuffix(value, fenceClose) {
+		return value
+	}
+	inner := strings.TrimSuffix(strings.TrimPrefix(value, jsonFence), fenceClose)
+	if strings.Contains(inner, fenceClose) {
+		return value
+	}
+	return strings.TrimSpace(inner)
+}

--- a/internal/state/documents/facets/codec.go
+++ b/internal/state/documents/facets/codec.go
@@ -61,12 +61,12 @@ func ParseLegacy(body string) (Payload, bool) {
 	var payload Payload
 	var preamble []string
 	current := ""
-	found := false
+	found := make(map[string]bool, len(sections))
 	collected := make(map[string][]string, len(sections))
 	for _, line := range strings.Split(body, "\n") {
 		if heading, ok := reservedHeadingOf(line); ok {
 			current = heading
-			found = true
+			found[heading] = true
 			continue
 		}
 		if current == "" {
@@ -89,7 +89,13 @@ func ParseLegacy(body string) (Payload, bool) {
 			payload.Full = leading + "\n\n" + payload.Full
 		}
 	}
-	return payload, found
+	// Status Line and Details were mandatory in every historical envelope.
+	// Requiring both keeps an ordinary document's legitimate "## Details" or
+	// "## Digest" section from being mistaken for private facet storage.
+	if !found["Status Line"] || !found["Details"] {
+		return Payload{Full: strings.TrimSpace(body)}, false
+	}
+	return payload, true
 }
 
 // RenderScaffold produces the canonical pre-first-write placeholder.

--- a/internal/state/documents/facets/codec_test.go
+++ b/internal/state/documents/facets/codec_test.go
@@ -1,0 +1,40 @@
+package facets
+
+import "testing"
+
+func TestParseLegacyRequiresCompleteEnvelope(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		body    string
+		faceted bool
+	}{
+		{
+			name:    "ordinary details section",
+			body:    "# Runbook\n\nOverview.\n\n## Details\n\nOperator-authored detail.",
+			faceted: false,
+		},
+		{
+			name:    "ordinary digest section",
+			body:    "# Notes\n\nOverview.\n\n## Digest\n\nA legitimate digest heading.",
+			faceted: false,
+		},
+		{
+			name:    "historical envelope",
+			body:    "## Status Line\n\nNominal.\n\n## Details\n\nFull state.",
+			faceted: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload, faceted := ParseLegacy(tt.body)
+			if faceted != tt.faceted {
+				t.Fatalf("ParseLegacy faceted = %v, want %v", faceted, tt.faceted)
+			}
+			if !tt.faceted && payload.Full != tt.body {
+				t.Fatalf("ordinary document full = %q, want original body %q", payload.Full, tt.body)
+			}
+		})
+	}
+}

--- a/internal/state/documents/facets/contract.go
+++ b/internal/state/documents/facets/contract.go
@@ -1,0 +1,241 @@
+package facets
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+)
+
+const (
+	statusLineMaxRunes = 120
+	teaserMaxRunes     = 500
+	digestMaxRunes     = 2048
+
+	// MaxDocumentBytes is the write ceiling that guarantees a maintained
+	// document can be read back whole by its owner in one call.
+	MaxDocumentBytes = 96 * 1024
+)
+
+// Contract defines the compact projections carried with a document's full
+// content. Declaration order is irrelevant; [Contract.Fields] is canonical.
+type Contract struct {
+	Facets []Spec `json:"facets"`
+}
+
+type section struct {
+	name         Name
+	field        Field
+	heading      string
+	scaffoldHint string
+	value        func(*Payload) *string
+}
+
+var sections = []section{
+	{
+		name:    StatusLine,
+		heading: "Status Line",
+		field: Field{
+			Key:         string(StatusLine),
+			MaxRunes:    statusLineMaxRunes,
+			SingleLine:  true,
+			Guidance:    "The tight signal shape: one standalone line of current state, no line breaks. Reads as an ambient status: what is true right now. This is the only thing some surfaces show, so it must stand alone without the document around it.",
+			ContextRole: agentctx.ContextRoleSignal,
+		},
+		scaffoldHint: "one standalone line of what is true right now",
+		value:        func(p *Payload) *string { return &p.StatusLine },
+	},
+	{
+		name:    Teaser,
+		heading: "Teaser",
+		field: Field{
+			Key:         string(Teaser),
+			MaxRunes:    teaserMaxRunes,
+			Guidance:    "The roomy signal shape: one short paragraph on why a reader would open this document right now. Surfaces as the snippet in search results and cross-references, so write the hook - the reason to look - rather than a compressed summary.",
+			ContextRole: agentctx.ContextRoleSignal,
+		},
+		scaffoldHint: "why a reader would open this document right now",
+		value:        func(p *Payload) *string { return &p.Teaser },
+	},
+	{
+		name:    Digest,
+		heading: "Digest",
+		field: Field{
+			Key:         string(Digest),
+			MaxRunes:    digestMaxRunes,
+			Guidance:    "The context payload: a standalone summary carrying enough substance to act on without opening the full document. Surfaces in subscription rows and periodic digests.",
+			ContextRole: agentctx.ContextRoleContext,
+		},
+		scaffoldHint: "a summary with enough substance to act on",
+		value:        func(p *Payload) *string { return &p.Digest },
+	},
+	{
+		heading: "Details",
+		field: Field{
+			Key:         "full",
+			Guidance:    "The detail payload: the complete current state in markdown. This is what a reader opens when the digest is not enough. Always required: it is the document's substance, and the other projections are views of it.",
+			ContextRole: agentctx.ContextRoleDetail,
+		},
+		scaffoldHint: "the complete current state",
+		value:        func(p *Payload) *string { return &p.Full },
+	},
+}
+
+// DefaultContract returns the normal document shape. Callers may omit teaser
+// or digest by constructing a narrower contract when no consumer needs them.
+func DefaultContract() Contract {
+	return Contract{Facets: []Spec{{Name: StatusLine}, {Name: Teaser}, {Name: Digest}}}
+}
+
+// Fields returns declared projections followed by full in canonical order.
+func (c Contract) Fields() []Field {
+	declared := make(map[Name]Spec, len(c.Facets))
+	for _, facet := range c.Facets {
+		declared[facet.Name] = facet
+	}
+	fields := make([]Field, 0, len(c.Facets)+1)
+	for _, item := range sections {
+		if item.name == "" {
+			fields = append(fields, item.field)
+			continue
+		}
+		if facet, ok := declared[item.name]; ok {
+			field := item.field
+			field.Format = facet.EffectiveFormat()
+			fields = append(fields, field)
+		}
+	}
+	return fields
+}
+
+// ValidateDefinition checks the facet set independently of any loop or domain
+// owner.
+func (c Contract) ValidateDefinition() error {
+	if len(c.Facets) == 0 {
+		return fmt.Errorf("facets must include %q", StatusLine)
+	}
+	seen := make(map[Name]struct{}, len(c.Facets))
+	hasStatus := false
+	for i, facet := range c.Facets {
+		switch facet.Name {
+		case StatusLine, Teaser, Digest:
+		default:
+			return fmt.Errorf("facets[%d]: unsupported facet %q; use %q, %q, or %q", i, facet.Name, StatusLine, Teaser, Digest)
+		}
+		switch facet.EffectiveFormat() {
+		case FormatMarkdown, FormatPlain, FormatJSON:
+		default:
+			return fmt.Errorf("facets[%d]: unsupported format %q for %q", i, facet.Format, facet.Name)
+		}
+		if _, duplicate := seen[facet.Name]; duplicate {
+			return fmt.Errorf("facets[%d]: duplicate facet %q", i, facet.Name)
+		}
+		seen[facet.Name] = struct{}{}
+		hasStatus = hasStatus || facet.Name == StatusLine
+	}
+	if !hasStatus {
+		return fmt.Errorf("facets must include %q; teaser and digest are optional", StatusLine)
+	}
+	return nil
+}
+
+// Validate checks one complete logical document and reports all independently
+// correctable field violations together.
+func (c Contract) Validate(payload Payload) error {
+	if err := c.ValidateDefinition(); err != nil {
+		return err
+	}
+	var validationErrors []error
+	for _, field := range c.Fields() {
+		item, _ := sectionByKey(field.Key)
+		value := strings.TrimSpace(*item.value(&payload))
+		if value == "" {
+			validationErrors = append(validationErrors, fmt.Errorf("%s is required; every declared projection is written together so they cannot describe different moments", field.Key))
+			continue
+		}
+		if field.Format == FormatJSON && !json.Valid([]byte(value)) {
+			validationErrors = append(validationErrors, fmt.Errorf("%s declares format %q but the value is not valid JSON; a consumer that asked for json cannot read prose", field.Key, FormatJSON))
+		}
+		if field.SingleLine && strings.ContainsAny(value, "\r\n") {
+			validationErrors = append(validationErrors, fmt.Errorf("%s must be a single line with no line breaks", field.Key))
+		}
+		if field.MaxRunes > 0 {
+			if runes := utf8.RuneCountInString(value); runes > field.MaxRunes {
+				validationErrors = append(validationErrors, fmt.Errorf("%s is %d characters and the limit is %d; tighten it rather than allowing truncation", field.Key, runes, field.MaxRunes))
+			}
+		}
+		if heading, found := firstReservedHeading(value); found {
+			validationErrors = append(validationErrors, fmt.Errorf("%s contains the reserved section heading %q; facet headings are rendered automatically, so pass only projection content", field.Key, heading))
+		}
+	}
+	fullTooLarge := false
+	if err := ValidateBodySize(payload.Full); err != nil {
+		validationErrors = append(validationErrors, fmt.Errorf("full: %w", err))
+		fullTooLarge = true
+	}
+	if !fullTooLarge {
+		if err := ValidateBodySize(c.Render(payload)); err != nil {
+			validationErrors = append(validationErrors, fmt.Errorf("the rendered document (every projection plus its headings): %w - full is the lever; compact projections are already budget-capped", err))
+		}
+	}
+	if len(validationErrors) > 0 {
+		return errors.Join(validationErrors...)
+	}
+	return nil
+}
+
+// ValidateBodySize enforces the maintained-document readback invariant.
+func ValidateBodySize(body string) error {
+	if size := len(body); size > MaxDocumentBytes {
+		return fmt.Errorf("the document body is %d bytes and a maintained document's ceiling is %d (96 KiB) - past this size the document has outgrown single-document maintenance; move detail into linked documents or trim the body. The ceiling guarantees you can always read back what you write in one call", size, MaxDocumentBytes)
+	}
+	return nil
+}
+
+// FieldByKey returns canonical metadata for one readable projection.
+func FieldByKey(key string) (Field, bool) {
+	item, ok := sectionByKey(key)
+	if !ok {
+		return Field{}, false
+	}
+	return item.field, true
+}
+
+// Keys returns the complete logical read ladder, including full.
+func Keys() []string {
+	keys := make([]string, 0, len(sections))
+	for _, item := range sections {
+		keys = append(keys, item.field.Key)
+	}
+	return keys
+}
+
+// IsKey reports whether key names a readable projection.
+func IsKey(key string) bool {
+	_, ok := sectionByKey(key)
+	return ok
+}
+
+// FormatGuidance returns model-facing guidance for non-default encodings.
+func FormatGuidance(format Format) string {
+	switch format {
+	case FormatPlain:
+		return " Write plain text with no markdown: this may be spoken aloud or shown somewhere that renders nothing."
+	case FormatJSON:
+		return " Emit valid JSON, not prose: this is read by code and a non-JSON value is rejected."
+	default:
+		return ""
+	}
+}
+
+func sectionByKey(key string) (section, bool) {
+	for _, item := range sections {
+		if item.field.Key == key {
+			return item, true
+		}
+	}
+	return section{}, false
+}

--- a/internal/state/documents/facets/manifest.go
+++ b/internal/state/documents/facets/manifest.go
@@ -1,0 +1,118 @@
+package facets
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const (
+	// SchemaKey stores the document codec/version in frontmatter.
+	SchemaKey = "thane_document"
+	// FacetsKey stores the declared compact public projections.
+	FacetsKey = "facets"
+	// FacetFormatsKey stores non-default encodings as name=format values.
+	FacetFormatsKey = "facet_formats"
+	// ManagedByKey stores the exact structured mutation tool that owns a
+	// document. Generic documents are owned by doc_write.
+	ManagedByKey = "managed_by"
+	// SchemaV1 is the canonical faceted Markdown codec written today.
+	SchemaV1 = "faceted/v1"
+)
+
+// Manifest is the durable self-description needed to decode and validate a
+// faceted document without knowing which loop or domain produced it.
+type Manifest struct {
+	Schema    string   `json:"schema"`
+	Contract  Contract `json:"contract"`
+	ManagedBy string   `json:"managed_by"`
+}
+
+// FromFrontmatter decodes a canonical manifest. A missing schema is not an
+// error; callers may then use [InferLegacy] for compatibility reads.
+func FromFrontmatter(frontmatter map[string][]string) (Manifest, bool, error) {
+	schema := first(frontmatter[SchemaKey])
+	if schema == "" {
+		return Manifest{}, false, nil
+	}
+	if schema != SchemaV1 {
+		return Manifest{}, true, fmt.Errorf("unsupported %s %q", SchemaKey, schema)
+	}
+	formats := make(map[Name]Format)
+	for _, encoded := range frontmatter[FacetFormatsKey] {
+		name, rawFormat, ok := strings.Cut(encoded, "=")
+		if !ok {
+			return Manifest{}, true, fmt.Errorf("invalid %s value %q; expected name=format", FacetFormatsKey, encoded)
+		}
+		formats[Name(strings.TrimSpace(name))] = Format(strings.TrimSpace(rawFormat))
+	}
+	contract := Contract{Facets: make([]Spec, 0, len(frontmatter[FacetsKey]))}
+	for _, rawName := range frontmatter[FacetsKey] {
+		name := Name(strings.TrimSpace(rawName))
+		contract.Facets = append(contract.Facets, Spec{Name: name, Format: formats[name]})
+	}
+	if err := contract.ValidateDefinition(); err != nil {
+		return Manifest{}, true, fmt.Errorf("invalid faceted document manifest: %w", err)
+	}
+	return Manifest{
+		Schema:    schema,
+		Contract:  contract,
+		ManagedBy: first(frontmatter[ManagedByKey]),
+	}, true, nil
+}
+
+// InferLegacy builds a compatibility manifest from a historical reserved-
+// heading envelope. It never writes that inferred manifest; the next
+// structured mutation does so through [Manifest.Frontmatter].
+func InferLegacy(body string, managedBy string) (Manifest, Payload, bool) {
+	payload, found := ParseLegacy(body)
+	if !found {
+		return Manifest{}, payload, false
+	}
+	contract := Contract{Facets: []Spec{{Name: StatusLine}}}
+	if strings.TrimSpace(payload.Teaser) != "" {
+		contract.Facets = append(contract.Facets, Spec{Name: Teaser})
+	}
+	if strings.TrimSpace(payload.Digest) != "" {
+		contract.Facets = append(contract.Facets, Spec{Name: Digest})
+	}
+	return Manifest{Schema: SchemaV1, Contract: contract, ManagedBy: strings.TrimSpace(managedBy)}, payload, true
+}
+
+// Frontmatter returns the canonical reserved keys for this manifest.
+func (m Manifest) Frontmatter() map[string][]string {
+	values := map[string][]string{
+		SchemaKey: {SchemaV1},
+	}
+	for _, facet := range m.Contract.Facets {
+		values[FacetsKey] = append(values[FacetsKey], string(facet.Name))
+		if format := facet.EffectiveFormat(); format != FormatMarkdown {
+			values[FacetFormatsKey] = append(values[FacetFormatsKey], string(facet.Name)+"="+string(format))
+		}
+	}
+	if owner := strings.TrimSpace(m.ManagedBy); owner != "" {
+		values[ManagedByKey] = []string{owner}
+	}
+	for key := range values {
+		sort.Strings(values[key])
+	}
+	return values
+}
+
+// ReservedFrontmatterKey reports whether key belongs to the storage codec and
+// should therefore be hidden from ordinary model-facing metadata.
+func ReservedFrontmatterKey(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(key)) {
+	case SchemaKey, FacetsKey, FacetFormatsKey, ManagedByKey:
+		return true
+	default:
+		return false
+	}
+}
+
+func first(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(values[0])
+}

--- a/internal/state/documents/facets/types.go
+++ b/internal/state/documents/facets/types.go
@@ -1,0 +1,153 @@
+// Package facets defines the logical projection contract for managed
+// documents. Markdown is the persistence codec; callers read and write
+// projections without depending on its reserved section envelope.
+package facets
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+)
+
+// Name identifies one compact public projection of a document. Full is the
+// document's substance and is therefore implicit rather than a declared facet.
+type Name string
+
+const (
+	// StatusLine is the ambient one-line projection.
+	StatusLine Name = "status_line"
+	// Teaser is the short reason to open the document.
+	Teaser Name = "teaser"
+	// Digest is the standalone actionable summary.
+	Digest Name = "digest"
+)
+
+// Format describes how a projection value is encoded.
+type Format string
+
+const (
+	// FormatMarkdown is prose with Markdown structure and is the default.
+	FormatMarkdown Format = "markdown"
+	// FormatPlain is prose intended for a surface that renders no markup.
+	FormatPlain Format = "plain"
+	// FormatJSON is a machine-readable JSON value.
+	FormatJSON Format = "json"
+)
+
+// Spec declares one compact projection and its encoding.
+//
+// It decodes from either a bare name or an object so the common YAML form can
+// remain compact while format-bearing projections remain explicit.
+type Spec struct {
+	Name   Name   `yaml:"name" json:"name"`
+	Format Format `yaml:"format,omitempty" json:"format,omitempty"`
+}
+
+// EffectiveFormat resolves the declared format, defaulting to Markdown.
+func (s Spec) EffectiveFormat() Format {
+	if s.Format == "" {
+		return FormatMarkdown
+	}
+	return s.Format
+}
+
+// UnmarshalJSON accepts either "status_line" or
+// {"name":"status_line","format":"plain"}.
+func (s *Spec) UnmarshalJSON(data []byte) error {
+	trimmed := strings.TrimSpace(string(data))
+	if strings.HasPrefix(trimmed, `"`) {
+		var name string
+		if err := json.Unmarshal(data, &name); err != nil {
+			return err
+		}
+		*s = Spec{Name: Name(name)}
+		return nil
+	}
+	type wire Spec
+	var value wire
+	if err := json.Unmarshal(data, &value); err != nil {
+		return fmt.Errorf("facet must be a name or an object with a name: %w", err)
+	}
+	*s = Spec(value)
+	return nil
+}
+
+// UnmarshalYAML accepts the same short and long forms as [Spec.UnmarshalJSON].
+func (s *Spec) UnmarshalYAML(unmarshal func(any) error) error {
+	var name string
+	if err := unmarshal(&name); err == nil {
+		*s = Spec{Name: Name(name)}
+		return nil
+	}
+	type wire Spec
+	var value wire
+	if err := unmarshal(&value); err != nil {
+		return fmt.Errorf("facet must be a name or a mapping with a name: %w", err)
+	}
+	*s = Spec(value)
+	return nil
+}
+
+// MarshalJSON emits the short form when no format override is present.
+func (s Spec) MarshalJSON() ([]byte, error) {
+	if s.Format == "" {
+		return json.Marshal(string(s.Name))
+	}
+	type wire Spec
+	return json.Marshal(wire(s))
+}
+
+// Payload is one complete logical document state. Every declared compact
+// projection moves with Full so readers never see projections from different
+// moments.
+type Payload struct {
+	StatusLine string `json:"status_line"`
+	Teaser     string `json:"teaser,omitempty"`
+	Digest     string `json:"digest,omitempty"`
+	Full       string `json:"full"`
+}
+
+// Field describes one projection field exposed by a structured writer.
+type Field struct {
+	Key         string                         `json:"key"`
+	MaxRunes    int                            `json:"max_runes"`
+	SingleLine  bool                           `json:"single_line"`
+	Guidance    string                         `json:"guidance"`
+	Format      Format                         `json:"format,omitempty"`
+	ContextRole agentctx.ContextProjectionRole `json:"context_role"`
+}
+
+// ByKey returns one projection value by its model-facing key. Full is
+// included even though it is not a declared compact facet.
+func (p Payload) ByKey(key string) (string, bool) {
+	section, ok := sectionByKey(key)
+	if !ok {
+		return "", false
+	}
+	value := *section.value(&p)
+	return value, strings.TrimSpace(value) != ""
+}
+
+// FromArgs decodes structured writer arguments according to contract. Missing
+// fields remain empty so [Contract.Validate] can report all omissions at once.
+func (c Contract) FromArgs(args map[string]any) (Payload, error) {
+	var payload Payload
+	for _, field := range c.Fields() {
+		section, ok := sectionByKey(field.Key)
+		if !ok {
+			continue
+		}
+		raw, present := args[field.Key]
+		if !present {
+			continue
+		}
+		value, ok := raw.(string)
+		if !ok {
+			return Payload{}, fmt.Errorf("%s must be a string", field.Key)
+		}
+		*section.value(&payload) = value
+	}
+	return payload, nil
+}

--- a/internal/state/documents/facets_test.go
+++ b/internal/state/documents/facets_test.go
@@ -398,3 +398,77 @@ func TestToolsPublishHonorsNarrowerOwner(t *testing.T) {
 		t.Fatalf("Publish error = %v, want owning-tool redirect", err)
 	}
 }
+
+func TestMalformedCanonicalManifestNeverExposesStorageEnvelope(t *testing.T) {
+	t.Parallel()
+
+	store, kbDir := newMutationStore(t)
+	path := filepath.Join(kbDir, "malformed.md")
+	raw := `---
+facets: ["digest"]
+managed_by: "doc_write"
+thane_document: "faceted/v1"
+---
+
+## Digest
+
+PRIVATE_DIGEST_MARKER
+
+## Details
+
+PRIVATE_FULL_MARKER
+`
+	if err := os.WriteFile(path, []byte(raw), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := store.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	tools := NewTools(store)
+
+	_, err := tools.Read(context.Background(), RefArgs{Ref: "kb:malformed.md"})
+	if err == nil {
+		t.Fatal("Read returned malformed private storage envelope")
+	}
+	for _, want := range []string{"invalid faceted manifest", DocumentWriteToolName, "no private storage envelope"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("Read error = %q, want %q", err, want)
+		}
+	}
+	for _, secret := range []string{"PRIVATE_DIGEST_MARKER", "PRIVATE_FULL_MARKER", "## Digest", "## Details"} {
+		if strings.Contains(err.Error(), secret) {
+			t.Errorf("Read error exposed %q: %v", secret, err)
+		}
+	}
+	results, err := store.Search(context.Background(), SearchQuery{Query: "PRIVATE_FULL_MARKER", Limit: 10})
+	if err != nil {
+		t.Fatalf("Search malformed document: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("search indexed malformed private storage content: %#v", results)
+	}
+
+	if _, err := tools.Write(context.Background(), WriteArgs{
+		Ref:  "kb:malformed.md",
+		Body: stringPtr("body-only overwrite"),
+	}); err == nil || !strings.Contains(err.Error(), DocumentWriteToolName) {
+		t.Fatalf("body write error = %v, want structured repair redirect", err)
+	}
+
+	digest := "Repaired digest."
+	if _, err := tools.Publish(context.Background(), PublishArgs{
+		Ref:        "kb:malformed.md",
+		StatusLine: "Manifest repaired.",
+		Digest:     &digest,
+		Full:       "Repaired complete state.",
+	}); err != nil {
+		t.Fatalf("Publish repair: %v", err)
+	}
+	read, err := tools.Read(context.Background(), RefArgs{Ref: "kb:malformed.md"})
+	if err != nil {
+		t.Fatalf("Read repaired document: %v", err)
+	}
+	if !strings.Contains(read, "Repaired complete state.") || strings.Contains(read, "PRIVATE_FULL_MARKER") {
+		t.Fatalf("repaired read = %s", read)
+	}
+}

--- a/internal/state/documents/facets_test.go
+++ b/internal/state/documents/facets_test.go
@@ -1,0 +1,400 @@
+package documents
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	documentfacets "github.com/nugget/thane-ai-agent/internal/state/documents/facets"
+)
+
+func TestToolsPublishCreatesCanonicalFacetedDocument(t *testing.T) {
+	t.Parallel()
+
+	store, kbDir := newMutationStore(t)
+	tools := NewTools(store)
+	teaser := "Open this for the current migration state."
+	digest := "The migration is complete and the old write path is retired."
+
+	result, err := tools.Publish(context.Background(), PublishArgs{
+		Ref:         "kb:roadmap.md",
+		Title:       "Roadmap",
+		Description: "Current roadmap state",
+		Tags:        []string{"roadmap", "status"},
+		StatusLine:  "Migration complete; monitoring the new path.",
+		Teaser:      &teaser,
+		Digest:      &digest,
+		Full:        "The migration completed cleanly.\n\n### Follow-up\n\nWatch production for one week.",
+	})
+	if err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if !strings.Contains(result, `"action": "doc_write"`) {
+		t.Fatalf("Publish result = %s, want doc_write action", result)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(kbDir, "roadmap.md"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	for _, want := range []string{
+		`managed_by: "doc_write"`,
+		`thane_document: "faceted/v1"`,
+		"## Status Line\n\nMigration complete; monitoring the new path.",
+		"## Teaser\n\n" + teaser,
+		"## Digest\n\n" + digest,
+		"## Details\n\nThe migration completed cleanly.",
+	} {
+		if !strings.Contains(string(raw), want) {
+			t.Fatalf("published document =\n%s\nwant %q", raw, want)
+		}
+	}
+
+	read, err := tools.Read(context.Background(), RefArgs{Ref: "kb:roadmap.md"})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	var payload struct {
+		Faceted   bool     `json:"faceted"`
+		Facets    []string `json:"facets"`
+		Levels    []string `json:"levels_available"`
+		WriteTool string   `json:"write_tool"`
+	}
+	if err := json.Unmarshal([]byte(read), &payload); err != nil {
+		t.Fatalf("Unmarshal read result: %v", err)
+	}
+	if !payload.Faceted {
+		t.Fatalf("read result = %s, want faceted=true", read)
+	}
+	if want := []string{"status_line", "teaser", "digest"}; !reflect.DeepEqual(payload.Facets, want) {
+		t.Fatalf("facets = %v, want %v", payload.Facets, want)
+	}
+	if want := []string{"status_line", "teaser", "digest", "full"}; !reflect.DeepEqual(payload.Levels, want) {
+		t.Fatalf("levels_available = %v, want %v", payload.Levels, want)
+	}
+	if payload.WriteTool != DocumentWriteToolName {
+		t.Fatalf("write_tool = %q, want %q", payload.WriteTool, DocumentWriteToolName)
+	}
+}
+
+func TestToolsPublishEquivalentLogicalStateIsByteStable(t *testing.T) {
+	t.Parallel()
+
+	store, kbDir := newMutationStore(t)
+	tools := NewTools(store)
+	contract := documentfacets.Contract{Facets: []documentfacets.Spec{{Name: documentfacets.StatusLine}}}
+	body := contract.Render(documentfacets.Payload{
+		StatusLine: "Production is healthy.",
+		Full:       "All monitored services are operating normally.",
+	})
+	frontmatter := (documentfacets.Manifest{
+		Schema:    documentfacets.SchemaV1,
+		Contract:  contract,
+		ManagedBy: DocumentWriteToolName,
+	}).Frontmatter()
+	frontmatter["title"] = []string{"Service status"}
+	frontmatter["tags"] = []string{"status", "operations"}
+	frontmatter["created"] = []string{"2026-01-02T03:04:05Z"}
+	frontmatter["updated"] = []string{"2026-02-03T04:05:06Z"}
+
+	path := filepath.Join(kbDir, "service-status.md")
+	before := []byte(renderDocument(frontmatter, body))
+	if err := os.WriteFile(path, before, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := store.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	if _, err := tools.Publish(context.Background(), PublishArgs{
+		Ref:        "kb:service-status.md",
+		Title:      "Service status",
+		Tags:       []string{"operations", "status", "operations"},
+		StatusLine: "Production is healthy.",
+		Full:       "All monitored services are operating normally.",
+	}); err != nil {
+		t.Fatalf("Publish equivalent state: %v", err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("equivalent publish changed canonical bytes:\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+}
+
+func TestWriteFacetedUsesOwningToolInRootCommitMessage(t *testing.T) {
+	t.Parallel()
+
+	writer := &recordingRootWriter{}
+	store, kbDir := newPolicyStore(t, map[string]RootPolicy{
+		"kb": {Indexing: true, Authoring: AuthoringManaged},
+	}, map[string]RootWriter{"kb": writer})
+	writer.root = kbDir
+	contract := documentfacets.Contract{Facets: []documentfacets.Spec{{Name: documentfacets.StatusLine}, {Name: documentfacets.Digest}}}
+
+	if _, err := NewTools(store).WriteFaceted(context.Background(), FacetedWriteArgs{
+		Ref:       "kb:owned.md",
+		Contract:  contract,
+		Payload:   documentfacets.Payload{StatusLine: "Current state.", Digest: "Current summary.", Full: "Current detail."},
+		WriteTool: "publish_output_owned",
+	}); err != nil {
+		t.Fatalf("WriteFaceted: %v", err)
+	}
+	if len(writer.writes) != 1 || !strings.HasPrefix(writer.writes[0], "owned.md|publish_output_owned kb:owned.md — Current state.") {
+		t.Fatalf("writer.writes = %#v, want owning tool in commit subject", writer.writes)
+	}
+}
+
+func TestToolsPublishRequiresEveryExistingProjectionWithoutChangingDocument(t *testing.T) {
+	t.Parallel()
+
+	store, kbDir := newMutationStore(t)
+	tools := NewTools(store)
+	teaser := "Open this for detail."
+	digest := "The current standalone summary."
+	_, err := tools.Publish(context.Background(), PublishArgs{
+		Ref:        "kb:status.md",
+		StatusLine: "Initial status.",
+		Teaser:     &teaser,
+		Digest:     &digest,
+		Full:       "Initial detail.",
+	})
+	if err != nil {
+		t.Fatalf("initial Publish: %v", err)
+	}
+	path := filepath.Join(kbDir, "status.md")
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile before: %v", err)
+	}
+
+	_, err = tools.Publish(context.Background(), PublishArgs{
+		Ref:        "kb:status.md",
+		StatusLine: "New status.",
+		Full:       "New detail.",
+	})
+	if err == nil || !strings.Contains(err.Error(), "teaser is required") || !strings.Contains(err.Error(), "digest is required") {
+		t.Fatalf("Publish omission error = %v, want both existing projections named", err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile after: %v", err)
+	}
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("rejected publish changed document:\nbefore=%s\nafter=%s", before, after)
+	}
+}
+
+func TestToolsPublishAdoptsOrdinaryDocument(t *testing.T) {
+	t.Parallel()
+
+	store, _ := newMutationStore(t)
+	ctx := context.Background()
+	_, err := store.Write(ctx, WriteArgs{
+		Ref:   "kb:notes.md",
+		Title: "Notes",
+		Body:  stringPtr("Old unstructured body."),
+	})
+	if err != nil {
+		t.Fatalf("initial Write: %v", err)
+	}
+	tools := NewTools(store)
+	full := "Replacement detail with a nested section.\n\n### Evidence\n\nThe exact supplied body."
+	_, err = tools.Publish(ctx, PublishArgs{
+		Ref:        "kb:notes.md",
+		StatusLine: "Notes have been structured.",
+		Full:       full,
+	})
+	if err != nil {
+		t.Fatalf("Publish adoption: %v", err)
+	}
+	record, err := store.Read(ctx, "kb:notes.md")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	payload, faceted := looppkg.ParseFacetSections(record.Body)
+	if !faceted {
+		t.Fatalf("adopted body = %q, want faceted document", record.Body)
+	}
+	if payload.Full != full {
+		t.Fatalf("full = %q, want exact supplied body %q", payload.Full, full)
+	}
+	if record.Title != "Notes" {
+		t.Fatalf("title = %q, want existing title preserved", record.Title)
+	}
+	if record.ManagedBy != DocumentWriteToolName {
+		t.Fatalf("managed_by = %q, want %q", record.ManagedBy, DocumentWriteToolName)
+	}
+}
+
+func TestGenericMutationsRedirectFacetedDocuments(t *testing.T) {
+	t.Parallel()
+
+	store, _ := newMutationStore(t)
+	ctx := context.Background()
+	tools := NewTools(store)
+	_, err := tools.Publish(ctx, PublishArgs{
+		Ref:        "kb:status.md",
+		StatusLine: "Current state.",
+		Full:       "Current detail.",
+	})
+	if err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	_, err = store.Write(ctx, WriteArgs{
+		Ref:  "kb:ordinary.md",
+		Body: stringPtr("## Source\n\nOrdinary section."),
+	})
+	if err != nil {
+		t.Fatalf("write ordinary source: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{
+			name: "write",
+			run: func() error {
+				_, err := tools.Write(ctx, WriteArgs{Ref: "kb:status.md", Body: stringPtr("replacement")})
+				return err
+			},
+		},
+		{
+			name: "edit",
+			run: func() error {
+				_, err := tools.Edit(ctx, EditArgs{Ref: "kb:status.md", Mode: "replace_body", Body: "replacement"})
+				return err
+			},
+		},
+		{
+			name: "journal",
+			run: func() error {
+				_, err := tools.JournalUpdate(ctx, JournalUpdateArgs{Ref: "kb:status.md", Entry: "note"})
+				return err
+			},
+		},
+		{
+			name: "copy section into",
+			run: func() error {
+				_, err := tools.CopySection(ctx, SectionTransferArgs{Ref: "kb:ordinary.md", Section: "Source", DestinationRef: "kb:status.md"})
+				return err
+			},
+		},
+		{
+			name: "move section out",
+			run: func() error {
+				_, err := tools.MoveSection(ctx, SectionTransferArgs{Ref: "kb:status.md", Section: "Details", DestinationRef: "kb:moved.md"})
+				return err
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.run()
+			if err == nil || !strings.Contains(err.Error(), DocumentWriteToolName) || !strings.Contains(err.Error(), "no change was made") {
+				t.Fatalf("mutation error = %v, want doc_write redirect", err)
+			}
+		})
+	}
+
+	record, err := store.Read(ctx, "kb:status.md")
+	if err != nil {
+		t.Fatalf("Read status: %v", err)
+	}
+	payload, _ := looppkg.ParseFacetSections(record.Body)
+	if payload.StatusLine != "Current state." || payload.Full != "Current detail." {
+		t.Fatalf("rejected mutations changed status document: %#v", payload)
+	}
+	if _, err := store.Read(ctx, "kb:moved.md"); !IsNotFound(err) {
+		t.Fatalf("move created destination despite rejection: %v", err)
+	}
+}
+
+func TestStoreRejectsInvalidFacetedBodyBeforeMutation(t *testing.T) {
+	t.Parallel()
+
+	store, kbDir := newMutationStore(t)
+	contract := documentfacets.Contract{Facets: []documentfacets.Spec{{Name: documentfacets.StatusLine}}}
+	frontmatter := (documentfacets.Manifest{Contract: contract, ManagedBy: DocumentWriteToolName}).Frontmatter()
+	_, err := store.Write(context.Background(), WriteArgs{
+		Ref:            "kb:invalid.md",
+		Frontmatter:    frontmatter,
+		Body:           stringPtr("## Status Line\n\n" + strings.Repeat("x", 121) + "\n\n## Details\n\nDetail."),
+		StructuredTool: DocumentWriteToolName,
+	})
+	if err == nil || !strings.Contains(err.Error(), "status_line is 121 characters") {
+		t.Fatalf("Write error = %v, want shared facet budget failure", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(kbDir, "invalid.md")); !os.IsNotExist(statErr) {
+		t.Fatalf("rejected write changed filesystem; stat error = %v", statErr)
+	}
+}
+
+func TestStoreAcceptsGeneratedJSONFacetEnvelope(t *testing.T) {
+	t.Parallel()
+
+	store, _ := newMutationStore(t)
+	output := looppkg.OutputSpec{
+		Name: "machine_status",
+		Type: looppkg.OutputTypeMaintainedDocument,
+		Facets: []looppkg.FacetSpec{{
+			Name:   looppkg.OutputFacetStatusLine,
+			Format: looppkg.FacetFormatJSON,
+		}},
+	}
+	body := output.RenderFacetDocument(looppkg.FacetPayload{
+		StatusLine: `{"healthy":true,"workers":3}`,
+		Full:       "All workers are healthy.",
+	})
+	contract := documentfacets.Contract{Facets: append([]documentfacets.Spec(nil), output.Facets...)}
+	_, err := store.Write(context.Background(), WriteArgs{
+		Ref:            "kb:machine-status.md",
+		Frontmatter:    (documentfacets.Manifest{Contract: contract, ManagedBy: output.ToolName()}).Frontmatter(),
+		Body:           &body,
+		StructuredTool: output.ToolName(),
+	})
+	if err != nil {
+		t.Fatalf("Write JSON-faceted output: %v", err)
+	}
+	record, err := store.Read(context.Background(), "kb:machine-status.md")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if !strings.Contains(record.Body, "```json\n") {
+		t.Fatalf("body = %q, want generated JSON fence preserved", record.Body)
+	}
+}
+
+func TestToolsPublishHonorsNarrowerOwner(t *testing.T) {
+	t.Parallel()
+
+	store, _ := newMutationStore(t)
+	ctx := context.Background()
+	contract := documentfacets.Contract{Facets: []documentfacets.Spec{{Name: documentfacets.StatusLine}}}
+	body := contract.Render(documentfacets.Payload{StatusLine: "Owned state.", Full: "Owned detail."})
+	_, err := store.Write(ctx, WriteArgs{
+		Ref:            "kb:owned.md",
+		Frontmatter:    (documentfacets.Manifest{Contract: contract, ManagedBy: "publish_output_owned"}).Frontmatter(),
+		Body:           &body,
+		StructuredTool: "publish_output_owned",
+	})
+	if err != nil {
+		t.Fatalf("seed owner document: %v", err)
+	}
+	_, err = NewTools(store).Publish(ctx, PublishArgs{
+		Ref:        "kb:owned.md",
+		StatusLine: "Replacement state.",
+		Full:       "Replacement detail.",
+	})
+	if err == nil || !strings.Contains(err.Error(), "publish_output_owned owns that document") {
+		t.Fatalf("Publish error = %v, want owning-tool redirect", err)
+	}
+}

--- a/internal/state/documents/frontmatter_roundtrip_test.go
+++ b/internal/state/documents/frontmatter_roundtrip_test.go
@@ -84,6 +84,27 @@ func TestFrontmatterInlineListRoundTripIsStable(t *testing.T) {
 	assertListRoundTripStable(t, meta, "tags", rendered)
 }
 
+func TestRenderFrontmatterCanonicalizesKeysAndSetValues(t *testing.T) {
+	t.Parallel()
+
+	rendered := renderFrontmatter(map[string][]string{
+		" Zeta ": {"two", "one", "two"},
+		"TITLE":  {"Document"},
+		"tags":   {"beta", "alpha", "beta"},
+		"alpha":  {"last"},
+	})
+	want := "title: \"Document\"\n" +
+		"tags: [\"alpha\", \"beta\"]\n" +
+		"alpha: \"last\"\n" +
+		"zeta: [\"one\", \"two\"]"
+	if rendered != want {
+		t.Fatalf("canonical frontmatter =\n%s\nwant\n%s", rendered, want)
+	}
+	if rerendered := renderFrontmatter(parseFrontmatterMap(rendered)); rerendered != rendered {
+		t.Fatalf("canonical frontmatter is not a fixed point:\n%s\nthen\n%s", rendered, rerendered)
+	}
+}
+
 // TestFrontmatterBlockListRoundTripIsStable covers the block-list path —
 //
 //	source_refs:

--- a/internal/state/documents/intake_test.go
+++ b/internal/state/documents/intake_test.go
@@ -42,8 +42,9 @@ func TestDocumentIntakeProposesCreateAndCommit(t *testing.T) {
 	}
 
 	commitOut, err := tools.Commit(ctx, CommitArgs{
-		IntakeID: intake.IntakeID,
-		Body:     "# Driveway Gate Notes\n\nThe reset process lives here.",
+		IntakeID:   intake.IntakeID,
+		StatusLine: "Driveway gate reset procedure is documented.",
+		Full:       "# Driveway Gate Notes\n\nThe reset process lives here.",
 	})
 	if err != nil {
 		t.Fatalf("Commit: %v", err)
@@ -303,7 +304,8 @@ func TestDocumentCreateCleanPathWritesInOneCall(t *testing.T) {
 		Root:         "kb",
 		DesiredTitle: "Water Softener Service Log",
 		Tags:         []string{"home"},
-		Body:         "# Water Softener Service Log\n\nSalt refilled; next check due in six weeks.",
+		StatusLine:   "Water softener salt was refilled; recheck in six weeks.",
+		Full:         "# Water Softener Service Log\n\nSalt refilled; next check due in six weeks.",
 	})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
@@ -349,7 +351,8 @@ func TestDocumentCreateDeclinesOnSimilarCorpus(t *testing.T) {
 		Root:         "kb",
 		DesiredTitle: "VLAN Guide",
 		Tags:         []string{"network", "vlans"},
-		Body:         body,
+		StatusLine:   "Home VLAN layout is documented.",
+		Full:         body,
 	})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
@@ -397,7 +400,7 @@ func TestDocumentCreateRequiresBody(t *testing.T) {
 	t.Parallel()
 
 	tools, _ := newIntakeTools(t, nil)
-	if _, err := tools.Create(context.Background(), CreateArgs{Root: "kb", DesiredTitle: "Empty"}); err == nil || !strings.Contains(err.Error(), "body is required") {
-		t.Fatalf("Create without body error = %v, want body-required", err)
+	if _, err := tools.Create(context.Background(), CreateArgs{Root: "kb", DesiredTitle: "Empty"}); err == nil || !strings.Contains(err.Error(), "full is required") {
+		t.Fatalf("Create without full error = %v, want full-required", err)
 	}
 }

--- a/internal/state/documents/intake_tools.go
+++ b/internal/state/documents/intake_tools.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -13,12 +14,16 @@ import (
 // plus an immediate managed write when the placement is clean.
 type CreateArgs struct {
 	Root         string   `json:"root,omitempty"`
-	Body         string   `json:"body"`
+	StatusLine   string   `json:"status_line"`
+	Teaser       *string  `json:"teaser,omitempty"`
+	Digest       *string  `json:"digest,omitempty"`
+	Full         string   `json:"full"`
 	DesiredTitle string   `json:"desired_title,omitempty"`
 	DesiredRef   string   `json:"desired_ref,omitempty"`
 	Tags         []string `json:"tags,omitempty"`
 	PathPrefix   string   `json:"path_prefix,omitempty"`
 	Intent       string   `json:"intent,omitempty"`
+	ReceiptScope string   `json:"-"`
 }
 
 // createDeclinedResult wraps the intake analysis when doc_create stops
@@ -43,9 +48,9 @@ func (t *Tools) Create(ctx context.Context, args CreateArgs) (string, error) {
 	if t == nil || t.store == nil {
 		return "", fmt.Errorf("document index not configured")
 	}
-	body := strings.TrimSpace(args.Body)
-	if body == "" {
-		return "", fmt.Errorf("body is required — doc_create writes the full document when placement is clean")
+	full := strings.TrimSpace(args.Full)
+	if full == "" {
+		return "", fmt.Errorf("full is required; doc_create writes the complete logical document when placement is clean")
 	}
 	intent := strings.TrimSpace(args.Intent)
 	if intent == "" {
@@ -54,7 +59,7 @@ func (t *Tools) Create(ctx context.Context, args CreateArgs) (string, error) {
 	result, err := t.store.Intake(ctx, IntakeArgs{
 		Root:         args.Root,
 		Intent:       intent,
-		BodySnippet:  body,
+		BodySnippet:  full,
 		DesiredTitle: args.DesiredTitle,
 		DesiredRef:   args.DesiredRef,
 		Tags:         args.Tags,
@@ -85,9 +90,13 @@ func (t *Tools) Create(ctx context.Context, args CreateArgs) (string, error) {
 		})
 	}
 	return t.Commit(ctx, CommitArgs{
-		IntakeID: result.IntakeID,
-		Action:   IntakeActionCreateNew,
-		Body:     body,
+		IntakeID:     result.IntakeID,
+		Action:       IntakeActionCreateNew,
+		StatusLine:   args.StatusLine,
+		Teaser:       args.Teaser,
+		Digest:       args.Digest,
+		Full:         full,
+		ReceiptScope: args.ReceiptScope,
 	})
 }
 
@@ -141,6 +150,7 @@ func (t *Tools) Commit(ctx context.Context, args CommitArgs) (string, error) {
 	}
 
 	body := strings.TrimSpace(args.Body)
+	full := strings.TrimSpace(args.Full)
 	status := "committed"
 	var (
 		ref string
@@ -153,8 +163,8 @@ func (t *Tools) Commit(ctx context.Context, args CommitArgs) (string, error) {
 		if ref == "" {
 			return "", fmt.Errorf("intake_id %q has no proposed_ref for create_new", args.IntakeID)
 		}
-		if body == "" {
-			return "", fmt.Errorf("body is required for create_new")
+		if full == "" {
+			return "", fmt.Errorf("full is required for create_new; status_line is also required")
 		}
 		root, relPath, parseErr := parseRef(ref)
 		if parseErr != nil {
@@ -163,14 +173,22 @@ func (t *Tools) Commit(ctx context.Context, args CommitArgs) (string, error) {
 		if t.store.refExists(ctx, root, relPath) {
 			return "", fmt.Errorf("proposed_ref %q already exists; rerun doc_intake or choose update_existing", ref)
 		}
-		out, err = t.store.Write(ctx, WriteArgs{
-			Ref:         ref,
-			Title:       result.NormalizedTitle,
-			Description: firstValue(result.NormalizedFrontmatter, "description"),
-			Tags:        result.NormalizedTags,
-			Frontmatter: result.NormalizedFrontmatter,
-			Body:        &body,
+		var published string
+		published, err = t.Publish(ctx, PublishArgs{
+			Ref:          ref,
+			Title:        result.NormalizedTitle,
+			Description:  firstValue(result.NormalizedFrontmatter, "description"),
+			Tags:         result.NormalizedTags,
+			Frontmatter:  result.NormalizedFrontmatter,
+			StatusLine:   args.StatusLine,
+			Teaser:       args.Teaser,
+			Digest:       args.Digest,
+			Full:         full,
+			ReceiptScope: args.ReceiptScope,
 		})
+		if err == nil {
+			out = json.RawMessage(published)
+		}
 	case IntakeActionUpdateExisting:
 		ref = result.TargetRef
 		if ref == "" {
@@ -178,6 +196,9 @@ func (t *Tools) Commit(ctx context.Context, args CommitArgs) (string, error) {
 		}
 		if body == "" {
 			return "", fmt.Errorf("body is required for update_existing")
+		}
+		if err := t.rejectStructuredIntakeTarget(ctx, ref, "doc_commit"); err != nil {
+			return "", err
 		}
 		mode := "append_body"
 		section := strings.TrimSpace(args.Section)
@@ -202,6 +223,9 @@ func (t *Tools) Commit(ctx context.Context, args CommitArgs) (string, error) {
 		}
 		if body == "" {
 			return "", fmt.Errorf("body is required for append_existing")
+		}
+		if err := t.rejectStructuredIntakeTarget(ctx, ref, "doc_commit"); err != nil {
+			return "", err
 		}
 		out, err = t.store.JournalUpdate(ctx, JournalUpdateArgs{
 			Ref:    ref,
@@ -233,6 +257,17 @@ func (t *Tools) Commit(ctx context.Context, args CommitArgs) (string, error) {
 		Status:   status,
 		Result:   out,
 	}, nowUTC()))
+}
+
+func (t *Tools) rejectStructuredIntakeTarget(ctx context.Context, ref, attempted string) error {
+	record, err := t.store.Read(ctx, ref)
+	if err != nil {
+		return err
+	}
+	if tool := structuredWriteTool(record); tool != "" {
+		return &StructuredDocumentMutationError{Ref: ref, Attempted: attempted, WriteTool: tool}
+	}
+	return nil
 }
 
 func (t *Tools) rememberIntake(result *IntakeResult) {

--- a/internal/state/documents/intake_tools.go
+++ b/internal/state/documents/intake_tools.go
@@ -209,13 +209,18 @@ func (t *Tools) Commit(ctx context.Context, args CommitArgs) (string, error) {
 				section = heading
 			}
 		}
-		out, err = t.store.Edit(ctx, EditArgs{
-			Ref:     ref,
-			Mode:    mode,
-			Body:    body,
-			Section: section,
-			Heading: heading,
+		var edited string
+		edited, err = t.Edit(ctx, EditArgs{
+			Ref:          ref,
+			Mode:         mode,
+			Body:         body,
+			Section:      section,
+			Heading:      heading,
+			ReceiptScope: args.ReceiptScope,
 		})
+		if err == nil {
+			out = json.RawMessage(edited)
+		}
 	case IntakeActionAppendExisting:
 		ref = result.TargetRef
 		if ref == "" {
@@ -227,11 +232,16 @@ func (t *Tools) Commit(ctx context.Context, args CommitArgs) (string, error) {
 		if err := t.rejectStructuredIntakeTarget(ctx, ref, "doc_commit"); err != nil {
 			return "", err
 		}
-		out, err = t.store.JournalUpdate(ctx, JournalUpdateArgs{
-			Ref:    ref,
-			Entry:  body,
-			Window: args.Window,
+		var appended string
+		appended, err = t.JournalUpdate(ctx, JournalUpdateArgs{
+			Ref:          ref,
+			Entry:        body,
+			Window:       args.Window,
+			ReceiptScope: args.ReceiptScope,
 		})
+		if err == nil {
+			out = json.RawMessage(appended)
+		}
 	case IntakeActionDraftForReview:
 		status = "draft_for_review"
 		ref = result.ProposedRef
@@ -249,7 +259,14 @@ func (t *Tools) Commit(ctx context.Context, args CommitArgs) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	t.forgetIntake(args.IntakeID)
+	if applied, known := nestedMutationApplied(out); known && !applied {
+		// Receipt conflicts are successful tool responses, not Go errors. Keep
+		// the intake plan so the model can reconcile the returned diff and retry
+		// the same doc_commit after the wrapper advances its hidden receipt.
+		status = "conflict"
+	} else {
+		t.forgetIntake(args.IntakeID)
+	}
 	return marshalToolResult(toModelCommitResult(CommitResult{
 		IntakeID: args.IntakeID,
 		Action:   action,
@@ -257,6 +274,20 @@ func (t *Tools) Commit(ctx context.Context, args CommitArgs) (string, error) {
 		Status:   status,
 		Result:   out,
 	}, nowUTC()))
+}
+
+func nestedMutationApplied(result any) (bool, bool) {
+	raw, ok := result.(json.RawMessage)
+	if !ok {
+		return false, false
+	}
+	var outcome struct {
+		Applied *bool `json:"applied"`
+	}
+	if err := json.Unmarshal(raw, &outcome); err != nil || outcome.Applied == nil {
+		return false, false
+	}
+	return *outcome.Applied, true
 }
 
 func (t *Tools) rejectStructuredIntakeTarget(ctx context.Context, ref, attempted string) error {

--- a/internal/state/documents/intake_types.go
+++ b/internal/state/documents/intake_types.go
@@ -104,13 +104,18 @@ type IntakeResult struct {
 
 // CommitArgs commits an approved document intake plan.
 type CommitArgs struct {
-	IntakeID string       `json:"intake_id"`
-	Action   IntakeAction `json:"action,omitempty"`
-	Body     string       `json:"body,omitempty"`
-	Section  string       `json:"section,omitempty"`
-	Heading  string       `json:"heading,omitempty"`
-	Window   string       `json:"window,omitempty"`
-	Confirm  bool         `json:"confirm,omitempty"`
+	IntakeID     string       `json:"intake_id"`
+	Action       IntakeAction `json:"action,omitempty"`
+	StatusLine   string       `json:"status_line,omitempty"`
+	Teaser       *string      `json:"teaser,omitempty"`
+	Digest       *string      `json:"digest,omitempty"`
+	Full         string       `json:"full,omitempty"`
+	Body         string       `json:"body,omitempty"`
+	Section      string       `json:"section,omitempty"`
+	Heading      string       `json:"heading,omitempty"`
+	Window       string       `json:"window,omitempty"`
+	Confirm      bool         `json:"confirm,omitempty"`
+	ReceiptScope string       `json:"-"`
 }
 
 // CommitResult describes the mutation, or draft, created from an intake.

--- a/internal/state/documents/model_tool_results.go
+++ b/internal/state/documents/model_tool_results.go
@@ -190,6 +190,14 @@ func modelDocumentSummaries(docs []DocumentSummary, now time.Time) []modelDocume
 }
 
 func toModelDocumentSummary(doc DocumentSummary, now time.Time) modelDocumentSummary {
+	writeTool := documentWriteTool(firstValue(doc.Frontmatter, documentfacets.ManagedByKey), doc.Facets)
+	if _, canonical, manifestErr := documentfacets.FromFrontmatter(doc.Frontmatter); canonical && manifestErr != nil {
+		doc.Summary = ""
+		doc.Facets = nil
+		if strings.TrimSpace(writeTool) == DocumentBodyWriteToolName {
+			writeTool = DocumentWriteToolName
+		}
+	}
 	return modelDocumentSummary{
 		Root:          doc.Root,
 		Ref:           doc.Ref,
@@ -197,7 +205,7 @@ func toModelDocumentSummary(doc DocumentSummary, now time.Time) modelDocumentSum
 		Title:         doc.Title,
 		Summary:       doc.Summary,
 		Facets:        append([]string(nil), doc.Facets...),
-		WriteTool:     documentWriteTool(firstValue(doc.Frontmatter, documentfacets.ManagedByKey), doc.Facets),
+		WriteTool:     writeTool,
 		Tags:          append([]string(nil), doc.Tags...),
 		Frontmatter:   modelFrontmatter(doc.Frontmatter, now),
 		ModifiedDelta: modelDelta(doc.ModifiedAt, now),
@@ -256,6 +264,10 @@ func toModelDocumentRecord(record *DocumentRecord, now time.Time) *modelDocument
 	if record == nil {
 		return nil
 	}
+	writeTool := documentWriteTool(record.ManagedBy, record.Facets)
+	if record.InvalidFacetManifest != "" && writeTool == DocumentBodyWriteToolName {
+		writeTool = DocumentWriteToolName
+	}
 	result := &modelDocumentRecord{
 		Root:          record.Root,
 		Ref:           record.Ref,
@@ -264,14 +276,17 @@ func toModelDocumentRecord(record *DocumentRecord, now time.Time) *modelDocument
 		Description:   record.Description,
 		Tags:          append([]string(nil), record.Tags...),
 		Frontmatter:   modelFrontmatter(record.Frontmatter, now),
-		Faceted:       len(record.Facets) > 0,
+		Faceted:       len(record.Facets) > 0 || record.InvalidFacetManifest != "",
 		Facets:        append([]string(nil), record.Facets...),
 		Levels:        documentLevels(record.Facets),
-		WriteTool:     documentWriteTool(record.ManagedBy, record.Facets),
+		WriteTool:     writeTool,
 		Outline:       append([]Section(nil), record.Outline...),
 		ModifiedDelta: modelDelta(record.ModifiedAt, now),
 		WordCount:     record.WordCount,
 		SizeBytes:     record.SizeBytes,
+	}
+	if record.InvalidFacetManifest != "" {
+		return result
 	}
 	if len(record.FacetContract.Facets) > 0 {
 		payload := record.FacetContract.Parse(record.Body)

--- a/internal/state/documents/model_tool_results.go
+++ b/internal/state/documents/model_tool_results.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
+	documentfacets "github.com/nugget/thane-ai-agent/internal/state/documents/facets"
 )
 
 type modelRootSummary struct {
@@ -50,6 +51,7 @@ type modelDocumentSummary struct {
 	// deliberate doc_read with level (#1250) — dropping the field here
 	// would break that promise at the model boundary.
 	Facets        []string            `json:"facets,omitempty"`
+	WriteTool     string              `json:"write_tool"`
 	Tags          []string            `json:"tags,omitempty"`
 	Frontmatter   map[string][]string `json:"frontmatter,omitempty"`
 	ModifiedDelta string              `json:"modified_delta,omitempty"`
@@ -81,18 +83,30 @@ type modelBrowseResult struct {
 }
 
 type modelDocumentRecord struct {
-	Root          string              `json:"root"`
-	Ref           string              `json:"ref"`
-	Path          string              `json:"path"`
-	Title         string              `json:"title"`
-	Description   string              `json:"description,omitempty"`
-	Tags          []string            `json:"tags,omitempty"`
-	Frontmatter   map[string][]string `json:"frontmatter,omitempty"`
-	Body          string              `json:"body"`
-	Outline       []Section           `json:"outline,omitempty"`
-	ModifiedDelta string              `json:"modified_delta,omitempty"`
-	WordCount     int                 `json:"word_count"`
-	SizeBytes     int64               `json:"size_bytes"`
+	Root          string                    `json:"root"`
+	Ref           string                    `json:"ref"`
+	Path          string                    `json:"path"`
+	Title         string                    `json:"title"`
+	Description   string                    `json:"description,omitempty"`
+	Tags          []string                  `json:"tags,omitempty"`
+	Frontmatter   map[string][]string       `json:"frontmatter,omitempty"`
+	Faceted       bool                      `json:"faceted"`
+	Facets        []string                  `json:"facets,omitempty"`
+	Levels        []string                  `json:"levels_available,omitempty"`
+	WriteTool     string                    `json:"write_tool"`
+	Projections   *modelDocumentProjections `json:"projections,omitempty"`
+	Body          string                    `json:"body,omitempty"`
+	Outline       []Section                 `json:"outline,omitempty"`
+	ModifiedDelta string                    `json:"modified_delta,omitempty"`
+	WordCount     int                       `json:"word_count"`
+	SizeBytes     int64                     `json:"size_bytes"`
+}
+
+type modelDocumentProjections struct {
+	StatusLine string `json:"status_line"`
+	Teaser     string `json:"teaser,omitempty"`
+	Digest     string `json:"digest,omitempty"`
+	Full       string `json:"full"`
 }
 
 type modelBacklink struct {
@@ -183,11 +197,30 @@ func toModelDocumentSummary(doc DocumentSummary, now time.Time) modelDocumentSum
 		Title:         doc.Title,
 		Summary:       doc.Summary,
 		Facets:        append([]string(nil), doc.Facets...),
+		WriteTool:     documentWriteTool(firstValue(doc.Frontmatter, documentfacets.ManagedByKey), doc.Facets),
 		Tags:          append([]string(nil), doc.Tags...),
 		Frontmatter:   modelFrontmatter(doc.Frontmatter, now),
 		ModifiedDelta: modelDelta(doc.ModifiedAt, now),
 		WordCount:     doc.WordCount,
 	}
+}
+
+func documentLevels(facets []string) []string {
+	if len(facets) == 0 {
+		return nil
+	}
+	levels := append([]string(nil), facets...)
+	return append(levels, "full")
+}
+
+func documentWriteTool(managedBy string, facets []string) string {
+	if managedBy = strings.TrimSpace(managedBy); managedBy != "" {
+		return managedBy
+	}
+	if len(facets) > 0 {
+		return DocumentWriteToolName
+	}
+	return DocumentBodyWriteToolName
 }
 
 func toModelSearchResult(args SearchArgs, query SearchQuery, results []DocumentSummary, now time.Time) modelSearchResult {
@@ -223,7 +256,7 @@ func toModelDocumentRecord(record *DocumentRecord, now time.Time) *modelDocument
 	if record == nil {
 		return nil
 	}
-	return &modelDocumentRecord{
+	result := &modelDocumentRecord{
 		Root:          record.Root,
 		Ref:           record.Ref,
 		Path:          record.Path,
@@ -231,12 +264,27 @@ func toModelDocumentRecord(record *DocumentRecord, now time.Time) *modelDocument
 		Description:   record.Description,
 		Tags:          append([]string(nil), record.Tags...),
 		Frontmatter:   modelFrontmatter(record.Frontmatter, now),
-		Body:          record.Body,
+		Faceted:       len(record.Facets) > 0,
+		Facets:        append([]string(nil), record.Facets...),
+		Levels:        documentLevels(record.Facets),
+		WriteTool:     documentWriteTool(record.ManagedBy, record.Facets),
 		Outline:       append([]Section(nil), record.Outline...),
 		ModifiedDelta: modelDelta(record.ModifiedAt, now),
 		WordCount:     record.WordCount,
 		SizeBytes:     record.SizeBytes,
 	}
+	if len(record.FacetContract.Facets) > 0 {
+		payload := record.FacetContract.Parse(record.Body)
+		result.Projections = &modelDocumentProjections{
+			StatusLine: payload.StatusLine,
+			Teaser:     payload.Teaser,
+			Digest:     payload.Digest,
+			Full:       payload.Full,
+		}
+	} else {
+		result.Body = record.Body
+	}
+	return result
 }
 
 func toModelLinksResult(result *LinksResult, now time.Time) *modelLinksResult {
@@ -303,6 +351,9 @@ func modelFrontmatter(frontmatter map[string][]string, now time.Time) map[string
 	sort.Strings(keys)
 
 	for _, key := range keys {
+		if documentfacets.ReservedFrontmatterKey(key) {
+			continue
+		}
 		values := frontmatter[key]
 		if deltaKey, ok := frontmatterDeltaFieldName(key); ok {
 			if _, exists := out[deltaKey]; exists {

--- a/internal/state/documents/mutate.go
+++ b/internal/state/documents/mutate.go
@@ -31,12 +31,16 @@ type DocumentRecord struct {
 	FacetContract documentfacets.Contract `json:"-"`
 	// ManagedBy names the structured mutation tool that owns this document,
 	// when one is stamped in frontmatter.
-	ManagedBy  string    `json:"managed_by,omitempty"`
-	Body       string    `json:"body"`
-	Outline    []Section `json:"outline,omitempty"`
-	ModifiedAt string    `json:"modified_at"`
-	WordCount  int       `json:"word_count"`
-	SizeBytes  int64     `json:"size_bytes"`
+	ManagedBy string `json:"managed_by,omitempty"`
+	// InvalidFacetManifest retains a bounded parse failure without causing the
+	// document to fall back to a body-only model view. Structured owners may
+	// repair the manifest; content-bearing reads refuse to expose its codec.
+	InvalidFacetManifest string    `json:"-"`
+	Body                 string    `json:"body"`
+	Outline              []Section `json:"outline,omitempty"`
+	ModifiedAt           string    `json:"modified_at"`
+	WordCount            int       `json:"word_count"`
+	SizeBytes            int64     `json:"size_bytes"`
 	// Revision is internal coordination state for a revision-backed root.
 	// Model-facing adapters retain it as a hidden read receipt.
 	Revision string `json:"-"`
@@ -57,6 +61,10 @@ type WriteArgs struct {
 	// StructuredTool names the contract-aware caller that is publishing a
 	// complete faceted document. Empty identifies the body-only surface.
 	StructuredTool string `json:"-"`
+	// PreviousWriteTools lists the exact former owners a trusted contract
+	// migration may replace. It is internal-only: models cannot use it to
+	// claim another writer's document.
+	PreviousWriteTools []string `json:"-"`
 }
 
 // EditArgs updates part of a managed document without leaving the
@@ -511,24 +519,41 @@ func documentRecordFromBytes(root, relPath string, rawBytes []byte, modifiedAt t
 	if !hasFrontmatter {
 		strippedBody = raw
 	}
+	manifestError := ""
+	if _, canonical, err := documentfacets.FromFrontmatter(meta); canonical && err != nil {
+		manifestError = boundedFacetManifestError(err)
+	}
 	doc := parseMarkdownDocumentParts(relPath, meta, strippedBody)
 	return &DocumentRecord{
-		Root:          root,
-		Ref:           makeRef(root, relPath),
-		Path:          relPath,
-		Title:         doc.Title,
-		Description:   firstValue(doc.Frontmatter, "description"),
-		Tags:          append([]string(nil), doc.Tags...),
-		Frontmatter:   cloneFrontmatter(doc.Frontmatter),
-		Facets:        append([]string(nil), doc.Facets...),
-		FacetContract: parsedFacetContract(doc.Frontmatter, strippedBody),
-		ManagedBy:     firstValue(doc.Frontmatter, documentfacets.ManagedByKey),
-		Body:          strippedBody,
-		Outline:       append([]Section(nil), doc.Sections...),
-		ModifiedAt:    modifiedAt.UTC().Format(time.RFC3339Nano),
-		WordCount:     doc.WordCount,
-		SizeBytes:     int64(len(rawBytes)),
+		Root:                 root,
+		Ref:                  makeRef(root, relPath),
+		Path:                 relPath,
+		Title:                doc.Title,
+		Description:          firstValue(doc.Frontmatter, "description"),
+		Tags:                 append([]string(nil), doc.Tags...),
+		Frontmatter:          cloneFrontmatter(doc.Frontmatter),
+		Facets:               append([]string(nil), doc.Facets...),
+		FacetContract:        parsedFacetContract(doc.Frontmatter, strippedBody),
+		ManagedBy:            firstValue(doc.Frontmatter, documentfacets.ManagedByKey),
+		InvalidFacetManifest: manifestError,
+		Body:                 strippedBody,
+		Outline:              append([]Section(nil), doc.Sections...),
+		ModifiedAt:           modifiedAt.UTC().Format(time.RFC3339Nano),
+		WordCount:            doc.WordCount,
+		SizeBytes:            int64(len(rawBytes)),
 	}, rawFrontmatter, body, nil
+}
+
+func boundedFacetManifestError(err error) string {
+	if err == nil {
+		return ""
+	}
+	const maxBytes = 512
+	message := err.Error()
+	if len(message) <= maxBytes {
+		return message
+	}
+	return truncateUTF8Bytes([]byte(message), maxBytes) + "…"
 }
 
 func (s *Store) resolveDocumentWritePath(root, relPath string) (string, error) {

--- a/internal/state/documents/mutate.go
+++ b/internal/state/documents/mutate.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	documentfacets "github.com/nugget/thane-ai-agent/internal/state/documents/facets"
 )
 
 // DocumentRecord is the full model-facing view of one managed document.
@@ -20,11 +22,21 @@ type DocumentRecord struct {
 	Description string              `json:"description,omitempty"`
 	Tags        []string            `json:"tags,omitempty"`
 	Frontmatter map[string][]string `json:"frontmatter,omitempty"`
-	Body        string              `json:"body"`
-	Outline     []Section           `json:"outline,omitempty"`
-	ModifiedAt  string              `json:"modified_at"`
-	WordCount   int                 `json:"word_count"`
-	SizeBytes   int64               `json:"size_bytes"`
+	// Facets lists the compact projections present in Body, in canonical
+	// contract order. Full is implicit and is not included.
+	Facets []string `json:"facets,omitempty"`
+	// FacetContract is the durable or legacy-inferred logical projection
+	// contract. Model-facing adapters expose its projections rather than this
+	// storage coordination shape.
+	FacetContract documentfacets.Contract `json:"-"`
+	// ManagedBy names the structured mutation tool that owns this document,
+	// when one is stamped in frontmatter.
+	ManagedBy  string    `json:"managed_by,omitempty"`
+	Body       string    `json:"body"`
+	Outline    []Section `json:"outline,omitempty"`
+	ModifiedAt string    `json:"modified_at"`
+	WordCount  int       `json:"word_count"`
+	SizeBytes  int64     `json:"size_bytes"`
 	// Revision is internal coordination state for a revision-backed root.
 	// Model-facing adapters retain it as a hidden read receipt.
 	Revision string `json:"-"`
@@ -42,6 +54,9 @@ type WriteArgs struct {
 	ExpectedRevision string              `json:"-"`
 	ReceiptScope     string              `json:"-"`
 	RequirePriorRead bool                `json:"-"`
+	// StructuredTool names the contract-aware caller that is publishing a
+	// complete faceted document. Empty identifies the body-only surface.
+	StructuredTool string `json:"-"`
 }
 
 // EditArgs updates part of a managed document without leaving the
@@ -210,13 +225,15 @@ func (s *Store) Write(ctx context.Context, args WriteArgs) (*MutationResult, err
 
 	existed := false
 	var existingRecord *DocumentRecord
+	var existingRaw string
 	if _, err := os.Stat(absPath); err == nil {
 		existed = true
-		record, _, _, readErr := s.readCurrentDocumentParts(ctx, absPath, root, relPath)
+		record, rawFrontmatter, currentBody, readErr := s.readCurrentDocumentParts(ctx, absPath, root, relPath)
 		if readErr != nil {
 			return nil, readErr
 		}
 		existingRecord = record
+		existingRaw = renderDocumentFromParts(rawFrontmatter, currentBody)
 	}
 	if existed && args.RequirePriorRead && args.ExpectedRevision == "" && args.Body != nil && s.rootWriter(root) != nil && s.rootReviser(root) != nil {
 		return nil, &PriorReadRequiredError{Ref: args.Ref}
@@ -249,9 +266,28 @@ func (s *Store) Write(ctx context.Context, args WriteArgs) (*MutationResult, err
 	}
 	meta := mergeDocumentFrontmatter(existingRecord, args.Title, args.Description, args.Tags, args.Frontmatter, now)
 	raw := renderDocument(meta, body)
+	if existingRecord != nil {
+		// An identical logical write must not manufacture a new revision solely
+		// by touching its mechanical timestamp. Compare the canonical candidate
+		// with the current bytes while preserving the old updated value. A
+		// non-canonical existing envelope still differs and is normalized once.
+		stableMeta := cloneFrontmatter(meta)
+		if updated, ok := existingRecord.Frontmatter["updated"]; ok {
+			stableMeta["updated"] = append([]string(nil), updated...)
+		} else {
+			delete(stableMeta, "updated")
+		}
+		if stableRaw := renderDocument(stableMeta, body); stableRaw == existingRaw {
+			raw = stableRaw
+		}
+	}
 
+	action := strings.TrimSpace(args.StructuredTool)
+	if action == "" {
+		action = DocumentBodyWriteToolName
+	}
 	expectedRevision := s.automaticExpectedRevision(root, existed, existingRecord, args.ExpectedRevision)
-	revision, err := s.writeDocumentFileAtRevision(ctx, root, relPath, raw, expectedRevision)
+	revision, err := s.writeDocumentFileAtRevision(ctx, root, relPath, raw, action, expectedRevision)
 	if err != nil {
 		return nil, err
 	}
@@ -260,7 +296,7 @@ func (s *Store) Write(ctx context.Context, args WriteArgs) (*MutationResult, err
 		return nil, err
 	}
 	s.attachMutationRevision(ctx, record, revision)
-	return mutationResultFromRecord("doc_write", record, existed, sectionName, ""), nil
+	return mutationResultFromRecord(action, record, existed, sectionName, ""), nil
 }
 
 func (s *Store) Edit(ctx context.Context, args EditArgs) (*MutationResult, error) {
@@ -323,7 +359,7 @@ func (s *Store) Edit(ctx context.Context, args EditArgs) (*MutationResult, error
 	}
 	rendered := renderDocumentFromParts(raw, editedBody)
 	expectedRevision := s.automaticExpectedRevision(root, true, record, args.ExpectedRevision)
-	revision, err := s.writeDocumentFileAtRevision(ctx, root, relPath, rendered, expectedRevision)
+	revision, err := s.writeDocumentFileAtRevision(ctx, root, relPath, rendered, "doc_edit", expectedRevision)
 	if err != nil {
 		return nil, err
 	}
@@ -399,7 +435,7 @@ func (s *Store) JournalUpdate(ctx context.Context, args JournalUpdateArgs) (*Mut
 		rendered = renderDocument(meta, updatedBody)
 	}
 	expectedRevision := s.automaticExpectedRevision(root, existed, record, args.ExpectedRevision)
-	revision, err := s.writeDocumentFileAtRevision(ctx, root, relPath, rendered, expectedRevision)
+	revision, err := s.writeDocumentFileAtRevision(ctx, root, relPath, rendered, "doc_journal_update", expectedRevision)
 	if err != nil {
 		return nil, err
 	}
@@ -477,18 +513,21 @@ func documentRecordFromBytes(root, relPath string, rawBytes []byte, modifiedAt t
 	}
 	doc := parseMarkdownDocumentParts(relPath, meta, strippedBody)
 	return &DocumentRecord{
-		Root:        root,
-		Ref:         makeRef(root, relPath),
-		Path:        relPath,
-		Title:       doc.Title,
-		Description: firstValue(doc.Frontmatter, "description"),
-		Tags:        append([]string(nil), doc.Tags...),
-		Frontmatter: cloneFrontmatter(doc.Frontmatter),
-		Body:        strippedBody,
-		Outline:     append([]Section(nil), doc.Sections...),
-		ModifiedAt:  modifiedAt.UTC().Format(time.RFC3339Nano),
-		WordCount:   doc.WordCount,
-		SizeBytes:   int64(len(rawBytes)),
+		Root:          root,
+		Ref:           makeRef(root, relPath),
+		Path:          relPath,
+		Title:         doc.Title,
+		Description:   firstValue(doc.Frontmatter, "description"),
+		Tags:          append([]string(nil), doc.Tags...),
+		Frontmatter:   cloneFrontmatter(doc.Frontmatter),
+		Facets:        append([]string(nil), doc.Facets...),
+		FacetContract: parsedFacetContract(doc.Frontmatter, strippedBody),
+		ManagedBy:     firstValue(doc.Frontmatter, documentfacets.ManagedByKey),
+		Body:          strippedBody,
+		Outline:       append([]Section(nil), doc.Sections...),
+		ModifiedAt:    modifiedAt.UTC().Format(time.RFC3339Nano),
+		WordCount:     doc.WordCount,
+		SizeBytes:     int64(len(rawBytes)),
 	}, rawFrontmatter, body, nil
 }
 

--- a/internal/state/documents/mutate_helpers.go
+++ b/internal/state/documents/mutate_helpers.go
@@ -54,6 +54,7 @@ func renderDocumentFromParts(frontmatterRaw, body string) string {
 }
 
 func renderFrontmatter(meta map[string][]string) string {
+	meta = canonicalFrontmatter(meta)
 	if len(meta) == 0 {
 		return ""
 	}
@@ -110,6 +111,31 @@ func renderFrontmatter(meta map[string][]string) string {
 		}
 	}
 	return strings.Join(lines, "\n")
+}
+
+// canonicalFrontmatter makes the persistence representation a fixed point.
+// Frontmatter is a set-valued metadata map, so key casing, insertion order,
+// duplicate values, and caller-provided value order must not create unrelated
+// Git churn. Values whose order is meaningful belong in the document's logical
+// content rather than this map.
+func canonicalFrontmatter(meta map[string][]string) map[string][]string {
+	canonical := make(map[string][]string, len(meta))
+	for key, values := range meta {
+		key = strings.ToLower(strings.TrimSpace(key))
+		if key == "" {
+			continue
+		}
+		canonical[key] = append(canonical[key], values...)
+	}
+	for key, values := range canonical {
+		values = normalizeFrontmatterValues(values)
+		if len(values) == 0 {
+			delete(canonical, key)
+			continue
+		}
+		canonical[key] = values
+	}
+	return canonical
 }
 
 func appendBlockListFrontmatter(lines []string, key string, values []string) []string {

--- a/internal/state/documents/mutate_policy.go
+++ b/internal/state/documents/mutate_policy.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 	"time"
 
-	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	documentfacets "github.com/nugget/thane-ai-agent/internal/state/documents/facets"
 )
 
 func (s *Store) writeDocumentFile(ctx context.Context, root, relPath, raw string) error {
-	_, err := s.writeDocumentFileAtRevision(ctx, root, relPath, raw, "")
+	_, err := s.writeDocumentFileAtRevision(ctx, root, relPath, raw, "doc_write", "")
 	return err
 }
 
@@ -20,7 +20,7 @@ func (s *Store) writeDocumentFile(ctx context.Context, root, relPath, raw string
 // precondition. Empty preserves the unconditional mutation contract used by
 // existing callers; a non-empty revision requires a writer that can compare
 // and commit atomically.
-func (s *Store) writeDocumentFileAtRevision(ctx context.Context, root, relPath, raw, expectedRevision string) (string, error) {
+func (s *Store) writeDocumentFileAtRevision(ctx context.Context, root, relPath, raw, action, expectedRevision string) (string, error) {
 	absPath, err := s.resolveDocumentWritePath(root, relPath)
 	if err != nil {
 		return "", err
@@ -28,8 +28,11 @@ func (s *Store) writeDocumentFileAtRevision(ctx context.Context, root, relPath, 
 	if err := s.ensureRootAuthoringAllowed(root); err != nil {
 		return "", err
 	}
+	frontmatter, body := splitFrontmatter(raw)
+	if err := validateFacetedDocumentBody(body, frontmatter); err != nil {
+		return "", fmt.Errorf("validate faceted document %s: %w", makeRef(root, relPath), err)
+	}
 	if validator := s.rootValidator(root); validator != nil {
-		frontmatter, body := splitFrontmatter(raw)
 		candidate := DocumentWriteCandidate{
 			Path:        filepath.ToSlash(relPath),
 			Tags:        append([]string(nil), frontmatter["tags"]...),
@@ -41,7 +44,7 @@ func (s *Store) writeDocumentFileAtRevision(ctx context.Context, root, relPath, 
 		}
 	}
 	if writer := s.rootWriter(root); writer != nil {
-		message := documentWriteMessage("doc_write", root, relPath, raw)
+		message := documentWriteMessage(action, root, relPath, raw)
 		expectedRevision = strings.TrimSpace(expectedRevision)
 		if expectedRevision != "" {
 			revision, err := writer.WriteIfRevision(ctx, relPath, raw, message, expectedRevision)
@@ -146,7 +149,7 @@ func documentMutationMessage(action, root, relPath string) string {
 // facetSubjectMaxRunes clamps a status_line borrowed into a commit
 // subject. Published projections are already budgeted below this, so
 // the clamp only fires on content that arrived through a non-publish
-// write (doc_write can put anything under a reserved heading) — and a
+// write (for example, a historical or externally authored envelope) — and a
 // commit subject is annotation, not the content itself, so clipping
 // here is honest where clipping a projection would not be.
 const facetSubjectMaxRunes = 120
@@ -157,18 +160,18 @@ const facetSubjectMaxRunes = 120
 // sections, the message borrows them: the status_line joins the
 // subject — so the root's git log reads as a timeline of the
 // document's own one-line verdicts — and the digest becomes the commit
-// body, the actionable summary at the moment of the write. No writer
-// cooperation is needed: the facet headings are the contract, so every
-// write of a faceted document gets this regardless of which tool or
-// author produced it.
+// body, the actionable summary at the moment of the write. The durable
+// manifest identifies the codec; legacy headings remain readable until the
+// document's first structured write migrates them.
 func documentWriteMessage(action, root, relPath, raw string) string {
 	subject := documentMutationMessage(action, root, relPath)
-	_, body := splitFrontmatter(raw)
-	payload, ok := looppkg.ParseFacetSections(body)
-	if !ok {
+	frontmatter, body := splitFrontmatter(raw)
+	contract := parsedFacetContract(frontmatter, body)
+	if len(contract.Facets) == 0 {
 		return subject
 	}
-	if verdict, ok := payload.FacetByKey("status_line"); ok {
+	payload := contract.Parse(body)
+	if verdict, ok := payload.ByKey(string(documentfacets.StatusLine)); ok {
 		if line := strings.TrimSpace(verdict); line != "" {
 			line = strings.Join(strings.Fields(line), " ")
 			if runes := []rune(line); len(runes) > facetSubjectMaxRunes {
@@ -177,7 +180,7 @@ func documentWriteMessage(action, root, relPath, raw string) string {
 			subject += " — " + line
 		}
 	}
-	if digest, ok := payload.FacetByKey("digest"); ok {
+	if digest, ok := payload.ByKey(string(documentfacets.Digest)); ok {
 		if summary := strings.TrimSpace(digest); summary != "" {
 			subject += "\n\n" + summary
 		}

--- a/internal/state/documents/mutate_section_ops.go
+++ b/internal/state/documents/mutate_section_ops.go
@@ -72,6 +72,15 @@ func (s *Store) transferSection(ctx context.Context, action string, args Section
 		}
 		return nil, err
 	}
+	if removeSource {
+		if tool := structuredWriteTool(sourceRecord); tool != "" {
+			return nil, &StructuredDocumentMutationError{
+				Ref:       args.Ref,
+				Attempted: action,
+				WriteTool: tool,
+			}
+		}
+	}
 	sourceSection, err := extractDocumentSection(srcBody, args.Section)
 	if err != nil {
 		return nil, err
@@ -90,6 +99,13 @@ func (s *Store) transferSection(ctx context.Context, action string, args Section
 		destinationRecord, dstFrontmatterRaw, dstBody, err = s.readDocumentFile(dstAbsPath, dstRoot, dstRelPath)
 		if err != nil {
 			return nil, err
+		}
+		if tool := structuredWriteTool(destinationRecord); tool != "" {
+			return nil, &StructuredDocumentMutationError{
+				Ref:       args.DestinationRef,
+				Attempted: action,
+				WriteTool: tool,
+			}
 		}
 	} else if !os.IsNotExist(err) {
 		return nil, fmt.Errorf("check destination document: %w", err)

--- a/internal/state/documents/mutation_revision_test.go
+++ b/internal/state/documents/mutation_revision_test.go
@@ -272,6 +272,100 @@ func TestHiddenRevisionReceiptAdvancesFromConflictWhenSnapshotFails(t *testing.T
 	}
 }
 
+func TestDocumentCommitUpdateAndAppendHonorHiddenRevisionReceipts(t *testing.T) {
+	t.Parallel()
+
+	for _, action := range []IntakeAction{IntakeActionUpdateExisting, IntakeActionAppendExisting} {
+		action := action
+		t.Run(string(action), func(t *testing.T) {
+			t.Parallel()
+
+			root := t.TempDir()
+			backend := &revisionMutationBackend{root: root, contents: make(map[string]string)}
+			db, err := database.OpenMemory()
+			if err != nil {
+				t.Fatalf("OpenMemory: %v", err)
+			}
+			t.Cleanup(func() { _ = db.Close() })
+			store, err := NewStoreWithOptions(db, map[string]string{"kb": root}, nil, StoreOptions{
+				RootWriters:  map[string]RootWriter{"kb": backend},
+				RootRevisers: map[string]RootReviser{"kb": backend},
+			})
+			if err != nil {
+				t.Fatalf("NewStoreWithOptions: %v", err)
+			}
+			tools := NewTools(store)
+			ctx := t.Context()
+			const (
+				ref   = "kb:person.md"
+				scope = "loop:archivist"
+			)
+			if _, err := tools.Write(ctx, WriteArgs{Ref: ref, Body: stringPtr("Initial fact."), ReceiptScope: scope}); err != nil {
+				t.Fatalf("seed document: %v", err)
+			}
+			if _, err := tools.Read(ctx, RefArgs{Ref: ref, ReceiptScope: scope}); err != nil {
+				t.Fatalf("read document: %v", err)
+			}
+			intake := &IntakeResult{
+				Status:            IntakeReady,
+				RecommendedAction: action,
+				TargetRef:         ref,
+				CommitPlan: IntakeCommitPlan{
+					RecommendedAction: action,
+					TargetRef:         ref,
+				},
+			}
+			tools.rememberIntake(intake)
+			if err := backend.Write(ctx, "person.md", "Operator's newer fact.", "operator update"); err != nil {
+				t.Fatalf("external update: %v", err)
+			}
+
+			commitArgs := CommitArgs{
+				IntakeID:     intake.IntakeID,
+				Action:       action,
+				Body:         "Archivist fact.",
+				ReceiptScope: scope,
+			}
+			conflictJSON, err := tools.Commit(ctx, commitArgs)
+			if err != nil {
+				t.Fatalf("stale Commit: %v", err)
+			}
+			var conflict struct {
+				Status string                `json:"status"`
+				Result modelMutationConflict `json:"result"`
+			}
+			if err := json.Unmarshal([]byte(conflictJSON), &conflict); err != nil {
+				t.Fatalf("unmarshal conflict: %v\n%s", err, conflictJSON)
+			}
+			if conflict.Status != "conflict" || conflict.Result.Applied || !strings.Contains(conflict.Result.ChangedSinceRead, "Operator's newer fact.") {
+				t.Fatalf("conflict = %#v, want unapplied diff and conflict status", conflict)
+			}
+			record, err := store.Read(ctx, ref)
+			if err != nil {
+				t.Fatalf("read after conflict: %v", err)
+			}
+			if strings.Contains(record.Body, "Archivist fact.") {
+				t.Fatalf("stale commit changed document: %q", record.Body)
+			}
+
+			retryJSON, err := tools.Commit(ctx, commitArgs)
+			if err != nil {
+				t.Fatalf("retry Commit: %v", err)
+			}
+			var retry struct {
+				Status string              `json:"status"`
+				Result modelMutationResult `json:"result"`
+			}
+			if err := json.Unmarshal([]byte(retryJSON), &retry); err != nil {
+				t.Fatalf("unmarshal retry: %v\n%s", err, retryJSON)
+			}
+			if retry.Status != "committed" || !retry.Result.Applied {
+				t.Fatalf("retry = %#v, want applied committed result", retry)
+			}
+		})
+	}
+}
+
 func TestTruncateRevisionConflictTextPreservesUTF8(t *testing.T) {
 	t.Parallel()
 	got, truncated := truncateRevisionConflictText("one 🧭 two", 6)

--- a/internal/state/documents/parser.go
+++ b/internal/state/documents/parser.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"unicode"
 
-	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	documentfacets "github.com/nugget/thane-ai-agent/internal/state/documents/facets"
 )
 
 var (
@@ -60,7 +60,14 @@ func parseMarkdownDocument(name, raw string) parsedDocument {
 }
 
 func parseMarkdownDocumentParts(name string, meta map[string][]string, body string) parsedDocument {
-	sections := parseSections(body)
+	contract := parsedFacetContract(meta, body)
+	payload := documentfacets.Payload{Full: strings.TrimSpace(body)}
+	faceted := len(contract.Facets) > 0
+	if faceted {
+		payload = contract.Parse(body)
+	}
+	logicalFull := payload.Full
+	sections := parseSections(logicalFull)
 	title := firstValue(meta, "title")
 	if title == "" {
 		for _, sec := range sections {
@@ -84,24 +91,23 @@ func parseMarkdownDocumentParts(name string, meta map[string][]string, body stri
 	// pull (#1250).
 	summary := ""
 	var facets []string
-	facetBytes := make(map[string]int, len(looppkg.FacetKeys()))
-	payload, faceted := looppkg.ParseFacetSections(body)
+	facetBytes := make(map[string]int, len(documentfacets.Keys()))
 	if faceted {
-		for _, key := range looppkg.FacetKeys() {
+		for _, key := range documentfacets.Keys() {
 			// full is every document's baseline and advertises nothing;
 			// the facet list exists to say which condensed projections
 			// doc_read can pull.
 			if key == "full" {
 				continue
 			}
-			if value, ok := payload.FacetByKey(key); ok && strings.TrimSpace(value) != "" {
+			if value, ok := payload.ByKey(key); ok && strings.TrimSpace(value) != "" {
 				facets = append(facets, key)
 				facetBytes[key] = len(value)
 			}
 		}
-		if teaser, ok := payload.FacetByKey(string(looppkg.OutputFacetTeaser)); ok && strings.TrimSpace(teaser) != "" {
+		if teaser, ok := payload.ByKey(string(documentfacets.Teaser)); ok && strings.TrimSpace(teaser) != "" {
 			summary = strings.TrimSpace(teaser)
-		} else if verdict, ok := payload.FacetByKey(string(looppkg.OutputFacetStatusLine)); ok && strings.TrimSpace(verdict) != "" {
+		} else if verdict, ok := payload.ByKey(string(documentfacets.StatusLine)); ok && strings.TrimSpace(verdict) != "" {
 			summary = strings.TrimSpace(verdict)
 		} else {
 			summary = firstParagraph(payload.Full)
@@ -113,7 +119,7 @@ func parseMarkdownDocumentParts(name string, meta map[string][]string, body stri
 	// is always a readable projection level, and an unfaceted body parses
 	// entirely into payload.Full, so both branches share one source of
 	// truth for what a full-level read yields.
-	facetBytes["full"] = len(payload.Full)
+	facetBytes["full"] = len(logicalFull)
 
 	return parsedDocument{
 		Title:       title,
@@ -121,12 +127,31 @@ func parseMarkdownDocumentParts(name string, meta map[string][]string, body stri
 		Audience:    firstValue(meta, audienceFrontmatterKey),
 		Facets:      facets,
 		FacetBytes:  facetBytes,
-		WordCount:   len(strings.Fields(body)),
+		WordCount:   len(strings.Fields(logicalFull)),
 		Tags:        append([]string(nil), meta["tags"]...),
 		Frontmatter: meta,
 		Sections:    sections,
-		Links:       parseLinks(body),
+		Links:       parseLinks(logicalFull),
 	}
+}
+
+// parsedFacetContract resolves a canonical durable manifest first and falls
+// back to the historical reserved-heading envelope for compatibility reads.
+// A malformed canonical manifest does not become an invented contract here;
+// mutation validation reports that error before any write, while indexing
+// keeps the document discoverable as a body-only record for repair.
+func parsedFacetContract(meta map[string][]string, body string) documentfacets.Contract {
+	manifest, canonical, err := documentfacets.FromFrontmatter(meta)
+	if canonical && err == nil {
+		return manifest.Contract
+	}
+	if !canonical {
+		manifest, _, found := documentfacets.InferLegacy(body, firstValue(meta, documentfacets.ManagedByKey))
+		if found {
+			return manifest.Contract
+		}
+	}
+	return documentfacets.Contract{}
 }
 
 func splitFrontmatter(raw string) (map[string][]string, string) {

--- a/internal/state/documents/parser.go
+++ b/internal/state/documents/parser.go
@@ -60,13 +60,21 @@ func parseMarkdownDocument(name, raw string) parsedDocument {
 }
 
 func parseMarkdownDocumentParts(name string, meta map[string][]string, body string) parsedDocument {
+	_, canonicalManifest, manifestErr := documentfacets.FromFrontmatter(meta)
+	invalidManifest := canonicalManifest && manifestErr != nil
 	contract := parsedFacetContract(meta, body)
 	payload := documentfacets.Payload{Full: strings.TrimSpace(body)}
-	faceted := len(contract.Facets) > 0
+	faceted := !invalidManifest && len(contract.Facets) > 0
 	if faceted {
 		payload = contract.Parse(body)
 	}
 	logicalFull := payload.Full
+	if invalidManifest {
+		// Keep the document discoverable by path/title/tags without indexing
+		// any private codec content. Direct reads carry the bounded repair
+		// error; an empty projection-size map also prevents context offers.
+		logicalFull = ""
+	}
 	sections := parseSections(logicalFull)
 	title := firstValue(meta, "title")
 	if title == "" {
@@ -112,14 +120,16 @@ func parseMarkdownDocumentParts(name string, meta map[string][]string, body stri
 		} else {
 			summary = firstParagraph(payload.Full)
 		}
-	} else {
+	} else if !invalidManifest {
 		summary = firstParagraph(body)
 	}
 	// full is measured for every document, faceted or not: the full body
 	// is always a readable projection level, and an unfaceted body parses
 	// entirely into payload.Full, so both branches share one source of
 	// truth for what a full-level read yields.
-	facetBytes["full"] = len(logicalFull)
+	if !invalidManifest {
+		facetBytes["full"] = len(logicalFull)
+	}
 
 	return parsedDocument{
 		Title:       title,
@@ -138,8 +148,8 @@ func parseMarkdownDocumentParts(name string, meta map[string][]string, body stri
 // parsedFacetContract resolves a canonical durable manifest first and falls
 // back to the historical reserved-heading envelope for compatibility reads.
 // A malformed canonical manifest does not become an invented contract here;
-// mutation validation reports that error before any write, while indexing
-// keeps the document discoverable as a body-only record for repair.
+// the record retains that invalid state so content-bearing reads fail closed
+// and direct repair to the owning structured writer.
 func parsedFacetContract(meta map[string][]string, body string) documentfacets.Contract {
 	manifest, canonical, err := documentfacets.FromFrontmatter(meta)
 	if canonical && err == nil {

--- a/internal/state/documents/policy_test.go
+++ b/internal/state/documents/policy_test.go
@@ -195,8 +195,8 @@ func TestStorePolicyRootWriterHandlesWriteAndDelete(t *testing.T) {
 	if _, err := store.Write(ctx, WriteArgs{Ref: "kb:writer/doc.md", Body: &body}); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
-	if len(writer.writes) != 1 || writer.writes[0] != "writer/doc.md|doc_write kb:writer/doc.md" {
-		t.Fatalf("writer.writes = %#v, want one doc_write call", writer.writes)
+	if len(writer.writes) != 1 || writer.writes[0] != "writer/doc.md|doc_body_write kb:writer/doc.md" {
+		t.Fatalf("writer.writes = %#v, want one doc_body_write call", writer.writes)
 	}
 
 	if _, err := store.Delete(ctx, DeleteArgs{Ref: "kb:writer/doc.md"}); err != nil {

--- a/internal/state/documents/query.go
+++ b/internal/state/documents/query.go
@@ -342,16 +342,20 @@ func (s *Store) Section(ctx context.Context, ref string, selector string) (*Sect
 	}
 	meta, body := splitFrontmatter(string(raw))
 	doc := parseMarkdownDocumentParts(relPath, meta, body)
+	logicalBody := body
+	if contract := parsedFacetContract(meta, body); len(contract.Facets) > 0 {
+		logicalBody = contract.Parse(body).Full
+	}
 	selector = strings.TrimSpace(selector)
 	if selector == "" {
-		lineCount := len(strings.Split(body, "\n"))
+		lineCount := len(strings.Split(logicalBody, "\n"))
 		return &Section{
 			Heading:   doc.Title,
 			Slug:      slugify(doc.Title),
 			Level:     0,
 			StartLine: 1,
 			EndLine:   lineCount,
-			Content:   strings.TrimSpace(body),
+			Content:   strings.TrimSpace(logicalBody),
 		}, nil
 	}
 	targetSlug := slugify(selector)

--- a/internal/state/documents/query.go
+++ b/internal/state/documents/query.go
@@ -276,6 +276,20 @@ func (s *Store) Outline(ctx context.Context, ref string) ([]Section, error) {
 	if err := s.verifyDocumentForConsumer(ctx, root, relPath, "doc_outline"); err != nil {
 		return nil, err
 	}
+	absPath, err := s.resolveDocumentPath(root, relPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("document not found: %s", ref)
+		}
+		return nil, err
+	}
+	record, err := s.readCurrentDocument(ctx, absPath, root, relPath)
+	if err != nil {
+		return nil, err
+	}
+	if err := invalidFacetManifestReadError(record); err != nil {
+		return nil, err
+	}
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT level, heading, slug, start_line, end_line
 		 FROM indexed_document_sections
@@ -341,6 +355,13 @@ func (s *Store) Section(ctx context.Context, ref string, selector string) (*Sect
 		return nil, fmt.Errorf("read document: %w", err)
 	}
 	meta, body := splitFrontmatter(string(raw))
+	record, _, _, err := readDocumentRecordBytes(absPath, root, relPath, raw)
+	if err != nil {
+		return nil, err
+	}
+	if err := invalidFacetManifestReadError(record); err != nil {
+		return nil, err
+	}
 	doc := parseMarkdownDocumentParts(relPath, meta, body)
 	logicalBody := body
 	if contract := parsedFacetContract(meta, body); len(contract.Facets) > 0 {

--- a/internal/state/documents/query_facets_test.go
+++ b/internal/state/documents/query_facets_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+
+	documentfacets "github.com/nugget/thane-ai-agent/internal/state/documents/facets"
 )
 
 // TestSearchUsesAuthoredFacetsForSnippetAndAdvertisesThem pins the
@@ -18,11 +20,11 @@ func TestSearchUsesAuthoredFacetsForSnippetAndAdvertisesThem(t *testing.T) {
 	ctx := context.Background()
 
 	teasered := "## Status Line\n\nverdict line here\n\n## Teaser\n\nThe authored orangutan teaser, written for search snippets.\n\n## Details\n\nlong working memory body\n"
-	if _, err := store.Write(ctx, WriteArgs{Ref: "kb:zoo/teasered.md", Title: "Teasered", Body: stringPtr(teasered)}); err != nil {
+	if _, err := store.Write(ctx, WriteArgs{Ref: "kb:zoo/teasered.md", Title: "Teasered", Frontmatter: facetTestManifest(teasered), Body: stringPtr(teasered)}); err != nil {
 		t.Fatalf("write teasered: %v", err)
 	}
 	verdictOnly := "## Status Line\n\norangutan verdict, no teaser declared\n\n## Details\n\nbody\n"
-	if _, err := store.Write(ctx, WriteArgs{Ref: "kb:zoo/verdict.md", Title: "VerdictOnly", Body: stringPtr(verdictOnly)}); err != nil {
+	if _, err := store.Write(ctx, WriteArgs{Ref: "kb:zoo/verdict.md", Title: "VerdictOnly", Frontmatter: facetTestManifest(verdictOnly), Body: stringPtr(verdictOnly)}); err != nil {
 		t.Fatalf("write verdict: %v", err)
 	}
 	plain := "# Plain\n\nA plain orangutan document with a first paragraph.\n"
@@ -82,7 +84,7 @@ func TestSearchToolResultCarriesFacetsAcrossModelBoundary(t *testing.T) {
 	ctx := context.Background()
 
 	body := "## Status Line\n\nverdict line here\n\n## Teaser\n\nThe authored capybara teaser.\n\n## Details\n\nlong body\n"
-	if _, err := store.Write(ctx, WriteArgs{Ref: "kb:zoo/faceted.md", Title: "Faceted", Body: stringPtr(body)}); err != nil {
+	if _, err := store.Write(ctx, WriteArgs{Ref: "kb:zoo/faceted.md", Title: "Faceted", Frontmatter: facetTestManifest(body), Body: stringPtr(body)}); err != nil {
 		t.Fatalf("write faceted: %v", err)
 	}
 	plain := "# Plain\n\nA plain capybara document.\n"
@@ -96,8 +98,9 @@ func TestSearchToolResultCarriesFacetsAcrossModelBoundary(t *testing.T) {
 	}
 	var payload struct {
 		Results []struct {
-			Ref    string   `json:"ref"`
-			Facets []string `json:"facets"`
+			Ref       string   `json:"ref"`
+			Facets    []string `json:"facets"`
+			WriteTool string   `json:"write_tool"`
 		} `json:"results"`
 	}
 	if err := json.Unmarshal([]byte(out), &payload); err != nil {
@@ -119,4 +122,24 @@ func TestSearchToolResultCarriesFacetsAcrossModelBoundary(t *testing.T) {
 	} else if plainFacets != nil {
 		t.Errorf("plain document's tool result advertises facets: %v", plainFacets)
 	}
+	for _, hit := range payload.Results {
+		switch hit.Ref {
+		case "kb:zoo/faceted.md":
+			if hit.WriteTool != DocumentWriteToolName {
+				t.Errorf("faceted write_tool = %q, want %q", hit.WriteTool, DocumentWriteToolName)
+			}
+		case "kb:zoo/plain.md":
+			if hit.WriteTool != DocumentBodyWriteToolName {
+				t.Errorf("plain write_tool = %q, want %s", hit.WriteTool, DocumentBodyWriteToolName)
+			}
+		}
+	}
+}
+
+func facetTestManifest(body string) map[string][]string {
+	manifest, _, ok := documentfacets.InferLegacy(body, DocumentWriteToolName)
+	if !ok {
+		return nil
+	}
+	return manifest.Frontmatter()
 }

--- a/internal/state/documents/read_absence_test.go
+++ b/internal/state/documents/read_absence_test.go
@@ -88,11 +88,9 @@ func TestReadStillVerifiesDocumentsThatExist(t *testing.T) {
 }
 
 // TestVerifyPathStillBlocksMissingFilesInRequiredRoots pins the
-// property I nearly broke while fixing the read path. VerifyPath also
-// guards new-file writes: a path that does not exist yet must still be
-// checked, or writing to an unwritten path would skip policy entirely.
-// The read-side reordering is deliberately scoped to reads for exactly
-// this reason.
+// property I nearly broke while fixing the read path. VerifyPath also guards
+// new-file writes: a path that does not exist yet must still be classified as
+// an indexed managed document rather than bypassing the logical tool surface.
 func TestVerifyPathStillBlocksMissingFilesInRequiredRoots(t *testing.T) {
 	t.Parallel()
 
@@ -102,7 +100,7 @@ func TestVerifyPathStillBlocksMissingFilesInRequiredRoots(t *testing.T) {
 	if err == nil {
 		t.Fatal("VerifyPath() waved through a missing file in a required root — that is a write bypass")
 	}
-	if !strings.Contains(err.Error(), "blocked by signature policy") {
-		t.Errorf("error = %q, want the policy block preserved for the write path", err)
+	if !strings.Contains(err.Error(), "indexed managed document path") {
+		t.Errorf("error = %q, want the logical document boundary preserved for the write path", err)
 	}
 }

--- a/internal/state/documents/revision_tools.go
+++ b/internal/state/documents/revision_tools.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
+	documentfacets "github.com/nugget/thane-ai-agent/internal/state/documents/facets"
 )
 
 const (
@@ -171,6 +172,9 @@ func (t *Tools) At(ctx context.Context, args AtArgs) (string, error) {
 	}
 	_, relPath, _ := parseRef(args.Ref)
 	meta, body := splitFrontmatter(content.Content)
+	if _, canonical, manifestErr := documentfacets.FromFrontmatter(meta); canonical && manifestErr != nil {
+		return "", fmt.Errorf("document %s at %s has an invalid faceted manifest; no private storage envelope was returned: %s", args.Ref, content.Revision.Short, boundedFacetManifestError(manifestErr))
+	}
 	parsed := parseMarkdownDocumentParts(relPath, meta, body)
 	now := nowUTC()
 	rev := content.Revision

--- a/internal/state/documents/tools.go
+++ b/internal/state/documents/tools.go
@@ -10,6 +10,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
+	documentfacets "github.com/nugget/thane-ai-agent/internal/state/documents/facets"
 )
 
 const (
@@ -298,9 +299,35 @@ func (t *Tools) Write(ctx context.Context, args WriteArgs) (string, error) {
 	if args.Ref == "" {
 		return "", fmt.Errorf("ref is required")
 	}
+	current, err := t.store.Read(ctx, args.Ref)
+	if err != nil && !IsNotFound(err) {
+		return "", fmt.Errorf("inspect %s before write: %w", args.Ref, err)
+	}
+	if args.StructuredTool == "" {
+		if tool := structuredWriteTool(current); tool != "" {
+			return "", &StructuredDocumentMutationError{Ref: args.Ref, Attempted: DocumentBodyWriteToolName, WriteTool: tool}
+		}
+		if args.Body != nil {
+			if _, faceted := documentfacets.ParseLegacy(*args.Body); faceted {
+				if current == nil {
+					return "", fmt.Errorf("%s cannot create a faceted section envelope; no change was made. Call %s with ref %s and each projection as its own field", DocumentBodyWriteToolName, DocumentWriteToolName, args.Ref)
+				}
+				return "", &StructuredDocumentMutationError{Ref: args.Ref, Attempted: DocumentBodyWriteToolName, WriteTool: DocumentWriteToolName}
+			}
+		}
+	} else if current != nil && current.ManagedBy != "" && current.ManagedBy != args.StructuredTool {
+		return "", &StructuredDocumentMutationError{Ref: args.Ref, Attempted: args.StructuredTool, WriteTool: current.ManagedBy}
+	}
 	t.prepareWriteReceipt(&args)
 	result, err := t.store.Write(ctx, args)
-	return t.marshalMutationResult(ctx, "doc_write", args.Ref, args.ReceiptScope, args.ExpectedRevision, result, err)
+	if result != nil && args.StructuredTool == "" {
+		result.Action = DocumentBodyWriteToolName
+	}
+	action := args.StructuredTool
+	if action == "" {
+		action = DocumentBodyWriteToolName
+	}
+	return t.marshalMutationResult(ctx, action, args.Ref, args.ReceiptScope, args.ExpectedRevision, result, err)
 }
 
 // Edit applies one structured edit to a managed document.
@@ -310,6 +337,13 @@ func (t *Tools) Edit(ctx context.Context, args EditArgs) (string, error) {
 	}
 	if args.Ref == "" {
 		return "", fmt.Errorf("ref is required")
+	}
+	current, err := t.store.Read(ctx, args.Ref)
+	if err != nil {
+		return "", err
+	}
+	if tool := structuredWriteTool(current); tool != "" {
+		return "", &StructuredDocumentMutationError{Ref: args.Ref, Attempted: "doc_edit", WriteTool: tool}
 	}
 	t.prepareEditReceipt(&args)
 	result, err := t.store.Edit(ctx, args)
@@ -323,6 +357,13 @@ func (t *Tools) JournalUpdate(ctx context.Context, args JournalUpdateArgs) (stri
 	}
 	if args.Ref == "" {
 		return "", fmt.Errorf("ref is required")
+	}
+	current, err := t.store.Read(ctx, args.Ref)
+	if err != nil && !IsNotFound(err) {
+		return "", err
+	}
+	if tool := structuredWriteTool(current); tool != "" {
+		return "", &StructuredDocumentMutationError{Ref: args.Ref, Attempted: "doc_journal_update", WriteTool: tool}
 	}
 	t.prepareJournalReceipt(&args)
 	result, err := t.store.JournalUpdate(ctx, args)

--- a/internal/state/documents/tools.go
+++ b/internal/state/documents/tools.go
@@ -119,6 +119,12 @@ func (t *Tools) ReadWithResultBudget(ctx context.Context, args RefArgs, resultBu
 	if err != nil {
 		return "", err
 	}
+	if err := invalidFacetManifestReadError(doc); err != nil {
+		// The read withholds codec content but still establishes the exact
+		// revision the directed structured repair is allowed to replace.
+		t.rememberDocumentReceipt(args.ReceiptScope, doc)
+		return "", err
+	}
 	t.rememberDocumentReceipt(args.ReceiptScope, doc)
 	return marshalToolResultBudget(toModelDocumentRecord(doc, nowUTC()), resultBudget)
 }
@@ -146,6 +152,10 @@ func (t *Tools) RecordWithReceipt(ctx context.Context, args RefArgs) (*DocumentR
 	}
 	doc, err := t.store.Read(ctx, args.Ref)
 	if err != nil {
+		return nil, err
+	}
+	if err := invalidFacetManifestReadError(doc); err != nil {
+		t.rememberDocumentReceipt(args.ReceiptScope, doc)
 		return nil, err
 	}
 	t.rememberDocumentReceipt(args.ReceiptScope, doc)
@@ -315,7 +325,7 @@ func (t *Tools) Write(ctx context.Context, args WriteArgs) (string, error) {
 				return "", &StructuredDocumentMutationError{Ref: args.Ref, Attempted: DocumentBodyWriteToolName, WriteTool: DocumentWriteToolName}
 			}
 		}
-	} else if current != nil && current.ManagedBy != "" && current.ManagedBy != args.StructuredTool {
+	} else if current != nil && current.ManagedBy != "" && current.ManagedBy != args.StructuredTool && !containsWriteTool(args.PreviousWriteTools, current.ManagedBy) {
 		return "", &StructuredDocumentMutationError{Ref: args.Ref, Attempted: args.StructuredTool, WriteTool: current.ManagedBy}
 	}
 	t.prepareWriteReceipt(&args)

--- a/internal/state/documents/verification.go
+++ b/internal/state/documents/verification.go
@@ -95,6 +95,9 @@ func (s *Store) VerifyPath(ctx context.Context, path string, consumer string) er
 	if !ok {
 		return nil
 	}
+	if s.rootPolicy(root).Indexing && strings.HasPrefix(consumer, "file_tools_") {
+		return managedDocumentFileToolError(root, relPath, consumer)
+	}
 	return s.verifyDocumentForConsumer(ctx, root, relPath, consumer)
 }
 
@@ -118,6 +121,9 @@ func (s *Store) VerifyMutationPath(_ context.Context, path string, consumer stri
 		return nil
 	}
 	policy := s.rootPolicy(root)
+	if policy.Indexing && strings.HasPrefix(consumer, "file_tools_") {
+		return managedDocumentFileToolError(root, relPath, consumer)
+	}
 	switch policy.Authoring {
 	case "", AuthoringManaged:
 	case AuthoringReadOnly, AuthoringRestricted:
@@ -129,6 +135,14 @@ func (s *Store) VerifyMutationPath(_ context.Context, path string, consumer stri
 		return fmt.Errorf("document %s:%s blocked by mutation policy for %s: raw file mutation would bypass signed document-root provenance; use managed document tools", root, relPath, consumer)
 	}
 	return nil
+}
+
+func managedDocumentFileToolError(root, relPath, consumer string) error {
+	ref := root + ":"
+	if relPath != "." {
+		ref += relPath
+	}
+	return fmt.Errorf("%s is an indexed managed document path and is not available through %s; use doc_browse, doc_search, doc_read, and the returned write_tool so Thane can expose the logical document instead of its private Markdown storage codec", ref, consumer)
 }
 
 func (s *Store) rootRefForPath(path string) (root string, relPath string, ok bool, err error) {

--- a/internal/state/documents/verification_test.go
+++ b/internal/state/documents/verification_test.go
@@ -46,7 +46,7 @@ func TestStoreVerifyPath_MissingFileInsideRequiredRootBlocked(t *testing.T) {
 	}
 
 	missing := filepath.Join(kbDir, "subdir", "new-file.md")
-	err = store.VerifyPath(context.Background(), missing, "file_tools_write")
+	err = store.VerifyPath(context.Background(), missing, "inject_files")
 	if err == nil {
 		t.Fatal("VerifyPath should block a missing file inside a required-mode root")
 	}
@@ -153,11 +153,11 @@ func TestStoreVerifyMutationPath_BlocksSignedRootEvenWhenContentTrusted(t *testi
 	target := filepath.Join(kbDir, "trusted.md")
 	writeFile(t, target, "# Trusted\n")
 
-	if err := store.VerifyPath(context.Background(), target, "file_tools_read"); err != nil {
+	if err := store.VerifyPath(context.Background(), target, "document_read_test"); err != nil {
 		t.Fatalf("trusted read verification should pass: %v", err)
 	}
 
-	err := store.VerifyMutationPath(context.Background(), target, "file_tools_write")
+	err := store.VerifyMutationPath(context.Background(), target, "internal_mutation_test")
 	if err == nil {
 		t.Fatal("VerifyMutationPath should block raw writes inside signed roots")
 	}
@@ -177,7 +177,7 @@ func TestStoreVerifyMutationPath_BlocksReadOnlyRoot(t *testing.T) {
 	}, nil)
 	target := filepath.Join(kbDir, "blocked.md")
 
-	err := store.VerifyMutationPath(context.Background(), target, "file_tools_write")
+	err := store.VerifyMutationPath(context.Background(), target, "internal_mutation_test")
 	if err == nil {
 		t.Fatal("VerifyMutationPath should block raw writes inside read-only roots")
 	}
@@ -186,7 +186,7 @@ func TestStoreVerifyMutationPath_BlocksReadOnlyRoot(t *testing.T) {
 	}
 }
 
-func TestStoreVerifyMutationPath_AllowsUnprotectedManagedRoot(t *testing.T) {
+func TestStoreVerifyMutationPath_BlocksIndexedManagedRoot(t *testing.T) {
 	t.Parallel()
 
 	store, kbDir := newPolicyStore(t, map[string]RootPolicy{
@@ -197,8 +197,35 @@ func TestStoreVerifyMutationPath_AllowsUnprotectedManagedRoot(t *testing.T) {
 	}, nil)
 	target := filepath.Join(kbDir, "plain.md")
 
-	if err := store.VerifyMutationPath(context.Background(), target, "file_tools_write"); err != nil {
-		t.Fatalf("unprotected managed root should allow raw file mutation: %v", err)
+	err := store.VerifyMutationPath(context.Background(), target, "file_tools_write")
+	if err == nil {
+		t.Fatal("indexed managed root allowed a raw file mutation")
+	}
+	for _, want := range []string{"indexed managed document", "doc_read", "write_tool"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %v, want logical document redirect containing %q", err, want)
+		}
+	}
+	if err := store.VerifyMutationPath(context.Background(), target, "internal_maintenance"); err != nil {
+		t.Fatalf("non-model internal caller should retain the root's configured policy: %v", err)
+	}
+}
+
+func TestStoreVerifyPath_BlocksFileToolsButNotInternalReaders(t *testing.T) {
+	t.Parallel()
+
+	store, kbDir := newPolicyStore(t, map[string]RootPolicy{
+		"kb": {Indexing: true, Authoring: AuthoringManaged},
+	}, nil)
+	target := filepath.Join(kbDir, "faceted.md")
+	writeFile(t, target, "private storage codec")
+
+	err := store.VerifyPath(context.Background(), target, "file_tools_read")
+	if err == nil || !strings.Contains(err.Error(), "use doc_browse") {
+		t.Fatalf("file-tool read error = %v, want logical document redirect", err)
+	}
+	if err := store.VerifyPath(context.Background(), target, "core_prompt_files"); err != nil {
+		t.Fatalf("internal reader should still follow signature policy: %v", err)
 	}
 }
 

--- a/internal/tools/contact_dossier_tool_test.go
+++ b/internal/tools/contact_dossier_tool_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 type contactDossierWriterRecorder struct {
-	args documents.WriteArgs
+	args documents.FacetedWriteArgs
 }
 
 type contactDossierReaderRecorder struct {
@@ -28,7 +28,7 @@ func (r *contactDossierReaderRecorder) Read(_ context.Context, args documents.Re
 	return r.result, r.err
 }
 
-func (w *contactDossierWriterRecorder) Write(_ context.Context, args documents.WriteArgs) (string, error) {
+func (w *contactDossierWriterRecorder) Write(_ context.Context, args documents.FacetedWriteArgs) (string, error) {
 	w.args = args
 	return `{"action":"doc_write","applied":true}`, nil
 }

--- a/internal/tools/contact_tools.go
+++ b/internal/tools/contact_tools.go
@@ -7,8 +7,8 @@ import (
 	"sort"
 	"strings"
 
-	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/state/contacts"
+	documentfacets "github.com/nugget/thane-ai-agent/internal/state/documents/facets"
 )
 
 // SetContactTools adds contact management tools to the registry.
@@ -385,7 +385,7 @@ func registerContactDossierWriteTool(r *Registry, contactTools *contacts.Tools) 
 	}
 	required := []string{"contact_id"}
 	for _, field := range fields {
-		description := field.Guidance + looppkg.FormatGuidance(field.Format)
+		description := field.Guidance + documentfacets.FormatGuidance(field.Format)
 		if field.Key == "status_line" || field.Key == "teaser" {
 			description += " Omit the contact's canonical name: the structured record and dossier title already identify the subject."
 		}

--- a/internal/tools/content_resolve_test.go
+++ b/internal/tools/content_resolve_test.go
@@ -479,8 +479,8 @@ func TestContentResolver_Execute_Integration(t *testing.T) {
 		reg.SetContentResolver(cr)
 		RegisterDocumentTools(reg, documents.NewTools(store))
 
-		if _, err := reg.Execute(ctx, "doc_write", `{"ref":"kb:new.md","title":"New","body":"temp:draft"}`); err != nil {
-			t.Fatalf("Execute doc_write: %v", err)
+		if _, err := reg.Execute(ctx, "doc_body_write", `{"ref":"kb:new.md","title":"New","body":"temp:draft"}`); err != nil {
+			t.Fatalf("Execute doc_body_write: %v", err)
 		}
 
 		record, err := store.Read(ctx, "kb:new.md")

--- a/internal/tools/document_facet_read_test.go
+++ b/internal/tools/document_facet_read_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/state/documents"
+	documentfacets "github.com/nugget/thane-ai-agent/internal/state/documents/facets"
 )
 
 // facetedBody renders a document the way a publishing loop would, so
@@ -198,7 +199,11 @@ func newSeededDocumentTools(t *testing.T, body string) *documents.Tools {
 
 func seedDocumentTools(t *testing.T, store *documents.Store, body string) *documents.Tools {
 	t.Helper()
-	if _, err := store.Write(t.Context(), documents.WriteArgs{Ref: "core:office.md", Body: &body}); err != nil {
+	manifest, _, ok := documentfacets.InferLegacy(body, documents.DocumentWriteToolName)
+	if !ok {
+		t.Fatal("seed body is not a faceted document")
+	}
+	if _, err := store.Write(t.Context(), documents.WriteArgs{Ref: "core:office.md", Frontmatter: manifest.Frontmatter(), Body: &body}); err != nil {
 		t.Fatalf("seed document: %v", err)
 	}
 	return documents.NewTools(store)
@@ -217,6 +222,9 @@ func TestDocReadAtALevelReturnsOnlyThatProjection(t *testing.T) {
 	}
 	if result["faceted"] != true {
 		t.Errorf("faceted = %v, want true", result["faceted"])
+	}
+	if result["write_tool"] != documents.DocumentWriteToolName {
+		t.Errorf("write_tool = %v, want %q", result["write_tool"], documents.DocumentWriteToolName)
 	}
 	// The point of reading at a level is not paying for the rest.
 	if strings.Contains(raw, "Two packages") {

--- a/internal/tools/document_intake_tools.go
+++ b/internal/tools/document_intake_tools.go
@@ -5,14 +5,15 @@ import (
 	"fmt"
 
 	"github.com/nugget/thane-ai-agent/internal/state/documents"
+	documentfacets "github.com/nugget/thane-ai-agent/internal/state/documents/facets"
 )
 
 func registerDocumentIntakeTools(r *Registry, dt *documents.Tools) {
 	r.Register(&Tool{
 		Name: "doc_create",
-		Description: "Create a new ordinary managed markdown document safely. Contract-owned documents use their dedicated structured tool instead—for example, contact_dossier_write owns contact dossiers and publish_output_* owns loop outputs. For ordinary documents, this runs the corpus-aware placement analysis (related-document search, title/tags/path normalization, root policy) and, when placement is clean, writes the document in the same call. " +
+		Description: "Create a normal faceted managed document safely. It runs corpus-aware placement analysis (related-document search, title/tags/path normalization, and root policy) and, when placement is clean, writes status_line, optional teaser/digest, and full through the same logical document contract as doc_write. " +
 			"When a similar document already exists or policy wants review, nothing is written: the result comes back created=false with the analysis and an intake_id for doc_commit. " +
-			"Prefer this over doc_write for any brand-new document; doc_write's create is for destinations that are already deliberate.",
+			"Prefer this when placement is not settled; doc_write creates directly when the ref is already deliberate.",
 		ContentResolveExempt: []string{"root", "title", "ref", "tags", "path_prefix"},
 		Parameters: map[string]any{
 			"type": "object",
@@ -21,10 +22,10 @@ func registerDocumentIntakeTools(r *Registry, dt *documents.Tools) {
 					"type":        "string",
 					"description": "Target managed root without trailing colon, such as `kb` or `scratchpad`. Required unless only one document root exists.",
 				},
-				"body": map[string]any{
-					"type":        "string",
-					"description": "Complete markdown body for the new document, written when placement is clean (outer whitespace is trimmed; frontmatter is managed by the tool).",
-				},
+				"status_line": projectionProperty(documentfacets.StatusLine, false),
+				"teaser":      projectionProperty(documentfacets.Teaser, true),
+				"digest":      projectionProperty(documentfacets.Digest, true),
+				"full":        projectionProperty("full", false),
 				"title": map[string]any{
 					"type":        "string",
 					"description": "Optional title hint; the tool may normalize it against corpus conventions.",
@@ -47,15 +48,17 @@ func registerDocumentIntakeTools(r *Registry, dt *documents.Tools) {
 					"description": "Optional note on what the document is for; improves placement analysis.",
 				},
 			},
-			"required": []string{"body"},
+			"required": []string{"status_line", "full"},
 		},
 		Handler: func(ctx context.Context, args map[string]any) (string, error) {
-			// The vocabulary invariant: every document tool's markdown
-			// parameter is named body (#1201).
+			// Mechanical-envelope arguments are always a mistake on this logical
+			// writer. Teach the projection name instead of silently dropping it.
 			if _, hasContent := args["content"]; hasContent {
-				return "", fmt.Errorf("doc_create has no %q parameter — markdown goes in %q (every document tool takes body)", "content", "body")
+				return "", fmt.Errorf("doc_create has no %q parameter; put complete document content in full and supply status_line", "content")
 			}
-			body, _ := args["body"].(string)
+			if _, hasBody := args["body"]; hasBody {
+				return "", fmt.Errorf("doc_create has no body parameter; put complete document content in full and supply status_line")
+			}
 			root, _ := args["root"].(string)
 			title, _ := args["title"].(string)
 			ref, _ := args["ref"].(string)
@@ -63,12 +66,16 @@ func registerDocumentIntakeTools(r *Registry, dt *documents.Tools) {
 			intent, _ := args["intent"].(string)
 			return dt.Create(ctx, documents.CreateArgs{
 				Root:         root,
-				Body:         body,
+				StatusLine:   stringArg(args, "status_line"),
+				Teaser:       optionalStringArg(args, "teaser"),
+				Digest:       optionalStringArg(args, "digest"),
+				Full:         stringArg(args, "full"),
 				DesiredTitle: title,
 				DesiredRef:   ref,
 				Tags:         documentStringSliceArg(args["tags"]),
 				PathPrefix:   pathPrefix,
 				Intent:       intent,
+				ReceiptScope: documentRevisionScope(ctx),
 			})
 		},
 	})
@@ -144,7 +151,7 @@ func registerDocumentIntakeTools(r *Registry, dt *documents.Tools) {
 
 	r.Register(&Tool{
 		Name:                 "doc_commit",
-		Description:          "Commit a prior doc_intake result through managed document mutations. Pass the intake_id from doc_intake, choose the approved action, and set confirm=true when doc_intake returned a caution or when overriding its recommendation.",
+		Description:          "Commit a prior doc_intake result. create_new writes a normal faceted document and requires status_line plus full; update_existing and append_existing retain their body parameter only for a body-only target. If the selected existing ref is faceted or contract-owned, use the write_tool returned by doc_read instead.",
 		ContentResolveExempt: []string{"intake_id", "action", "section", "heading", "window", "confirm"},
 		Parameters: map[string]any{
 			"type": "object",
@@ -160,8 +167,12 @@ func registerDocumentIntakeTools(r *Registry, dt *documents.Tools) {
 				},
 				"body": map[string]any{
 					"type":        "string",
-					"description": "Full markdown body, section content, or journal entry to commit. Required for create_new, update_existing, and append_existing.",
+					"description": "Body-only section content or journal entry for update_existing/append_existing. Never use for create_new.",
 				},
+				"status_line": projectionProperty(documentfacets.StatusLine, false),
+				"teaser":      projectionProperty(documentfacets.Teaser, true),
+				"digest":      projectionProperty(documentfacets.Digest, true),
+				"full":        projectionProperty("full", false),
 				"section": map[string]any{
 					"type":        "string",
 					"description": "For update_existing, upsert this section instead of appending to the body.",
@@ -194,14 +205,35 @@ func registerDocumentIntakeTools(r *Registry, dt *documents.Tools) {
 			window, _ := args["window"].(string)
 			confirm, _ := args["confirm"].(bool)
 			return dt.Commit(ctx, documents.CommitArgs{
-				IntakeID: intakeID,
-				Action:   documents.IntakeAction(action),
-				Body:     body,
-				Section:  section,
-				Heading:  heading,
-				Window:   window,
-				Confirm:  confirm,
+				IntakeID:     intakeID,
+				Action:       documents.IntakeAction(action),
+				StatusLine:   stringArg(args, "status_line"),
+				Teaser:       optionalStringArg(args, "teaser"),
+				Digest:       optionalStringArg(args, "digest"),
+				Full:         stringArg(args, "full"),
+				Body:         body,
+				Section:      section,
+				Heading:      heading,
+				Window:       window,
+				Confirm:      confirm,
+				ReceiptScope: documentRevisionScope(ctx),
 			})
 		},
 	})
+}
+
+func projectionProperty(name documentfacets.Name, optional bool) map[string]any {
+	key := string(name)
+	if key == "" {
+		key = "full"
+	}
+	field, _ := documentfacets.FieldByKey(key)
+	description := field.Guidance + documentfacets.FormatGuidance(field.Format)
+	if field.MaxRunes > 0 {
+		description = fmt.Sprintf("%s Maximum %d characters.", description, field.MaxRunes)
+	}
+	if optional {
+		description += " Optional on first creation."
+	}
+	return map[string]any{"type": "string", "description": description}
 }

--- a/internal/tools/document_lifecycle_tools.go
+++ b/internal/tools/document_lifecycle_tools.go
@@ -113,7 +113,7 @@ func registerDocumentLifecycleTools(r *Registry, dt *documents.Tools) {
 
 	r.Register(&Tool{
 		Name:                 "doc_copy_section",
-		Description:          "Copy one named section from a source managed document into a destination managed document. The destination section is upserted, so this is a good fit for reorganizing or curating knowledge without losing the source.",
+		Description:          "Copy one named section from a source managed document into an ordinary destination document. The destination section is upserted, so this is a good fit for reorganizing or curating ordinary knowledge without losing the source. A faceted or contract-owned destination rejects the mutation and names its write_tool because its projections must be republished together.",
 		ContentResolveExempt: []string{"ref", "section", "destination_ref", "destination_section", "destination_level"},
 		Parameters: map[string]any{
 			"type": "object",
@@ -167,7 +167,7 @@ func registerDocumentLifecycleTools(r *Registry, dt *documents.Tools) {
 
 	r.Register(&Tool{
 		Name:                 "doc_move_section",
-		Description:          "Move one named section from a source managed document into a destination managed document. This copies the section into the destination and then removes it from the source, so it is ideal for refactoring a corpus without falling back to raw file edits.",
+		Description:          "Move one named section between ordinary managed documents. This copies the section into the destination and then removes it from the source, so it is useful for refactoring an ordinary corpus without falling back to raw file edits. A faceted or contract-owned source or destination rejects the mutation and names its write_tool because its projections must be republished together.",
 		ContentResolveExempt: []string{"ref", "section", "destination_ref", "destination_section", "destination_level"},
 		Parameters: map[string]any{
 			"type": "object",

--- a/internal/tools/document_mutation_tools.go
+++ b/internal/tools/document_mutation_tools.go
@@ -4,18 +4,20 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/nugget/thane-ai-agent/internal/state/documents"
+	documentfacets "github.com/nugget/thane-ai-agent/internal/state/documents/facets"
 )
 
 func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 	registerDocumentLifecycleTools(r, dt)
 
 	r.Register(&Tool{
-		Name:                 "doc_write",
-		Description:          "Write (replace) an ordinary managed markdown document by semantic ref like `kb:article.md`. Contract-owned documents use their dedicated structured tool instead—for example, contact_dossier_write owns contact dossiers and publish_output_* owns loop outputs. This tool owns frontmatter integrity for title, description, tags, created, and updated timestamps, and it can append a stamped entry to a standard `Journal` section so the model can think in documents instead of filesystem paths. For brand-new ordinary documents prefer doc_create, which collision-checks the corpus and normalizes placement first — doc_write creating a fresh ref is for destinations that are already deliberate. On revision-backed roots Thane automatically protects a document you read from intervening edits; if it changed, no write occurs and the result includes the bounded intervening diff. Read an existing document before replacing its whole body.",
+		Name:                 documents.DocumentBodyWriteToolName,
+		Description:          "Write one undifferentiated Markdown body for the unusual managed document that intentionally has no projection ladder. This is not a filesystem bypass: Thane still owns metadata, root policy, revision protection, and Git. Most documents belong on doc_write instead. This tool cannot write or mutate a faceted document; doc_read and doc_search return the exact write_tool for an existing target.",
 		ContentResolveExempt: []string{"ref", "title", "description", "tags", "frontmatter"},
 		Parameters: map[string]any{
 			"type": "object",
@@ -44,7 +46,7 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 				},
 				"body": map[string]any{
 					"type":        "string",
-					"description": "Markdown body content to write. Omit to preserve an existing document's body; pass an empty string to intentionally clear it. Creating a new document requires body. Every document tool's markdown parameter is named body.",
+					"description": "Markdown body content to write. Omit to preserve an existing document's body; pass an empty string to intentionally clear it. Creating a new document requires body. Ordinary content-mutation tools name their markdown parameter body; structured publish tools expose projections such as full instead.",
 				},
 				"journal_entry": map[string]any{
 					"type":        "string",
@@ -58,20 +60,20 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 			if ref == "" {
 				return "", fmt.Errorf("ref is required")
 			}
-			// Confusable-parameter guards: doc_edit's vocabulary on
-			// doc_write previously vanished silently — the unknown key was
+			// Confusable-parameter guards: doc_edit's vocabulary on a body
+			// write previously vanished silently — the unknown key was
 			// ignored, an empty document was written, and success was
 			// returned. A prod archivist run lost three dossiers this way
 			// (the model sent content + mode: replace_body). Fail fast
 			// with a redirect so the model self-corrects on retry.
 			if _, hasContent := args["content"]; hasContent {
-				return "", fmt.Errorf("doc_write has no %q parameter — markdown goes in %q (every document tool takes body). Re-call with body", "content", "body")
+				return "", fmt.Errorf("%s has no %q parameter; body-only Markdown goes in %q. Re-call with body, or use doc_write for projections", documents.DocumentBodyWriteToolName, "content", "body")
 			}
 			if _, hasMode := args["mode"]; hasMode {
-				return "", fmt.Errorf("doc_write has no %q parameter — it always creates or replaces the whole document. For mode-based edits (replace_body, append_body, upsert_section, ...) use doc_edit", "mode")
+				return "", fmt.Errorf("%s has no %q parameter; it always creates or replaces the whole body. For mode-based body edits use doc_edit", documents.DocumentBodyWriteToolName, "mode")
 			}
 			if _, hasRevision := args["expected_revision"]; hasRevision {
-				return "", fmt.Errorf("doc_write has no %q parameter — Thane tracks revision preconditions automatically. Omit it; read an existing document before replacing its whole body", "expected_revision")
+				return "", fmt.Errorf("%s has no %q parameter; Thane tracks revision preconditions automatically. Omit it and read an existing document before replacement", documents.DocumentBodyWriteToolName, "expected_revision")
 			}
 			title, _ := args["title"].(string)
 			description, _ := args["description"].(string)
@@ -88,9 +90,11 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 		},
 	})
 
+	registerDocumentWriteTool(r, dt)
+
 	r.Register(&Tool{
 		Name:                 "doc_edit",
-		Description:          "Edit an ordinary managed markdown document without leaving semantic refs behind. Contract-owned documents use their dedicated structured tool instead—for example, contact_dossier_write must update every dossier projection together, while publish_output_* owns loop outputs. A section edit on one of those documents can leave its other projections describing stale state. For ordinary documents, this supports metadata-only updates, whole-body replacement, body append/prepend, and section-aware upsert/delete operations. On revision-backed roots Thane automatically uses this loop's last read as the comparison base. If another loop or operator changed the document, no edit occurs and the result includes a bounded diff to reconcile before retrying.",
+		Description:          "Edit a body-only managed Markdown document without leaving semantic refs behind. Faceted documents use doc_write or the narrower write_tool returned by doc_read/doc_search because a section edit could leave compact projections stale. This supports metadata-only updates, whole-body replacement, body append/prepend, and section-aware upsert/delete operations for the exceptional body-only shape.",
 		ContentResolveExempt: []string{"ref", "mode", "section", "heading", "level", "title", "description", "tags", "frontmatter"},
 		Parameters: map[string]any{
 			"type": "object",
@@ -105,7 +109,7 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 				},
 				"body": map[string]any{
 					"type":        "string",
-					"description": "Markdown text for the edit — the same parameter name doc_write uses. For the body modes this is the document's new body (whole or appended/prepended text); for upsert_section it is only that one section's text — never the whole document, and never the section's heading line (the heading is rendered automatically from `section`/`heading`; a leading duplicate heading line is stripped).",
+					"description": "Markdown text for the body-only edit — the same parameter name doc_body_write uses. For the body modes this is the document's new body (whole or appended/prepended text); for upsert_section it is only that one section's text — never the whole document, and never the section's heading line (the heading is rendered automatically from `section`/`heading`; a leading duplicate heading line is stripped).",
 				},
 				"section": map[string]any{
 					"type":        "string",
@@ -150,11 +154,11 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 				return "", fmt.Errorf("mode is required")
 			}
 			// Rename guard: doc_edit's text parameter was unified with
-			// doc_write's as body (the content/body split silently ate a
+			// doc_body_write's as body (the content/body split silently ate a
 			// write's markdown — see doc_write's guard). Teach the rename
 			// instead of silently ignoring the old key.
 			if _, hasContent := args["content"]; hasContent {
-				return "", fmt.Errorf("doc_edit's markdown parameter is %q (the %q parameter was renamed for consistency with doc_write) — re-call with body", "body", "content")
+				return "", fmt.Errorf("doc_edit's markdown parameter is %q (the %q parameter was renamed for consistency with doc_body_write) — re-call with body", "body", "content")
 			}
 			if _, hasRevision := args["expected_revision"]; hasRevision {
 				return "", fmt.Errorf("doc_edit has no %q parameter — Thane tracks revision preconditions automatically. Omit it and retry", "expected_revision")
@@ -182,7 +186,7 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 
 	r.Register(&Tool{
 		Name:                 "doc_journal_update",
-		Description:          "Append a timestamped note into a rolling managed journal document. The tool creates the document if needed, keeps created/updated timestamps current, groups entries by day/week/month window headings, and prunes older windows for you. On revision-backed roots Thane automatically protects the update against intervening edits; a conflict makes no change and returns a bounded diff to reconcile before retrying.",
+		Description:          "Append a timestamped note into an ordinary rolling managed journal document. Faceted and contract-owned documents use the write_tool returned by doc_read/doc_search instead because every projection must move together. For ordinary journals, the tool creates the document if needed, keeps created/updated timestamps current, groups entries by day/week/month window headings, and prunes older windows for you. On revision-backed roots Thane automatically protects the update against intervening edits; a conflict makes no change and returns a bounded diff to reconcile before retrying.",
 		ContentResolveExempt: []string{"ref", "window", "max_windows", "heading_level", "title", "description", "tags", "frontmatter"},
 		Parameters: map[string]any{
 			"type": "object",
@@ -253,6 +257,83 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 				Description:  description,
 				Tags:         documentStringSliceArg(args["tags"]),
 				Frontmatter:  documentFrontmatterArg(args["frontmatter"]),
+				ReceiptScope: documentRevisionScope(ctx),
+			})
+		},
+	})
+}
+
+func registerDocumentWriteTool(r *Registry, dt *documents.Tools) {
+	properties := map[string]any{
+		"ref": map[string]any{
+			"type":        "string",
+			"description": "Canonical document ref like `kb:network/vlans.md`. The same tool works across every managed root.",
+		},
+		"title": map[string]any{
+			"type":        "string",
+			"description": "Optional title frontmatter override. Omit to preserve an existing title or derive a new document's title from its ref.",
+		},
+		"description": map[string]any{
+			"type":        "string",
+			"description": "Optional description frontmatter override.",
+		},
+		"tags": map[string]any{
+			"type":        "array",
+			"description": "Optional tags frontmatter override.",
+			"items":       map[string]any{"type": "string"},
+		},
+	}
+	for _, key := range documentfacets.Keys() {
+		field, ok := documentfacets.FieldByKey(key)
+		if !ok {
+			continue
+		}
+		description := field.Guidance + documentfacets.FormatGuidance(field.Format)
+		if field.MaxRunes > 0 {
+			description = fmt.Sprintf("%s Maximum %d characters — a ceiling, not a target; compose comfortably under it.", description, field.MaxRunes)
+		}
+		if key == "teaser" || key == "digest" {
+			description += " Optional when first adopting a document, but required on every later publish if the document already carries this projection."
+		}
+		properties[key] = map[string]any{
+			"type":        "string",
+			"description": description,
+		}
+	}
+	allowed := make(map[string]struct{}, len(properties))
+	for key := range properties {
+		allowed[key] = struct{}{}
+	}
+
+	r.Register(&Tool{
+		Name:               documents.DocumentWriteToolName,
+		Description:        "Create, adopt, or update the normal managed document as logical projections in any document root. Pass status_line, optional teaser/digest, and full as separate fields; Thane validates them together, stores its own durable manifest and Markdown codec, and protects revision-backed writes automatically. A legacy or body-only document self-migrates on this first structured write. Read an existing document first and preserve every projection it already publishes. If doc_read names a narrower owner such as contact_dossier_write or publish_output_*, use that tool instead.",
+		SkipContentResolve: true,
+		Parameters: map[string]any{
+			"type":       "object",
+			"properties": properties,
+			"required":   []string{"ref", "status_line", "full"},
+		},
+		Handler: func(ctx context.Context, args map[string]any) (string, error) {
+			unexpected := make([]string, 0)
+			for key := range args {
+				if _, ok := allowed[key]; !ok {
+					unexpected = append(unexpected, key)
+				}
+			}
+			if len(unexpected) > 0 {
+				sort.Strings(unexpected)
+				return "", fmt.Errorf("doc_write accepts only ref, title, description, tags, status_line, teaser, digest, and full; remove unsupported parameter(s) [%s]", strings.Join(unexpected, ", "))
+			}
+			return dt.Publish(ctx, documents.PublishArgs{
+				Ref:          stringArg(args, "ref"),
+				Title:        stringArg(args, "title"),
+				Description:  stringArg(args, "description"),
+				Tags:         documentStringSliceArg(args["tags"]),
+				StatusLine:   stringArg(args, "status_line"),
+				Teaser:       optionalStringArg(args, "teaser"),
+				Digest:       optionalStringArg(args, "digest"),
+				Full:         stringArg(args, "full"),
 				ReceiptScope: documentRevisionScope(ctx),
 			})
 		},

--- a/internal/tools/document_read_helpers.go
+++ b/internal/tools/document_read_helpers.go
@@ -1,0 +1,106 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/nugget/thane-ai-agent/internal/state/documents"
+	documentfacets "github.com/nugget/thane-ai-agent/internal/state/documents/facets"
+)
+
+// readDocumentFacet returns one projection of a faceted document.
+//
+// This is the read half of the document facet contract: a consumer states the
+// cost it can afford and gets a value authored for exactly that, rather than a
+// whole document it has to summarize itself or a blind truncation of one.
+//
+// It deliberately reads the contract rather than the document's structure.
+// The facet sections are rendered by Go and parsed back by Go; asking for
+// "status_line" is asking the contract a question, and a caller never needs to
+// know -- or be able to depend on -- that the answer is a section titled
+// "Status Line".
+func readDocumentFacet(ctx context.Context, dt *documents.Tools, ref, level string) (string, error) {
+	if !documentfacets.IsKey(level) {
+		return "", fmt.Errorf("unknown level %q; valid levels are %s", level, strings.Join(documentfacets.Keys(), ", "))
+	}
+	doc, err := dt.RecordWithReceipt(ctx, documents.RefArgs{Ref: ref, ReceiptScope: documentRevisionScope(ctx)})
+	if err != nil {
+		return "", err
+	}
+
+	faceted := len(doc.FacetContract.Facets) > 0
+	payload := documentfacets.Payload{Full: doc.Body}
+	if faceted {
+		payload = doc.FacetContract.Parse(doc.Body)
+	}
+	available := make([]string, 0, len(documentfacets.Keys()))
+	for _, key := range documentfacets.Keys() {
+		if _, ok := payload.ByKey(key); ok {
+			available = append(available, key)
+		}
+	}
+
+	result := map[string]any{
+		"ref":              ref,
+		"level":            level,
+		"faceted":          faceted,
+		"levels_available": available,
+		"write_tool":       documentRecordWriteTool(doc),
+	}
+	if title := strings.TrimSpace(doc.Title); title != "" {
+		result["title"] = title
+	}
+
+	content, ok := payload.ByKey(level)
+	if !ok {
+		// Not an error: the document exists and the level does not. Say
+		// which levels it does have, so the next call is a choice rather
+		// than a retry.
+		result["content"] = ""
+		if faceted {
+			result["note"] = fmt.Sprintf("This document publishes no %s. Read one of: %s.", level, strings.Join(available, ", "))
+		} else {
+			result["note"] = "This is a body-only document. Read it without level, keep that exceptional shape with doc_body_write, or update it with doc_write to migrate it into the normal projection contract."
+		}
+		return marshalDocumentToolResult(result)
+	}
+	result["content"] = content
+
+	// full is the one facet with no budget, so it is the one that can
+	// outgrow the tool-result ceiling. When it does and the document
+	// publishes something cheaper, saying so beats handing back a
+	// byte-truncated document: choosing a level is the remedy this tool
+	// exists to offer, and the generic envelope would instead advise
+	// picking a section -- the structure a level read deliberately hides.
+	if len(content) > documents.MaxToolResultBytes && len(available) > 1 {
+		cheaper := available[:len(available)-1]
+		result["content"] = ""
+		result["truncated"] = true
+		result["bytes_total"] = len(content)
+		result["note"] = fmt.Sprintf(
+			"full is %d bytes, past the %d-byte tool-result ceiling. Read it at %s instead, or use doc_outline and doc_section to take the part you need.",
+			len(content), documents.MaxToolResultBytes, strings.Join(cheaper, ", "),
+		)
+	}
+	return marshalDocumentToolResult(result)
+}
+
+func documentRecordWriteTool(doc *documents.DocumentRecord) string {
+	if doc == nil {
+		return documents.DocumentBodyWriteToolName
+	}
+	if managedBy := strings.TrimSpace(doc.ManagedBy); managedBy != "" {
+		return managedBy
+	}
+	if len(doc.Facets) > 0 {
+		return documents.DocumentWriteToolName
+	}
+	return documents.DocumentBodyWriteToolName
+}
+
+// marshalDocumentToolResult renders a facet read under the same ceiling every
+// other document tool result is held to.
+func marshalDocumentToolResult(result map[string]any) (string, error) {
+	return documents.MarshalToolResult(result)
+}

--- a/internal/tools/document_revision_scope.go
+++ b/internal/tools/document_revision_scope.go
@@ -5,11 +5,13 @@ import (
 	"strings"
 )
 
-// documentRevisionScope identifies the model consciousness whose document
-// reads should protect later writes. A loop/conversation pair is stable across
-// turns without leaking receipts between concurrent conversations; request is
-// only a last-resort scope for one-shot callers.
-func documentRevisionScope(ctx context.Context) string {
+// DocumentRevisionScope identifies the model consciousness whose document
+// reads should protect later writes. Runtime-scoped document adapters use the
+// same scope so generated and global writers share one receipt/CAS path. A
+// loop/conversation pair is stable across turns without leaking receipts
+// between concurrent conversations; request is only a last-resort scope for
+// one-shot callers.
+func DocumentRevisionScope(ctx context.Context) string {
 	parts := make([]string, 0, 2)
 	if loopID := strings.TrimSpace(LoopIDFromContext(ctx)); loopID != "" {
 		parts = append(parts, "loop:"+loopID)
@@ -27,4 +29,8 @@ func documentRevisionScope(ctx context.Context) string {
 		return "request:" + requestID
 	}
 	return ""
+}
+
+func documentRevisionScope(ctx context.Context) string {
+	return DocumentRevisionScope(ctx)
 }

--- a/internal/tools/document_tools.go
+++ b/internal/tools/document_tools.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/state/documents"
+	documentfacets "github.com/nugget/thane-ai-agent/internal/state/documents/facets"
 )
 
 const (
@@ -24,7 +24,7 @@ func RegisterDocumentTools(r *Registry, dt *documents.Tools) {
 
 	r.Register(&Tool{
 		Name:                 "doc_read",
-		Description:          "Read one managed markdown document by semantic ref like `kb:article.md`. Returns frontmatter, body, outline, and derived metadata in one payload. Large documents may be truncated by tool output limits, so use `doc_outline` plus `doc_section` when you need to navigate or read larger documents in full. When a document is maintained by a loop that publishes facets, pass `level` to read one projection instead of the whole thing — a glance costs a line rather than a document.",
+		Description:          "Read one logical managed document by semantic ref like `kb:article.md`. Faceted documents return projections rather than their mechanical Markdown storage envelope; body-only documents return body. The result names available levels and the exact write_tool. Pass level for one projection when that is enough; use doc_outline and doc_section to navigate the logical full projection of a large document.",
 		ContentResolveExempt: []string{"ref"},
 		Parameters: map[string]any{
 			"type": "object",
@@ -35,7 +35,7 @@ func RegisterDocumentTools(r *Registry, dt *documents.Tools) {
 				},
 				"level": map[string]any{
 					"type":        "string",
-					"enum":        looppkg.FacetKeys(),
+					"enum":        documentfacets.Keys(),
 					"description": "How much of a faceted document to read. status_line is a tight ambient signal; teaser is a roomier search or cross-reference signal; digest carries enough context to act; full is the whole body. Omit for the standard whole-document payload. Read at the level your decision actually needs — pulling full when a signal or digest would answer the question spends context you will want later.",
 				},
 			},
@@ -183,7 +183,7 @@ func RegisterDocumentTools(r *Registry, dt *documents.Tools) {
 
 	r.Register(&Tool{
 		Name:        "doc_search",
-		Description: "Search indexed markdown documents by root, path prefix, query text, tags, frontmatter filters, and modified-time bounds. Returns compact document summaries with canonical refs like `kb:article.md` and modified-time delta fields like `-3600s`, not full bodies. A faceted document’s summary is its authored outward-facing signal: teaser when present, otherwise status_line, rather than a derived excerpt. The hit lists its available facets so the next step is one deliberate doc_read with level. Documents whose frontmatter declares `audience: internal` (private working surfaces such as loop working notes) are excluded by default; set include_internal true, or filter on the audience key explicitly, to see them.",
+		Description: "Search indexed markdown documents by root, path prefix, query text, tags, frontmatter filters, and modified-time bounds. Returns compact document summaries with canonical refs like `kb:article.md`, modified-time delta fields like `-3600s`, available facets, and the exact write_tool for mutation—not full bodies. A faceted document’s summary is its authored outward-facing signal: teaser when present, otherwise status_line, rather than a derived excerpt. The hit lists its available facets so the next step is one deliberate doc_read with level. Documents whose frontmatter declares `audience: internal` (private working surfaces such as loop working notes) are excluded by default; set include_internal true, or filter on the audience key explicitly, to see them.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -400,84 +400,4 @@ func RegisterDocumentTools(r *Registry, dt *documents.Tools) {
 	})
 	registerDocumentIntakeTools(r, dt)
 	registerDocumentMutationTools(r, dt)
-}
-
-// readDocumentFacet returns one projection of a faceted document.
-//
-// This is the read half of the loop-output facet contract, and the
-// reason a curating loop's work is worth publishing at several
-// fidelities: a consumer states the cost it can afford and gets a
-// value cut for exactly that, rather than a whole document it has to
-// summarize itself or a blind truncation of one.
-//
-// It deliberately reads the contract rather than the document's
-// structure. The facet sections are rendered by Go and parsed back by
-// Go; asking for "status_line" is asking the contract a question, and a
-// caller never needs to know — or be able to depend on — that the answer
-// is a section titled "Status Line".
-func readDocumentFacet(ctx context.Context, dt *documents.Tools, ref, level string) (string, error) {
-	if !looppkg.IsFacetKey(level) {
-		return "", fmt.Errorf("unknown level %q; valid levels are %s", level, strings.Join(looppkg.FacetKeys(), ", "))
-	}
-	doc, err := dt.RecordWithReceipt(ctx, documents.RefArgs{Ref: ref, ReceiptScope: documentRevisionScope(ctx)})
-	if err != nil {
-		return "", err
-	}
-
-	payload, faceted := looppkg.ParseFacetSections(doc.Body)
-	available := make([]string, 0, len(looppkg.FacetKeys()))
-	for _, key := range looppkg.FacetKeys() {
-		if _, ok := payload.FacetByKey(key); ok {
-			available = append(available, key)
-		}
-	}
-
-	result := map[string]any{
-		"ref":              ref,
-		"level":            level,
-		"faceted":          faceted,
-		"levels_available": available,
-	}
-	if title := strings.TrimSpace(doc.Title); title != "" {
-		result["title"] = title
-	}
-
-	content, ok := payload.FacetByKey(level)
-	if !ok {
-		// Not an error: the document exists and the level does not. Say
-		// which levels it does have, so the next call is a choice rather
-		// than a retry.
-		result["content"] = ""
-		if faceted {
-			result["note"] = fmt.Sprintf("This document publishes no %s. Read one of: %s.", level, strings.Join(available, ", "))
-		} else {
-			result["note"] = "This document is not maintained as a faceted loop output, so it has no projections to choose between. Read it without a level to get the whole document."
-		}
-		return marshalDocumentToolResult(result)
-	}
-	result["content"] = content
-
-	// full is the one facet with no budget, so it is the one that can
-	// outgrow the tool-result ceiling. When it does and the document
-	// publishes something cheaper, saying so beats handing back a
-	// byte-truncated document: choosing a level is the remedy this tool
-	// exists to offer, and the generic envelope would instead advise
-	// picking a section — the structure a level read deliberately hides.
-	if len(content) > documents.MaxToolResultBytes && len(available) > 1 {
-		cheaper := available[:len(available)-1]
-		result["content"] = ""
-		result["truncated"] = true
-		result["bytes_total"] = len(content)
-		result["note"] = fmt.Sprintf(
-			"full is %d bytes, past the %d-byte tool-result ceiling. Read it at %s instead, or use doc_outline and doc_section to take the part you need.",
-			len(content), documents.MaxToolResultBytes, strings.Join(cheaper, ", "),
-		)
-	}
-	return marshalDocumentToolResult(result)
-}
-
-// marshalDocumentToolResult renders a facet read under the same ceiling
-// every other document tool result is held to.
-func marshalDocumentToolResult(result map[string]any) (string, error) {
-	return documents.MarshalToolResult(result)
 }

--- a/internal/tools/document_tools_test.go
+++ b/internal/tools/document_tools_test.go
@@ -43,16 +43,92 @@ func TestNumericArgSupportsCommonTypesAndBounds(t *testing.T) {
 
 func TestGenericDocumentMutationDescriptionsDeferToContractOwnedTools(t *testing.T) {
 	registry, _ := newTestDocumentRegistry(t)
-	for _, name := range []string{"doc_create", "doc_write", "doc_edit"} {
+	for _, name := range []string{"doc_create", "doc_body_write", "doc_edit"} {
 		tool := registry.Get(name)
 		if tool == nil {
 			t.Fatalf("%s not registered", name)
 		}
-		for _, want := range []string{"Contract-owned", "contact_dossier_write"} {
-			if !strings.Contains(tool.Description, want) {
+		for _, want := range []string{"faceted", "doc_write"} {
+			if !strings.Contains(strings.ToLower(tool.Description), want) {
 				t.Errorf("%s description = %q, want it to mention %q", name, tool.Description, want)
 			}
 		}
+	}
+}
+
+func TestDocWriteSchemaSharesFacetContract(t *testing.T) {
+	t.Parallel()
+
+	registry, _ := newTestDocumentRegistry(t)
+	tool := registry.Get("doc_write")
+	if tool == nil {
+		t.Fatal("doc_write not registered")
+	}
+	properties, ok := tool.Parameters["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("doc_write properties have unexpected shape: %#v", tool.Parameters["properties"])
+	}
+	for _, key := range []string{"ref", "title", "description", "tags", "status_line", "teaser", "digest", "full"} {
+		if _, ok := properties[key]; !ok {
+			t.Errorf("doc_write schema missing %q", key)
+		}
+	}
+	required, ok := tool.Parameters["required"].([]string)
+	if !ok {
+		t.Fatalf("doc_write required has unexpected shape: %#v", tool.Parameters["required"])
+	}
+	if want := []string{"ref", "status_line", "full"}; !reflect.DeepEqual(required, want) {
+		t.Fatalf("doc_write required = %v, want %v", required, want)
+	}
+	status, _ := properties["status_line"].(map[string]any)
+	if description, _ := status["description"].(string); !strings.Contains(description, "Maximum 120 characters") || !strings.Contains(description, "no line breaks") {
+		t.Fatalf("status_line description = %q, want shared budget and shape", description)
+	}
+}
+
+func TestDocWriteHandlerWritesStructuredDocumentAndRejectsUnknownInput(t *testing.T) {
+	t.Parallel()
+
+	registry, store := newTestDocumentRegistry(t)
+	tool := registry.Get("doc_write")
+	if tool == nil {
+		t.Fatal("doc_write not registered")
+	}
+	_, err := tool.Handler(context.Background(), map[string]any{
+		"ref":           "kb:faceted.md",
+		"status_line":   "Current state.",
+		"full":          "Complete detail.",
+		"journal_entry": "must not disappear",
+	})
+	if err == nil || !strings.Contains(err.Error(), "unsupported parameter(s) [journal_entry]") {
+		t.Fatalf("unknown parameter error = %v, want strict rejection", err)
+	}
+	if _, readErr := store.Read(context.Background(), "kb:faceted.md"); !documents.IsNotFound(readErr) {
+		t.Fatalf("rejected write changed the document: %v", readErr)
+	}
+
+	out, err := tool.Handler(context.Background(), map[string]any{
+		"ref":         "kb:faceted.md",
+		"title":       "Faceted",
+		"status_line": "Current state.",
+		"teaser":      "Open this for the current detail.",
+		"full":        "Complete detail.",
+	})
+	if err != nil {
+		t.Fatalf("doc_write: %v", err)
+	}
+	if !strings.Contains(out, `"action": "doc_write"`) {
+		t.Fatalf("doc_write result = %s, want action", out)
+	}
+	record, err := store.Read(context.Background(), "kb:faceted.md")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if record.ManagedBy != documents.DocumentWriteToolName {
+		t.Fatalf("managed_by = %q, want %q", record.ManagedBy, documents.DocumentWriteToolName)
+	}
+	if want := []string{"status_line", "teaser"}; !reflect.DeepEqual(record.Facets, want) {
+		t.Fatalf("facets = %v, want %v", record.Facets, want)
 	}
 }
 
@@ -75,13 +151,13 @@ func TestDocumentFrontmatterArgSupportsStringsAndArrays(t *testing.T) {
 	}
 }
 
-func TestDocWriteHandlerPreservesOrClearsBodyByIntent(t *testing.T) {
+func TestDocBodyWriteHandlerPreservesOrClearsBodyByIntent(t *testing.T) {
 	t.Parallel()
 
 	reg, store := newTestDocumentRegistry(t)
-	writeTool := reg.Get("doc_write")
+	writeTool := reg.Get("doc_body_write")
 	if writeTool == nil {
-		t.Fatal("doc_write not registered")
+		t.Fatal("doc_body_write not registered")
 	}
 
 	_, err := writeTool.Handler(context.Background(), map[string]any{
@@ -90,11 +166,11 @@ func TestDocWriteHandlerPreservesOrClearsBodyByIntent(t *testing.T) {
 		"body":  "Original body.",
 	})
 	if err != nil {
-		t.Fatalf("initial doc_write: %v", err)
+		t.Fatalf("initial doc_body_write: %v", err)
 	}
 	before, err := store.Read(context.Background(), "kb:notes/handler.md")
 	if err != nil {
-		t.Fatalf("Read after initial doc_write: %v", err)
+		t.Fatalf("Read after initial doc_body_write: %v", err)
 	}
 
 	_, err = writeTool.Handler(context.Background(), map[string]any{
@@ -102,14 +178,14 @@ func TestDocWriteHandlerPreservesOrClearsBodyByIntent(t *testing.T) {
 		"title": "Handler Renamed",
 	})
 	if err != nil {
-		t.Fatalf("metadata-only doc_write: %v", err)
+		t.Fatalf("metadata-only doc_body_write: %v", err)
 	}
 	record, err := store.Read(context.Background(), "kb:notes/handler.md")
 	if err != nil {
-		t.Fatalf("Read after metadata-only doc_write: %v", err)
+		t.Fatalf("Read after metadata-only doc_body_write: %v", err)
 	}
 	if record.Body != before.Body {
-		t.Fatalf("body after omitted-body doc_write = %q, want %q preserved", record.Body, before.Body)
+		t.Fatalf("body after omitted-body doc_body_write = %q, want %q preserved", record.Body, before.Body)
 	}
 
 	_, err = writeTool.Handler(context.Background(), map[string]any{
@@ -117,24 +193,24 @@ func TestDocWriteHandlerPreservesOrClearsBodyByIntent(t *testing.T) {
 		"body": "",
 	})
 	if err != nil {
-		t.Fatalf("empty-body doc_write: %v", err)
+		t.Fatalf("empty-body doc_body_write: %v", err)
 	}
 	record, err = store.Read(context.Background(), "kb:notes/handler.md")
 	if err != nil {
-		t.Fatalf("Read after empty-body doc_write: %v", err)
+		t.Fatalf("Read after empty-body doc_body_write: %v", err)
 	}
 	if record.Body != "" {
-		t.Fatalf("body after explicit empty-body doc_write = %q, want empty body", record.Body)
+		t.Fatalf("body after explicit empty-body doc_body_write = %q, want empty body", record.Body)
 	}
 }
 
-func TestDocWriteHandlerAppendsJournalEntry(t *testing.T) {
+func TestDocBodyWriteHandlerAppendsJournalEntry(t *testing.T) {
 	t.Parallel()
 
 	reg, store := newTestDocumentRegistry(t)
-	writeTool := reg.Get("doc_write")
+	writeTool := reg.Get("doc_body_write")
 	if writeTool == nil {
-		t.Fatal("doc_write not registered")
+		t.Fatal("doc_body_write not registered")
 	}
 
 	_, err := writeTool.Handler(context.Background(), map[string]any{
@@ -143,12 +219,12 @@ func TestDocWriteHandlerAppendsJournalEntry(t *testing.T) {
 		"journal_entry": "Captured the first checkpoint.",
 	})
 	if err != nil {
-		t.Fatalf("doc_write with journal_entry: %v", err)
+		t.Fatalf("doc_body_write with journal_entry: %v", err)
 	}
 
 	record, err := store.Read(context.Background(), "kb:notes/journaled.md")
 	if err != nil {
-		t.Fatalf("Read after journaled doc_write: %v", err)
+		t.Fatalf("Read after journaled doc_body_write: %v", err)
 	}
 	if !strings.Contains(record.Body, "## Journal") {
 		t.Fatalf("body = %q, want Journal section", record.Body)
@@ -168,7 +244,7 @@ func TestDocumentMutationToolsHideRevisionPreconditions(t *testing.T) {
 		args map[string]any
 	}{
 		{
-			name: "doc_write",
+			name: "doc_body_write",
 			args: map[string]any{
 				"ref":               "kb:new.md",
 				"body":              "New body.",
@@ -393,8 +469,9 @@ func TestDocumentIntakeAndCommitHandlersCreateManagedDocument(t *testing.T) {
 	}
 
 	if _, err := commitTool.Handler(context.Background(), map[string]any{
-		"intake_id": intake.IntakeID,
-		"body":      "# Garage Door Reset\n\nHold the wall button until the opener resets.",
+		"intake_id":   intake.IntakeID,
+		"status_line": "Garage door reset procedure is documented.",
+		"full":        "# Garage Door Reset\n\nHold the wall button until the opener resets.",
 	}); err != nil {
 		t.Fatalf("doc_commit: %v", err)
 	}
@@ -436,17 +513,17 @@ func stringPtr(s string) *string {
 	return &s
 }
 
-// The prod incident (2026-07-02): the archivist model called doc_write
+// The prod incident (2026-07-02): the archivist model called the body writer
 // with doc_edit's vocabulary — {"content": <full dossier>, "mode":
 // "replace_body", "ref": ...}. The unknown keys were silently ignored,
 // an empty document was created, and success was returned; three
 // dossiers' content survived only in the tool-call log. These guards
 // turn that silent data loss into a self-correcting error.
-func TestDocWriteRejectsDocEditVocabulary(t *testing.T) {
+func TestDocBodyWriteRejectsDocEditVocabulary(t *testing.T) {
 	t.Parallel()
 
 	reg, store := newTestDocumentRegistry(t)
-	writeTool := reg.Get("doc_write")
+	writeTool := reg.Get("doc_body_write")
 
 	// The exact prod argument shape.
 	_, err := writeTool.Handler(context.Background(), map[string]any{
@@ -455,14 +532,14 @@ func TestDocWriteRejectsDocEditVocabulary(t *testing.T) {
 		"mode":    "replace_body",
 	})
 	if err == nil {
-		t.Fatal("doc_write with content+mode succeeded; want a redirect error")
+		t.Fatal("doc_body_write with content+mode succeeded; want a redirect error")
 	}
 	if !strings.Contains(err.Error(), "body") {
 		t.Errorf("error should teach the body parameter: %v", err)
 	}
 	// Nothing may be created by the failed call.
 	if _, readErr := store.Read(context.Background(), "kb:dossiers/entity-binary_sensor-zone25_garage_bay_3.md"); readErr == nil {
-		t.Error("failed doc_write still created a document")
+		t.Error("failed doc_body_write still created a document")
 	}
 
 	// mode alone (even with a valid body) is doc_edit vocabulary.
@@ -472,7 +549,7 @@ func TestDocWriteRejectsDocEditVocabulary(t *testing.T) {
 		"mode": "append_body",
 	})
 	if err == nil || !strings.Contains(err.Error(), "doc_edit") {
-		t.Errorf("doc_write with mode should redirect to doc_edit, got: %v", err)
+		t.Errorf("doc_body_write with mode should redirect to doc_edit, got: %v", err)
 	}
 }
 
@@ -484,14 +561,14 @@ func TestDocEditTakesBodyAndTeachesContentRename(t *testing.T) {
 	t.Parallel()
 
 	reg, store := newTestDocumentRegistry(t)
-	writeTool := reg.Get("doc_write")
+	writeTool := reg.Get("doc_body_write")
 	editTool := reg.Get("doc_edit")
 
 	if _, err := writeTool.Handler(context.Background(), map[string]any{
 		"ref":  "kb:notes/unified.md",
 		"body": "original",
 	}); err != nil {
-		t.Fatalf("seed doc_write: %v", err)
+		t.Fatalf("seed doc_body_write: %v", err)
 	}
 
 	// The unified vocabulary: body works on doc_edit.
@@ -532,11 +609,11 @@ func TestDocEditTakesBodyAndTeachesContentRename(t *testing.T) {
 // "preserve", which is meaningless on a create and is the signature of
 // arguments that missed the schema. An explicit empty string stays the
 // documented way to create a blank document.
-func TestDocWriteCreateRequiresBody(t *testing.T) {
+func TestDocBodyWriteCreateRequiresBody(t *testing.T) {
 	t.Parallel()
 
 	reg, store := newTestDocumentRegistry(t)
-	writeTool := reg.Get("doc_write")
+	writeTool := reg.Get("doc_body_write")
 
 	_, err := writeTool.Handler(context.Background(), map[string]any{
 		"ref":   "kb:notes/bodiless-create.md",
@@ -558,8 +635,8 @@ func TestDocWriteCreateRequiresBody(t *testing.T) {
 	}
 }
 
-// doc_create is the default create verb (#1038): one call collision-
-// checks and writes. It carries the unified body vocabulary (#1201).
+// doc_create is the default create verb (#1038): one call collision-checks
+// and writes the logical projection contract.
 func TestDocCreateHandlerWritesAndGuardsVocabulary(t *testing.T) {
 	t.Parallel()
 
@@ -570,9 +647,10 @@ func TestDocCreateHandlerWritesAndGuardsVocabulary(t *testing.T) {
 	}
 
 	out, err := createTool.Handler(context.Background(), map[string]any{
-		"root":  "kb",
-		"title": "Fence Charger Notes",
-		"body":  "# Fence Charger Notes\n\nSouth paddock charger reads 7.2kV after the storm.",
+		"root":        "kb",
+		"title":       "Fence Charger Notes",
+		"status_line": "South paddock fence charger is operating normally.",
+		"full":        "# Fence Charger Notes\n\nSouth paddock charger reads 7.2kV after the storm.",
 	})
 	if err != nil {
 		t.Fatalf("doc_create: %v", err)
@@ -591,12 +669,12 @@ func TestDocCreateHandlerWritesAndGuardsVocabulary(t *testing.T) {
 		t.Fatalf("created doc unreadable: %v", err)
 	}
 
-	// The unified vocabulary holds here too.
+	// Body-only vocabulary is rejected with a projection redirect.
 	_, err = createTool.Handler(context.Background(), map[string]any{
 		"root":    "kb",
 		"content": "markdown in the wrong parameter",
 	})
-	if err == nil || !strings.Contains(err.Error(), "body") {
-		t.Errorf("doc_create with content should teach body, got: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "full") {
+		t.Errorf("doc_create with content should teach full, got: %v", err)
 	}
 }

--- a/internal/tools/file_tools.go
+++ b/internal/tools/file_tools.go
@@ -51,12 +51,11 @@ var skipDirs = map[string]bool{
 	".cache":       true,
 }
 
-// PathVerifier reports whether a path inside a managed document root
-// satisfies that root's signature policy. Implementations must treat
-// paths outside any configured root as a no-op (nil error). The
-// concrete implementation is [documents.Store.VerifyPath]; this
-// interface is used to keep file_tools free of an upward dependency
-// on the documents package.
+// PathVerifier reports whether a path may be exposed through model-facing file
+// tools. Implementations must treat paths outside any configured root as a
+// no-op (nil error). The concrete implementation is
+// [documents.Store.VerifyPath]; this interface keeps file_tools free of an
+// upward dependency on the documents package.
 //
 // Verifier is consulted in [FileTools.Read], [FileTools.Write], and
 // [FileTools.Edit] so a managed root with `verify_signatures: required`
@@ -65,13 +64,10 @@ var skipDirs = map[string]bool{
 // raw filesystem mutations cannot dirty signed or read-only document
 // roots after a pre-write trust check passes.
 //
-// The directory-walk tools (List, Tree, Stat, Search, Grep) are
-// intentionally not gated: List/Tree/Stat/Search return only
-// path/metadata, while Grep can surface short content excerpts that
-// remain unverified. Operators relying on signature gating should
-// route trust-sensitive content through `read_file` (which goes
-// through VerifyPath) rather than grep results. See
-// docs/understanding/document-roots.md for the full boundary.
+// Every file surface is gated. Indexed managed documents are a logical model
+// surface, so file tools must not expose their private Markdown codec, sibling
+// files, or physical section layout. Direct access returns an actionable
+// doc-tool redirect; workspace-wide walks skip managed subtrees.
 type PathVerifier interface {
 	VerifyPath(ctx context.Context, path string, consumer string) error
 	VerifyMutationPath(ctx context.Context, path string, consumer string) error
@@ -390,6 +386,9 @@ func (ft *FileTools) List(ctx context.Context, path string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := ft.verifyPath(ctx, absPath, "file_tools_list"); err != nil {
+		return nil, err
+	}
 
 	entries, err := os.ReadDir(absPath)
 	if err != nil {
@@ -419,6 +418,9 @@ func (ft *FileTools) Search(ctx context.Context, dir, pattern string, maxDepth i
 	if err != nil {
 		return "", err
 	}
+	if err := ft.verifyPath(ctx, absDir, "file_tools_search"); err != nil {
+		return "", err
+	}
 
 	if _, err := filepath.Match(pattern, "test"); err != nil {
 		return "", fmt.Errorf("invalid glob pattern: %w", err)
@@ -446,6 +448,14 @@ func (ft *FileTools) Search(ctx context.Context, dir, pattern string, maxDepth i
 		}
 		if searchCtx.Err() != nil {
 			return searchCtx.Err()
+		}
+		if path != absDir {
+			if err := ft.verifyPath(searchCtx, path, "file_tools_search"); err != nil {
+				if d.IsDir() {
+					return fs.SkipDir
+				}
+				return nil
+			}
 		}
 
 		visited++
@@ -514,6 +524,9 @@ func (ft *FileTools) Grep(ctx context.Context, dir, pattern, filePattern string,
 	if err != nil {
 		return "", err
 	}
+	if err := ft.verifyPath(ctx, absDir, "file_tools_grep"); err != nil {
+		return "", err
+	}
 
 	regexPattern := pattern
 	if caseInsensitive {
@@ -556,6 +569,14 @@ func (ft *FileTools) Grep(ctx context.Context, dir, pattern, filePattern string,
 		}
 		if grepCtx.Err() != nil {
 			return grepCtx.Err()
+		}
+		if path != absDir {
+			if err := ft.verifyPath(grepCtx, path, "file_tools_grep"); err != nil {
+				if d.IsDir() {
+					return fs.SkipDir
+				}
+				return nil
+			}
 		}
 
 		visited++
@@ -744,6 +765,10 @@ func (ft *FileTools) Stat(ctx context.Context, paths string) (string, error) {
 			results = append(results, fmt.Sprintf("%s: %s", p, err))
 			continue
 		}
+		if err := ft.verifyPath(ctx, absPath, "file_tools_stat"); err != nil {
+			results = append(results, fmt.Sprintf("%s: %s", p, err))
+			continue
+		}
 
 		info, err := os.Lstat(absPath)
 		if err != nil {
@@ -776,6 +801,9 @@ func (ft *FileTools) Stat(ctx context.Context, paths string) (string, error) {
 func (ft *FileTools) Tree(ctx context.Context, dir string, maxDepth int) (string, error) {
 	absDir, _, err := ft.resolvePath(ctx, dir)
 	if err != nil {
+		return "", err
+	}
+	if err := ft.verifyPath(ctx, absDir, "file_tools_tree"); err != nil {
 		return "", err
 	}
 
@@ -832,6 +860,11 @@ func (ft *FileTools) renderTree(buf *strings.Builder, dir, prefix string, maxDep
 			return ctx.Err()
 		}
 
+		entryPath := filepath.Join(dir, entry.Name())
+		if err := ft.verifyPath(ctx, entryPath, "file_tools_tree"); err != nil {
+			continue
+		}
+
 		isLast := i == len(entries)-1
 		connector := "├── "
 		childPrefix := "│   "
@@ -845,7 +878,7 @@ func (ft *FileTools) renderTree(buf *strings.Builder, dir, prefix string, maxDep
 			name += "/"
 			*dirCount++
 			buf.WriteString(prefix + connector + name + "\n")
-			err := ft.renderTree(buf, filepath.Join(dir, entry.Name()), prefix+childPrefix, maxDepth, currentDepth+1, dirCount, fileCount, ctx)
+			err := ft.renderTree(buf, entryPath, prefix+childPrefix, maxDepth, currentDepth+1, dirCount, fileCount, ctx)
 			if err != nil {
 				return err
 			}

--- a/internal/tools/file_tools.go
+++ b/internal/tools/file_tools.go
@@ -855,17 +855,21 @@ func (ft *FileTools) renderTree(buf *strings.Builder, dir, prefix string, maxDep
 		return nil // skip unreadable directories
 	}
 
-	for i, entry := range entries {
+	visible := make([]os.DirEntry, 0, len(entries))
+	for _, entry := range entries {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-
 		entryPath := filepath.Join(dir, entry.Name())
 		if err := ft.verifyPath(ctx, entryPath, "file_tools_tree"); err != nil {
 			continue
 		}
+		visible = append(visible, entry)
+	}
 
-		isLast := i == len(entries)-1
+	for i, entry := range visible {
+		entryPath := filepath.Join(dir, entry.Name())
+		isLast := i == len(visible)-1
 		connector := "├── "
 		childPrefix := "│   "
 		if isLast {

--- a/internal/tools/file_tools_verifier_test.go
+++ b/internal/tools/file_tools_verifier_test.go
@@ -247,3 +247,38 @@ func TestFileTools_MetadataAndWalkSurfacesRespectManagedDocumentBoundary(t *test
 		t.Fatalf("stat boundary result = %s", stat)
 	}
 }
+
+func TestFileToolsTreeUsesVisibleEntriesForConnectors(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workspace, "a-visible.txt"), []byte("visible"), 0o600); err != nil {
+		t.Fatalf("seed visible file: %v", err)
+	}
+	hidden := filepath.Join(workspace, "z-managed")
+	if err := os.Mkdir(hidden, 0o755); err != nil {
+		t.Fatalf("seed hidden directory: %v", err)
+	}
+	hiddenResolved, err := filepath.EvalSymlinks(hidden)
+	if err != nil {
+		t.Fatalf("EvalSymlinks hidden directory: %v", err)
+	}
+	ft := NewFileTools(workspace, nil)
+	ft.SetPathVerifier(&fakePathVerifier{verify: func(path, _ string) error {
+		if path == hiddenResolved {
+			return errors.New("managed root")
+		}
+		return nil
+	}})
+
+	tree, err := ft.Tree(t.Context(), ".", 2)
+	if err != nil {
+		t.Fatalf("Tree: %v", err)
+	}
+	if !strings.Contains(tree, "└── a-visible.txt") {
+		t.Fatalf("tree did not render the final visible entry as last:\n%s", tree)
+	}
+	if strings.Contains(tree, "├── a-visible.txt") || strings.Contains(tree, "z-managed") {
+		t.Fatalf("tree used denied entries when choosing connectors:\n%s", tree)
+	}
+}

--- a/internal/tools/file_tools_verifier_test.go
+++ b/internal/tools/file_tools_verifier_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -14,6 +15,7 @@ import (
 type fakePathVerifier struct {
 	err         error
 	mutationErr error
+	verify      func(path, consumer string) error
 	calls       []verifyCall
 }
 
@@ -24,6 +26,9 @@ type verifyCall struct {
 
 func (f *fakePathVerifier) VerifyPath(_ context.Context, path string, consumer string) error {
 	f.calls = append(f.calls, verifyCall{path: path, consumer: consumer})
+	if f.verify != nil {
+		return f.verify(path, consumer)
+	}
 	return f.err
 }
 
@@ -172,5 +177,73 @@ func TestFileTools_Read_NoVerifierUnchanged(t *testing.T) {
 	}
 	if got != "hello" {
 		t.Errorf("Read = %q, want hello", got)
+	}
+}
+
+func TestFileTools_MetadataAndWalkSurfacesRespectManagedDocumentBoundary(t *testing.T) {
+	workspace := t.TempDir()
+	managed := filepath.Join(workspace, "managed")
+	if err := os.MkdirAll(managed, 0o755); err != nil {
+		t.Fatalf("MkdirAll managed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(managed, "private.md"), []byte("PRIVATE_CODEC_MARKER"), 0o600); err != nil {
+		t.Fatalf("seed managed file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workspace, "public.txt"), []byte("PUBLIC_MARKER"), 0o600); err != nil {
+		t.Fatalf("seed public file: %v", err)
+	}
+
+	ft := NewFileTools(workspace, nil)
+	managedResolved, err := filepath.EvalSymlinks(managed)
+	if err != nil {
+		t.Fatalf("EvalSymlinks managed: %v", err)
+	}
+	ft.SetPathVerifier(&fakePathVerifier{verify: func(path, _ string) error {
+		if path == managedResolved || strings.HasPrefix(path, managedResolved+string(filepath.Separator)) {
+			return errors.New("indexed managed document path; use doc_read")
+		}
+		return nil
+	}})
+
+	for name, call := range map[string]func() error{
+		"list":   func() error { _, err := ft.List(t.Context(), "managed"); return err },
+		"search": func() error { _, err := ft.Search(t.Context(), "managed", "*.md", 2); return err },
+		"grep":   func() error { _, err := ft.Grep(t.Context(), "managed", "MARKER", "", 2, false); return err },
+		"tree":   func() error { _, err := ft.Tree(t.Context(), "managed", 2); return err },
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := call(); err == nil || !strings.Contains(err.Error(), "doc_read") {
+				t.Fatalf("direct managed access error = %v, want document-tool redirect", err)
+			}
+		})
+	}
+
+	search, err := ft.Search(t.Context(), ".", "*", 3)
+	if err != nil {
+		t.Fatalf("Search workspace: %v", err)
+	}
+	if !strings.Contains(search, "public.txt") || strings.Contains(search, "private.md") {
+		t.Fatalf("workspace search crossed managed boundary: %s", search)
+	}
+	grep, err := ft.Grep(t.Context(), ".", "MARKER", "", 3, false)
+	if err != nil {
+		t.Fatalf("Grep workspace: %v", err)
+	}
+	if !strings.Contains(grep, "PUBLIC_MARKER") || strings.Contains(grep, "PRIVATE_CODEC_MARKER") {
+		t.Fatalf("workspace grep crossed managed boundary: %s", grep)
+	}
+	tree, err := ft.Tree(t.Context(), ".", 3)
+	if err != nil {
+		t.Fatalf("Tree workspace: %v", err)
+	}
+	if !strings.Contains(tree, "public.txt") || strings.Contains(tree, "private.md") {
+		t.Fatalf("workspace tree crossed managed boundary: %s", tree)
+	}
+	stat, err := ft.Stat(t.Context(), "managed/private.md,public.txt")
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if !strings.Contains(stat, "use doc_read") || !strings.Contains(stat, "public.txt: type=file") {
+		t.Fatalf("stat boundary result = %s", stat)
 	}
 }

--- a/internal/tools/loop_create_fluency_test.go
+++ b/internal/tools/loop_create_fluency_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/state/documents"
+	documentfacets "github.com/nugget/thane-ai-agent/internal/state/documents/facets"
 )
 
 // dryRunSpec runs thane_loop_create in dry-run and returns the decoded
@@ -402,6 +403,157 @@ func TestGuidedCreateReplacePreservesDocuments(t *testing.T) {
 	}
 	if !strings.Contains(notes, "UPS fan") {
 		t.Errorf("replace clobbered the working notes:\n%s", notes)
+	}
+}
+
+func TestGuidedCreateMigratesBodyOutputToFacets(t *testing.T) {
+	rig := newCurateTestRig(t)
+	ctx := context.Background()
+	if _, err := rig.tool.Handler(ctx, curateArgs(nil)); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	body := "Accumulated closet belief with no projection envelope."
+	if _, err := rig.docTools.Write(ctx, documents.WriteArgs{
+		Ref:            "kb:dashboards/closet.md",
+		Body:           &body,
+		StructuredTool: "replace_output_closet_guardian",
+	}); err != nil {
+		t.Fatalf("simulate loop write: %v", err)
+	}
+
+	args := curateArgs(map[string]any{
+		"facets": []any{"status_line"},
+		"migration": map[string]any{
+			"status_line": "Closet nominal.",
+		},
+	})
+	args["replace"] = true
+	out, err := rig.tool.Handler(ctx, args)
+	if err != nil {
+		t.Fatalf("migrate create: %v", err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if result["document_state"] != "migrated_contract" {
+		t.Fatalf("document_state = %v, want migrated_contract", result["document_state"])
+	}
+	read, err := rig.docTools.Read(ctx, documents.RefArgs{Ref: "kb:dashboards/closet.md"})
+	if err != nil {
+		t.Fatalf("read migrated output: %v", err)
+	}
+	for _, want := range []string{"Closet nominal.", body, `"write_tool": "publish_output_closet_guardian"`} {
+		if !strings.Contains(read, want) {
+			t.Errorf("migrated output missing %q:\n%s", want, read)
+		}
+	}
+}
+
+func TestGuidedCreateMigrationAddsProjectionWithoutRewritingState(t *testing.T) {
+	rig := newCurateTestRig(t)
+	ctx := context.Background()
+	if _, err := rig.tool.Handler(ctx, curateArgs(map[string]any{"facets": []any{"status_line"}})); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	contract := documentfacets.Contract{Facets: []documentfacets.Spec{{Name: documentfacets.StatusLine}}}
+	if _, err := rig.docTools.WriteFaceted(ctx, documents.FacetedWriteArgs{
+		Ref:       "kb:dashboards/closet.md",
+		Contract:  contract,
+		Payload:   documentfacets.Payload{StatusLine: "Existing status.", Full: "Existing complete state."},
+		WriteTool: "publish_output_closet_guardian",
+	}); err != nil {
+		t.Fatalf("simulate faceted loop write: %v", err)
+	}
+
+	args := curateArgs(map[string]any{
+		"facets": []any{"status_line", "digest"},
+		"migration": map[string]any{
+			"digest": "New standalone summary.",
+		},
+	})
+	args["replace"] = true
+	if _, err := rig.tool.Handler(ctx, args); err != nil {
+		t.Fatalf("add digest migration: %v", err)
+	}
+	read, err := rig.docTools.Read(ctx, documents.RefArgs{Ref: "kb:dashboards/closet.md"})
+	if err != nil {
+		t.Fatalf("read migrated output: %v", err)
+	}
+	for _, want := range []string{"Existing status.", "Existing complete state.", "New standalone summary."} {
+		if !strings.Contains(read, want) {
+			t.Errorf("migrated output missing %q:\n%s", want, read)
+		}
+	}
+
+	dropArgs := curateArgs(map[string]any{"migration": map[string]any{}})
+	dropArgs["replace"] = true
+	if _, err := rig.tool.Handler(ctx, dropArgs); err != nil {
+		t.Fatalf("remove facet contract: %v", err)
+	}
+	read, err = rig.docTools.Read(ctx, documents.RefArgs{Ref: "kb:dashboards/closet.md"})
+	if err != nil {
+		t.Fatalf("read body-only migration: %v", err)
+	}
+	if !strings.Contains(read, "Existing complete state.") || !strings.Contains(read, `"write_tool": "replace_output_closet_guardian"`) {
+		t.Fatalf("body-only migration did not preserve full state and change owner:\n%s", read)
+	}
+	if strings.Contains(read, "Existing status.") || strings.Contains(read, "New standalone summary.") || strings.Contains(read, `"faceted": true`) {
+		t.Fatalf("body-only migration retained private facet envelope:\n%s", read)
+	}
+}
+
+func TestGuidedCreateContractChangeRequiresExplicitMigration(t *testing.T) {
+	rig := newCurateTestRig(t)
+	ctx := context.Background()
+	if _, err := rig.tool.Handler(ctx, curateArgs(nil)); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	body := "State that must survive a rejected contract change."
+	if _, err := rig.docTools.Write(ctx, documents.WriteArgs{
+		Ref:            "kb:dashboards/closet.md",
+		Body:           &body,
+		StructuredTool: "replace_output_closet_guardian",
+	}); err != nil {
+		t.Fatalf("simulate loop write: %v", err)
+	}
+
+	args := curateArgs(map[string]any{"facets": []any{"status_line"}})
+	args["replace"] = true
+	_, err := rig.tool.Handler(ctx, args)
+	if err == nil || !strings.Contains(err.Error(), "output.migration") {
+		t.Fatalf("contract change error = %v, want migration instruction", err)
+	}
+	read, readErr := rig.docTools.Read(ctx, documents.RefArgs{Ref: "kb:dashboards/closet.md"})
+	if readErr != nil {
+		t.Fatalf("read unchanged output: %v", readErr)
+	}
+	if !strings.Contains(read, body) || strings.Contains(read, "awaiting first cycle") {
+		t.Fatalf("rejected migration changed output:\n%s", read)
+	}
+}
+
+func TestGuidedCreateMigrationRefusesRunningOldContract(t *testing.T) {
+	rig := newCurateTestRig(t)
+	ctx := context.Background()
+	if _, err := rig.tool.Handler(ctx, curateArgs(nil)); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	registerRunningLoop(t, rig.live, "closet_guardian")
+
+	args := curateArgs(map[string]any{
+		"facets":    []any{"status_line"},
+		"migration": map[string]any{"status_line": "Closet nominal."},
+	})
+	args["replace"] = true
+	_, err := rig.tool.Handler(ctx, args)
+	if err == nil {
+		t.Fatal("migration should refuse while the old loop contract is live")
+	}
+	for _, want := range []string{"stop_loop", "loop_status", "no document was changed"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("migration error = %q, want %q", err, want)
+		}
 	}
 }
 

--- a/internal/tools/loop_create_fluency_test.go
+++ b/internal/tools/loop_create_fluency_test.go
@@ -284,10 +284,10 @@ func TestGuidedCreateScaffoldsFacetSkeleton(t *testing.T) {
 		t.Fatalf("read scaffold: %v", err)
 	}
 	for _, want := range []string{
-		"## Status Line", "## Digest", "## Details",
+		`"status_line"`, `"digest"`, `"full"`,
 		"awaiting first cycle",
 		`"audience"`, `"published"`,
-		`"managed_by"`, `"publish_output_closet_guardian"`,
+		`"write_tool"`, `"publish_output_closet_guardian"`,
 	} {
 		if !strings.Contains(doc, want) {
 			t.Errorf("faceted scaffold missing %q:\n%s", want, doc)
@@ -330,7 +330,7 @@ func TestGuidedCreateScaffoldsWorkingNotes(t *testing.T) {
 	}
 	for _, want := range []string{
 		`"audience"`, `"internal"`,
-		`"managed_by"`, `"replace_output_closet_guardian_notes"`,
+		`"write_tool"`, `"replace_output_closet_guardian_notes"`,
 		"loop_definition_name",
 		"awaiting first cycle",
 	} {
@@ -356,12 +356,15 @@ func TestGuidedCreateReplacePreservesDocuments(t *testing.T) {
 	// The loop has "run": both documents now hold real state.
 	docBody := "## Status Line\n\nCloset nominal.\n\n## Details\n\nAccumulated belief."
 	notesBody := "Current theory: the UPS fan is the noise."
-	for ref, body := range map[string]string{
-		"kb:dashboards/closet.md":       docBody,
-		"kb:dashboards/closet-notes.md": notesBody,
+	for ref, state := range map[string]struct {
+		body string
+		tool string
+	}{
+		"kb:dashboards/closet.md":       {body: docBody, tool: "publish_output_closet_guardian"},
+		"kb:dashboards/closet-notes.md": {body: notesBody, tool: "replace_output_closet_guardian_notes"},
 	} {
-		body := body
-		if _, err := rig.docTools.Write(ctx, documents.WriteArgs{Ref: ref, Body: &body}); err != nil {
+		body := state.body
+		if _, err := rig.docTools.Write(ctx, documents.WriteArgs{Ref: ref, Body: &body, StructuredTool: state.tool}); err != nil {
 			t.Fatalf("simulate loop write to %s: %v", ref, err)
 		}
 	}
@@ -468,9 +471,9 @@ func TestGuidedCreateSeedsFirstPublish(t *testing.T) {
 		t.Fatalf("read seeded doc: %v", err)
 	}
 	for _, want := range []string{
-		"## Status Line", "Closet 21.4°C, UPS on mains.",
-		"## Digest", "dehumidifier idle",
-		"## Details", "full charge",
+		`"status_line"`, "Closet 21.4°C, UPS on mains.",
+		`"digest"`, "dehumidifier idle",
+		`"full"`, "full charge",
 	} {
 		if !strings.Contains(doc, want) {
 			t.Errorf("seeded document missing %q:\n%s", want, doc)

--- a/internal/tools/loop_create_tool.go
+++ b/internal/tools/loop_create_tool.go
@@ -33,7 +33,7 @@ func (r *Registry) registerThaneLoopCreate() {
 			"\"service\" = a recurring loop that self-paces within a sleep envelope (requires sleep_min and sleep_max); " +
 			"\"event_driven\" = a quiescent handler with no timer that runs only when an external trigger wakes it — give it an entity subscription with wake: true (wakes on that entity's changes), point a feed/forge subscription or an MQTT wake at it, or have another loop notify it; without at least one trigger it never runs; " +
 			"\"container\" = a non-executing node that groups loops and shares its tags with descendants; like every operation it requires intent, takes the optional parent_name and tags, and rejects execution/output fields (sleep knobs, output, entities, instructions, etc.). " +
-			"output (service/event_driven only) declares a managed markdown document the loop maintains, rewriting it each cycle to reflect current state; declaring facets publishes condensed projections alongside the body instead. It comes with a private working-notes document for the loop's own thinking, and both documents are scaffolded with ownership frontmatter before launch — a faceted output's scaffold carries the exact section skeleton its publish tool fills, so the loop's first iteration sees the shape it is expected to produce. Better than the placeholder skeleton: output.initial authors the first publish at create time from the survey you just did (same arguments as the publish tool; see the parameter). A document that already exists is preserved rather than re-scaffolded or seeded (document_state / working_notes_state in the result report which happened). Document-owning loops carry the read-side doc tools regardless of tags (doc_read — which returns this loop's own outputs whole, even when large — plus doc_outline/doc_section for paging other large documents, and doc_history/doc_diff/doc_at for revision history). Omit output for a loop that acts without maintaining a document. " +
+			"output (service/event_driven only) declares a managed markdown document the loop maintains, rewriting it each cycle to reflect current state; declaring facets publishes condensed projections alongside the body instead. It comes with a private working-notes document for the loop's own thinking, and both documents are scaffolded with ownership frontmatter before launch — a faceted output's scaffold carries the exact section skeleton its publish tool fills, so the loop's first iteration sees the shape it is expected to produce. Better than the placeholder skeleton: output.initial authors the first publish at create time from the survey you just did (same arguments as the publish tool; see the parameter). A document that already exists is preserved rather than re-scaffolded or seeded; if replace=true also changes its facet contract, output.migration explicitly supplies only newly required projections while Go preserves the full body and retained projections (document_state / working_notes_state in the result report which happened). Document-owning loops carry the read-side doc tools regardless of tags (doc_read — which returns this loop's own outputs whole, even when large — plus doc_outline/doc_section for paging other large documents, and doc_history/doc_diff/doc_at for revision history). Omit output for a loop that acts without maintaining a document. " +
 			"parent_name nests the loop under a container by name, inheriting its tags and subscriptions. " +
 			"bindings restricts which named shared resources the loop may reach (forge_account and repo_root); a caller already inside a binding carries it into the new loop and cannot override it or place the loop under an incompatible container. " +
 			"prompt_mode picks the system-prompt shape: set \"task\" for a mechanical maintainer/watcher/poller (fetch a source, check a state, update a document) — the compact worker prompt drops the reflective identity stack, the largest single prompt cost in a background loop; leave it unset for a loop that reflects on the agent or composes messages in its voice. " +
@@ -204,6 +204,12 @@ type executingLoopPlan struct {
 	seedDocument bool
 	seedPayload  looppkg.FacetPayload
 	seedNotes    string
+	// migrateDocument records an explicit output.migration request. Its
+	// values contain only compact projections newly required by the proposed
+	// contract; the existing document supplies every retained projection and
+	// the full logical body.
+	migrateDocument bool
+	migrationValues map[string]string
 }
 
 // planExecutingLoop derives the plan without writing anything. It reads
@@ -264,16 +270,18 @@ func (r *Registry) planExecutingLoop(ctx context.Context, args map[string]any, n
 	// managed OutputSpec + a curate-style task; otherwise the loop's per-iteration
 	// task is its intent.
 	var (
-		outputs      []looppkg.OutputSpec
-		outputSpec   looppkg.OutputSpec
-		documentRef  string
-		title        string
-		hasOutput    bool
-		facets       []looppkg.FacetSpec
-		notesRef     string
-		seedDocument bool
-		seedPayload  looppkg.FacetPayload
-		seedNotes    string
+		outputs         []looppkg.OutputSpec
+		outputSpec      looppkg.OutputSpec
+		documentRef     string
+		title           string
+		hasOutput       bool
+		facets          []looppkg.FacetSpec
+		notesRef        string
+		seedDocument    bool
+		seedPayload     looppkg.FacetPayload
+		seedNotes       string
+		migrateDocument bool
+		migrationValues map[string]string
 	)
 	if raw, ok := args["output"].(map[string]any); ok && raw != nil {
 		hasOutput = true
@@ -308,6 +316,13 @@ func (r *Registry) planExecutingLoop(ctx context.Context, args map[string]any, n
 		seedPayload, seedNotes, seedDocument, err = parseOutputInitial(raw["initial"], outputSpec)
 		if err != nil {
 			return nil, err
+		}
+		migrationValues, migrateDocument, err = parseOutputMigration(raw["migration"], outputSpec)
+		if err != nil {
+			return nil, err
+		}
+		if migrateDocument && !replace {
+			return nil, fmt.Errorf("output.migration requires replace=true because it changes an existing loop output contract")
 		}
 	}
 
@@ -363,20 +378,22 @@ func (r *Registry) planExecutingLoop(ctx context.Context, args map[string]any, n
 	warnings := looppkg.BuildDefinitionWarnings(spec)
 
 	return &executingLoopPlan{
-		spec:         spec,
-		warnings:     warnings,
-		replace:      replace,
-		hasOutput:    hasOutput,
-		documentRef:  documentRef,
-		title:        title,
-		outputTool:   outputSpec.ToolName(),
-		notesRef:     notesRef,
-		entityCount:  len(entities),
-		envelope:     envelope,
-		createdAt:    now,
-		seedDocument: seedDocument,
-		seedPayload:  seedPayload,
-		seedNotes:    seedNotes,
+		spec:            spec,
+		warnings:        warnings,
+		replace:         replace,
+		hasOutput:       hasOutput,
+		documentRef:     documentRef,
+		title:           title,
+		outputTool:      outputSpec.ToolName(),
+		notesRef:        notesRef,
+		entityCount:     len(entities),
+		envelope:        envelope,
+		createdAt:       now,
+		seedDocument:    seedDocument,
+		seedPayload:     seedPayload,
+		seedNotes:       seedNotes,
+		migrateDocument: migrateDocument,
+		migrationValues: migrationValues,
 	}, nil
 }
 
@@ -473,6 +490,41 @@ func parseOutputInitial(raw any, output looppkg.OutputSpec) (payload looppkg.Fac
 	return payload, notes, true, nil
 }
 
+// parseOutputMigration accepts only compact projections declared by the new
+// contract. The existing document contributes its full body and every retained
+// projection, so accepting full or already-existing projection replacements
+// here would turn a schema migration into an unobvious content rewrite.
+func parseOutputMigration(raw any, output looppkg.OutputSpec) (map[string]string, bool, error) {
+	if raw == nil {
+		return nil, false, nil
+	}
+	migration, ok := raw.(map[string]any)
+	if !ok {
+		return nil, false, fmt.Errorf("output.migration must be an object containing newly declared projections, got %T", raw)
+	}
+	allowed := make(map[string]bool, len(output.Facets))
+	for _, field := range output.FacetFields() {
+		if field.Key != "full" {
+			allowed[field.Key] = true
+		}
+	}
+	values := make(map[string]string, len(migration))
+	for key, rawValue := range migration {
+		if !allowed[key] {
+			return nil, false, fmt.Errorf("output.migration.%s is not a compact projection declared by the new output contract", key)
+		}
+		value, ok := rawValue.(string)
+		if !ok {
+			return nil, false, fmt.Errorf("output.migration.%s must be a string, got %T", key, rawValue)
+		}
+		if strings.TrimSpace(value) == "" {
+			return nil, false, fmt.Errorf("output.migration.%s is empty; supply the new projection's current value", key)
+		}
+		values[key] = value
+	}
+	return values, true, nil
+}
+
 func (r *Registry) createLoopExecuting(ctx context.Context, args map[string]any, name, intent string, op looppkg.Operation) (string, error) {
 	deps := r.loopIntentDeps
 	plan, err := r.planExecutingLoop(ctx, args, name, intent, op)
@@ -504,6 +556,15 @@ func (r *Registry) createLoopExecuting(ctx context.Context, args map[string]any,
 		}
 		return ldMarshalToolJSON(result)
 	}
+	if plan.migrateDocument {
+		live := r.resolveLiveRegistry()
+		if live == nil {
+			return "", fmt.Errorf("output.migration cannot verify that loop %q is stopped because the live loop registry is unavailable; no document was changed", name)
+		}
+		if running := live.GetByName(name); running != nil {
+			return "", fmt.Errorf("output.migration cannot change %q while loop %q is running under its old output contract; no document was changed. Call stop_loop for this loop, confirm loop_status no longer reports it, then retry this exact thane_loop_create call", plan.documentRef, name)
+		}
+	}
 
 	hasOutput, documentRef, title := plan.hasOutput, plan.documentRef, plan.title
 	replace, warnings, envelope, now := plan.replace, plan.warnings, plan.envelope, plan.createdAt
@@ -520,6 +581,9 @@ func (r *Registry) createLoopExecuting(ctx context.Context, args map[string]any,
 		}
 		if docExists && !replace {
 			return "", fmt.Errorf("output document %q already exists; pass replace=true to replace the loop definition and adopt the document — its body is preserved, only its ownership frontmatter refreshes", documentRef)
+		}
+		if plan.migrateDocument && !docExists {
+			return "", fmt.Errorf("output.migration requires an existing output document; omit migration and use output.initial to author a new document")
 		}
 		// A seed against an existing document is a conflict to surface, not
 		// resolve: the document's accumulated state wins over create-time
@@ -567,15 +631,34 @@ func (r *Registry) createLoopExecuting(ctx context.Context, args map[string]any,
 		documentState, notesState = "scaffolded", "scaffolded"
 		var payload looppkg.FacetPayload
 		var body string
+		var previousWriteTools []string
 		switch {
 		case docExists:
-			documentState = "preserved_existing"
-			if outputSpec.HasFacets() {
-				record, readErr := deps.DocTools.RecordWithReceipt(ctx, documents.RefArgs{Ref: documentRef, ReceiptScope: DocumentRevisionScope(ctx)})
-				if readErr != nil {
-					return "", fmt.Errorf("read existing output document for adoption: %w", readErr)
+			record, readErr := deps.DocTools.RecordWithReceipt(ctx, documents.RefArgs{Ref: documentRef, ReceiptScope: DocumentRevisionScope(ctx)})
+			if readErr != nil {
+				return "", fmt.Errorf("read existing output document for adoption: %w", readErr)
+			}
+			newContract := documentfacets.Contract{Facets: append([]documentfacets.Spec(nil), outputSpec.Facets...)}
+			contractChanged := !facetContractsEqual(record.FacetContract, newContract)
+			switch {
+			case contractChanged:
+				if !plan.migrateDocument {
+					return "", fmt.Errorf("output document %q uses a different projection contract; pass output.migration with values for every newly declared projection (or an empty object when only removing projections) so its full body and retained projections can be migrated explicitly", documentRef)
 				}
-				payload = outputSpec.ParseFacetDocument(record.Body)
+				payload, err = migrateOutputPayload(record, newContract, plan.migrationValues)
+				if err != nil {
+					return "", fmt.Errorf("output.migration: %w", err)
+				}
+				body = payload.Full
+				documentState = "migrated_contract"
+				previousWriteTools = outputWriteToolAliases(outputSpec)
+			case plan.migrateDocument:
+				return "", fmt.Errorf("output.migration was supplied, but output document %q already uses the declared projection contract; omit migration to preserve it", documentRef)
+			default:
+				documentState = "preserved_existing"
+				if outputSpec.HasFacets() {
+					payload = looppkg.FacetPayload(record.FacetContract.Parse(record.Body))
+				}
 			}
 		case plan.seedDocument:
 			frontmatter["created"] = []string{now.Format(time.RFC3339)}
@@ -591,26 +674,33 @@ func (r *Registry) createLoopExecuting(ctx context.Context, args map[string]any,
 		}
 		if outputSpec.HasFacets() {
 			if _, err := deps.DocTools.WriteFaceted(ctx, documents.FacetedWriteArgs{
-				Ref:          documentRef,
-				Title:        title,
-				Frontmatter:  frontmatter,
-				Contract:     documentfacets.Contract{Facets: append([]documentfacets.Spec(nil), outputSpec.Facets...)},
-				Payload:      documentfacets.Payload(payload),
-				WriteTool:    outputSpec.ToolName(),
-				ReceiptScope: DocumentRevisionScope(ctx),
+				Ref:                documentRef,
+				Title:              title,
+				Frontmatter:        frontmatter,
+				Contract:           documentfacets.Contract{Facets: append([]documentfacets.Spec(nil), outputSpec.Facets...)},
+				Payload:            documentfacets.Payload(payload),
+				WriteTool:          outputSpec.ToolName(),
+				ReceiptScope:       DocumentRevisionScope(ctx),
+				PreviousWriteTools: previousWriteTools,
 			}); err != nil {
 				return "", fmt.Errorf("scaffold faceted output document: %w", err)
 			}
 		} else {
 			writeArgs := documents.WriteArgs{
-				Ref:            documentRef,
-				Title:          title,
-				Frontmatter:    frontmatter,
-				StructuredTool: outputSpec.ToolName(),
-				ReceiptScope:   DocumentRevisionScope(ctx),
+				Ref:                documentRef,
+				Title:              title,
+				Frontmatter:        frontmatter,
+				StructuredTool:     outputSpec.ToolName(),
+				ReceiptScope:       DocumentRevisionScope(ctx),
+				PreviousWriteTools: previousWriteTools,
 			}
-			if !docExists {
+			if !docExists || documentState == "migrated_contract" {
 				writeArgs.Body = &body
+			}
+			if documentState == "migrated_contract" {
+				writeArgs.Frontmatter[documentfacets.SchemaKey] = nil
+				writeArgs.Frontmatter[documentfacets.FacetsKey] = nil
+				writeArgs.Frontmatter[documentfacets.FacetFormatsKey] = nil
 			}
 			if _, err := deps.DocTools.Write(ctx, writeArgs); err != nil {
 				return "", fmt.Errorf("scaffold output document: %w", err)
@@ -829,6 +919,78 @@ func declaredDocumentExists(ctx context.Context, docTools *documents.Tools, ref 
 	}
 }
 
+func facetContractsEqual(left, right documentfacets.Contract) bool {
+	if len(left.Facets) != len(right.Facets) {
+		return false
+	}
+	leftFacets := make(map[documentfacets.Name]documentfacets.Format, len(left.Facets))
+	for _, facet := range left.Facets {
+		leftFacets[facet.Name] = facet.EffectiveFormat()
+	}
+	for _, facet := range right.Facets {
+		if leftFacets[facet.Name] != facet.EffectiveFormat() {
+			return false
+		}
+	}
+	return true
+}
+
+func migrateOutputPayload(record *documents.DocumentRecord, contract documentfacets.Contract, supplied map[string]string) (looppkg.FacetPayload, error) {
+	current := documentfacets.Payload{Full: record.Body}
+	if len(record.FacetContract.Facets) > 0 {
+		current = record.FacetContract.Parse(record.Body)
+	}
+	previous := make(map[documentfacets.Name]bool, len(record.FacetContract.Facets))
+	for _, facet := range record.FacetContract.Facets {
+		previous[facet.Name] = true
+	}
+	for key := range supplied {
+		if previous[documentfacets.Name(key)] {
+			return looppkg.FacetPayload{}, fmt.Errorf("%s already exists and is preserved from the current document; migration accepts only newly declared projections", key)
+		}
+	}
+
+	next := documentfacets.Payload{Full: current.Full}
+	for _, facet := range contract.Facets {
+		key := string(facet.Name)
+		value := ""
+		if previous[facet.Name] {
+			value, _ = current.ByKey(key)
+		} else {
+			value = supplied[key]
+			if strings.TrimSpace(value) == "" {
+				return looppkg.FacetPayload{}, fmt.Errorf("%s is newly declared and requires a current value", key)
+			}
+		}
+		switch facet.Name {
+		case documentfacets.StatusLine:
+			next.StatusLine = value
+		case documentfacets.Teaser:
+			next.Teaser = value
+		case documentfacets.Digest:
+			next.Digest = value
+		}
+	}
+	if len(contract.Facets) > 0 {
+		if err := contract.Validate(next); err != nil {
+			return looppkg.FacetPayload{}, err
+		}
+	}
+	return looppkg.FacetPayload(next), nil
+}
+
+// outputWriteToolAliases returns only the two tool names the same guided loop
+// output can own. Supplying these through an internal-only field lets a
+// contract migration cross replace_output_* / publish_output_* without
+// weakening document ownership for arbitrary structured writers.
+func outputWriteToolAliases(output looppkg.OutputSpec) []string {
+	bodyOutput := output
+	bodyOutput.Facets = nil
+	facetedOutput := output
+	facetedOutput.Facets = []looppkg.FacetSpec{{Name: looppkg.OutputFacetStatusLine}}
+	return []string{bodyOutput.ToolName(), facetedOutput.ToolName()}
+}
+
 // declaredOutputSpecs splits a created loop's outputs into the
 // maintained document and its derived working notes, by type rather
 // than by position so the scaffold cannot silently bind to the wrong
@@ -910,6 +1072,15 @@ func thaneLoopCreateSchema() map[string]any {
 							"digest":      map[string]any{"type": "string"},
 							"full":        map[string]any{"type": "string"},
 							"notes":       map[string]any{"type": "string"},
+						},
+					},
+					"migration": map[string]any{
+						"type":        "object",
+						"description": "Explicitly migrate an existing output when replace=true changes its facet contract and the old loop is stopped. Supply only each newly declared compact projection; Go preserves the current full body and retained projections. Use an empty object when only removing facets or moving from faceted to body-only. Omit when the contract is unchanged or the document is new.",
+						"properties": map[string]any{
+							"status_line": map[string]any{"type": "string"},
+							"teaser":      map[string]any{"type": "string"},
+							"digest":      map[string]any{"type": "string"},
 						},
 					},
 				},

--- a/internal/tools/loop_create_tool.go
+++ b/internal/tools/loop_create_tool.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/state/documents"
+	documentfacets "github.com/nugget/thane-ai-agent/internal/state/documents/facets"
 	"github.com/nugget/thane-ai-agent/internal/tools/toolargs"
 )
 
@@ -564,29 +565,56 @@ func (r *Registry) createLoopExecuting(ctx context.Context, args map[string]any,
 		// authored while the creating model still holds the survey that
 		// justified the loop — and the placeholder skeleton otherwise.
 		documentState, notesState = "scaffolded", "scaffolded"
-		writeArgs := documents.WriteArgs{
-			Ref:         documentRef,
-			Title:       title,
-			Frontmatter: frontmatter,
-		}
+		var payload looppkg.FacetPayload
+		var body string
 		switch {
 		case docExists:
 			documentState = "preserved_existing"
+			if outputSpec.HasFacets() {
+				record, readErr := deps.DocTools.RecordWithReceipt(ctx, documents.RefArgs{Ref: documentRef, ReceiptScope: DocumentRevisionScope(ctx)})
+				if readErr != nil {
+					return "", fmt.Errorf("read existing output document for adoption: %w", readErr)
+				}
+				payload = outputSpec.ParseFacetDocument(record.Body)
+			}
 		case plan.seedDocument:
 			frontmatter["created"] = []string{now.Format(time.RFC3339)}
-			body := plan.seedPayload.Full
-			if outputSpec.HasFacets() {
-				body = outputSpec.RenderFacetDocument(plan.seedPayload)
-			}
-			writeArgs.Body = &body
+			payload = plan.seedPayload
+			body = plan.seedPayload.Full
 			documentState = "seeded"
 		default:
 			frontmatter["created"] = []string{now.Format(time.RFC3339)}
-			body := renderOutputScaffoldBody(outputSpec, title, intent)
-			writeArgs.Body = &body
+			body = renderOutputScaffoldBody(outputSpec, title, intent)
+			if outputSpec.HasFacets() {
+				payload = outputSpec.ParseFacetDocument(body)
+			}
 		}
-		if _, err := deps.DocTools.Write(ctx, writeArgs); err != nil {
-			return "", fmt.Errorf("scaffold output document: %w", err)
+		if outputSpec.HasFacets() {
+			if _, err := deps.DocTools.WriteFaceted(ctx, documents.FacetedWriteArgs{
+				Ref:          documentRef,
+				Title:        title,
+				Frontmatter:  frontmatter,
+				Contract:     documentfacets.Contract{Facets: append([]documentfacets.Spec(nil), outputSpec.Facets...)},
+				Payload:      documentfacets.Payload(payload),
+				WriteTool:    outputSpec.ToolName(),
+				ReceiptScope: DocumentRevisionScope(ctx),
+			}); err != nil {
+				return "", fmt.Errorf("scaffold faceted output document: %w", err)
+			}
+		} else {
+			writeArgs := documents.WriteArgs{
+				Ref:            documentRef,
+				Title:          title,
+				Frontmatter:    frontmatter,
+				StructuredTool: outputSpec.ToolName(),
+				ReceiptScope:   DocumentRevisionScope(ctx),
+			}
+			if !docExists {
+				writeArgs.Body = &body
+			}
+			if _, err := deps.DocTools.Write(ctx, writeArgs); err != nil {
+				return "", fmt.Errorf("scaffold output document: %w", err)
+			}
 		}
 
 		if notesSpec != nil {
@@ -596,9 +624,10 @@ func (r *Registry) createLoopExecuting(ctx context.Context, args map[string]any,
 				looppkg.OutputManagedByFrontmatterKey: {notesSpec.ToolName()},
 			}
 			notesArgs := documents.WriteArgs{
-				Ref:         notesSpec.Ref,
-				Title:       title + " — Working Notes",
-				Frontmatter: notesFrontmatter,
+				Ref:            notesSpec.Ref,
+				Title:          title + " — Working Notes",
+				Frontmatter:    notesFrontmatter,
+				StructuredTool: notesSpec.ToolName(),
 			}
 			switch {
 			case notesExists:

--- a/internal/tools/loop_intent_tools_test.go
+++ b/internal/tools/loop_intent_tools_test.go
@@ -768,6 +768,7 @@ type curateTestRig struct {
 	tool        *Tool
 	defRegistry *looppkg.DefinitionRegistry
 	docTools    *documents.Tools
+	live        *looppkg.Registry
 }
 
 func newCurateTestRig(t *testing.T) *curateTestRig {
@@ -794,6 +795,7 @@ func newCurateTestRig(t *testing.T) *curateTestRig {
 	rig := &curateTestRig{
 		defRegistry: defRegistry,
 		docTools:    docTools,
+		live:        looppkg.NewRegistry(),
 	}
 	rig.reg = NewEmptyRegistry()
 	rig.reg.ConfigureLoopIntentTools(LoopIntentToolDeps{
@@ -804,6 +806,7 @@ func newCurateTestRig(t *testing.T) *curateTestRig {
 		LaunchDefinition: func(_ context.Context, name string, _ looppkg.Launch) (looppkg.LaunchResult, error) {
 			return looppkg.LaunchResult{LoopID: "loop-test-" + name}, nil
 		},
+		LiveRegistry: rig.live,
 	})
 	rig.tool = rig.reg.Get("thane_loop_create")
 	if rig.tool == nil {

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -444,6 +444,8 @@ func (r *Registry) registerFactTools() {
 	})
 }
 
+const fileToolDocumentBoundary = " Indexed managed document roots are intentionally unavailable here; use doc_browse, doc_search, doc_read, and the returned write_tool so Thane can preserve the logical document abstraction."
+
 func (r *Registry) registerFileTools() {
 	if r.fileTools == nil || !r.fileTools.Enabled() {
 		return
@@ -452,7 +454,7 @@ func (r *Registry) registerFileTools() {
 	r.Register(&Tool{
 		Name:               "file_read",
 		SkipContentResolve: true,
-		Description:        "Read the contents of a file from the workspace. Use for accessing configuration, memory files, documentation, or any text file.",
+		Description:        "Read the contents of an ordinary workspace or non-indexed repository file." + fileToolDocumentBoundary,
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -488,7 +490,7 @@ func (r *Registry) registerFileTools() {
 	r.Register(&Tool{
 		Name:               "file_write",
 		SkipContentResolve: true,
-		Description:        "Write content to a file in the workspace. Creates the file if it doesn't exist, overwrites if it does. Automatically creates parent directories.",
+		Description:        "Write content to an ordinary workspace file. Creates the file if it doesn't exist, overwrites if it does, and creates parent directories." + fileToolDocumentBoundary,
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -516,7 +518,7 @@ func (r *Registry) registerFileTools() {
 	r.Register(&Tool{
 		Name:               "file_edit",
 		SkipContentResolve: true,
-		Description:        "Edit a file by replacing exact text. The old text must match exactly (including whitespace). Use this for precise, surgical edits.",
+		Description:        "Edit an ordinary workspace file by replacing exact text. The old text must match exactly, including whitespace." + fileToolDocumentBoundary,
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -549,7 +551,7 @@ func (r *Registry) registerFileTools() {
 	r.Register(&Tool{
 		Name:               "file_list",
 		SkipContentResolve: true,
-		Description:        "List files and directories in a workspace path.",
+		Description:        "List files and directories in an ordinary workspace or non-indexed repository path." + fileToolDocumentBoundary,
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -579,7 +581,7 @@ func (r *Registry) registerFileTools() {
 	r.Register(&Tool{
 		Name:               "file_search",
 		SkipContentResolve: true,
-		Description:        "Search for files by name using glob patterns. Recursively searches a directory tree and returns matching file paths. Useful for finding configuration files, specific file types, or files with certain naming patterns.",
+		Description:        "Search ordinary workspace and non-indexed repository files by name using glob patterns. Recursively searches a directory tree and returns matching file paths." + fileToolDocumentBoundary,
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -615,7 +617,7 @@ func (r *Registry) registerFileTools() {
 	r.Register(&Tool{
 		Name:               "file_grep",
 		SkipContentResolve: true,
-		Description:        "Search file contents for a regular expression pattern. Recursively searches files and returns matching lines with file paths and line numbers. Use file_pattern to keep source searches inside a filename glob such as '*.go'. Skips binary files and files larger than 1MB.",
+		Description:        "Search ordinary workspace and non-indexed repository file contents for a regular expression. Returns matching lines with file paths and line numbers; skips binary files and files larger than 1MB." + fileToolDocumentBoundary,
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -664,7 +666,7 @@ func (r *Registry) registerFileTools() {
 	r.Register(&Tool{
 		Name:               "file_stat",
 		SkipContentResolve: true,
-		Description:        "Get detailed information about one or more files or directories. Returns type, size, permissions, and modification time. Supports batch queries with comma-separated paths.",
+		Description:        "Get type, size, permissions, and modification time for ordinary workspace or non-indexed repository paths. Supports comma-separated paths." + fileToolDocumentBoundary,
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -684,7 +686,7 @@ func (r *Registry) registerFileTools() {
 	r.Register(&Tool{
 		Name:               "file_tree",
 		SkipContentResolve: true,
-		Description:        "Display a directory tree structure with indentation. Shows the hierarchy of files and directories with a summary count. Useful for understanding project layout.",
+		Description:        "Display an ordinary workspace or non-indexed repository directory tree with a summary count." + fileToolDocumentBoundary,
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{

--- a/loops/archivist.md
+++ b/loops/archivist.md
@@ -174,11 +174,23 @@ durable queue holds that).
      contact root or writer is unavailable, record that outcome in archivist.md
      and call `queue_defer`; do not acknowledge unpublished evidence or create a
      fallback document.
-   - Every non-contact subject remains an ordinary managed document under the
+   - Every non-contact subject is a faceted managed document under the
      `dossiers:` root. Use canonical `root:path` refs — for the game room door,
      `dossiers:entity-binary_sensor-game_room_door.md`, never a bare
      `dossiers/...` path or the retired `kb:dossiers/` namespace. Read the
-     existing document before replacing it.
+     existing document before replacing it and trust its returned `write_tool`.
+     A legacy body-only dossier reports `doc_body_write`; adopt it once by
+     calling `doc_write`, not by manually authoring facet headings. An already
+     adopted dossier reports `doc_write`. Reconcile the complete existing
+     content with the new evidence, then pass status-line, every compact
+     projection already present, and full in one call. Go owns the canonical
+     section envelope, projection budgets, frontmatter, and revision receipt. If
+     another narrower
+     owner is reported, use that exact tool or defer rather than bypassing it.
+     When a queue item explicitly requests facet adoption, make only that
+     structural change: derive compact projections solely from claims already
+     present, preserve the existing body unchanged as `full`, and do not search
+     for new evidence, revise claims, or fold adjacent work into the migration.
 4. **Ack every item you handle** — Call `queue_ack` with each item's
    subject only after every warranted dossier write succeeded, or after an
    evidence-based decision that the complete source changes nothing. Correct a
@@ -210,54 +222,33 @@ durable queue holds that).
 
 ## What a dossier should look like
 
-A short markdown document. The standard skeleton:
+A short faceted document. Both `doc_write` and
+`contact_dossier_write` take authored projections rather than an outer markdown
+envelope:
 
-```markdown
-# Dossier: <subject identifier>
+- `status_line`: the one-line current truth.
+- `teaser`: the reason to open this dossier now.
+- `digest`: enough standalone context to act without opening the full dossier.
+- `full`: durable evidence under detail-level headings such as `### Aliases`,
+  `### Relationship Summary`, `### Claims`, `### Open Questions`, and
+  `### Connections`.
 
-**Subject:** `entity:binary_sensor.game_room_door`
-**Aliases:** "game room door", "smoke-break door", "the brass-handle door"
-**Last refreshed:** <ISO date>
-**Cross-silo presence:** archive (N hits), sessions (M summaries), facts (K), working_memory (J)
-
-## Summary
-
-One paragraph synthesizing what thane currently understands about this
-subject. Write it so a fresh wake into a conversation mentioning the
-subject benefits from reading just this paragraph.
-
-## Claims
-
-- <claim> — evidence: archive:session:019c598e-7f5c-7123-8f31-0123456789ab, fact:home/game_room_door
-- <claim> — evidence: archive:session:019c5990-8a6d-7456-9b42-abcdef012345
-- <claim> — evidence: contact:019c76e4 notes field
-
-## Open questions
-
-- <question> — what evidence might resolve it
-
-## Connections
-
-- Related subjects: `area:game_room`, `zone:smoke_break`
-- Dossiers that reference this one: `dossiers:<other-subject>.md`, …
-```
+Go renders `## Status Line`, `## Teaser`, `## Digest`, and `## Details`. Never
+include those reserved headings in a projection. The compact projections should
+not spend tokens repeating a subject name or identifier already supplied by the
+document title; digest and full may name the subject where standalone prose
+needs it. All supplied projections describe the same revision.
 
 Every claim line carries citations. If you cannot back a claim with specific
 evidence from the corpus, do not assert it — note it as an open question
 instead. Synthesis is connecting things you can defend, not generating
 plausible-sounding text.
 
-For a contact, pass the four projections to `contact_dossier_write`; do not
-author the outer document structure shown above. The `full` projection carries
-the durable evidence under detail-level headings such as `### Aliases`,
-`### Relationship Summary`, `### Claims`, `### Open Questions`, and
-`### Connections`. The subject's UUID, ref, and private tag already arrive
-through the document envelope and never belong in the authored content. The
-status line and teaser also omit the subject's name because the dossier title
-supplies it; digest and full may use the name where standalone prose needs it.
-The status line is the one-line current truth, the teaser is the reason to open
-the dossier, and the digest must stand alone as enough relationship context to
-act. All four describe the same revision.
+For a contact, pass all four projections to `contact_dossier_write`. The
+subject's UUID, ref, and private tag already arrive through the document
+envelope and never belong in authored content. For a non-contact, call
+`doc_write`; teaser and digest may be absent on a first write, but every
+projection the dossier already carries is required on later publishes.
 
 ## What you are NOT for
 

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,4 +1,4 @@
-packages=69
+packages=70
 interfaces=88
 large_files=59
 set_mutators=124

--- a/talents/documents.md
+++ b/talents/documents.md
@@ -108,11 +108,11 @@ Use `doc_outline` when you need the heading tree before deciding what
 to read; use `doc_read` when the whole document is worth loading in
 one payload.
 
-## A curated document, at the size you need
+## A faceted document, at the size you need
 
-Some documents are maintained by a loop that curates them for readers,
-and those publish the same understanding at several fidelities. Pass
-`level` to `doc_read` to take the one you can afford:
+Some documents publish the same understanding at several fidelities,
+regardless of which managed root holds them or which owner maintains them.
+Pass `level` to `doc_read` to take the one you can afford:
 
 ```json
 {
@@ -128,12 +128,12 @@ different shapes of the same outward-facing signal role; `digest` is the
 context payload after that signal earns attention.
 
 This is not truncation — each level was written to stand alone at that
-size by the loop that owns the subject, so a status line is a sentence
-someone composed, not the first hundred characters of a paragraph.
+size, so a status line is a sentence someone composed, not the first
+hundred characters of a paragraph.
 
-The result reports `levels_available`, so one read tells you both the
-answer and what else you could have asked for. A document nobody curates
-answers `faceted: false` and sends you back to an ordinary read.
+The result reports `levels_available` and `write_tool`, so one read tells you
+both what else you could have asked for and which mutation surface owns the
+document. An ordinary document answers `faceted: false`.
 
 Read at the level your decision needs. Pulling `full` to answer a
 question a status line settles spends context you will want later in the
@@ -261,11 +261,12 @@ against the whole corpus are usually too broad to be useful:
 ```
 
 `modified_after` and `modified_before` take RFC3339 timestamps or signed
-deltas (`-7d` = past week). Search returns compact summaries with
-refs, not bodies — pipe a ref to `documents_read` to actually read the
-hit. A hit from a loop-curated document shows its authored teaser and
-lists its available facets — follow up with one deliberate `doc_read`
-at the `level` your decision needs rather than pulling the whole body.
+deltas (`-7d` = past week). Search returns compact summaries with refs,
+not bodies — pipe a ref to `doc_read` to actually read the hit. Every
+hit names its `write_tool`. A faceted hit also shows its authored teaser
+and lists its available facets — follow up with one deliberate
+`doc_read` at the `level` your decision needs rather than pulling the
+whole body.
 
 If `tags` filtering returns nothing unexpected, run `doc_values` for
 `tags` against that root to see the actual vocabulary.
@@ -280,9 +281,18 @@ next_tags: [documents_mutate_content, documents_mutate_structure, documents_muta
 
 # Mutate a managed document
 
-Two questions decide which sub-shape fits:
+Three questions decide which sub-shape fits:
 
-1. **Are you changing what's inside one document, or moving content
+1. **What does the document say owns its writes?** `doc_read`,
+   `doc_search`, and `doc_browse` return `write_tool`; trust that field
+   rather than inferring ownership from a root, path, or heading.
+   - `doc_write` means it is a normal logical document: write every
+     projection together.
+   - `doc_body_write` means it is the unusual body-only shape.
+   - Any narrower name, such as `contact_dossier_write` or
+     `publish_output_*`, is the exact tool to use.
+
+2. **Are you changing what's inside one document, or moving content
    between documents, or operating on the document as a whole?**
    - Inside one document (body, sections, metadata, journal entries)
      → activate `documents_mutate_content`
@@ -291,7 +301,7 @@ Two questions decide which sub-shape fits:
    - Acting on the document as a unit (copy, rename, delete) → activate
      `documents_mutate_lifecycle`
 
-2. **Is this brand-new knowledge being introduced to the corpus?** If
+3. **Is this brand-new knowledge being introduced to the corpus?** If
    yes, none of the mutate leaves are quite right — back out and
    activate `documents_curate` instead. The intake step decides the
    title/path/tags before writing, which is the whole point.
@@ -311,17 +321,18 @@ teaser: "Body, section, or metadata changes inside one existing document."
 
 # Mutate content inside one document
 
-Three tools, each owning a different mutation shape.
+Four tools, each owning a different mutation shape.
 
-## Create a new ordinary document — `doc_create`
+## Create a new logical document — `doc_create`
 
-The default way to make an ordinary document exist. A contract-owned document
-uses the structured tool that names it: `contact_dossier_write` for a contact
-dossier, or a generated `publish_output_*` / `replace_output_*` tool for a loop
-output. Probe a contact dossier with `contact_dossier_read` first and branch on
-its stable `dossier.exists` field; an absent
+The default way to make a normal faceted document exist. A document with a
+narrower contract-owned writer uses that structured tool instead:
+`contact_dossier_write` for a contact dossier, or a generated
+`publish_output_*` / `replace_output_*` tool for a loop output. Probe
+a contact dossier with `contact_dossier_read` first and branch on its stable
+`dossier.exists` field; an absent
 result is successful and names the exact create action, so never guess its ref
-for `doc_read`. For ordinary corpus knowledge, one `doc_create` call
+for `doc_read`. For normal corpus knowledge, one `doc_create` call
 collision-checks related documents, title/tags/path normalization, and root
 policy, then writes when placement is clean:
 
@@ -330,7 +341,8 @@ policy, then writes when placement is clean:
   "root": "kb",
   "title": "VLAN renumbering decision",
   "tags": ["network"],
-  "body": "# VLAN renumbering decision\n\nGuest VLAN moved from 50 to 40...\n"
+  "status_line": "Guest VLAN now uses VLAN 40.",
+  "full": "# VLAN renumbering decision\n\nGuest VLAN moved from 50 to 40...\n"
 }
 ```
 
@@ -341,13 +353,39 @@ review `related_documents`, then `doc_commit` with the intake_id
 adjust and re-call. Creating safely is the default, not something to
 remember.
 
-## Replace — `doc_write`
+## Write a logical document — `doc_write`
 
-Use when an existing ordinary document should hold *exactly* this body. It can
-also create at a fresh ref, but that skips the collision check — reach for
-`doc_create` unless the destination is already deliberate. For a contract-owned
-document, use its dedicated structured tool instead. `doc_write` owns
-`title`, `description`, `tags`, `created`, `updated`:
+Use when a document needs multiple views of one current state in any managed
+root: a one-line status, optional teaser and digest, and the full detail. Pass
+content as projections; Go validates their shared budgets and renders the
+canonical headings. Never put `## Status Line`, `## Teaser`, `## Digest`, or
+`## Details` inside a projection.
+
+```json
+{
+  "ref": "dossiers:entity-binary_sensor-game_room_door.md",
+  "title": "Game room door",
+  "status_line": "Stable behavior; the remaining uncertainty is the intermittent open event.",
+  "teaser": "Open this when diagnosing game-room access or the unexplained open event.",
+  "digest": "The sensor is reliable in routine use, with one unresolved intermittent-open pattern tied to late-night activity.",
+  "full": "### Aliases\n\n- game room door\n\n### Claims\n\n- Routine state is reliable."
+}
+```
+
+On the first write, teaser and digest are optional. Once a document carries
+either projection, every later call must supply it along with `status_line` and
+`full`; omission is rejected before the document changes. Read an existing
+document first. `doc_write` self-migrates a legacy or body-only document at a
+deliberate ref, but if placement is undecided run `doc_intake` before writing.
+
+## Replace an exceptional body-only document — `doc_body_write`
+
+Use only when a document intentionally has one undifferentiated Markdown body
+instead of a projection ladder. It can also create at a fresh ref, but that
+skips the collision check — reach for `doc_create` unless the destination is
+already deliberate. For a faceted or contract-owned document, use the returned
+`write_tool` instead. `doc_body_write` still owns metadata, root policy,
+revision protection, and Git; it is not raw filesystem access:
 
 ```json
 {
@@ -371,12 +409,12 @@ under a managed `Journal` section in one call:
 
 ## Surgical edit — `doc_edit`
 
-Use when only part of an ordinary document should change. Contract-owned
-documents use their dedicated structured tool instead: a section edit to a
-contact dossier's `Details` can leave its status line, teaser, and digest
-describing the previous state, while `contact_dossier_write` republishes all
-four together. The `mode` parameter picks the ordinary-document shape:
-metadata-only, whole-body replace/append/prepend, or section-level
+Use when only part of an ordinary document should change. Faceted and
+contract-owned documents use their returned `write_tool` instead: a section
+edit to `Details` can leave status line, teaser, and digest describing the
+previous state, while `doc_write` or a narrower owner republishes every view
+together. The `mode` parameter picks the body-only document shape:
+metadata-only, whole-body replacement/append/prepend, or section-level
 upsert/delete.
 
 ```json
@@ -395,14 +433,15 @@ the named section entirely. In section modes, `body` carries only that
 one section's text — never the whole document, and never the section's
 heading line: the heading is rendered automatically from `section` and
 `heading`, so repeating it in `body` would double it. The rest of the
-document is untouched. (For whole-document rewrites, `body` is the full
-new document body, same as `doc_write`.)
+document is untouched. (For whole-document body-only rewrites, `body` is the
+full document body, same as `doc_body_write`.)
 
 ## Rolling journal — `doc_journal_update`
 
-Use for recurring loop notes or any document where each entry gets its
-own dated window. The tool owns window grouping and pruning so the
-model doesn't have to:
+Use for recurring loop notes or any ordinary document where each entry gets
+its own dated window. Faceted and contract-owned documents use their returned
+`write_tool` instead. For an ordinary journal, this tool owns window grouping
+and pruning so the model doesn't have to:
 
 ```json
 {
@@ -417,8 +456,8 @@ Right for any append-only chronology — including a service loop
 (`thane_loop_create`, `operation: service`) that wants a dated record
 beside its maintained output; loop outputs no longer have a journal
 type, so the loop calls `doc_journal_update` directly.
-Wrong when the goal is to replace what's there — that's `doc_write` or
-`doc_edit` with `replace_body`.
+Wrong when the goal is to replace what's there — that's `doc_body_write` or
+`doc_edit` in whole-body replacement mode.
 
 ---
 name: documents_mutate_structure
@@ -431,7 +470,10 @@ teaser: "Move or copy a section from one managed document into another."
 
 When a section belongs in a different document than the one currently
 holding it. Both tools upsert the destination section, so the
-destination document is created if needed.
+destination document is created if needed. These are ordinary-document
+operations: copying into a faceted or contract-owned destination, or moving
+out of one, is rejected with its `write_tool` because a partial section
+mutation can leave projections stale. Republish the complete state instead.
 
 ## Copy — leave the source intact
 


### PR DESCRIPTION
## Summary

- move facet manifests, projection contracts, parsing, rendering, validation, and size budgets into the document layer
- make `doc_write` the normal logical faceted writer and retain `doc_body_write` for the exceptional body-only shape
- route loop-owned outputs, contact dossiers, and document intake through the shared receipt/CAS/persistence path
- make current document reads, search, browse, outlines, sections, links, and advertisements project logical content instead of the private Markdown envelope
- block model-facing filesystem tools from bypassing indexed managed document roots
- canonicalize frontmatter and suppress equivalent-write timestamp/revision churn

## Why

Faceted documents are becoming the normal document shape, but the implementation had parallel loop, contact, and generic write paths with overlapping contracts and subtly different behavior. Models also had to understand storage headings and could reach indexed documents through filesystem tools.

This establishes one document-owned logical aggregate and treats Markdown as its private persistence codec. Active legacy documents migrate lazily on their first structured write.

## User impact

Agents now use `doc_write` with `status_line`, optional `teaser`/`digest`, and `full` across managed roots. Reads name the exact `write_tool`, while narrower owners such as `contact_dossier_write` and `publish_output_*` remain explicit thin adapters. Body-only documents remain supported through `doc_body_write`.

Equivalent logical rewrites are byte-stable, so reordered tags or frontmatter do not manufacture Git history. Existing noncanonical documents normalize once when next changed.

This is the foundational slice of #1492. Same-file owner-private working notes and logical projection of historical `doc_at`/`doc_diff` remain follow-up work; this PR intentionally does not close the roadmap issue.

## Test plan

- [x] `just ci`
- [x] generic faceted create/read/update and lazy adoption coverage
- [x] loop-output and contact-dossier shared-writer coverage
- [x] malformed/over-budget projection rejection with no mutation
- [x] hidden receipt/CAS and owning-tool commit attribution coverage
- [x] indexed-root filesystem bypass coverage
- [x] canonical frontmatter fixed-point and equivalent-write byte stability coverage

Refs #1492