### PR TITLE
fix: bound archivist turns and dossier placement

### DIFF
--- a/docs/model-facing-tools.md
+++ b/docs/model-facing-tools.md
@@ -229,6 +229,14 @@ interface. Loop-declared document outputs are the current example:
 `replace_output_<name>` replaces one maintained document, and
 `publish_output_<name>` writes every projection of a faceted one.
 
+Loop queue tools are another runtime-only interface. One successful
+`queue_pull` defines the iteration's bounded work batch; a second pull in the
+same model request returns recovery guidance instead of extending the turn.
+Subjects from that batch must be completed with `queue_ack` or retained with
+`queue_defer`, never refreshed through `queue_enqueue` by the consumer itself.
+This keeps a self-paced loop from turning one wake into an unbounded queue
+drain or manufacturing work that no new evidence requested.
+
 Do not register these tools globally or ask the model to discover the
 underlying file path. Generate them from the loop spec, advertise them
 only for that request, and make errors name the output and document

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -241,8 +241,8 @@ the operation.
 | `doc_create` | Create a normal faceted document safely: corpus collision check + normalized placement + logical write in one call. New `dossiers:` documents must be direct children. |
 | `doc_intake` | Analyze proposed knowledge against the existing corpus before writing it (the deliberate two-step form of `doc_create`); the `dossiers:` root rejects nested placement. |
 | `doc_commit` | Commit an approved `doc_intake`/declined `doc_create` result through the normal logical document mutation. |
-| `doc_write` | Create, self-migrate, or update a normal managed document from status-line, optional teaser/digest, and full projections; Go validates and renders its private storage codec atomically. |
-| `doc_body_write` | Write one undifferentiated Markdown body for the unusual document that intentionally has no projection ladder. |
+| `doc_write` | Create, self-migrate, or update a normal managed document from status-line, optional teaser/digest, and full projections; Go validates and renders its private storage codec atomically. New `dossiers:` targets must be direct children. |
+| `doc_body_write` | Write one undifferentiated Markdown body for the unusual document that intentionally has no projection ladder. It cannot create a nested `dossiers:` target. |
 | `doc_edit` | Targeted edit within an ordinary document, with automatic stale-write protection; faceted and contract-owned documents use their returned `write_tool`. |
 | `doc_copy` | Copy a document to another location. |
 | `doc_move` | Move or rename a document. |

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -238,8 +238,8 @@ the operation.
 | `doc_search` | Full-text and tagged search across roots; hits advertise facets and exact `write_tool`. |
 | `doc_links` | List inbound/outbound links for a document. |
 | `doc_values` | List frontmatter values (tags, statuses, etc.) across a root. |
-| `doc_create` | Create a normal faceted document safely: corpus collision check + normalized placement + logical write in one call. |
-| `doc_intake` | Analyze proposed knowledge against the existing corpus before writing it (the deliberate two-step form of `doc_create`). |
+| `doc_create` | Create a normal faceted document safely: corpus collision check + normalized placement + logical write in one call. New `dossiers:` documents must be direct children. |
+| `doc_intake` | Analyze proposed knowledge against the existing corpus before writing it (the deliberate two-step form of `doc_create`); the `dossiers:` root rejects nested placement. |
 | `doc_commit` | Commit an approved `doc_intake`/declined `doc_create` result through the normal logical document mutation. |
 | `doc_write` | Create, self-migrate, or update a normal managed document from status-line, optional teaser/digest, and full projections; Go validates and renders its private storage codec atomically. |
 | `doc_body_write` | Write one undifferentiated Markdown body for the unusual document that intentionally has no projection ladder. |

--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -561,10 +561,12 @@ external subjects. Confabulation patterns, prompting behavior, loop health,
 model routing and failures, queues, and spend belong to the metacognitive
 documents under `self:` instead of a generic dossier.
 
-The root is intentionally a flat subject catalog. New intake requires an
-explicit direct-child ref selected after inspecting related and sibling names;
-`path_prefix` and nested proposed refs are rejected. Kind-prefixed siblings
-therefore stay visibly related, such as `dossiers:entity-cat-yuki.md` and
+The root is intentionally a flat subject catalog. Every new document must be a
+direct child, including creation through the direct logical and body-only
+writers. Corpus-aware intake additionally requires an explicit ref selected
+after inspecting related and sibling names; `path_prefix` and nested proposed
+refs are rejected. Kind-prefixed siblings therefore stay visibly related, such
+as `dossiers:entity-cat-yuki.md` and
 `dossiers:entity-cat-goro-goro.md`. Existing nested legacy documents remain
 readable and writable at their current refs so the guardrail does not strand
 history; normal authoring does not fork one into a second flat document merely

--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -552,6 +552,24 @@ declares and establishes both as managed, signed roots. Existing instances can
 adopt either independently by adding its policy and restoring or initializing
 the repository at that derived path.
 
+### Subject dossiers
+
+`dossiers` holds longitudinal synthesis about durable subjects in the external
+world: animals, places, devices, projects, routines, events, and recurring
+themes in the operator's life. Thane's own cognition and operation are not
+external subjects. Confabulation patterns, prompting behavior, loop health,
+model routing and failures, queues, and spend belong to the metacognitive
+documents under `self:` instead of a generic dossier.
+
+The root is intentionally a flat subject catalog. New intake requires an
+explicit direct-child ref selected after inspecting related and sibling names;
+`path_prefix` and nested proposed refs are rejected. Kind-prefixed siblings
+therefore stay visibly related, such as `dossiers:entity-cat-yuki.md` and
+`dossiers:entity-cat-goro-goro.md`. Existing nested legacy documents remain
+readable and writable at their current refs so the guardrail does not strand
+history; normal authoring does not fork one into a second flat document merely
+to repair topology.
+
 ### Contact dossiers
 
 `contacts` is the optional longitudinal document side of the structured

--- a/internal/app/loop_queue_tools.go
+++ b/internal/app/loop_queue_tools.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/channels/messages"
 	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
 	"github.com/nugget/thane-ai-agent/internal/platform/logging"
+	"github.com/nugget/thane-ai-agent/internal/runtime/archivist"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/state/loopqueue"
 )
@@ -18,6 +19,7 @@ import (
 const (
 	queuePullDefaultLimit = 5
 	queuePullMaxLimit     = 25
+	archivistPullLimit    = 3
 )
 
 // buildLoopQueueTools returns the loop-private work-queue tools for one
@@ -35,6 +37,7 @@ const (
 // rate (this loop's sleep cadence).
 func buildLoopQueueTools(store *loopqueue.Store, loopName string) []looppkg.RuntimeTool {
 	receipts := newQueueReceipts()
+	defaultPullLimit, maxPullLimit := queuePullLimits(loopName)
 	return []looppkg.RuntimeTool{
 		{
 			Name: "queue_pull",
@@ -48,7 +51,7 @@ func buildLoopQueueTools(store *loopqueue.Store, loopName string) []looppkg.Runt
 				"properties": map[string]any{
 					"limit": map[string]any{
 						"type":        "integer",
-						"description": "Maximum items to pull this turn (default 5, capped at 25). Pull a batch you can actually process before sleeping.",
+						"description": fmt.Sprintf("Maximum items to pull this turn (default %d, capped at %d). Pull a batch you can actually process before sleeping.", defaultPullLimit, maxPullLimit),
 					},
 				},
 			},
@@ -63,10 +66,10 @@ func buildLoopQueueTools(store *loopqueue.Store, loopName string) []looppkg.Runt
 					return "", fmt.Errorf("limit: %w", err)
 				}
 				if limit <= 0 {
-					limit = queuePullDefaultLimit
+					limit = defaultPullLimit
 				}
-				if limit > queuePullMaxLimit {
-					limit = queuePullMaxLimit
+				if limit > maxPullLimit {
+					limit = maxPullLimit
 				}
 				items, err := store.Peek(ctx, loopName, limit)
 				if err != nil {
@@ -214,6 +217,13 @@ func buildLoopQueueTools(store *loopqueue.Store, loopName string) []looppkg.Runt
 			},
 		},
 	}
+}
+
+func queuePullLimits(loopName string) (defaultLimit, maxLimit int) {
+	if strings.TrimSpace(loopName) == archivist.DefinitionName {
+		return archivistPullLimit, archivistPullLimit
+	}
+	return queuePullDefaultLimit, queuePullMaxLimit
 }
 
 type queueReceipts struct {

--- a/internal/app/loop_queue_tools.go
+++ b/internal/app/loop_queue_tools.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/nugget/thane-ai-agent/internal/channels/messages"
 	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
+	"github.com/nugget/thane-ai-agent/internal/platform/logging"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/state/loopqueue"
 )
@@ -39,7 +40,8 @@ func buildLoopQueueTools(store *loopqueue.Store, loopName string) []looppkg.Runt
 			Name: "queue_pull",
 			Description: "Pull a batch of pending work items from your queue, highest priority first then oldest. " +
 				"Each item gives a subject (the key you pass to queue_ack), its source, a short summary, priority, and age — not the full payload. " +
-				"Items stay queued until you queue_ack them, so an interrupted iteration just re-serves them next time. This is your inbox: drain it; you are never paged.",
+				"Exactly one batch may be pulled per loop iteration. Items stay queued until you queue_ack them, so an interrupted iteration just re-serves them next time. " +
+				"Finish this batch, persist your state, and sleep; remaining work belongs to the next iteration.",
 			SkipContentResolve: true,
 			Parameters: map[string]any{
 				"type": "object",
@@ -51,8 +53,13 @@ func buildLoopQueueTools(store *loopqueue.Store, loopName string) []looppkg.Runt
 				},
 			},
 			Handler: func(ctx context.Context, args map[string]any) (string, error) {
+				requestID := logging.RequestIDFromContext(ctx)
+				if err := receipts.beginPull(requestID); err != nil {
+					return "", err
+				}
 				limit, err := intFromMap(args, "limit")
 				if err != nil {
+					receipts.releasePull(requestID)
 					return "", fmt.Errorf("limit: %w", err)
 				}
 				if limit <= 0 {
@@ -63,6 +70,7 @@ func buildLoopQueueTools(store *loopqueue.Store, loopName string) []looppkg.Runt
 				}
 				items, err := store.Peek(ctx, loopName, limit)
 				if err != nil {
+					receipts.releasePull(requestID)
 					return "", err
 				}
 				now := time.Now().UTC()
@@ -152,7 +160,8 @@ func buildLoopQueueTools(store *loopqueue.Store, loopName string) []looppkg.Runt
 		{
 			Name: "queue_enqueue",
 			Description: "Add a subject to your own queue for a future iteration — this is how you expand the frontier (a related entity, a sibling dossier worth refreshing) without spawning anything. " +
-				"Coalesces: enqueuing a subject already pending just refreshes it, so the same discovery from two angles can't pile up. You are a single self-paced consumer, so enqueue is the only way you make more work for yourself, and it can never run away.",
+				"Coalesces: enqueuing a subject already pending just refreshes it, so the same discovery from two angles can't pile up. " +
+				"A subject in the current pulled batch must be finished with queue_ack or queue_defer, not re-enqueued. You are a single self-paced consumer, so enqueue is the only way you make more work for yourself, and it can never run away.",
 			SkipContentResolve: true,
 			Parameters: map[string]any{
 				"type": "object",
@@ -176,6 +185,9 @@ func buildLoopQueueTools(store *loopqueue.Store, loopName string) []looppkg.Runt
 				subject := strings.TrimSpace(stringMapValue(args, "subject"))
 				if subject == "" {
 					return "", fmt.Errorf("subject is required")
+				}
+				if _, pulled := receipts.receipt(subject); pulled {
+					return "", fmt.Errorf("subject %q is already in this turn's pulled batch; finish it with queue_ack or queue_defer instead of re-enqueueing it", subject)
 				}
 				reason := strings.TrimSpace(stringMapValue(args, "reason"))
 				priority, err := intFromMap(args, "priority")
@@ -205,8 +217,37 @@ func buildLoopQueueTools(store *loopqueue.Store, loopName string) []looppkg.Runt
 }
 
 type queueReceipts struct {
-	mu        sync.Mutex
-	bySubject map[string]string
+	mu                sync.Mutex
+	bySubject         map[string]string
+	lastPullRequestID string
+}
+
+func (r *queueReceipts) beginPull(requestID string) error {
+	requestID = strings.TrimSpace(requestID)
+	if requestID == "" {
+		// Internal callers without a model request scope retain the historical
+		// behavior. Every model-driven loop iteration carries a request ID.
+		return nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.lastPullRequestID == requestID {
+		return fmt.Errorf("queue_pull already returned this turn's batch; finish those items, persist durable state, and call set_next_sleep — remaining work stays queued for the next iteration")
+	}
+	r.lastPullRequestID = requestID
+	return nil
+}
+
+func (r *queueReceipts) releasePull(requestID string) {
+	requestID = strings.TrimSpace(requestID)
+	if requestID == "" {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.lastPullRequestID == requestID {
+		r.lastPullRequestID = ""
+	}
 }
 
 func newQueueReceipts() *queueReceipts {

--- a/internal/app/loop_queue_tools_test.go
+++ b/internal/app/loop_queue_tools_test.go
@@ -7,8 +7,85 @@ import (
 	"testing"
 
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
+	"github.com/nugget/thane-ai-agent/internal/platform/logging"
 	"github.com/nugget/thane-ai-agent/internal/state/loopqueue"
 )
+
+func TestQueuePullAllowsOneBatchPerModelRequest(t *testing.T) {
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store, err := loopqueue.NewStore(db, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, subject := range []string{"session:one", "session:two"} {
+		if err := store.Enqueue(t.Context(), "archivist", subject, 0, []byte(`{}`)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tools := buildLoopQueueTools(store, "archivist")
+	var pull func(context.Context, map[string]any) (string, error)
+	for _, tool := range tools {
+		if tool.Name == "queue_pull" {
+			pull = tool.Handler
+		}
+	}
+	if pull == nil {
+		t.Fatal("queue_pull not generated")
+	}
+
+	firstCtx := logging.WithRequestID(t.Context(), "r_first")
+	if _, err := pull(firstCtx, map[string]any{"limit": 1}); err != nil {
+		t.Fatalf("first pull: %v", err)
+	}
+	if _, err := pull(firstCtx, map[string]any{"limit": 1}); err == nil || !strings.Contains(err.Error(), "next iteration") {
+		t.Fatalf("second same-request pull error = %v, want iteration boundary", err)
+	}
+	secondCtx := logging.WithRequestID(t.Context(), "r_second")
+	if _, err := pull(secondCtx, map[string]any{"limit": 1}); err != nil {
+		t.Fatalf("next-request pull: %v", err)
+	}
+}
+
+func TestQueueEnqueueRejectsPulledSubject(t *testing.T) {
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store, err := loopqueue.NewStore(db, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const subject = "theme:not-yet"
+	if err := store.Enqueue(t.Context(), "archivist", subject, 0, []byte(`{}`)); err != nil {
+		t.Fatal(err)
+	}
+
+	tools := buildLoopQueueTools(store, "archivist")
+	var pull, enqueue func(context.Context, map[string]any) (string, error)
+	for _, tool := range tools {
+		switch tool.Name {
+		case "queue_pull":
+			pull = tool.Handler
+		case "queue_enqueue":
+			enqueue = tool.Handler
+		}
+	}
+	if pull == nil || enqueue == nil {
+		t.Fatal("queue pull/enqueue tools not generated")
+	}
+	if _, err := pull(t.Context(), map[string]any{"limit": 1}); err != nil {
+		t.Fatalf("queue_pull: %v", err)
+	}
+	if _, err := enqueue(t.Context(), map[string]any{"subject": subject}); err == nil || !strings.Contains(err.Error(), "queue_ack or queue_defer") {
+		t.Fatalf("queue_enqueue pulled subject error = %v, want completion guidance", err)
+	}
+}
 
 func TestQueueDeferToolRetainsWorkAndMovesItBehindThePartition(t *testing.T) {
 	db, err := database.OpenMemory()

--- a/internal/app/loop_queue_tools_test.go
+++ b/internal/app/loop_queue_tools_test.go
@@ -51,6 +51,57 @@ func TestQueuePullAllowsOneBatchPerModelRequest(t *testing.T) {
 	}
 }
 
+func TestArchivistQueuePullEnforcesWakeBatchLimit(t *testing.T) {
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store, err := loopqueue.NewStore(db, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, subject := range []string{"session:one", "session:two", "session:three", "session:four", "session:five"} {
+		if err := store.Enqueue(t.Context(), "archivist", subject, 0, []byte(`{}`)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tools := buildLoopQueueTools(store, "archivist")
+	var pull func(context.Context, map[string]any) (string, error)
+	for _, tool := range tools {
+		if tool.Name == "queue_pull" {
+			pull = tool.Handler
+		}
+	}
+	if pull == nil {
+		t.Fatal("queue_pull not generated")
+	}
+
+	for _, tc := range []struct {
+		name      string
+		requestID string
+		args      map[string]any
+	}{
+		{name: "omitted limit", requestID: "r_default", args: map[string]any{}},
+		{name: "oversized limit", requestID: "r_oversized", args: map[string]any{"limit": 25}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := pull(logging.WithRequestID(t.Context(), tc.requestID), tc.args)
+			if err != nil {
+				t.Fatalf("queue_pull: %v", err)
+			}
+			var result queuePullResult
+			if err := json.Unmarshal([]byte(out), &result); err != nil {
+				t.Fatalf("decode queue_pull: %v", err)
+			}
+			if result.Count != archivistPullLimit || len(result.Items) != archivistPullLimit {
+				t.Fatalf("queue_pull result = %#v, want %d items", result, archivistPullLimit)
+			}
+		})
+	}
+}
+
 func TestQueueEnqueueRejectsPulledSubject(t *testing.T) {
 	db, err := database.OpenMemory()
 	if err != nil {

--- a/internal/model/fleet/providers/openaicompat_test.go
+++ b/internal/model/fleet/providers/openaicompat_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -446,6 +447,9 @@ func TestOpenAICompatStreamIdleTimeout(t *testing.T) {
 	case err := <-done:
 		if err == nil {
 			t.Fatal("a stalled stream returned success")
+		}
+		if !errors.Is(err, ErrStreamIdleTimeout) || !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("stalled stream error = %v, want typed deadline-exceeded idle timeout", err)
 		}
 	case <-time.After(10 * time.Second):
 		t.Fatal("stalled stream was never abandoned — the idle guard did not fire")

--- a/internal/model/fleet/providers/streamidle.go
+++ b/internal/model/fleet/providers/streamidle.go
@@ -2,11 +2,34 @@ package providers
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"sync"
 	"sync/atomic"
 	"time"
 )
+
+// ErrStreamIdleTimeout marks a model response that stopped delivering bytes
+// long enough for the endpoint's stream-idle guard to abandon it.
+var ErrStreamIdleTimeout = errors.New("model stream idle timeout")
+
+// StreamIdleTimeoutError reports the silence window that expired. It also
+// classifies as [context.DeadlineExceeded], so the agent's ordinary timeout
+// retry and recovery path handles a stalled provider response.
+type StreamIdleTimeoutError struct {
+	Idle time.Duration
+}
+
+// Error implements error.
+func (e *StreamIdleTimeoutError) Error() string {
+	return fmt.Sprintf("model stream idle timeout after %s with no bytes", e.Idle)
+}
+
+// Is supports both provider-specific and generic timeout classification.
+func (e *StreamIdleTimeoutError) Is(target error) bool {
+	return target == ErrStreamIdleTimeout || target == context.DeadlineExceeded
+}
 
 // DefaultStreamIdleTimeout bounds how long a model server may deliver
 // nothing at all before the request is abandoned.
@@ -57,9 +80,10 @@ func newStreamIdleGuard(body io.ReadCloser, cancel context.CancelFunc, idle time
 // contend over the same timer state.
 type streamIdleGuard struct {
 	io.ReadCloser
-	cancel context.CancelFunc
-	idle   time.Duration
-	last   atomic.Int64
+	cancel   context.CancelFunc
+	idle     time.Duration
+	last     atomic.Int64
+	timedOut atomic.Bool
 
 	once sync.Once
 	done chan struct{}
@@ -84,6 +108,7 @@ func (g *streamIdleGuard) watch() {
 			return
 		case now := <-tick.C:
 			if now.UnixNano()-g.last.Load() >= int64(g.idle) {
+				g.timedOut.Store(true)
 				g.cancel()
 				return
 			}
@@ -95,6 +120,9 @@ func (g *streamIdleGuard) Read(p []byte) (int, error) {
 	n, err := g.ReadCloser.Read(p)
 	if n > 0 {
 		g.touch()
+	}
+	if err != nil && g.timedOut.Load() {
+		return n, &StreamIdleTimeoutError{Idle: g.idle}
 	}
 	return n, err
 }

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -2689,7 +2689,7 @@ func (l *Loop) buildLLMErrorHandler(ctx context.Context, stream llm.StreamCallba
 		_ llm.StreamCallback) (*llm.ChatResponse, string, error) {
 
 		iterLog := logging.Logger(iterCtx)
-		if cancelErr := canceledContextError(err, ctx, iterCtx); cancelErr != nil {
+		if cancelErr := canceledContextError(ctx, iterCtx); cancelErr != nil {
 			iterLog.Debug("LLM call canceled", "error", cancelErr, "model", model)
 			return nil, "", cancelErr
 		}
@@ -2988,7 +2988,7 @@ func isTimeout(err error) bool {
 		strings.Contains(msg, "529")
 }
 
-func canceledContextError(err error, contexts ...context.Context) error {
+func canceledContextError(contexts ...context.Context) error {
 	for _, ctx := range contexts {
 		if ctx == nil {
 			continue
@@ -2997,9 +2997,11 @@ func canceledContextError(err error, contexts ...context.Context) error {
 			return context.Canceled
 		}
 	}
-	if errors.Is(err, context.Canceled) {
-		return context.Canceled
-	}
+	// A provider may cancel a private child context to unblock its own
+	// transport guard. That is a provider failure, not evidence that the
+	// caller abandoned the turn. Only the caller contexts above are
+	// authoritative for cancellation; the underlying error is classified by
+	// timeout/failover handling when those contexts remain live.
 	return nil
 }
 

--- a/internal/runtime/agent/timeout_recovery_test.go
+++ b/internal/runtime/agent/timeout_recovery_test.go
@@ -466,6 +466,44 @@ func TestCanceledContext_DoesNotFailOver(t *testing.T) {
 	}
 }
 
+func TestProviderPrivateCancellationCanFailOver(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockTimeoutLLM{
+		responses: []*llm.ChatResponse{{
+			Model:   "fallback-model",
+			Message: llm.Message{Role: "assistant", Content: "Recovered through provider failover."},
+		}},
+	}
+	loop := buildTestLoopWithLLM(mock, nil)
+	loop.model = "fallback-model"
+
+	timeoutRecovered := false
+	handler := loop.buildLLMErrorHandler(context.Background(), nil, loop.model, &Request{}, &timeoutRecovered)
+
+	resp, model, err := handler(
+		context.Background(),
+		fmt.Errorf("provider stream guard: %w", context.Canceled),
+		"stalled-model",
+		nil,
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("handler error = %v, want provider failover", err)
+	}
+	if resp == nil || model != "fallback-model" {
+		t.Fatalf("handler result = resp %#v model %q, want fallback-model response", resp, model)
+	}
+
+	mock.mu.Lock()
+	callCount := len(mock.calls)
+	mock.mu.Unlock()
+	if callCount != 1 {
+		t.Fatalf("LLM call count = %d, want 1 failover", callCount)
+	}
+}
+
 func TestRoutedUserFixableAPIError_DoesNotFailOver(t *testing.T) {
 	t.Parallel()
 

--- a/internal/state/documents/facets_test.go
+++ b/internal/state/documents/facets_test.go
@@ -82,6 +82,62 @@ func TestToolsPublishCreatesCanonicalFacetedDocument(t *testing.T) {
 	}
 }
 
+func TestDirectWritersRequireFlatNewDossierRefs(t *testing.T) {
+	t.Parallel()
+
+	store, dossiersDir := newMutationStoreForRoot(t, "dossiers")
+	tools := NewTools(store)
+	ctx := context.Background()
+	const nestedRef = "dossiers:entity/new-cat.md"
+
+	for _, tc := range []struct {
+		name string
+		run  func() error
+	}{
+		{
+			name: "doc_body_write",
+			run: func() error {
+				_, err := tools.Write(ctx, WriteArgs{Ref: nestedRef, Body: stringPtr("New cat dossier.")})
+				return err
+			},
+		},
+		{
+			name: "doc_write",
+			run: func() error {
+				_, err := tools.Publish(ctx, PublishArgs{Ref: nestedRef, StatusLine: "Resident cat.", Full: "### Claims\n\n- Resident cat."})
+				return err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.run(); err == nil || !strings.Contains(err.Error(), "direct-child refs only") {
+				t.Fatalf("nested dossier creation error = %v, want direct-child guidance", err)
+			}
+		})
+	}
+	if _, err := os.Stat(filepath.Join(dossiersDir, "entity", "new-cat.md")); !os.IsNotExist(err) {
+		t.Fatalf("rejected nested creation changed filesystem: %v", err)
+	}
+
+	legacyPath := filepath.Join(dossiersDir, "entity", "legacy-cat.md")
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacyPath, []byte("Legacy cat dossier.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Refresh(ctx); err != nil {
+		t.Fatalf("refresh legacy dossier: %v", err)
+	}
+	const legacyRef = "dossiers:entity/legacy-cat.md"
+	if _, err := tools.Write(ctx, WriteArgs{Ref: legacyRef, Body: stringPtr("Updated legacy cat dossier.")}); err != nil {
+		t.Fatalf("doc_body_write existing nested dossier: %v", err)
+	}
+	if _, err := tools.Publish(ctx, PublishArgs{Ref: legacyRef, StatusLine: "Legacy resident cat.", Full: "### Claims\n\n- Existing nested dossier remains writable."}); err != nil {
+		t.Fatalf("doc_write existing nested dossier: %v", err)
+	}
+}
+
 func TestToolsPublishEquivalentLogicalStateIsByteStable(t *testing.T) {
 	t.Parallel()
 

--- a/internal/state/documents/intake_paths.go
+++ b/internal/state/documents/intake_paths.go
@@ -77,10 +77,10 @@ func (s *Store) proposeIntakeRef(ctx context.Context, root string, args IntakeAr
 	if strings.TrimSpace(args.DesiredRef) != "" {
 		desiredRoot, relPath, err := parseRef(args.DesiredRef)
 		if err != nil {
-			return "", "", fmt.Errorf("desired_ref: %w", err)
+			return "", "", fmt.Errorf("invalid document ref: %w", err)
 		}
 		if normalizeRootName(desiredRoot) != root {
-			return "", "", fmt.Errorf("desired_ref root %q does not match intake root %q", desiredRoot, root)
+			return "", "", fmt.Errorf("document ref root %q does not match requested root %q", desiredRoot, root)
 		}
 		return makeRef(root, relPath), relPath, nil
 	}
@@ -133,17 +133,17 @@ func ValidateIntakePlacement(root, desiredRef, pathPrefix string) error {
 		return fmt.Errorf("dossiers is a flat subject catalog; omit path_prefix, inspect sibling refs, and use an explicit direct-child ref such as dossiers:entity-cat-goro-goro.md")
 	}
 	if desiredRef == "" {
-		return fmt.Errorf("dossiers requires an explicit direct-child desired_ref chosen after inspecting sibling refs, such as dossiers:entity-cat-goro-goro.md")
+		return fmt.Errorf("dossiers requires an explicit direct-child document ref chosen after inspecting sibling refs, such as dossiers:entity-cat-goro-goro.md")
 	}
 	if refErr != nil {
-		return fmt.Errorf("dossiers desired_ref: %w", refErr)
+		return fmt.Errorf("invalid dossiers document ref: %w", refErr)
 	}
 	refRoot = normalizeRootName(refRoot)
 	if root == "" {
 		root = refRoot
 	}
 	if refRoot != root {
-		return fmt.Errorf("desired_ref root %q does not match intake root %q", refRoot, root)
+		return fmt.Errorf("document ref root %q does not match requested root %q", refRoot, root)
 	}
 	return validateNewDocumentPlacement(root, relPath)
 }

--- a/internal/state/documents/intake_paths.go
+++ b/internal/state/documents/intake_paths.go
@@ -70,6 +70,9 @@ func slugifyIntakeValue(raw string) string {
 }
 
 func (s *Store) proposeIntakeRef(ctx context.Context, root string, args IntakeArgs, title string, tags []string, related []IntakeRelatedDocument) (string, string, error) {
+	if err := ValidateIntakePlacement(root, args.DesiredRef, args.PathPrefix); err != nil {
+		return "", "", err
+	}
 	if strings.TrimSpace(args.DesiredRef) != "" {
 		desiredRoot, relPath, err := parseRef(args.DesiredRef)
 		if err != nil {
@@ -102,6 +105,45 @@ func (s *Store) proposeIntakeRef(ctx context.Context, root string, args IntakeAr
 		return "", "", err
 	}
 	return makeRef(root, relPath), relPath, nil
+}
+
+// ValidateIntakePlacement enforces root-owned placement invariants before
+// corpus-aware intake proposes or commits a destination. The dossiers root is
+// a flat subject catalog whose names must be chosen deliberately after sibling
+// inspection, so it requires an explicit direct-child ref and never accepts a
+// path prefix.
+func ValidateIntakePlacement(root, desiredRef, pathPrefix string) error {
+	root = normalizeRootName(root)
+	desiredRef = strings.TrimSpace(desiredRef)
+
+	var (
+		refRoot string
+		relPath string
+		refErr  error
+	)
+	if desiredRef != "" {
+		refRoot, relPath, refErr = parseRef(desiredRef)
+	}
+	isDossiers := root == "dossiers" || (refErr == nil && normalizeRootName(refRoot) == "dossiers")
+	if !isDossiers {
+		return nil
+	}
+	if trimPathPrefix(pathPrefix) != "" {
+		return fmt.Errorf("dossiers is a flat subject catalog; omit path_prefix, inspect sibling refs, and use an explicit direct-child ref such as dossiers:entity-cat-goro-goro.md")
+	}
+	if desiredRef == "" {
+		return fmt.Errorf("dossiers requires an explicit direct-child desired_ref chosen after inspecting sibling refs, such as dossiers:entity-cat-goro-goro.md")
+	}
+	if refErr != nil {
+		return fmt.Errorf("dossiers desired_ref: %w", refErr)
+	}
+	if normalizeRootName(refRoot) != "dossiers" {
+		return fmt.Errorf("desired_ref root %q does not match intake root %q", refRoot, root)
+	}
+	if strings.Contains(relPath, "/") {
+		return fmt.Errorf("dossiers accepts direct-child refs only; inspect sibling naming and retry with a flat ref such as dossiers:entity-cat-goro-goro.md")
+	}
+	return nil
 }
 
 func (s *Store) uniqueIntakePath(ctx context.Context, root, dir, slug string) (string, error) {

--- a/internal/state/documents/intake_paths.go
+++ b/internal/state/documents/intake_paths.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"unicode"
 )
@@ -137,10 +138,18 @@ func ValidateIntakePlacement(root, desiredRef, pathPrefix string) error {
 	if refErr != nil {
 		return fmt.Errorf("dossiers desired_ref: %w", refErr)
 	}
-	if normalizeRootName(refRoot) != "dossiers" {
+	refRoot = normalizeRootName(refRoot)
+	if root == "" {
+		root = refRoot
+	}
+	if refRoot != root {
 		return fmt.Errorf("desired_ref root %q does not match intake root %q", refRoot, root)
 	}
-	if strings.Contains(relPath, "/") {
+	return validateNewDocumentPlacement(root, relPath)
+}
+
+func validateNewDocumentPlacement(root, relPath string) error {
+	if normalizeRootName(root) == "dossiers" && strings.Contains(filepath.ToSlash(relPath), "/") {
 		return fmt.Errorf("dossiers accepts direct-child refs only; inspect sibling naming and retry with a flat ref such as dossiers:entity-cat-goro-goro.md")
 	}
 	return nil

--- a/internal/state/documents/intake_test.go
+++ b/internal/state/documents/intake_test.go
@@ -65,6 +65,39 @@ func TestDocumentIntakeProposesCreateAndCommit(t *testing.T) {
 	}
 }
 
+func TestValidateIntakePlacementRequiresDeliberateFlatDossierRef(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		root       string
+		ref        string
+		pathPrefix string
+		wantError  string
+	}{
+		{name: "ordinary root remains hierarchical", root: "kb", pathPrefix: "network/unifi"},
+		{name: "flat dossier ref", root: "dossiers", ref: "dossiers:entity-cat-goro-goro.md"},
+		{name: "missing deliberate ref", root: "dossiers", wantError: "explicit direct-child"},
+		{name: "path prefix", root: "dossiers", ref: "dossiers:entity-cat-goro-goro.md", pathPrefix: "entity", wantError: "flat subject catalog"},
+		{name: "nested ref", ref: "dossiers:entity/goro-goro-the-cat.md", wantError: "direct-child refs only"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateIntakePlacement(tc.root, tc.ref, tc.pathPrefix)
+			if tc.wantError == "" {
+				if err != nil {
+					t.Fatalf("ValidateIntakePlacement: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantError) {
+				t.Fatalf("ValidateIntakePlacement error = %v, want %q", err, tc.wantError)
+			}
+		})
+	}
+}
+
 func TestDocumentIntakeRequiresConfirmationForSimilarCorpus(t *testing.T) {
 	t.Parallel()
 

--- a/internal/state/documents/mutate_policy.go
+++ b/internal/state/documents/mutate_policy.go
@@ -25,6 +25,13 @@ func (s *Store) writeDocumentFileAtRevision(ctx context.Context, root, relPath, 
 	if err != nil {
 		return "", err
 	}
+	if _, statErr := os.Stat(absPath); os.IsNotExist(statErr) {
+		if err := validateNewDocumentPlacement(root, relPath); err != nil {
+			return "", fmt.Errorf("validate %s creation: %w", makeRef(root, relPath), err)
+		}
+	} else if statErr != nil {
+		return "", fmt.Errorf("inspect %s before write: %w", makeRef(root, relPath), statErr)
+	}
 	if err := s.ensureRootAuthoringAllowed(root); err != nil {
 		return "", err
 	}

--- a/internal/state/documents/mutate_test.go
+++ b/internal/state/documents/mutate_test.go
@@ -687,11 +687,15 @@ func TestStoreMoveSectionRemovesSourceSection(t *testing.T) {
 }
 
 func newMutationStore(t *testing.T) (*Store, string) {
+	return newMutationStoreForRoot(t, "kb")
+}
+
+func newMutationStoreForRoot(t *testing.T, root string) (*Store, string) {
 	t.Helper()
 
 	rootDir := t.TempDir()
-	kbDir := filepath.Join(rootDir, "kb")
-	if err := os.MkdirAll(kbDir, 0o755); err != nil {
+	docDir := filepath.Join(rootDir, root)
+	if err := os.MkdirAll(docDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
 
@@ -701,11 +705,11 @@ func newMutationStore(t *testing.T) (*Store, string) {
 	}
 	t.Cleanup(func() { db.Close() })
 
-	store, err := NewStore(db, map[string]string{"kb": kbDir}, nil)
+	store, err := NewStore(db, map[string]string{root: docDir}, nil)
 	if err != nil {
 		t.Fatalf("NewStore: %v", err)
 	}
-	return store, kbDir
+	return store, docDir
 }
 
 func TestStoreWritePreservesOrClearsBodyByIntent(t *testing.T) {

--- a/internal/tools/document_intake_tools.go
+++ b/internal/tools/document_intake_tools.go
@@ -13,7 +13,7 @@ func registerDocumentIntakeTools(r *Registry, dt *documents.Tools) {
 		Name: "doc_create",
 		Description: "Create a normal faceted managed document safely. It runs corpus-aware placement analysis (related-document search, title/tags/path normalization, and root policy) and, when placement is clean, writes status_line, optional teaser/digest, and full through the same logical document contract as doc_write. " +
 			"When a similar document already exists or policy wants review, nothing is written: the result comes back created=false with the analysis and an intake_id for doc_commit. " +
-			"Prefer this when placement is not settled; doc_write creates directly when the ref is already deliberate.",
+			"Prefer this when placement is not settled; doc_write creates directly when the ref is already deliberate. The reserved dossiers root is a flat subject catalog: inspect sibling refs and use a direct-child ref, never path_prefix.",
 		ContentResolveExempt: []string{"root", "title", "ref", "tags", "path_prefix"},
 		Parameters: map[string]any{
 			"type": "object",
@@ -32,7 +32,7 @@ func registerDocumentIntakeTools(r *Registry, dt *documents.Tools) {
 				},
 				"ref": map[string]any{
 					"type":        "string",
-					"description": "Optional explicit document ref such as `kb:network/unifi/vlans.md`. Use only when the destination is already intentional.",
+					"description": "Optional explicit document ref such as `kb:network/unifi/vlans.md`. Use only when the destination is already intentional; required as a direct-child ref for the `dossiers` root.",
 				},
 				"tags": map[string]any{
 					"type":        "array",
@@ -41,7 +41,7 @@ func registerDocumentIntakeTools(r *Registry, dt *documents.Tools) {
 				},
 				"path_prefix": map[string]any{
 					"type":        "string",
-					"description": "Optional directory hint inside the root, such as `network/unifi`.",
+					"description": "Optional directory hint inside the root, such as `network/unifi`. Never use for the flat `dossiers` root.",
 				},
 				"intent": map[string]any{
 					"type":        "string",
@@ -63,6 +63,9 @@ func registerDocumentIntakeTools(r *Registry, dt *documents.Tools) {
 			title, _ := args["title"].(string)
 			ref, _ := args["ref"].(string)
 			pathPrefix, _ := args["path_prefix"].(string)
+			if err := documents.ValidateIntakePlacement(root, ref, pathPrefix); err != nil {
+				return "", err
+			}
 			intent, _ := args["intent"].(string)
 			return dt.Create(ctx, documents.CreateArgs{
 				Root:         root,
@@ -82,7 +85,7 @@ func registerDocumentIntakeTools(r *Registry, dt *documents.Tools) {
 
 	r.Register(&Tool{
 		Name:                 "doc_intake",
-		Description:          "Analyze where proposed new knowledge belongs in a managed markdown corpus before writing it — the deliberate two-step flow. It searches related documents, normalizes title/tags/path, checks root policy, and returns an intake_id plus a commit_plan for doc_commit. For the common create case, doc_create runs this analysis and commits in one call; reach for doc_intake when you want to inspect the plan first or when the knowledge may belong in an existing document (update/append).",
+		Description:          "Analyze where proposed new knowledge belongs in a managed markdown corpus before writing it — the deliberate two-step flow. It searches related documents, normalizes title/tags/path, checks root policy, and returns an intake_id plus a commit_plan for doc_commit. For the common create case, doc_create runs this analysis and commits in one call; reach for doc_intake when you want to inspect the plan first or when the knowledge may belong in an existing document (update/append). The reserved dossiers root accepts only direct-child refs and no path_prefix.",
 		ContentResolveExempt: []string{"root", "desired_title", "desired_ref", "tags", "path_prefix"},
 		Parameters: map[string]any{
 			"type": "object",
@@ -113,7 +116,7 @@ func registerDocumentIntakeTools(r *Registry, dt *documents.Tools) {
 				},
 				"desired_ref": map[string]any{
 					"type":        "string",
-					"description": "Optional explicit document ref such as `kb:network/unifi/vlans.md`. Use only when the destination is already intentional.",
+					"description": "Optional explicit document ref such as `kb:network/unifi/vlans.md`. Use only when the destination is already intentional; required as a direct-child ref for the `dossiers` root.",
 				},
 				"tags": map[string]any{
 					"type":        "array",
@@ -122,7 +125,7 @@ func registerDocumentIntakeTools(r *Registry, dt *documents.Tools) {
 				},
 				"path_prefix": map[string]any{
 					"type":        "string",
-					"description": "Optional directory hint inside the root, such as `network/unifi`.",
+					"description": "Optional directory hint inside the root, such as `network/unifi`. Never use for the flat `dossiers` root.",
 				},
 			},
 		},
@@ -135,6 +138,9 @@ func registerDocumentIntakeTools(r *Registry, dt *documents.Tools) {
 			desiredTitle, _ := args["desired_title"].(string)
 			desiredRef, _ := args["desired_ref"].(string)
 			pathPrefix, _ := args["path_prefix"].(string)
+			if err := documents.ValidateIntakePlacement(root, desiredRef, pathPrefix); err != nil {
+				return "", err
+			}
 			return dt.Intake(ctx, documents.IntakeArgs{
 				Root:          root,
 				Intent:        intent,

--- a/internal/tools/document_mutation_tools.go
+++ b/internal/tools/document_mutation_tools.go
@@ -17,14 +17,14 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 
 	r.Register(&Tool{
 		Name:                 documents.DocumentBodyWriteToolName,
-		Description:          "Write one undifferentiated Markdown body for the unusual managed document that intentionally has no projection ladder. This is not a filesystem bypass: Thane still owns metadata, root policy, revision protection, and Git. Most documents belong on doc_write instead. This tool cannot write or mutate a faceted document; doc_read and doc_search return the exact write_tool for an existing target.",
+		Description:          "Write one undifferentiated Markdown body for the unusual managed document that intentionally has no projection ladder. This is not a filesystem bypass: Thane still owns metadata, root policy, revision protection, and Git. Most documents belong on doc_write instead. This tool cannot write or mutate a faceted document; doc_read and doc_search return the exact write_tool for an existing target. New documents in the reserved dossiers root must be direct children; existing nested legacy refs remain writable.",
 		ContentResolveExempt: []string{"ref", "title", "description", "tags", "frontmatter"},
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
 				"ref": map[string]any{
 					"type":        "string",
-					"description": "Canonical document ref like `kb:network/vlans.md`.",
+					"description": "Canonical document ref like `kb:network/vlans.md`. A new `dossiers:` document must be a direct child; an existing nested legacy ref remains writable.",
 				},
 				"title": map[string]any{
 					"type":        "string",
@@ -267,7 +267,7 @@ func registerDocumentWriteTool(r *Registry, dt *documents.Tools) {
 	properties := map[string]any{
 		"ref": map[string]any{
 			"type":        "string",
-			"description": "Canonical document ref like `kb:network/vlans.md`. The same tool works across every managed root.",
+			"description": "Canonical document ref like `kb:network/vlans.md`. The same tool works across every managed root; a new `dossiers:` document must be a direct child, while an existing nested legacy ref remains writable.",
 		},
 		"title": map[string]any{
 			"type":        "string",
@@ -307,7 +307,7 @@ func registerDocumentWriteTool(r *Registry, dt *documents.Tools) {
 
 	r.Register(&Tool{
 		Name:               documents.DocumentWriteToolName,
-		Description:        "Create, adopt, or update the normal managed document as logical projections in any document root. Pass status_line, optional teaser/digest, and full as separate fields; Thane validates them together, stores its own durable manifest and Markdown codec, and protects revision-backed writes automatically. A legacy or body-only document self-migrates on this first structured write. Read an existing document first and preserve every projection it already publishes. If doc_read names a narrower owner such as contact_dossier_write or publish_output_*, use that tool instead.",
+		Description:        "Create, adopt, or update the normal managed document as logical projections in any document root. Pass status_line, optional teaser/digest, and full as separate fields; Thane validates them together, stores its own durable manifest and Markdown codec, and protects revision-backed writes automatically. A legacy or body-only document self-migrates on this first structured write. New documents in the reserved dossiers root must be direct children; existing nested legacy refs remain writable. Read an existing document first and preserve every projection it already publishes. If doc_read names a narrower owner such as contact_dossier_write or publish_output_*, use that tool instead.",
 		SkipContentResolve: true,
 		Parameters: map[string]any{
 			"type":       "object",

--- a/internal/tools/document_tools_test.go
+++ b/internal/tools/document_tools_test.go
@@ -677,4 +677,27 @@ func TestDocCreateHandlerWritesAndGuardsVocabulary(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "full") {
 		t.Errorf("doc_create with content should teach full, got: %v", err)
 	}
+
+	for _, args := range []map[string]any{
+		{
+			"root":        "dossiers",
+			"path_prefix": "entity",
+			"status_line": "Goro-goro is a resident cat.",
+			"full":        "### Claims\n\n- Resident cat.",
+		},
+		{
+			"ref":         "dossiers:entity/goro-goro-the-cat.md",
+			"status_line": "Goro-goro is a resident cat.",
+			"full":        "### Claims\n\n- Resident cat.",
+		},
+		{
+			"root":        "dossiers",
+			"status_line": "Goro-goro is a resident cat.",
+			"full":        "### Claims\n\n- Resident cat.",
+		},
+	} {
+		if _, err := createTool.Handler(context.Background(), args); err == nil || (!strings.Contains(err.Error(), "flat") && !strings.Contains(err.Error(), "direct-child")) {
+			t.Errorf("unsafe dossiers placement error = %v, want direct-child guidance", err)
+		}
+	}
 }

--- a/internal/tools/document_tools_test.go
+++ b/internal/tools/document_tools_test.go
@@ -700,4 +700,18 @@ func TestDocCreateHandlerWritesAndGuardsVocabulary(t *testing.T) {
 			t.Errorf("unsafe dossiers placement error = %v, want direct-child guidance", err)
 		}
 	}
+
+	for _, name := range []string{"doc_create", "doc_intake"} {
+		tool := reg.Get(name)
+		if tool == nil {
+			t.Fatalf("%s not registered", name)
+		}
+		_, err := tool.Handler(context.Background(), map[string]any{"root": "dossiers"})
+		if err == nil || !strings.Contains(err.Error(), "document ref") {
+			t.Errorf("%s missing-ref error = %v, want parameter-neutral document ref guidance", name, err)
+		}
+		if err != nil && strings.Contains(err.Error(), "desired_ref") {
+			t.Errorf("%s missing-ref error names another tool's parameter: %v", name, err)
+		}
+	}
 }

--- a/loops/archivist.md
+++ b/loops/archivist.md
@@ -88,7 +88,7 @@ dossiers keyed by subject.
 
 You are self-paced and pull-based. You are NEVER paged. Producers drop
 work into your queue — a closed session, a subject worth (re)visiting —
-and each time you wake you drain that queue at your own pace. A burst of
+and each time you wake you take one bounded batch at your own pace. A burst of
 activity cannot turn into a burst of work for you: the queue absorbs it
 and you work through it steadily.
 
@@ -108,13 +108,25 @@ durable queue holds that).
 
 ## What To Do This Iteration
 
-1. **Pull your queue** — Call `queue_pull` for a small batch of pending
-   work items. Each item is a subject: a `session:<id>` (a conversation
+1. **Pull your queue once** — Call `queue_pull` exactly once with `limit: 3`.
+   That one batch is the complete work budget for this iteration: never pull
+   again after it succeeds, even if you finish early. Each item is a subject:
+   a `session:<id>` (a conversation
    that just closed), an `entity:<...>`, an `area:<...>`, a
    `contact:<...>`, a theme. If the queue is empty, optionally pick one
    stale-but-fertile subject from your archivist.md directory; otherwise
    note the quiet and sleep long.
 2. **Process each item.**
+   First apply the dossier admission boundary. A dossier describes a durable
+   subject in the external world or in the operator's relationships: a person,
+   animal, place, device, project, routine, event, or recurring outside-world
+   theme. Thane's own cognition and operation — confabulation patterns,
+   prompting behavior, loop health, routing, provider failures, queue mechanics,
+   spend, and similar self-observation — belong to `self:` and the metacognitive
+   loop, not `dossiers:`. Do not create or refresh a dossier for that material.
+   Ack a session whose only durable evidence is out of scope; if an existing
+   dossier is mis-owned this way, leave it unchanged and note the ownership
+   problem in archivist.md rather than deepening or duplicating it.
    - For a `session:<id>` item: read it with `archive_session_transcript`
      and fold any new evidence into the dossiers it touches. When the
      evidence is about a person, resolve the human name or alias with
@@ -175,10 +187,22 @@ durable queue holds that).
      and call `queue_defer`; do not acknowledge unpublished evidence or create a
      fallback document.
    - Every non-contact subject is a faceted managed document under the
-     `dossiers:` root. Use canonical `root:path` refs — for the game room door,
+     `dossiers:` root. This root is a flat subject catalog: every new dossier is
+     a direct child, and `path_prefix` is forbidden. Before choosing a new ref,
+     use `doc_search` and `doc_browse` to inspect related documents and sibling
+     filename conventions. Related subjects use the same stable kind prefix —
+     for example, `dossiers:entity-cat-yuki.md` and
+     `dossiers:entity-cat-goro-goro.md` — rather than one flat file and one
+     improvised directory. Use canonical `root:path` refs — for the game room door,
      `dossiers:entity-binary_sensor-game_room_door.md`, never a bare
      `dossiers/...` path or the retired `kb:dossiers/` namespace. Read the
      existing document before replacing it and trust its returned `write_tool`.
+     Use `doc_create` with `root: dossiers` and an explicit direct-child `ref`
+     for a genuinely new dossier; use `doc_write` only after locating and
+     reading an existing one.
+     Do not create a duplicate merely to normalize a legacy nested or oddly
+     named ref: keep updating the existing canonical ref and record the topology
+     problem in archivist.md for deliberate migration.
      A legacy body-only dossier reports `doc_body_write`; adopt it once by
      calling `doc_write`, not by manually authoring facet headings. An already
      adopted dossier reports `doc_write`. Reconcile the complete existing
@@ -210,7 +234,9 @@ durable queue holds that).
    area), call `queue_enqueue` to add it to your queue for a future
    iteration. This is how the frontier expands. You do NOT spawn loops —
    you have no such tools; `queue_enqueue` is the only way you create
-   more work, and it can never run away.
+   more work, and it can never run away. Never enqueue a subject from the batch
+   you just pulled; finish it with `queue_ack` or `queue_defer`. A future
+   evidence producer will naturally enqueue that subject again when it changes.
 6. **Update archivist.md** — Call the declared replacement tool
    (replace_output_archivist_state) with the complete updated body:
    dossier pointers and notes for your next-iteration self.
@@ -259,6 +285,9 @@ projection the dossier already carries is required on later publishes.
   `remember_fact` instinct. Your job is synthesis above that layer.
 - Creating a second contact dossier in a generic document root. The structured
   contact UUID and `contact_dossier_write` select the only canonical history.
+- Curating Thane's own cognition or operation as an external subject dossier.
+  Confabulation, model behavior, loop health, routing, queues, and provider
+  failures belong to the metacognitive `self:` surface.
 - Spawning loops or delegating. You are a single self-paced consumer; the
   only work you create is via `queue_enqueue` into your own queue.
 - Sending messages to the user or any channel. The archivist is silent;
@@ -274,10 +303,10 @@ projection the dossier already carries is required on later publishes.
   the interactive model during retrieval.
 - Quality over coverage. A small set of evidence-grounded dossiers beats
   a sprawling collection of plausibly-worded ones.
-- If you cannot find enough cross-silo evidence to write a meaningful
-  dossier on a subject, ack the item and enqueue it again with a note
-  about what evidence would have to accumulate first. Honest "not yet"
-  beats premature synthesis.
+- If you cannot find enough cross-silo evidence to write a meaningful dossier
+  on a subject, ack the item without immediately re-enqueueing it. A later
+  producer will refresh the subject when new evidence actually exists. Honest
+  "not yet" beats premature synthesis and a self-sustaining queue.
 - Quiet is a valid outcome. If the queue is empty and nothing feels worth
   a fresh pass, note that in your state file and sleep long.
 

--- a/talents/documents.md
+++ b/talents/documents.md
@@ -60,7 +60,7 @@ teaser: "Extract content, structure, links, or vocabulary from a document whose 
 
 # Read a known document
 
-You have a canonical ref (`kb:network/vlans.md`, `dossiers:people/alice.md`,
+You have a canonical ref (`kb:network/vlans.md`, `dossiers:entity-cat-yuki.md`,
 etc.) and need something out of it. Pick the most specific extractor.
 
 ## The whole document
@@ -353,6 +353,12 @@ review `related_documents`, then `doc_commit` with the intake_id
 adjust and re-call. Creating safely is the default, not something to
 remember.
 
+The reserved `dossiers` root is a flat subject catalog. Inspect related and
+sibling refs before naming a new dossier, pass an explicit direct-child ref
+such as `dossiers:entity-cat-goro-goro.md`, and never pass `path_prefix`.
+Existing nested legacy refs remain readable and writable at their current
+location; do not fork one merely to normalize its name.
+
 ## Write a logical document — `doc_write`
 
 Use when a document needs multiple views of one current state in any managed
@@ -586,6 +592,9 @@ document (update/append) rather than a new one.
 `doc_intake` searches related documents, normalizes the proposed
 title/tags/path against the corpus, checks the target root's policy,
 and returns an `intake_id` plus a `commit_plan`:
+
+For the reserved `dossiers` root, propose only a direct-child ref and omit
+`path_prefix`; its subject catalog is intentionally flat.
 
 ```json
 {

--- a/talents/documents.md
+++ b/talents/documents.md
@@ -357,7 +357,8 @@ The reserved `dossiers` root is a flat subject catalog. Inspect related and
 sibling refs before naming a new dossier, pass an explicit direct-child ref
 such as `dossiers:entity-cat-goro-goro.md`, and never pass `path_prefix`.
 Existing nested legacy refs remain readable and writable at their current
-location; do not fork one merely to normalize its name.
+location; direct writers also reject a missing nested `dossiers:` target, so do
+not fork one merely to normalize its name.
 
 ## Write a logical document — `doc_write`
 


### PR DESCRIPTION
## Summary

- bound each autonomous loop wake to one successful queue batch and enforce archivist's three-item maximum in Go
- classify OpenAI-compatible stream-idle cancellation as a real timeout so retry, recovery, and failover remain available
- enforce deliberate flat placement for every newly created `dossiers:` document at the shared mutation boundary while preserving existing legacy refs
- teach archivist to keep Thane self-observation on the metacognitive `self:` surface

## Why

Production archivist wakes repeatedly pulled more queue work inside one model request, allowing a single wake to grow to dozens of iterations and extreme cumulative context. When a later local-model response went silent, the provider idle guard canceled its private HTTP context, but the agent interpreted that as caller cancellation and skipped recovery.

The same overnight run exposed two corpus-contract gaps: sibling cats landed at flat and nested refs, and a document about Thane confabulation was treated as an external-world dossier instead of metacognitive self-state.

## User impact

Archivist now takes at most one three-item batch per wake regardless of an omitted or oversized model argument; remaining durable work naturally waits for the next wake. A genuinely stalled model response enters ordinary timeout recovery instead of ending as `context canceled`. Every managed writer refuses to create a missing nested `dossiers:` target, and self-operational material is acknowledged without creating or refreshing a dossier.

Existing nested dossiers and mis-owned legacy documents are not moved or rewritten by this change. Existing nested dossiers remain writable at their current refs for deliberate migration with Git history intact.

## Test plan

- [x] `just ci`
- [x] queue tool tests cover one pull per request, Go-enforced default/maximum batch size, and rejection of pulled-subject re-enqueue
- [x] provider tests assert stream-idle errors classify as both provider-specific and deadline-exceeded
- [x] agent recovery tests distinguish caller cancellation from provider-private cancellation
- [x] document intake tests cover ordinary hierarchy, explicit flat dossier refs, missing refs, path prefixes, and nested refs
- [x] shared document-writer tests reject nested dossier creation through `doc_write` and `doc_body_write` while allowing both surfaces to update an existing nested legacy dossier

Refs #1406, #1492