### PR TITLE
feat(server): perimeter hardening, phase 0

### DIFF
--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -529,5 +529,15 @@ openai_api:
 Network binding for the API servers. `listen:` binds the native Thane
 /v1 API and web dashboard (default port 8080). The optional
 Ollama-compatible (port 11434) and OpenAI-compatible (port 8081) shims
-bind separately under their own blocks. Default is localhost-only; set
-`address` to `0.0.0.0` to accept connections from other hosts.
+bind separately under their own blocks. An empty or omitted `address`
+binds **all interfaces**, so every host that can reach the machine can
+reach the listener; set `address` to `127.0.0.1` to keep a listener
+local to the host, for example behind a reverse proxy that terminates
+TLS and enforces its own access policy.
+
+Every listener refuses state-changing requests (`POST`, `PUT`, `DELETE`,
+`PATCH`) that a browser marks as cross-origin, using the `Sec-Fetch-Site`
+and `Origin` headers browsers attach and non-browser clients do not. This
+closes the blind cross-site request forgery path from a page the operator
+happens to have open; it does not restrict `curl`, Home Assistant,
+companion apps, or reverse proxies, none of which send those headers.

--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -519,11 +519,13 @@ ollama_api:
   enabled: true
   address: ""
   port: 11434
+  api_key: ""        # optional bearer token; HA's Ollama integration cannot send one
 
 openai_api:
   enabled: true
   address: ""
   port: 8081
+  api_key: ""        # optional bearer token; OpenAI clients send it natively
 ```
 
 Network binding for the API servers. `listen:` binds the native Thane

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -189,6 +189,16 @@ Enabled via `openai_api` in config. The `model` field selects a
 [virtual model](../operating/routing-profiles.md) such as `thane:latest` or
 `thane:premium`.
 
+**Authentication:** optional bearer token, `openai_api.api_key`. When set,
+every request must carry `Authorization: Bearer <key>`, the header OpenAI
+client libraries send by default; a missing or wrong token gets a `401` in
+the OpenAI error envelope with a `WWW-Authenticate: Bearer realm="openai"`
+challenge. When unset the surface is open to every host that can reach the
+port, and it drives the full agent loop, so set a key unless the network
+boundary already enforces who may connect. The Ollama shim has the same
+option (`ollama_api.api_key`); it is off by default there because Home
+Assistant's Ollama integration cannot send a bearer token.
+
 | Method | Path | Purpose |
 | --- | --- | --- |
 | `POST` | `/v1/chat/completions` | OpenAI-compatible chat completions with streaming support. |

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -4,6 +4,12 @@ Thane can serve up to four network listeners from a single binary. The native
 API (port 8080) is always on; the OpenAI-compatible (8081), Ollama-compatible
 (11434), and CardDAV (8843) listeners are each optional, enabled via config.
 
+Every HTTP listener refuses state-changing requests (`POST`, `PUT`, `DELETE`,
+`PATCH`) that a browser marks as cross-origin, via the `Sec-Fetch-Site` and
+`Origin` request headers, with a `403` and an `{"error": ...}` body. Requests
+without those headers, which is every non-browser client, are unaffected. See
+[Listen Addresses](../operating/configuration.md#listen-addresses).
+
 ## Port 8080 — Native API
 
 Port 8080 serves the Thane-native API and the embedded Cognition Engine

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -10,6 +10,11 @@ Every HTTP listener refuses state-changing requests (`POST`, `PUT`, `DELETE`,
 without those headers, which is every non-browser client, are unaffected. See
 [Listen Addresses](../operating/configuration.md#listen-addresses).
 
+Request bodies are capped at 8 MiB on the native API and 32 MiB on the
+compatibility shims (room for chat history with base64 images); a body past
+the cap fails the request and closes the connection. All listeners bound
+header read time, idle keep-alive time, and header size.
+
 ## Port 8080 — Native API
 
 Port 8080 serves the Thane-native API and the embedded Cognition Engine

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -44,6 +44,13 @@ openai_api:
   enabled: true
   address: ""
   port: 8081
+  # APIKey, when set, requires every request to the OpenAI-compatible
+  # surface to present it as a bearer token (Authorization: Bearer
+  # <key>), which is the header every OpenAI client library already
+  # sends. This surface drives the full agent loop — tools, memory,
+  # delegation — so leaving it empty (open) is appropriate only when
+  # every host that can reach the port is trusted.
+  api_key: ""
 #
 # (optional) CardDAV configures the optional CardDAV server for native
 # carddav:

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -237,7 +237,7 @@ func (a *App) initServers(s *newState) error {
 	// (/v1/chat/completions, /v1/models) on its own port, keeping the
 	// Thane-native /v1 API on the primary port free of foreign shapes.
 	if cfg.OpenAIAPI.Enabled {
-		a.openaiServer = api.NewOpenAIServer(cfg.OpenAIAPI.Address, cfg.OpenAIAPI.Port, a.server, logger)
+		a.openaiServer = api.NewOpenAIServer(cfg.OpenAIAPI.Address, cfg.OpenAIAPI.Port, cfg.OpenAIAPI.APIKey, a.server, logger)
 	}
 
 	// --- Companion app endpoint ---

--- a/internal/integrations/companion/handler.go
+++ b/internal/integrations/companion/handler.go
@@ -47,11 +47,11 @@ var upgrader = websocket.Upgrader{
 
 // Handler is the HTTP handler for companion app WebSocket connections.
 type Handler struct {
-	tokenIndex map[string]string // token → account name
-	registry   *Registry
-	devices    DeviceRecorder             // optional durable inventory sink; nil disables
-	deviceOps  chan func(context.Context) // ordered async inventory writes
-	logger     *slog.Logger
+	tokens    tokenMatcher // hashed token → account resolution
+	registry  *Registry
+	devices   DeviceRecorder             // optional durable inventory sink; nil disables
+	deviceOps chan func(context.Context) // ordered async inventory writes
+	logger    *slog.Logger
 
 	deviceOpsMu     sync.Mutex    // guards enqueue vs. close
 	deviceOpsClosed bool          // no new ops accepted once set
@@ -60,8 +60,9 @@ type Handler struct {
 
 // NewHandler creates a new companion WebSocket handler. The tokenIndex
 // maps authentication tokens to account names (built by
-// config.CompanionConfig.TokenIndex). If registry is nil, a default
-// Registry is created.
+// config.CompanionConfig.TokenIndex); it is hashed at construction and the
+// plaintext is not retained. If registry is nil, a default Registry is
+// created.
 func NewHandler(tokenIndex map[string]string, registry *Registry, logger *slog.Logger) *Handler {
 	if logger == nil {
 		logger = slog.Default()
@@ -70,9 +71,9 @@ func NewHandler(tokenIndex map[string]string, registry *Registry, logger *slog.L
 		registry = NewRegistry(logger)
 	}
 	return &Handler{
-		tokenIndex: tokenIndex,
-		registry:   registry,
-		logger:     logger,
+		tokens:   newTokenMatcher(tokenIndex),
+		registry: registry,
+		logger:   logger,
 	}
 }
 
@@ -198,8 +199,10 @@ func (h *Handler) authenticate(conn *websocket.Conn, requestType string) (*Provi
 		return nil, &authError{"expected auth message, got " + msg.Type}
 	}
 
-	// Step 3: Validate token and resolve account.
-	account, ok := h.tokenIndex[msg.Token]
+	// Step 3: Validate token and resolve account. Constant-time over
+	// digests, matching the HTTP observation path; a map lookup keyed by
+	// the plaintext token compared byte-by-byte and stopped early.
+	account, ok := h.tokens.match(msg.Token)
 	if !ok {
 		_ = writeJSONWithDeadline(conn, writeWait, authFailed{
 			Type:    typeAuthFailed,

--- a/internal/integrations/companion/observation_auth.go
+++ b/internal/integrations/companion/observation_auth.go
@@ -2,8 +2,6 @@ package companion
 
 import (
 	"context"
-	"crypto/sha256"
-	"crypto/subtle"
 	"errors"
 	"fmt"
 	"net/http"
@@ -36,35 +34,23 @@ type ObservationAuthenticator interface {
 	AuthenticateObservation(context.Context, ObservationAuthRequest) (ObservationPrincipal, error)
 }
 
-type bearerObservationCredential struct {
-	digest  [sha256.Size]byte
-	account string
-}
-
 // BearerObservationAuthenticator adapts configured companion bearer tokens to
-// the replaceable observation-authentication seam. Configured and candidate
-// tokens are compared as fixed-size SHA-256 digests in constant time.
+// the replaceable observation-authentication seam. Token comparison is the
+// shared tokenMatcher, so this path and the WebSocket handshake hold the
+// same constant-time, digest-only posture.
 type BearerObservationAuthenticator struct {
-	credentials    []bearerObservationCredential
+	tokens         tokenMatcher
 	identityLookup ObservationIdentityLookup
 }
 
 // NewBearerObservationAuthenticator copies and hashes the configured token
 // index so the authenticator does not retain plaintext bearer credentials.
 func NewBearerObservationAuthenticator(tokenIndex map[string]string, identityLookup ObservationIdentityLookup) *BearerObservationAuthenticator {
-	credentials := make([]bearerObservationCredential, 0, len(tokenIndex))
-	for token, account := range tokenIndex {
-		credentials = append(credentials, bearerObservationCredential{
-			digest: sha256.Sum256([]byte(token)), account: account,
-		})
-	}
-	return &BearerObservationAuthenticator{credentials: credentials, identityLookup: identityLookup}
+	return &BearerObservationAuthenticator{tokens: newTokenMatcher(tokenIndex), identityLookup: identityLookup}
 }
 
 // AuthenticateObservation validates one bearer header, resolves the account,
 // then maps today's claimed client ID to the inventory's immutable device ID.
-// The comparison loop never returns early, so a matching credential's
-// position does not affect the number of constant-time comparisons.
 func (a *BearerObservationAuthenticator) AuthenticateObservation(
 	ctx context.Context,
 	request ObservationAuthRequest,
@@ -78,17 +64,8 @@ func (a *BearerObservationAuthenticator) AuthenticateObservation(
 		return ObservationPrincipal{}, ErrObservationUnauthorized
 	}
 
-	candidate := sha256.Sum256([]byte(token))
-	matched := 0
-	account := ""
-	for _, credential := range a.credentials {
-		isMatch := subtle.ConstantTimeCompare(candidate[:], credential.digest[:])
-		matched |= isMatch
-		if isMatch == 1 {
-			account = credential.account
-		}
-	}
-	if matched != 1 {
+	account, matched := a.tokens.match(token)
+	if !matched {
 		// Deliberately avoid a dummy SQLite lookup for invalid bearer tokens.
 		// This temporary bearer path is restricted to Thane's private-network
 		// boundary; dummy database work would amplify unauthenticated traffic

--- a/internal/integrations/companion/token_matcher.go
+++ b/internal/integrations/companion/token_matcher.go
@@ -1,0 +1,54 @@
+package companion
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+)
+
+// tokenCredential is one configured bearer token, retained only as its
+// SHA-256 digest alongside the account it authenticates.
+type tokenCredential struct {
+	digest  [sha256.Size]byte
+	account string
+}
+
+// tokenMatcher resolves a presented bearer token to its account. It is the
+// single comparison both companion authentication paths use, the
+// WebSocket handshake and HTTP observation ingestion, so the two cannot
+// drift in posture: configured tokens are hashed at construction so no
+// plaintext is retained, candidates are compared as fixed-size digests in
+// constant time, and the loop never returns early, so a matching
+// credential's position does not change the work done.
+type tokenMatcher struct {
+	credentials []tokenCredential
+}
+
+// newTokenMatcher hashes a token → account index (see
+// config.CompanionConfig.TokenIndex) into a matcher.
+func newTokenMatcher(tokenIndex map[string]string) tokenMatcher {
+	credentials := make([]tokenCredential, 0, len(tokenIndex))
+	for token, account := range tokenIndex {
+		credentials = append(credentials, tokenCredential{
+			digest: sha256.Sum256([]byte(token)), account: account,
+		})
+	}
+	return tokenMatcher{credentials: credentials}
+}
+
+// match returns the account the token authenticates, or ok=false. An empty
+// token never matches, even if an empty string was configured.
+func (m tokenMatcher) match(token string) (account string, ok bool) {
+	if token == "" {
+		return "", false
+	}
+	candidate := sha256.Sum256([]byte(token))
+	matched := 0
+	for _, credential := range m.credentials {
+		isMatch := subtle.ConstantTimeCompare(candidate[:], credential.digest[:])
+		matched |= isMatch
+		if isMatch == 1 {
+			account = credential.account
+		}
+	}
+	return account, matched == 1
+}

--- a/internal/integrations/companion/token_matcher_test.go
+++ b/internal/integrations/companion/token_matcher_test.go
@@ -1,0 +1,48 @@
+package companion
+
+import "testing"
+
+func TestTokenMatcher(t *testing.T) {
+	t.Parallel()
+
+	matcher := newTokenMatcher(map[string]string{
+		"alice-token": "alice",
+		"bob-token":   "bob",
+	})
+
+	tests := []struct {
+		name        string
+		token       string
+		wantAccount string
+		wantOK      bool
+	}{
+		{"first account resolves", "alice-token", "alice", true},
+		{"second account resolves", "bob-token", "bob", true},
+		{"unknown token rejected", "carol-token", "", false},
+		{"prefix of a token rejected", "alice-tok", "", false},
+		{"token with trailing byte rejected", "alice-token ", "", false},
+		{"empty token rejected", "", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			account, ok := matcher.match(tc.token)
+			if ok != tc.wantOK || account != tc.wantAccount {
+				t.Fatalf("match(%q) = (%q, %v), want (%q, %v)", tc.token, account, ok, tc.wantAccount, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestTokenMatcher_EmptyIndexAndEmptyConfiguredToken(t *testing.T) {
+	t.Parallel()
+
+	if _, ok := newTokenMatcher(nil).match("anything"); ok {
+		t.Fatal("empty index matched a token")
+	}
+	// A blank configured token must not turn a blank presented token into
+	// an authenticated account.
+	if _, ok := newTokenMatcher(map[string]string{"": "ghost"}).match(""); ok {
+		t.Fatal("empty configured token authenticated an empty presented token")
+	}
+}

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -761,6 +761,13 @@ type OpenAIAPIConfig struct {
 	Enabled bool   `yaml:"enabled"`
 	Address string `yaml:"address"` // Bind address; empty = all interfaces
 	Port    int    `yaml:"port"`    // Default: 8081
+	// APIKey, when set, requires every request to the OpenAI-compatible
+	// surface to present it as a bearer token (Authorization: Bearer
+	// <key>), which is the header every OpenAI client library already
+	// sends. This surface drives the full agent loop — tools, memory,
+	// delegation — so leaving it empty (open) is appropriate only when
+	// every host that can reach the port is trusted.
+	APIKey string `yaml:"api_key"`
 }
 
 // CardDAVConfig configures the optional CardDAV server for native

--- a/internal/server/api/body_limits.go
+++ b/internal/server/api/body_limits.go
@@ -1,0 +1,14 @@
+package api
+
+// Request body caps per surface. The shared listener bounds live in
+// package listen; these differ by surface because payload shapes differ.
+const (
+	// nativeMaxBodyBytes caps native /v1 request bodies. The largest
+	// legitimate payloads are loop definitions and contact records; 8 MiB
+	// is far above either while bounding what an unauthenticated caller
+	// can make the decoder hold.
+	nativeMaxBodyBytes = 8 << 20
+	// compatMaxBodyBytes caps compat-shim bodies, which may carry chat
+	// history plus base64 images. Matches the Ollama handler's own cap.
+	compatMaxBodyBytes = 32 << 20
+)

--- a/internal/server/api/middleware.go
+++ b/internal/server/api/middleware.go
@@ -1,0 +1,100 @@
+package api
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// rejectCrossOriginWrites refuses state-changing requests that a browser
+// reports as coming from another origin. It closes the blind cross-site
+// request forgery path: a POST with a text/plain body is a CORS "simple
+// request", so a page on any origin can fire it at a listener without a
+// preflight, and the absence of CORS headers only hides the response, it
+// does not stop the write.
+//
+// The guard reads two signals browsers attach and non-browser clients do
+// not. Sec-Fetch-Site of cross-site or same-site is refused outright;
+// same-site is refused too because sibling hostnames under one
+// registrable domain are not the same trust boundary. When an Origin
+// header is present, its host must equal the request Host; an opaque
+// "null" origin is refused. A request carrying neither header, which is
+// every curl, Home Assistant, companion, and reverse-proxy client, passes
+// unchanged. Safe methods pass unconditionally because they change no
+// state and because the WebSocket upgrade is a GET.
+//
+// When the native API grows a credentialed CORS allowlist for detached
+// UI origins, that allowlist belongs here as the one place an Origin is
+// admitted.
+func rejectCrossOriginWrites(logger *slog.Logger, next http.Handler) http.Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !isSafeMethod(r.Method) {
+			if reason := crossOriginWriteReason(r); reason != "" {
+				logger.Warn("refused cross-origin write",
+					"method", r.Method,
+					"path", r.URL.Path,
+					"host", r.Host,
+					"origin", r.Header.Get("Origin"),
+					"sec_fetch_site", r.Header.Get("Sec-Fetch-Site"),
+					"reason", reason,
+				)
+				writeJSONError(w, http.StatusForbidden, "cross-origin request refused")
+				return
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// isSafeMethod reports whether the method is defined as safe by RFC 9110
+// §9.2.1, meaning it must not change server state.
+func isSafeMethod(method string) bool {
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+		return true
+	}
+	return false
+}
+
+// crossOriginWriteReason returns a short reason when the request's
+// browser-supplied origin signals disagree with the request Host, or ""
+// when the request is same-origin or carries no such signals.
+func crossOriginWriteReason(r *http.Request) string {
+	switch site := r.Header.Get("Sec-Fetch-Site"); site {
+	case "cross-site", "same-site":
+		return "sec-fetch-site " + site
+	}
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return ""
+	}
+	if origin == "null" {
+		return "opaque origin"
+	}
+	u, err := url.Parse(origin)
+	if err != nil || u.Host == "" {
+		return "unparseable origin"
+	}
+	if !strings.EqualFold(u.Host, r.Host) {
+		return "origin host mismatch"
+	}
+	return ""
+}
+
+// writeJSONError writes a minimal {"error": message} body. It is the shape
+// every listener's clients can parse, which matters for a guard shared
+// across the native, Ollama, and OpenAI surfaces.
+func writeJSONError(w http.ResponseWriter, code int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	body, err := json.Marshal(map[string]string{"error": message})
+	if err != nil {
+		body = []byte(`{"error":"internal error"}`)
+	}
+	_, _ = w.Write(body)
+}

--- a/internal/server/api/middleware.go
+++ b/internal/server/api/middleware.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
 
 // rejectCrossOriginWrites refuses state-changing requests that a browser
@@ -97,4 +98,54 @@ func writeJSONError(w http.ResponseWriter, code int, message string) {
 		body = []byte(`{"error":"internal error"}`)
 	}
 	_, _ = w.Write(body)
+}
+
+// Listener-wide bounds shared by every HTTP server Thane runs. Read and
+// write timeouts stay per-surface because streaming budgets differ; these
+// are the limits that have no reason to differ.
+const (
+	// serverReadHeaderTimeout bounds how long a client may take to finish
+	// sending request headers, closing the slow-header connection hold
+	// that a bare ReadTimeout does not start counting until the body.
+	serverReadHeaderTimeout = 10 * time.Second
+	// serverIdleTimeout reclaims keep-alive connections nobody is using.
+	serverIdleTimeout = 120 * time.Second
+	// serverMaxHeaderBytes is generous for real clients and a fraction of
+	// the 1 MiB net/http default.
+	serverMaxHeaderBytes = 64 << 10
+
+	// nativeMaxBodyBytes caps native /v1 request bodies. The largest
+	// legitimate payloads are loop definitions and contact records; 8 MiB
+	// is far above either while bounding what an unauthenticated caller
+	// can make the decoder hold.
+	nativeMaxBodyBytes = 8 << 20
+	// compatMaxBodyBytes caps compat-shim bodies, which may carry chat
+	// history plus base64 images. Matches the Ollama handler's own cap.
+	compatMaxBodyBytes = 32 << 20
+)
+
+// newHTTPServer builds an http.Server with the shared listener bounds
+// applied, so no listener can be added without them.
+func newHTTPServer(addr string, handler http.Handler, readTimeout, writeTimeout time.Duration) *http.Server {
+	return &http.Server{
+		Addr:              addr,
+		Handler:           handler,
+		ReadTimeout:       readTimeout,
+		ReadHeaderTimeout: serverReadHeaderTimeout,
+		WriteTimeout:      writeTimeout,
+		IdleTimeout:       serverIdleTimeout,
+		MaxHeaderBytes:    serverMaxHeaderBytes,
+	}
+}
+
+// limitRequestBody caps every request body at maxBytes before handlers
+// decode it. Reads past the cap fail with *http.MaxBytesError, and
+// net/http closes the connection rather than draining the excess.
+func limitRequestBody(maxBytes int64, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Body != nil && r.Body != http.NoBody {
+			r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+		}
+		next.ServeHTTP(w, r)
+	})
 }

--- a/internal/server/api/middleware_test.go
+++ b/internal/server/api/middleware_test.go
@@ -1,9 +1,13 @@
 package api
 
 import (
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestRejectCrossOriginWrites(t *testing.T) {
@@ -60,4 +64,45 @@ func TestRejectCrossOriginWrites(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewHTTPServerAppliesSharedBounds(t *testing.T) {
+	t.Parallel()
+
+	srv := newHTTPServer(":0", http.NotFoundHandler(), 30*time.Second, 120*time.Second)
+	if srv.ReadTimeout != 30*time.Second || srv.WriteTimeout != 120*time.Second {
+		t.Fatalf("per-surface timeouts not preserved: read=%s write=%s", srv.ReadTimeout, srv.WriteTimeout)
+	}
+	if srv.ReadHeaderTimeout == 0 || srv.IdleTimeout == 0 || srv.MaxHeaderBytes == 0 {
+		t.Fatalf("shared bounds missing: header=%s idle=%s maxHeader=%d", srv.ReadHeaderTimeout, srv.IdleTimeout, srv.MaxHeaderBytes)
+	}
+}
+
+func TestLimitRequestBody(t *testing.T) {
+	t.Parallel()
+
+	var readErr error
+	var readLen int
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, err := io.ReadAll(r.Body)
+		readLen, readErr = len(b), err
+		w.WriteHeader(http.StatusOK)
+	})
+
+	t.Run("body within cap reads fully", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat", strings.NewReader(strings.Repeat("a", 16)))
+		limitRequestBody(32, next).ServeHTTP(httptest.NewRecorder(), req)
+		if readErr != nil || readLen != 16 {
+			t.Fatalf("read = (%d, %v), want (16, nil)", readLen, readErr)
+		}
+	})
+
+	t.Run("body past cap fails with MaxBytesError", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat", strings.NewReader(strings.Repeat("a", 64)))
+		limitRequestBody(32, next).ServeHTTP(httptest.NewRecorder(), req)
+		var maxErr *http.MaxBytesError
+		if !errors.As(readErr, &maxErr) {
+			t.Fatalf("read error = %v, want *http.MaxBytesError", readErr)
+		}
+	})
 }

--- a/internal/server/api/middleware_test.go
+++ b/internal/server/api/middleware_test.go
@@ -1,0 +1,63 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRejectCrossOriginWrites(t *testing.T) {
+	t.Parallel()
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	tests := []struct {
+		name     string
+		method   string
+		host     string
+		headers  map[string]string
+		wantCode int
+	}{
+		{"GET cross-site passes: safe method", http.MethodGet, "thane:8080", map[string]string{"Sec-Fetch-Site": "cross-site", "Origin": "https://evil.example"}, http.StatusOK},
+		{"HEAD passes", http.MethodHead, "thane:8080", map[string]string{"Origin": "https://evil.example"}, http.StatusOK},
+		{"OPTIONS passes", http.MethodOptions, "thane:8080", map[string]string{"Origin": "https://evil.example"}, http.StatusOK},
+		{"POST without browser headers passes: curl, HA, proxies", http.MethodPost, "thane:8080", nil, http.StatusOK},
+		{"POST same-origin passes", http.MethodPost, "thane:8080", map[string]string{"Sec-Fetch-Site": "same-origin", "Origin": "http://thane:8080"}, http.StatusOK},
+		{"POST user-initiated navigation passes", http.MethodPost, "thane:8080", map[string]string{"Sec-Fetch-Site": "none"}, http.StatusOK},
+		{"POST matching Origin passes without Sec-Fetch-Site", http.MethodPost, "thane:8080", map[string]string{"Origin": "http://thane:8080"}, http.StatusOK},
+		{"POST Origin host case-insensitive", http.MethodPost, "Thane:8080", map[string]string{"Origin": "http://thane:8080"}, http.StatusOK},
+		{"POST proxied hostname without port matches", http.MethodPost, "aimee.example.net", map[string]string{"Origin": "https://aimee.example.net"}, http.StatusOK},
+		{"POST cross-site refused", http.MethodPost, "thane:8080", map[string]string{"Sec-Fetch-Site": "cross-site"}, http.StatusForbidden},
+		{"POST same-site refused: sibling host is another boundary", http.MethodPost, "thane:8080", map[string]string{"Sec-Fetch-Site": "same-site"}, http.StatusForbidden},
+		{"POST mismatched Origin refused", http.MethodPost, "thane:8080", map[string]string{"Origin": "https://evil.example"}, http.StatusForbidden},
+		{"POST Origin differing only by port refused", http.MethodPost, "thane:8080", map[string]string{"Origin": "http://thane:8081"}, http.StatusForbidden},
+		{"POST opaque null Origin refused", http.MethodPost, "thane:8080", map[string]string{"Origin": "null"}, http.StatusForbidden},
+		{"POST unparseable Origin refused", http.MethodPost, "thane:8080", map[string]string{"Origin": "not a url"}, http.StatusForbidden},
+		{"PUT mismatched Origin refused", http.MethodPut, "thane:8080", map[string]string{"Origin": "https://evil.example"}, http.StatusForbidden},
+		{"DELETE cross-site refused", http.MethodDelete, "thane:8080", map[string]string{"Sec-Fetch-Site": "cross-site"}, http.StatusForbidden},
+		{"PATCH mismatched Origin refused", http.MethodPatch, "thane:8080", map[string]string{"Origin": "https://evil.example"}, http.StatusForbidden},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequest(tc.method, "http://"+tc.host+"/v1/loop-definitions", nil)
+			req.Host = tc.host
+			for k, v := range tc.headers {
+				req.Header.Set(k, v)
+			}
+			rec := httptest.NewRecorder()
+			rejectCrossOriginWrites(testAPILogger(), next).ServeHTTP(rec, req)
+			if rec.Code != tc.wantCode {
+				t.Fatalf("status = %d, want %d (body: %s)", rec.Code, tc.wantCode, rec.Body.String())
+			}
+			if tc.wantCode == http.StatusForbidden {
+				if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+					t.Fatalf("Content-Type = %q, want application/json", ct)
+				}
+			}
+		})
+	}
+}

--- a/internal/server/api/ollama.go
+++ b/internal/server/api/ollama.go
@@ -29,16 +29,42 @@ const ollamaMaxBodyBytes = 32 << 20
 // ollamaAuth enforces bearer-token auth on the Ollama-compatible
 // surface when apiKey is non-empty. An empty key passes every request
 // through unchanged, preserving the open-surface default for trusted
-// networks.
+// networks. Rejections use the Ollama error shape.
 func ollamaAuth(apiKey string, next http.Handler) http.Handler {
+	return bearerAuth(apiKey, "ollama", func(w http.ResponseWriter) {
+		ollamaError(w, http.StatusUnauthorized, "authentication required")
+	}, next)
+}
+
+// openaiAuth enforces bearer-token auth on the OpenAI-compatible surface
+// when apiKey is non-empty, with the same open-when-empty default as
+// ollamaAuth. Rejections use the OpenAI error envelope so client
+// libraries surface them as authentication errors rather than parse
+// failures.
+func openaiAuth(apiKey string, next http.Handler) http.Handler {
+	return bearerAuth(apiKey, "openai", func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"message":"authentication required","type":"invalid_request_error","code":"invalid_api_key"}}`))
+	}, next)
+}
+
+// bearerAuth is the shared bearer-token gate behind the compat shims. The
+// configured key and the presented token are compared as fixed-size
+// SHA-256 digests in constant time, so neither the key's length nor its
+// content leaks through timing. reject writes the surface-specific 401
+// body after the WWW-Authenticate challenge for realm has been set.
+func bearerAuth(apiKey, realm string, reject func(http.ResponseWriter), next http.Handler) http.Handler {
 	if apiKey == "" {
 		return next
 	}
+	want := sha256.Sum256([]byte(apiKey))
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		token, ok := strings.CutPrefix(r.Header.Get("Authorization"), "Bearer ")
-		if !ok || subtle.ConstantTimeCompare([]byte(token), []byte(apiKey)) != 1 {
-			w.Header().Set("WWW-Authenticate", `Bearer realm="ollama"`)
-			ollamaError(w, http.StatusUnauthorized, "authentication required")
+		got := sha256.Sum256([]byte(token))
+		if !ok || subtle.ConstantTimeCompare(got[:], want[:]) != 1 {
+			w.Header().Set("WWW-Authenticate", `Bearer realm="`+realm+`"`)
+			reject(w)
 			return
 		}
 		next.ServeHTTP(w, r)

--- a/internal/server/api/ollama_hardening_test.go
+++ b/internal/server/api/ollama_hardening_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -147,5 +148,61 @@ func TestHandleOllamaStreamingChatShared_SanitizesErrorDetail(t *testing.T) {
 	}
 	if !strings.Contains(body, "agent error") {
 		t.Fatalf("expected sanitized generic message in body: %s", body)
+	}
+}
+
+func TestOpenAIAuth(t *testing.T) {
+	t.Parallel()
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	tests := []struct {
+		name       string
+		apiKey     string
+		authHeader string
+		wantCode   int
+	}{
+		{"no key configured leaves surface open", "", "", http.StatusOK},
+		{"missing header rejected", "sekrit", "", http.StatusUnauthorized},
+		{"wrong scheme rejected", "sekrit", "Basic sekrit", http.StatusUnauthorized},
+		{"wrong token rejected", "sekrit", "Bearer wrong", http.StatusUnauthorized},
+		{"prefix of key rejected", "sekrit", "Bearer sekri", http.StatusUnauthorized},
+		{"correct token accepted", "sekrit", "Bearer sekrit", http.StatusOK},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+			if tc.authHeader != "" {
+				req.Header.Set("Authorization", tc.authHeader)
+			}
+			rec := httptest.NewRecorder()
+			openaiAuth(tc.apiKey, next).ServeHTTP(rec, req)
+			if rec.Code != tc.wantCode {
+				t.Fatalf("status = %d, want %d (body: %s)", rec.Code, tc.wantCode, rec.Body.String())
+			}
+			if tc.wantCode != http.StatusUnauthorized {
+				return
+			}
+			if got := rec.Header().Get("WWW-Authenticate"); got != `Bearer realm="openai"` {
+				t.Fatalf("WWW-Authenticate = %q, want openai realm challenge", got)
+			}
+			var body struct {
+				Error struct {
+					Message string `json:"message"`
+					Type    string `json:"type"`
+					Code    string `json:"code"`
+				} `json:"error"`
+			}
+			if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+				t.Fatalf("decode OpenAI error envelope: %v (body: %s)", err, rec.Body.String())
+			}
+			if body.Error.Code != "invalid_api_key" || body.Error.Type != "invalid_request_error" {
+				t.Fatalf("error envelope = %+v, want invalid_api_key/invalid_request_error", body.Error)
+			}
+		})
 	}
 }

--- a/internal/server/api/ollama_server.go
+++ b/internal/server/api/ollama_server.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/nugget/thane-ai-agent/internal/platform/logging"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agent"
+	"github.com/nugget/thane-ai-agent/internal/server/listen"
 )
 
 // OllamaServer is a dedicated server for Ollama-compatible API endpoints.
@@ -81,9 +82,9 @@ func (s *OllamaServer) Start(ctx context.Context) error {
 
 	// Auth and the cross-origin guard sit inside logging so rejected
 	// requests still produce access-log lines with their 401/403 status.
-	s.server = newHTTPServer(
+	s.server = listen.NewServer(
 		fmt.Sprintf("%s:%d", s.address, s.port),
-		s.withLogging(rejectCrossOriginWrites(s.logger, ollamaAuth(s.apiKey, mux))),
+		s.withLogging(listen.RejectCrossOriginWrites(s.logger, ollamaAuth(s.apiKey, mux))),
 		30*time.Second,
 		300*time.Second, // Long for slow models
 	)

--- a/internal/server/api/ollama_server.go
+++ b/internal/server/api/ollama_server.go
@@ -79,11 +79,11 @@ func (s *OllamaServer) Start(ctx context.Context) error {
 	mux.HandleFunc("HEAD /{$}", s.handleHead)
 	mux.HandleFunc("GET /{$}", s.handleHealth)
 
-	// Auth sits inside logging so rejected requests still produce
-	// access-log lines with their 401 status.
+	// Auth and the cross-origin guard sit inside logging so rejected
+	// requests still produce access-log lines with their 401/403 status.
 	s.server = &http.Server{
 		Addr:         fmt.Sprintf("%s:%d", s.address, s.port),
-		Handler:      s.withLogging(ollamaAuth(s.apiKey, mux)),
+		Handler:      s.withLogging(rejectCrossOriginWrites(s.logger, ollamaAuth(s.apiKey, mux))),
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 300 * time.Second, // Long for slow models
 	}

--- a/internal/server/api/ollama_server.go
+++ b/internal/server/api/ollama_server.go
@@ -81,12 +81,12 @@ func (s *OllamaServer) Start(ctx context.Context) error {
 
 	// Auth and the cross-origin guard sit inside logging so rejected
 	// requests still produce access-log lines with their 401/403 status.
-	s.server = &http.Server{
-		Addr:         fmt.Sprintf("%s:%d", s.address, s.port),
-		Handler:      s.withLogging(rejectCrossOriginWrites(s.logger, ollamaAuth(s.apiKey, mux))),
-		ReadTimeout:  30 * time.Second,
-		WriteTimeout: 300 * time.Second, // Long for slow models
-	}
+	s.server = newHTTPServer(
+		fmt.Sprintf("%s:%d", s.address, s.port),
+		s.withLogging(rejectCrossOriginWrites(s.logger, ollamaAuth(s.apiKey, mux))),
+		30*time.Second,
+		300*time.Second, // Long for slow models
+	)
 
 	addr := s.address
 	if addr == "" {

--- a/internal/server/api/openai_server.go
+++ b/internal/server/api/openai_server.go
@@ -55,12 +55,12 @@ func (s *OpenAIServer) Start(ctx context.Context) error {
 	mux := http.NewServeMux()
 	s.api.RegisterOpenAIRoutes(mux)
 
-	s.server = &http.Server{
-		Addr:         fmt.Sprintf("%s:%d", s.address, s.port),
-		Handler:      s.withLogging(rejectCrossOriginWrites(s.logger, openaiAuth(s.apiKey, mux))),
-		ReadTimeout:  30 * time.Second,
-		WriteTimeout: 300 * time.Second, // Long for slow models
-	}
+	s.server = newHTTPServer(
+		fmt.Sprintf("%s:%d", s.address, s.port),
+		s.withLogging(rejectCrossOriginWrites(s.logger, openaiAuth(s.apiKey, limitRequestBody(compatMaxBodyBytes, mux)))),
+		30*time.Second,
+		300*time.Second, // Long for slow models
+	)
 
 	addr := s.address
 	if addr == "" {

--- a/internal/server/api/openai_server.go
+++ b/internal/server/api/openai_server.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/platform/logging"
+	"github.com/nugget/thane-ai-agent/internal/server/listen"
 )
 
 // OpenAIServer is a dedicated server for the OpenAI-compatible API surface.
@@ -55,9 +56,9 @@ func (s *OpenAIServer) Start(ctx context.Context) error {
 	mux := http.NewServeMux()
 	s.api.RegisterOpenAIRoutes(mux)
 
-	s.server = newHTTPServer(
+	s.server = listen.NewServer(
 		fmt.Sprintf("%s:%d", s.address, s.port),
-		s.withLogging(rejectCrossOriginWrites(s.logger, openaiAuth(s.apiKey, limitRequestBody(compatMaxBodyBytes, mux)))),
+		s.withLogging(listen.RejectCrossOriginWrites(s.logger, openaiAuth(s.apiKey, listen.LimitRequestBody(compatMaxBodyBytes, mux)))),
 		30*time.Second,
 		300*time.Second, // Long for slow models
 	)

--- a/internal/server/api/openai_server.go
+++ b/internal/server/api/openai_server.go
@@ -18,6 +18,7 @@ import (
 // owns only the listener and route registration.
 type OpenAIServer struct {
 	address string
+	apiKey  string // bearer token required when non-empty; see openaiAuth
 	port    int
 	api     *Server
 	logger  *slog.Logger
@@ -30,15 +31,17 @@ type OpenAIServer struct {
 // Parameters:
 //   - address: IP address to bind to (empty string binds to all interfaces)
 //   - port: Port to listen on (default 8081)
+//   - apiKey: bearer token every request must present; empty leaves the
+//     surface open (see config.OpenAIAPIConfig.APIKey)
 //   - apiServer: The native Server whose OpenAI-compatible handlers are served
 //   - logger: Logger for request and error logging
 //
 // The server is created but not started. Call Start to begin serving requests.
-func NewOpenAIServer(address string, port int, apiServer *Server, logger *slog.Logger) *OpenAIServer {
+func NewOpenAIServer(address string, port int, apiKey string, apiServer *Server, logger *slog.Logger) *OpenAIServer {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &OpenAIServer{address: address, port: port, api: apiServer, logger: logger}
+	return &OpenAIServer{address: address, port: port, apiKey: apiKey, api: apiServer, logger: logger}
 }
 
 // Start begins serving the OpenAI-compatible surface and blocks until the
@@ -54,7 +57,7 @@ func (s *OpenAIServer) Start(ctx context.Context) error {
 
 	s.server = &http.Server{
 		Addr:         fmt.Sprintf("%s:%d", s.address, s.port),
-		Handler:      s.withLogging(rejectCrossOriginWrites(s.logger, mux)),
+		Handler:      s.withLogging(rejectCrossOriginWrites(s.logger, openaiAuth(s.apiKey, mux))),
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 300 * time.Second, // Long for slow models
 	}

--- a/internal/server/api/openai_server.go
+++ b/internal/server/api/openai_server.go
@@ -54,7 +54,7 @@ func (s *OpenAIServer) Start(ctx context.Context) error {
 
 	s.server = &http.Server{
 		Addr:         fmt.Sprintf("%s:%d", s.address, s.port),
-		Handler:      s.withLogging(mux),
+		Handler:      s.withLogging(rejectCrossOriginWrites(s.logger, mux)),
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 300 * time.Second, // Long for slow models
 	}

--- a/internal/server/api/server.go
+++ b/internal/server/api/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/runtime/archivist"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/server/legacyroute"
+	"github.com/nugget/thane-ai-agent/internal/server/listen"
 	"github.com/nugget/thane-ai-agent/internal/server/openapi"
 	"github.com/nugget/thane-ai-agent/internal/state/contacts"
 	"github.com/nugget/thane-ai-agent/internal/state/memory"
@@ -582,9 +583,9 @@ func (s *Server) Start(ctx context.Context) error {
 	// when ollama_api.enabled is true in config. Use RegisterOllamaRoutes()
 	// only if you need single-port operation.
 
-	s.server = newHTTPServer(
+	s.server = listen.NewServer(
 		fmt.Sprintf("%s:%d", s.address, s.port),
-		s.withLogging(rejectCrossOriginWrites(s.logger, limitRequestBody(nativeMaxBodyBytes, mux))),
+		s.withLogging(listen.RejectCrossOriginWrites(s.logger, listen.LimitRequestBody(nativeMaxBodyBytes, mux))),
 		30*time.Second,
 		120*time.Second, // Long for streaming responses
 	)

--- a/internal/server/api/server.go
+++ b/internal/server/api/server.go
@@ -582,12 +582,12 @@ func (s *Server) Start(ctx context.Context) error {
 	// when ollama_api.enabled is true in config. Use RegisterOllamaRoutes()
 	// only if you need single-port operation.
 
-	s.server = &http.Server{
-		Addr:         fmt.Sprintf("%s:%d", s.address, s.port),
-		Handler:      s.withLogging(rejectCrossOriginWrites(s.logger, mux)),
-		ReadTimeout:  30 * time.Second,
-		WriteTimeout: 120 * time.Second, // Long for streaming responses
-	}
+	s.server = newHTTPServer(
+		fmt.Sprintf("%s:%d", s.address, s.port),
+		s.withLogging(rejectCrossOriginWrites(s.logger, limitRequestBody(nativeMaxBodyBytes, mux))),
+		30*time.Second,
+		120*time.Second, // Long for streaming responses
+	)
 
 	addr := s.address
 	if addr == "" {

--- a/internal/server/api/server.go
+++ b/internal/server/api/server.go
@@ -584,7 +584,7 @@ func (s *Server) Start(ctx context.Context) error {
 
 	s.server = &http.Server{
 		Addr:         fmt.Sprintf("%s:%d", s.address, s.port),
-		Handler:      s.withLogging(mux),
+		Handler:      s.withLogging(rejectCrossOriginWrites(s.logger, mux)),
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 120 * time.Second, // Long for streaming responses
 	}

--- a/internal/server/carddav/server.go
+++ b/internal/server/carddav/server.go
@@ -14,6 +14,7 @@ import (
 
 	libcarddav "github.com/emersion/go-webdav/carddav"
 	"github.com/nugget/thane-ai-agent/internal/platform/logging"
+	"github.com/nugget/thane-ai-agent/internal/server/listen"
 )
 
 // Server wraps a CardDAV handler with HTTP server lifecycle, Basic
@@ -112,11 +113,7 @@ func (s *Server) bind(addr string) error {
 		return err
 	}
 
-	srv := &http.Server{
-		Handler:      s.handler,
-		ReadTimeout:  30 * time.Second,
-		WriteTimeout: 60 * time.Second,
-	}
+	srv := listen.NewServer("", s.handler, 30*time.Second, 60*time.Second)
 
 	s.mu.Lock()
 	s.servers[addr] = srv
@@ -182,13 +179,16 @@ func (s *Server) tryRebind() {
 }
 
 // buildHandler creates the HTTP handler chain: auth → logging →
-// carddav.Handler.
+// cross-origin guard → carddav.Handler. The guard sits after auth
+// because the forgery it stops is a browser replaying cached Basic
+// credentials on a cross-site request; the credentials pass, the origin
+// does not.
 func (s *Server) buildHandler() http.Handler {
 	davHandler := &libcarddav.Handler{
 		Backend: s.backend,
 		Prefix:  "/carddav",
 	}
-	return s.withAuth(s.withLogging(davHandler))
+	return s.withAuth(s.withLogging(listen.RejectCrossOriginWrites(s.logger, davHandler)))
 }
 
 // withAuth wraps a handler with HTTP Basic Auth.  The .well-known

--- a/internal/server/listen/listen.go
+++ b/internal/server/listen/listen.go
@@ -1,4 +1,10 @@
-package api
+// Package listen holds the bounds and guards every inbound HTTP listener
+// Thane runs must share: the native API, the Ollama and OpenAI shims, and
+// CardDAV. It exists so that a listener cannot be added, or a new
+// http.Server constructed, without them. Per-surface read and write
+// budgets stay with the surface because streaming needs differ; what
+// lives here is everything that has no reason to differ.
+package listen
 
 import (
 	"encoding/json"
@@ -9,7 +15,49 @@ import (
 	"time"
 )
 
-// rejectCrossOriginWrites refuses state-changing requests that a browser
+const (
+	// ReadHeaderTimeout is a header-specific bound, shorter than any
+	// surface's ReadTimeout. ReadTimeout covers the whole request read,
+	// headers included, but is sized for bodies that may legitimately
+	// take tens of seconds to arrive; a client that trickles headers for
+	// that long is not a legitimate client, so headers get their own,
+	// tighter clock.
+	ReadHeaderTimeout = 10 * time.Second
+	// IdleTimeout reclaims keep-alive connections nobody is using.
+	IdleTimeout = 120 * time.Second
+	// MaxHeaderBytes is generous for real clients and a fraction of the
+	// 1 MiB net/http default.
+	MaxHeaderBytes = 64 << 10
+)
+
+// NewServer builds an http.Server with the shared listener bounds applied
+// around the surface's own read and write timeouts. addr may be empty when
+// the caller serves on a listener it created itself.
+func NewServer(addr string, handler http.Handler, readTimeout, writeTimeout time.Duration) *http.Server {
+	return &http.Server{
+		Addr:              addr,
+		Handler:           handler,
+		ReadTimeout:       readTimeout,
+		ReadHeaderTimeout: ReadHeaderTimeout,
+		WriteTimeout:      writeTimeout,
+		IdleTimeout:       IdleTimeout,
+		MaxHeaderBytes:    MaxHeaderBytes,
+	}
+}
+
+// LimitRequestBody caps every request body at maxBytes before handlers
+// decode it. Reads past the cap fail with *http.MaxBytesError, and
+// net/http closes the connection rather than draining the excess.
+func LimitRequestBody(maxBytes int64, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Body != nil && r.Body != http.NoBody {
+			r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// RejectCrossOriginWrites refuses state-changing requests that a browser
 // reports as coming from another origin. It closes the blind cross-site
 // request forgery path: a POST with a text/plain body is a CORS "simple
 // request", so a page on any origin can fire it at a listener without a
@@ -22,14 +70,14 @@ import (
 // registrable domain are not the same trust boundary. When an Origin
 // header is present, its host must equal the request Host; an opaque
 // "null" origin is refused. A request carrying neither header, which is
-// every curl, Home Assistant, companion, and reverse-proxy client, passes
-// unchanged. Safe methods pass unconditionally because they change no
-// state and because the WebSocket upgrade is a GET.
+// every curl, Home Assistant, companion, CardDAV, and reverse-proxy
+// client, passes unchanged. Safe methods pass unconditionally because
+// they change no state and because the WebSocket upgrade is a GET.
 //
 // When the native API grows a credentialed CORS allowlist for detached
 // UI origins, that allowlist belongs here as the one place an Origin is
 // admitted.
-func rejectCrossOriginWrites(logger *slog.Logger, next http.Handler) http.Handler {
+func RejectCrossOriginWrites(logger *slog.Logger, next http.Handler) http.Handler {
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -89,7 +137,7 @@ func crossOriginWriteReason(r *http.Request) string {
 
 // writeJSONError writes a minimal {"error": message} body. It is the shape
 // every listener's clients can parse, which matters for a guard shared
-// across the native, Ollama, and OpenAI surfaces.
+// across surfaces with different native error envelopes.
 func writeJSONError(w http.ResponseWriter, code int, message string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
@@ -98,54 +146,4 @@ func writeJSONError(w http.ResponseWriter, code int, message string) {
 		body = []byte(`{"error":"internal error"}`)
 	}
 	_, _ = w.Write(body)
-}
-
-// Listener-wide bounds shared by every HTTP server Thane runs. Read and
-// write timeouts stay per-surface because streaming budgets differ; these
-// are the limits that have no reason to differ.
-const (
-	// serverReadHeaderTimeout bounds how long a client may take to finish
-	// sending request headers, closing the slow-header connection hold
-	// that a bare ReadTimeout does not start counting until the body.
-	serverReadHeaderTimeout = 10 * time.Second
-	// serverIdleTimeout reclaims keep-alive connections nobody is using.
-	serverIdleTimeout = 120 * time.Second
-	// serverMaxHeaderBytes is generous for real clients and a fraction of
-	// the 1 MiB net/http default.
-	serverMaxHeaderBytes = 64 << 10
-
-	// nativeMaxBodyBytes caps native /v1 request bodies. The largest
-	// legitimate payloads are loop definitions and contact records; 8 MiB
-	// is far above either while bounding what an unauthenticated caller
-	// can make the decoder hold.
-	nativeMaxBodyBytes = 8 << 20
-	// compatMaxBodyBytes caps compat-shim bodies, which may carry chat
-	// history plus base64 images. Matches the Ollama handler's own cap.
-	compatMaxBodyBytes = 32 << 20
-)
-
-// newHTTPServer builds an http.Server with the shared listener bounds
-// applied, so no listener can be added without them.
-func newHTTPServer(addr string, handler http.Handler, readTimeout, writeTimeout time.Duration) *http.Server {
-	return &http.Server{
-		Addr:              addr,
-		Handler:           handler,
-		ReadTimeout:       readTimeout,
-		ReadHeaderTimeout: serverReadHeaderTimeout,
-		WriteTimeout:      writeTimeout,
-		IdleTimeout:       serverIdleTimeout,
-		MaxHeaderBytes:    serverMaxHeaderBytes,
-	}
-}
-
-// limitRequestBody caps every request body at maxBytes before handlers
-// decode it. Reads past the cap fail with *http.MaxBytesError, and
-// net/http closes the connection rather than draining the excess.
-func limitRequestBody(maxBytes int64, next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Body != nil && r.Body != http.NoBody {
-			r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
-		}
-		next.ServeHTTP(w, r)
-	})
 }

--- a/internal/server/listen/listen_test.go
+++ b/internal/server/listen/listen_test.go
@@ -1,4 +1,4 @@
-package api
+package listen
 
 import (
 	"errors"
@@ -53,7 +53,7 @@ func TestRejectCrossOriginWrites(t *testing.T) {
 				req.Header.Set(k, v)
 			}
 			rec := httptest.NewRecorder()
-			rejectCrossOriginWrites(testAPILogger(), next).ServeHTTP(rec, req)
+			RejectCrossOriginWrites(nil, next).ServeHTTP(rec, req)
 			if rec.Code != tc.wantCode {
 				t.Fatalf("status = %d, want %d (body: %s)", rec.Code, tc.wantCode, rec.Body.String())
 			}
@@ -66,10 +66,10 @@ func TestRejectCrossOriginWrites(t *testing.T) {
 	}
 }
 
-func TestNewHTTPServerAppliesSharedBounds(t *testing.T) {
+func TestNewServerAppliesSharedBounds(t *testing.T) {
 	t.Parallel()
 
-	srv := newHTTPServer(":0", http.NotFoundHandler(), 30*time.Second, 120*time.Second)
+	srv := NewServer(":0", http.NotFoundHandler(), 30*time.Second, 120*time.Second)
 	if srv.ReadTimeout != 30*time.Second || srv.WriteTimeout != 120*time.Second {
 		t.Fatalf("per-surface timeouts not preserved: read=%s write=%s", srv.ReadTimeout, srv.WriteTimeout)
 	}
@@ -91,7 +91,7 @@ func TestLimitRequestBody(t *testing.T) {
 
 	t.Run("body within cap reads fully", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/v1/chat", strings.NewReader(strings.Repeat("a", 16)))
-		limitRequestBody(32, next).ServeHTTP(httptest.NewRecorder(), req)
+		LimitRequestBody(32, next).ServeHTTP(httptest.NewRecorder(), req)
 		if readErr != nil || readLen != 16 {
 			t.Fatalf("read = (%d, %v), want (16, nil)", readLen, readErr)
 		}
@@ -99,7 +99,7 @@ func TestLimitRequestBody(t *testing.T) {
 
 	t.Run("body past cap fails with MaxBytesError", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/v1/chat", strings.NewReader(strings.Repeat("a", 64)))
-		limitRequestBody(32, next).ServeHTTP(httptest.NewRecorder(), req)
+		LimitRequestBody(32, next).ServeHTTP(httptest.NewRecorder(), req)
 		var maxErr *http.MaxBytesError
 		if !errors.As(readErr, &maxErr) {
 			t.Fatalf("read error = %v, want *http.MaxBytesError", readErr)

--- a/internal/server/openapi/compat.yaml
+++ b/internal/server/openapi/compat.yaml
@@ -69,6 +69,7 @@ paths:
               schema:
                 type: string
                 description: SSE stream of completion chunks (OpenAI delta format).
+        "401": { $ref: "#/components/responses/OpenAIUnauthorized" }
   /v1/models:
     get:
       tags: [openai]
@@ -86,6 +87,7 @@ paths:
           content:
             application/json:
               schema: { $ref: "#/components/schemas/ModelList" }
+        "401": { $ref: "#/components/responses/OpenAIUnauthorized" }
 
   /api/chat:
     post:
@@ -183,8 +185,23 @@ components:
     apiKey:
       type: http
       scheme: bearer
-      description: Per-client API key. Coarse inference access (no granular scopes).
+      description: >-
+        Per-client API key. Coarse inference access (no granular scopes).
+        Configured per surface (`openai_api.api_key`, `ollama_api.api_key`);
+        a surface with no key configured is open and never returns 401.
   responses:
+    OpenAIUnauthorized:
+      description: >-
+        Missing or invalid bearer token. Returned only when `openai_api.api_key`
+        is configured; with no key configured the surface is open (the
+        trusted-network default) and never returns 401.
+      headers:
+        WWW-Authenticate:
+          description: 'Authentication challenge: `Bearer realm="openai"`.'
+          schema: { type: string }
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/OpenAIError" }
     OllamaUnauthorized:
       description: >-
         Missing or invalid bearer token. Returned only when an API key is
@@ -198,6 +215,28 @@ components:
         application/json:
           schema: { $ref: "#/components/schemas/OllamaError" }
   schemas:
+    OpenAIError:
+      type: object
+      description: OpenAI error envelope, as client libraries expect it.
+      required: [error]
+      properties:
+        error:
+          type: object
+          description: The error object; always present on a non-2xx response.
+          required: [message, type]
+          properties:
+            message:
+              type: string
+              description: Human-readable reason for the failure.
+              examples: ["authentication required"]
+            type:
+              type: string
+              description: OpenAI error class; authentication failures use `invalid_request_error`.
+              examples: ["invalid_request_error"]
+            code:
+              type: string
+              description: Machine-readable code; `invalid_api_key` for a missing or wrong bearer token.
+              examples: ["invalid_api_key"]
     ChatMessage:
       type: object
       description: One message in a chat exchange (OpenAI/Ollama shape).

--- a/internal/server/openapi/compat.yaml
+++ b/internal/server/openapi/compat.yaml
@@ -16,9 +16,11 @@ info:
     - **OpenAI-compatible** (`/v1/chat/completions`, `/v1/models`) — default port 8081.
     - **Ollama-compatible** (`/api/*`) — default port 11434.
 
-    AuthN is a per-client bearer API key (`Authorization: Bearer <key>`);
-    authorization is coarse (inference access), intentionally distinct from the
-    native API's granular `resource:action` scopes.
+    AuthN is one bearer API key per surface (`Authorization: Bearer <key>`),
+    configured as `openai_api.api_key` and `ollama_api.api_key`; there are no
+    per-client credentials, so revocation means rotating the surface's key.
+    Authorization is coarse (inference access), intentionally distinct from
+    the native API's granular `resource:action` scopes.
   contact:
     name: Thane — nugget/thane-ai-agent
     url: https://github.com/nugget/thane-ai-agent
@@ -186,9 +188,10 @@ components:
       type: http
       scheme: bearer
       description: >-
-        Per-client API key. Coarse inference access (no granular scopes).
-        Configured per surface (`openai_api.api_key`, `ollama_api.api_key`);
-        a surface with no key configured is open and never returns 401.
+        Per-surface API key, shared by every client of that surface. Coarse
+        inference access (no granular scopes). Configured as
+        `openai_api.api_key` and `ollama_api.api_key`; a surface with no key
+        configured is open and never returns 401.
   responses:
     OpenAIUnauthorized:
       description: >-

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,4 +1,4 @@
-packages=70
+packages=71
 interfaces=88
 large_files=59
 set_mutators=124


### PR DESCRIPTION
## The perimeter was a bind address

A survey of every inbound listener found that the native API on port 8080 runs behind logging middleware and nothing else. Loop definition, loop launch, checkpoint restore, contact deletion, and session reset are all reachable by anyone who can open a TCP connection, and the listener binds every interface by default while the configuration guide said it bound localhost. The OpenAI shim had no auth option at all, though the compatibility spec had declared one since it was written. The companion WebSocket looked its account tokens up in a plain Go map while the sibling HTTP path hashed and compared them in constant time. No listener bounded header read time, idle connections, or header size, and only the Ollama handler capped request bodies.

None of that is the design flaw the survey turned up. The design flaw is that the trust model treats the network as the boundary and enforces trust zones only as prompt text. That is a larger arc, chartered in #1499; this PR is its phase 0. What this PR does is close the cheap, blind, and misleading paths first so the larger arc starts from an honest floor.

## What lands here, one commit each

**Cross-origin writes are refused on every listener.** A POST with a text/plain body is a CORS simple request. A page on any origin the operator has open could fire one at the native API without a preflight, and the absence of CORS headers only hid the response; it never stopped the write. One guard now runs ahead of every route on all three HTTP servers. Unsafe methods carrying `Sec-Fetch-Site: cross-site` or `same-site` are refused, as is an `Origin` whose host differs from the request `Host` or is the opaque `null` origin. Requests with neither header, which is every curl, Home Assistant, companion, and reverse-proxy client, pass unchanged, and safe methods pass unconditionally so the WebSocket upgrade is untouched. Refusals log at WARN with the signals that triggered them. The configuration guide now states the real bind default and how to keep a listener host-local.

**The OpenAI shim gains `openai_api.api_key`.** It gates the surface the same way the Ollama key does, open when empty, and rejects in the OpenAI error envelope with `invalid_api_key` so client libraries raise an authentication error rather than a parse failure. Both shims now share one bearer gate that compares SHA-256 digests in constant time, so the key's length no longer leaks the way a raw compare of unequal-length byte slices allowed. The compat spec documents the 401 for both OpenAI operations.

**Companion tokens resolve through one matcher.** The WebSocket handshake and HTTP observation ingestion authenticate the same secret set. They now share a matcher that hashes tokens at construction, compares fixed-size digests in constant time, and never returns early, so the two paths cannot drift in posture by editing one of them. `NewHandler` keeps its signature.

**Shared listener bounds and body caps.** All three servers are built through one constructor that applies a header-read timeout, an idle timeout, and a header size cap, so a listener cannot be added without them. Per-surface read and write budgets are unchanged. The native API caps bodies at 8 MiB and the OpenAI shim at 32 MiB, matching the Ollama handler's existing cap.

## What this deliberately does not do

It does not add authentication to the native API, flip the default bind to loopback, or gate the open-by-default Ollama surface that Home Assistant depends on. Each of those changes prod behaviour and each belongs to the next phase, where the native API gets a bearer middleware with an explicitly enumerated exemption list pinned by a route-table test, the console gets a login exchange, and the Ollama listener gets a source allowlist HA can satisfy. Boot warnings for open listeners were considered and skipped: they describe a state the next phase removes.

## Test plan

- [x] `just ci` passes locally (fmt, lint, OpenAPI lint, race tests).
- [x] New table-driven tests: cross-origin guard across methods and header combinations, OpenAI bearer gate including envelope shape and realm, token matcher including empty and prefix tokens, shared server bounds, body cap failing with `MaxBytesError`.
- [ ] Post-deploy: dashboard loads and its SSE stream runs (same-origin GETs, unaffected by the guard); Home Assistant conversation via the Ollama port still answers; companion app reconnects over `/v1/realtime/ws`; Traefik-fronted `https://` host still serves `/v1/version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
