### PR TITLE
feat: expose channel CA certificate metadata

### DIFF
--- a/internal/platform/identity/evidence.go
+++ b/internal/platform/identity/evidence.go
@@ -70,15 +70,24 @@ type PublicKeyEvidence struct {
 // X509CertificateEvidence is operator-readable metadata parsed from committed
 // public certificate material. It contains no private key material.
 type X509CertificateEvidence struct {
-	Subject            string    `json:"subject"`
-	Issuer             string    `json:"issuer"`
-	SerialNumber       string    `json:"serial_number"`
-	NotBefore          time.Time `json:"not_before"`
-	NotAfter           time.Time `json:"not_after"`
-	IsCA               bool      `json:"is_ca"`
-	SelfSigned         bool      `json:"self_signed"`
-	PublicKeyAlgorithm string    `json:"public_key_algorithm"`
-	SignatureAlgorithm string    `json:"signature_algorithm"`
+	// Subject is the certificate subject's distinguished name.
+	Subject string `json:"subject"`
+	// Issuer is the certificate issuer's distinguished name.
+	Issuer string `json:"issuer"`
+	// SerialNumber is the uppercase hexadecimal certificate serial number.
+	SerialNumber string `json:"serial_number"`
+	// NotBefore begins the certificate validity interval.
+	NotBefore time.Time `json:"not_before"`
+	// NotAfter ends the certificate validity interval.
+	NotAfter time.Time `json:"not_after"`
+	// IsCA reports whether the certificate asserts CA basic constraints.
+	IsCA bool `json:"is_ca"`
+	// SelfSigned reports whether the certificate verifies with its own public key.
+	SelfSigned bool `json:"self_signed"`
+	// PublicKeyAlgorithm names the parsed certificate's public-key algorithm.
+	PublicKeyAlgorithm string `json:"public_key_algorithm"`
+	// SignatureAlgorithm names the parsed certificate's signature algorithm.
+	SignatureAlgorithm string `json:"signature_algorithm"`
 }
 
 // CoreEvidence describes the birth, active revision, and verification posture

--- a/internal/platform/identity/evidence.go
+++ b/internal/platform/identity/evidence.go
@@ -343,13 +343,17 @@ func Observe(ctx context.Context, coreDir string, seeds []provenance.TrustedSign
 
 func x509CertificateEvidence(certificate *x509.Certificate) *X509CertificateEvidence {
 	return &X509CertificateEvidence{
-		Subject:            certificate.Subject.String(),
-		Issuer:             certificate.Issuer.String(),
-		SerialNumber:       strings.ToUpper(certificate.SerialNumber.Text(16)),
-		NotBefore:          certificate.NotBefore.UTC(),
-		NotAfter:           certificate.NotAfter.UTC(),
-		IsCA:               certificate.IsCA,
-		SelfSigned:         certificate.CheckSignatureFrom(certificate) == nil,
+		Subject:      certificate.Subject.String(),
+		Issuer:       certificate.Issuer.String(),
+		SerialNumber: strings.ToUpper(certificate.SerialNumber.Text(16)),
+		NotBefore:    certificate.NotBefore.UTC(),
+		NotAfter:     certificate.NotAfter.UTC(),
+		IsCA:         certificate.IsCA,
+		SelfSigned: certificate.CheckSignature(
+			certificate.SignatureAlgorithm,
+			certificate.RawTBSCertificate,
+			certificate.Signature,
+		) == nil,
 		PublicKeyAlgorithm: certificate.PublicKeyAlgorithm.String(),
 		SignatureAlgorithm: certificate.SignatureAlgorithm.String(),
 	}

--- a/internal/platform/identity/evidence.go
+++ b/internal/platform/identity/evidence.go
@@ -3,6 +3,7 @@ package identity
 import (
 	"bytes"
 	"context"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"os/exec"
@@ -61,6 +62,23 @@ type PublicKeyEvidence struct {
 	Algorithm string `json:"algorithm"`
 	// Fingerprint is the SHA-256 fingerprint recomputed from committed material.
 	Fingerprint string `json:"fingerprint"`
+	// Certificate describes committed X.509 material when this identity is a
+	// certificate rather than a bare public key.
+	Certificate *X509CertificateEvidence `json:"certificate,omitempty"`
+}
+
+// X509CertificateEvidence is operator-readable metadata parsed from committed
+// public certificate material. It contains no private key material.
+type X509CertificateEvidence struct {
+	Subject            string    `json:"subject"`
+	Issuer             string    `json:"issuer"`
+	SerialNumber       string    `json:"serial_number"`
+	NotBefore          time.Time `json:"not_before"`
+	NotAfter           time.Time `json:"not_after"`
+	IsCA               bool      `json:"is_ca"`
+	SelfSigned         bool      `json:"self_signed"`
+	PublicKeyAlgorithm string    `json:"public_key_algorithm"`
+	SignatureAlgorithm string    `json:"signature_algorithm"`
 }
 
 // CoreEvidence describes the birth, active revision, and verification posture
@@ -290,6 +308,7 @@ func Observe(ctx context.Context, coreDir string, seeds []provenance.TrustedSign
 			ChannelCA: PublicKeyEvidence{
 				Algorithm:   "x509-ed25519",
 				Fingerprint: caFingerprint,
+				Certificate: x509CertificateEvidence(certificate),
 			},
 		},
 		Core: CoreEvidence{
@@ -311,6 +330,20 @@ func Observe(ctx context.Context, coreDir string, seeds []provenance.TrustedSign
 		},
 	}
 	return evidence, nil
+}
+
+func x509CertificateEvidence(certificate *x509.Certificate) *X509CertificateEvidence {
+	return &X509CertificateEvidence{
+		Subject:            certificate.Subject.String(),
+		Issuer:             certificate.Issuer.String(),
+		SerialNumber:       strings.ToUpper(certificate.SerialNumber.Text(16)),
+		NotBefore:          certificate.NotBefore.UTC(),
+		NotAfter:           certificate.NotAfter.UTC(),
+		IsCA:               certificate.IsCA,
+		SelfSigned:         certificate.CheckSignatureFrom(certificate) == nil,
+		PublicKeyAlgorithm: certificate.PublicKeyAlgorithm.String(),
+		SignatureAlgorithm: certificate.SignatureAlgorithm.String(),
+	}
 }
 
 func anchorKind(identityKey ssh.PublicKey, seeds []provenance.TrustedSigner) string {

--- a/internal/platform/identity/evidence_test.go
+++ b/internal/platform/identity/evidence_test.go
@@ -1,13 +1,51 @@
 package identity
 
 import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"math/big"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
 )
+
+func TestX509CertificateEvidenceSelfSignedUsesRawSignature(t *testing.T) {
+	t.Parallel()
+
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(time.Hour),
+		BasicConstraintsValid: true,
+		IsCA:                  false,
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, publicKey, privateKey)
+	if err != nil {
+		t.Fatalf("CreateCertificate: %v", err)
+	}
+	certificate, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("ParseCertificate: %v", err)
+	}
+	if err := certificate.CheckSignatureFrom(certificate); err == nil {
+		t.Fatal("CheckSignatureFrom accepted a non-CA certificate; test does not exercise the intended distinction")
+	}
+
+	got := x509CertificateEvidence(certificate)
+	if !got.SelfSigned {
+		t.Fatal("SelfSigned = false for a certificate signed by its own public key")
+	}
+}
 
 func TestObserveCoreIdentityEvidence(t *testing.T) {
 	t.Parallel()

--- a/internal/platform/identity/evidence_test.go
+++ b/internal/platform/identity/evidence_test.go
@@ -41,6 +41,25 @@ func TestObserveCoreIdentityEvidence(t *testing.T) {
 			if got.Instance.IdentityKey.Fingerprint == "" || got.Instance.ChannelCA.Fingerprint == "" {
 				t.Errorf("public fingerprints are incomplete: %+v", got.Instance)
 			}
+			certificate := got.Instance.ChannelCA.Certificate
+			if certificate == nil {
+				t.Fatal("channel CA certificate metadata is missing")
+			}
+			if certificate.Subject != "CN=pocket Thane Channel CA" || certificate.Issuer != certificate.Subject {
+				t.Errorf("channel CA names = subject %q, issuer %q", certificate.Subject, certificate.Issuer)
+			}
+			if certificate.SerialNumber == "" {
+				t.Error("channel CA serial number is empty")
+			}
+			if !certificate.IsCA || !certificate.SelfSigned {
+				t.Errorf("channel CA posture = is_ca %t, self_signed %t", certificate.IsCA, certificate.SelfSigned)
+			}
+			if certificate.PublicKeyAlgorithm != "Ed25519" || certificate.SignatureAlgorithm != "Ed25519" {
+				t.Errorf("channel CA algorithms = public %q, signature %q", certificate.PublicKeyAlgorithm, certificate.SignatureAlgorithm)
+			}
+			if !certificate.NotAfter.After(certificate.NotBefore) {
+				t.Errorf("channel CA validity = %s through %s", certificate.NotBefore, certificate.NotAfter)
+			}
 			if got.Core.Birth.Anchor != tc.wantAnchor {
 				t.Errorf("anchor = %q, want %q", got.Core.Birth.Anchor, tc.wantAnchor)
 			}

--- a/internal/server/openapi/native.yaml
+++ b/internal/server/openapi/native.yaml
@@ -1727,7 +1727,19 @@ components:
           id: "thane:ed25519:SHA256:8N6XQdQfeJrVxZ5xI3a2S9Ozb5Nss4J2t7zJ1lKfJNo"
           name: pocket
           identity_key: { algorithm: ed25519, fingerprint: "SHA256:8N6XQdQfeJrVxZ5xI3a2S9Ozb5Nss4J2t7zJ1lKfJNo" }
-          channel_ca: { algorithm: x509-ed25519, fingerprint: "SHA256:q2QHfRjP9xjV8nL4Dzg0zz1IxF5XHFM9TPrWHhsLqXQ" }
+          channel_ca:
+            algorithm: x509-ed25519
+            fingerprint: "SHA256:q2QHfRjP9xjV8nL4Dzg0zz1IxF5XHFM9TPrWHhsLqXQ"
+            certificate:
+              subject: "CN=pocket Thane Channel CA"
+              issuer: "CN=pocket Thane Channel CA"
+              serial_number: "4F3A19D270EBC1"
+              not_before: "2026-07-01T12:00:00Z"
+              not_after: "2036-07-01T12:00:00Z"
+              is_ca: true
+              self_signed: true
+              public_key_algorithm: Ed25519
+              signature_algorithm: Ed25519
         core:
           birth:
             commit: { algorithm: sha1, oid: "0123456789abcdef0123456789abcdef01234567" }
@@ -1780,6 +1792,54 @@ components:
           type: string
           description: SHA-256 fingerprint recomputed from committed birth material.
           pattern: "^SHA256:"
+        certificate:
+          description: Parsed public metadata when the material is an X.509 certificate.
+          allOf:
+            - $ref: "#/components/schemas/X509CertificateEvidence"
+
+    X509CertificateEvidence:
+      type: object
+      description: Operator-readable metadata parsed from a committed public X.509 certificate.
+      required:
+        - subject
+        - issuer
+        - serial_number
+        - not_before
+        - not_after
+        - is_ca
+        - self_signed
+        - public_key_algorithm
+        - signature_algorithm
+      properties:
+        subject:
+          type: string
+          description: RFC 2253-style distinguished name of the certificate subject.
+        issuer:
+          type: string
+          description: RFC 2253-style distinguished name of the certificate issuer.
+        serial_number:
+          type: string
+          description: Uppercase hexadecimal certificate serial number.
+        not_before:
+          type: string
+          format: date-time
+          description: Beginning of the certificate validity interval.
+        not_after:
+          type: string
+          format: date-time
+          description: End of the certificate validity interval.
+        is_ca:
+          type: boolean
+          description: Whether the certificate asserts certificate-authority basic constraints.
+        self_signed:
+          type: boolean
+          description: Whether the certificate signature verifies using its own public key.
+        public_key_algorithm:
+          type: string
+          description: Public-key algorithm reported by the parsed certificate.
+        signature_algorithm:
+          type: string
+          description: Signature algorithm reported by the parsed certificate.
 
     CoreIdentityEvidence:
       type: object


### PR DESCRIPTION
## Summary

- add operator-readable X.509 metadata for the committed Thane channel CA to `GET /v1/identity`
- report subject, issuer, serial number, validity interval, CA and self-signed posture, and certificate algorithms
- keep the encoded certificate contents and all private key material out of the response
- document the additive identity-evidence fields in the native OpenAPI contract

## Why

Companion operators can already compare the channel CA's SHA-256 fingerprint, but cannot inspect the certificate properties that fingerprint identifies. Exposing parsed public metadata makes the internal X.509 identity understandable without conflating it with the unrelated HTTPS/WSS transport certificate.

The metadata is derived from the same committed founding certificate that identity observation already parses and verifies against the birth policy. It remains evidence reported by the authenticated Thane endpoint, not an independent trust verdict.

## User impact

Updated companion clients can show the Thane-generated channel CA's subject, issuer, serial number, validity window, algorithms, and self-signed CA posture alongside its existing fingerprint. Existing clients continue to work because the nested `certificate` object is additive and optional.

No private key bytes or filesystem paths are exposed.

## Test plan

- [x] `just test`
- [x] `just ci`
- [x] verify observed channel CA metadata matches the generated self-signed Ed25519 certificate
- [x] verify the native OpenAPI contract documents every additive field

The iOS inspection UI is included in [thane-agent-ios PR #11](https://github.com/nugget/thane-agent-ios/pull/11).