### PR TITLE
feat: expose companion runtime diagnostics

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -127,7 +127,9 @@ cadence.
 During the realtime handshake, the pre-authentication `auth_required.version`
 field identifies the companion protocol version. After successful
 authentication, `auth_ok.server_version` identifies the running Thane build
-using the same stamped version reported by `GET /v1/version`.
+using the same stamped version reported by `GET /v1/version`, while
+`auth_ok.server_uptime_seconds` reports whole seconds since that process
+started. Both runtime diagnostics are disclosed only after authentication.
 
 `POST /v1/companion/observations` uses a configured companion bearer token,
 which determines the account, and a stable opaque `client_id` claim supplied by

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -124,6 +124,11 @@ cadence.
 | `GET` | `/v1/platform/ws` | Realtime WebSocket — legacy alias (deprecated; see below). |
 | `POST` | `/v1/companion/observations` | Submit a bounded latest-value observation batch from an authenticated companion. |
 
+During the realtime handshake, the pre-authentication `auth_required.version`
+field identifies the companion protocol version. After successful
+authentication, `auth_ok.server_version` identifies the running Thane build
+using the same stamped version reported by `GET /v1/version`.
+
 `POST /v1/companion/observations` uses a configured companion bearer token,
 which determines the account, and a stable opaque `client_id` claim supplied by
 the app. The ingestion authenticator resolves that account and claim through

--- a/internal/integrations/companion/handler.go
+++ b/internal/integrations/companion/handler.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/nugget/thane-ai-agent/internal/platform/buildinfo"
 	"github.com/nugget/thane-ai-agent/internal/server/legacyroute"
 )
 
@@ -144,10 +145,11 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	if err := writeJSONWithDeadline(conn, writeWait, authOK{
-		Type:        typeAuthOK,
-		ProviderID:  provider.ID,
-		Account:     provider.Account,
-		Deprecation: deprecation,
+		Type:          typeAuthOK,
+		ProviderID:    provider.ID,
+		Account:       provider.Account,
+		ServerVersion: buildinfo.Version,
+		Deprecation:   deprecation,
 	}); err != nil {
 		return
 	}

--- a/internal/integrations/companion/handler.go
+++ b/internal/integrations/companion/handler.go
@@ -145,11 +145,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	if err := writeJSONWithDeadline(conn, writeWait, authOK{
-		Type:          typeAuthOK,
-		ProviderID:    provider.ID,
-		Account:       provider.Account,
-		ServerVersion: buildinfo.Version,
-		Deprecation:   deprecation,
+		Type:                typeAuthOK,
+		ProviderID:          provider.ID,
+		Account:             provider.Account,
+		ServerVersion:       buildinfo.Version,
+		ServerUptimeSeconds: int64(buildinfo.Uptime() / time.Second),
+		Deprecation:         deprecation,
 	}); err != nil {
 		return
 	}

--- a/internal/integrations/companion/handler_test.go
+++ b/internal/integrations/companion/handler_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/nugget/thane-ai-agent/internal/platform/buildinfo"
 	"github.com/nugget/thane-ai-agent/internal/server/legacyroute"
 )
 
@@ -85,6 +86,9 @@ func TestAuthHandshakeSuccess(t *testing.T) {
 	}
 	if ok.Account != "nugget" {
 		t.Errorf("expected account %q, got %q", "nugget", ok.Account)
+	}
+	if ok.ServerVersion != buildinfo.Version {
+		t.Errorf("expected server version %q, got %q", buildinfo.Version, ok.ServerVersion)
 	}
 }
 

--- a/internal/integrations/companion/handler_test.go
+++ b/internal/integrations/companion/handler_test.go
@@ -62,6 +62,7 @@ func TestAuthHandshakeSuccess(t *testing.T) {
 	}
 
 	// Step 2: Send auth.
+	uptimeBeforeAuth := int64(buildinfo.Uptime() / time.Second)
 	conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
 	if err := conn.WriteJSON(authMessage{
 		Type:       typeAuth,
@@ -73,7 +74,13 @@ func TestAuthHandshakeSuccess(t *testing.T) {
 	}
 
 	// Step 3: Expect auth_ok with account.
-	var ok authOK
+	var ok struct {
+		Type                string `json:"type"`
+		ProviderID          string `json:"provider_id"`
+		Account             string `json:"account"`
+		ServerVersion       string `json:"server_version"`
+		ServerUptimeSeconds int64  `json:"server_uptime_seconds"`
+	}
 	readJSON(t, conn, &ok)
 	if ok.Type != typeAuthOK {
 		t.Fatalf("expected type %q, got %q", typeAuthOK, ok.Type)
@@ -90,8 +97,14 @@ func TestAuthHandshakeSuccess(t *testing.T) {
 	if ok.ServerVersion != buildinfo.Version {
 		t.Errorf("expected server version %q, got %q", buildinfo.Version, ok.ServerVersion)
 	}
-	if ok.ServerUptimeSeconds < 0 || ok.ServerUptimeSeconds > 300 {
-		t.Errorf("expected recent non-negative server uptime, got %d seconds", ok.ServerUptimeSeconds)
+	uptimeAfterAuth := int64(buildinfo.Uptime()/time.Second) + 1
+	if ok.ServerUptimeSeconds < uptimeBeforeAuth || ok.ServerUptimeSeconds > uptimeAfterAuth {
+		t.Errorf(
+			"server uptime = %d seconds, want between %d and %d",
+			ok.ServerUptimeSeconds,
+			uptimeBeforeAuth,
+			uptimeAfterAuth,
+		)
 	}
 }
 

--- a/internal/integrations/companion/handler_test.go
+++ b/internal/integrations/companion/handler_test.go
@@ -90,6 +90,9 @@ func TestAuthHandshakeSuccess(t *testing.T) {
 	if ok.ServerVersion != buildinfo.Version {
 		t.Errorf("expected server version %q, got %q", buildinfo.Version, ok.ServerVersion)
 	}
+	if ok.ServerUptimeSeconds < 0 || ok.ServerUptimeSeconds > 300 {
+		t.Errorf("expected recent non-negative server uptime, got %d seconds", ok.ServerUptimeSeconds)
+	}
 }
 
 func TestAuthHandshakeBadToken(t *testing.T) {

--- a/internal/integrations/companion/message.go
+++ b/internal/integrations/companion/message.go
@@ -92,16 +92,17 @@ type authMessage struct {
 }
 
 // authOK confirms successful authentication, assigns a provider ID, and
-// echoes back the server-resolved account name and running server build.
+// echoes back the server-resolved account name and runtime diagnostics.
 // Deprecation is populated only when the client connected on a legacy path
 // alias, giving in-band notice to WebSocket clients that do not surface HTTP
 // response headers.
 type authOK struct {
-	Type          string             `json:"type"`
-	ProviderID    string             `json:"provider_id"`
-	Account       string             `json:"account"`
-	ServerVersion string             `json:"server_version"`
-	Deprecation   *deprecationNotice `json:"deprecation,omitempty"`
+	Type                string             `json:"type"`
+	ProviderID          string             `json:"provider_id"`
+	Account             string             `json:"account"`
+	ServerVersion       string             `json:"server_version"`
+	ServerUptimeSeconds int64              `json:"server_uptime_seconds"`
+	Deprecation         *deprecationNotice `json:"deprecation,omitempty"`
 }
 
 // deprecationNotice is the in-band companion to the RFC 8594 Sunset /

--- a/internal/integrations/companion/message.go
+++ b/internal/integrations/companion/message.go
@@ -92,14 +92,16 @@ type authMessage struct {
 }
 
 // authOK confirms successful authentication, assigns a provider ID, and
-// echoes back the server-resolved account name. Deprecation is populated
-// only when the client connected on a legacy path alias, giving in-band
-// notice to WebSocket clients that do not surface HTTP response headers.
+// echoes back the server-resolved account name and running server build.
+// Deprecation is populated only when the client connected on a legacy path
+// alias, giving in-band notice to WebSocket clients that do not surface HTTP
+// response headers.
 type authOK struct {
-	Type        string             `json:"type"`
-	ProviderID  string             `json:"provider_id"`
-	Account     string             `json:"account"`
-	Deprecation *deprecationNotice `json:"deprecation,omitempty"`
+	Type          string             `json:"type"`
+	ProviderID    string             `json:"provider_id"`
+	Account       string             `json:"account"`
+	ServerVersion string             `json:"server_version"`
+	Deprecation   *deprecationNotice `json:"deprecation,omitempty"`
 }
 
 // deprecationNotice is the in-band companion to the RFC 8594 Sunset /


### PR DESCRIPTION
## Summary

- keep `auth_required.version` as the realtime companion protocol version
- add the stamped Thane build version to the authenticated `auth_ok.server_version` response
- add whole-second process uptime to authenticated `auth_ok.server_uptime_seconds`
- document and test the distinct wire semantics

## Why

Companion clients currently receive only `version: "0.1.0"` during the pre-authentication handshake. The iOS app treated that value as the server version even though it identifies the protocol, leaving the app unable to show which Thane build it is actually connected to or how long that process has been running.

Both runtime diagnostics are returned only after successful authentication. This gives trusted companions useful operational context without adding unauthenticated server-fingerprinting fields.

## User impact

Updated companion clients can display the running Thane build, live process uptime, and realtime protocol version separately. Existing clients continue to work because the new authenticated fields are additive, and updated clients remain compatible with older servers by treating the runtime fields as optional.

## Test plan

- [x] `just test`
- [x] `just ci`
- [x] handshake coverage verifies `auth_required.version` remains the protocol version
- [x] handshake coverage verifies `auth_ok.server_version` matches the stamped build version
- [x] handshake coverage verifies `auth_ok.server_uptime_seconds` reports a recent non-negative uptime

The iOS consumer is included in [thane-agent-ios PR #11](https://github.com/nugget/thane-agent-ios/pull/11).