### PR TITLE
fix(tls): public_port for redirects behind a packet filter, and honest privileged-port guidance

### DIFF
--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -581,8 +581,8 @@ dashboard, `ollama`, or `openai`), a plain-HTTP listener answers with a
 permanent redirect and nothing else, and every HTTPS response carries
 `Strict-Transport-Security` (`hsts_max_age` sets its lifetime,
 `hsts_disabled: true` omits it). A request for a hostname that is not listed
-gets `421 Misdirected Request`. Ports 80 and 443 need privilege Thane should
-not hold; where it runs unprivileged, bind high ports, redirect the public
+gets `421 Misdirected Request`. Ports 80 and 443 need privilege that Thane
+should not hold; where it runs unprivileged, bind high ports, redirect the public
 ones to them with the OS packet filter, and set `https.public_port` so the
 redirect names the port clients use (see
 [Deployment](deployment.md#network-requirements)). Hostnames are explicit and lowercase;

--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -551,6 +551,7 @@ tls:
   enabled: true
   https:
     port: 443
+    # public_port: 443  # when a packet filter maps 443 to a high port Thane binds
   http:
     port: 80            # redirect only; disabled: true turns it off
   hsts_max_age: 4320h
@@ -580,7 +581,11 @@ dashboard, `ollama`, or `openai`), a plain-HTTP listener answers with a
 permanent redirect and nothing else, and every HTTPS response carries
 `Strict-Transport-Security` (`hsts_max_age` sets its lifetime,
 `hsts_disabled: true` omits it). A request for a hostname that is not listed
-gets `421 Misdirected Request`. Hostnames are explicit and lowercase;
+gets `421 Misdirected Request`. Ports 80 and 443 need privilege Thane should
+not hold; where it runs unprivileged, bind high ports, redirect the public
+ones to them with the OS packet filter, and set `https.public_port` so the
+redirect names the port clients use (see
+[Deployment](deployment.md#network-requirements)). Hostnames are explicit and lowercase;
 wildcards and IP literals are refused, and a hostname routed to a shim
 that is not enabled fails validation. The plaintext listeners under
 `listen:`, `ollama_api:`, and `openai_api:` are unaffected; the front door

--- a/docs/operating/deployment.md
+++ b/docs/operating/deployment.md
@@ -112,11 +112,27 @@ Thane listens on these ports (all configurable):
 
 The HTTPS front door terminates TLS in-process and routes each configured
 hostname to one of the plaintext surfaces above, so no reverse proxy is
-needed; see [HTTPS Front Door](configuration.md#https-front-door). On macOS
-an unprivileged process may bind ports 80 and 443. On Linux, grant the
-binary `CAP_NET_BIND_SERVICE` (`setcap 'cap_net_bind_service=+ep'
-/path/to/thane`, or `AmbientCapabilities=CAP_NET_BIND_SERVICE` in the
-systemd unit) or lower `net.ipv4.ip_unprivileged_port_start`.
+needed; see [HTTPS Front Door](configuration.md#https-front-door).
+
+Ports 80 and 443 need privilege on every platform Thane runs on, and
+Thane should not have it. On Linux, grant the binary
+`CAP_NET_BIND_SERVICE` (`setcap 'cap_net_bind_service=+ep' /path/to/thane`,
+or `AmbientCapabilities=CAP_NET_BIND_SERVICE` in the systemd unit) or lower
+`net.ipv4.ip_unprivileged_port_start`. macOS refuses ports below 1024 to
+ordinary users and offers no capability to grant, so keep Thane on high
+ports and let the packet filter carry the public ones: bind
+`tls.https.port: 8443` and `tls.http.port: 8880`, set
+`tls.https.public_port: 443` so the HTTP redirect names the port clients
+use, and install a `pf` redirect once as root, for example an anchor
+containing
+
+```
+rdr pass on en0 inet proto tcp from any to any port 443 -> 127.0.0.1 port 8443
+rdr pass on en0 inet proto tcp from any to any port 80  -> 127.0.0.1 port 8880
+```
+
+loaded from `/etc/pf.conf` so it survives a reboot. Adjust the interface
+name to the one carrying LAN traffic and verify with `pfctl -s nat`.
 
 ### Replacing a reverse proxy with the front door
 

--- a/docs/operating/deployment.md
+++ b/docs/operating/deployment.md
@@ -123,16 +123,25 @@ ordinary users and offers no capability to grant, so keep Thane on high
 ports and let the packet filter carry the public ones: bind
 `tls.https.port: 8443` and `tls.http.port: 8880`, set
 `tls.https.public_port: 443` so the HTTP redirect names the port clients
-use, and install a `pf` redirect once as root, for example an anchor
-containing
+use, and install a `pf` redirect once as root. Put the rules in an anchor
+file, `/etc/pf.anchors/thane`:
 
 ```
 rdr pass on en0 inet proto tcp from any to any port 443 -> 127.0.0.1 port 8443
 rdr pass on en0 inet proto tcp from any to any port 80  -> 127.0.0.1 port 8880
 ```
 
-loaded from `/etc/pf.conf` so it survives a reboot. Adjust the interface
-name to the one carrying LAN traffic and verify with `pfctl -s nat`.
+and reference it from `/etc/pf.conf` so it survives a reboot:
+
+```
+rdr-anchor "thane"
+load anchor "thane" from "/etc/pf.anchors/thane"
+```
+
+Adjust the interface name to the one carrying LAN traffic, load with
+`pfctl -f /etc/pf.conf` and enable with `pfctl -e`, and verify by naming
+the anchor, since `pfctl -s nat` alone does not descend into anchors:
+`pfctl -a thane -s nat`.
 
 ### Replacing a reverse proxy with the front door
 
@@ -142,10 +151,15 @@ directory and `https.port` on an alternate port such as 8443, then start
 Thane and watch `subsystem=tls` log lines for `tls certificate obtained`
 against every hostname. Staging certificates are not browser-trusted, so
 verify with `curl --insecure` or by inspecting the issuer. Once every
-hostname issues, remove `certmagic.ca`, set `https.port` to 443, stop the
-proxy, and restart Thane; the hostnames already point at the host, so no
-DNS change is involved. Thane's own access log now records real client
-addresses where the proxy reported its own.
+hostname issues, remove `certmagic.ca`, move the front door onto the public
+ports, stop the proxy, and restart Thane; the hostnames already point at
+the host, so no DNS change is involved. Moving onto the public ports means
+`https.port: 443` and `http.port: 80` only where Thane has been granted
+the privilege to bind them (the Linux capability above); on macOS, and on
+any host where Thane stays unprivileged, keep the high binds and set
+`https.public_port: 443` with the packet-filter redirect above carrying
+443 and 80. Thane's own access log now records real client addresses where
+the proxy reported its own.
 
 Thane also needs outbound access to:
 - Your Home Assistant instance (REST + WebSocket)

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -58,14 +58,23 @@ tls:
   # Enabled starts the HTTPS front door. Off by default; the plaintext
   # listeners are unaffected either way.
   enabled: false
-  # HTTPS is the TLS listener. Port defaults to 443. macOS permits an
-  # unprivileged process to bind it; Linux needs CAP_NET_BIND_SERVICE
-  # or the unprivileged-port sysctl.
+  # HTTPS is the TLS listener. Port defaults to 443. Binding it needs
+  # privilege on every platform Thane runs on: Linux wants
+  # CAP_NET_BIND_SERVICE or the unprivileged-port sysctl, and macOS
+  # refuses ports below 1024 to ordinary users outright. Where Thane
+  # runs unprivileged, bind a high port and redirect 443 to it with the
+  # OS packet filter, then set PublicPort so redirects name the port
+  # clients actually use.
   https:
     # Address is the bind address; empty means all interfaces.
     address: ""
-    # Port is the TCP port. Default: 443.
+    # Port is the TCP port Thane binds. Default: 443.
     port: 443
+    # PublicPort is the port clients reach the listener on when a packet
+    # filter or port map sits in front of it (Thane bound to 8443, the
+    # OS redirecting 443 to it). It is what the plain-HTTP redirect names
+    # in its Location; zero means the same as Port.
+    public_port: 0
   # HTTP is the plain listener that answers every request with a
   # permanent redirect to HTTPS and nothing else. Port defaults to 80.
   http:

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -793,9 +793,13 @@ type TLSConfig struct {
 	// listeners are unaffected either way.
 	Enabled bool `yaml:"enabled"`
 
-	// HTTPS is the TLS listener. Port defaults to 443. macOS permits an
-	// unprivileged process to bind it; Linux needs CAP_NET_BIND_SERVICE
-	// or the unprivileged-port sysctl.
+	// HTTPS is the TLS listener. Port defaults to 443. Binding it needs
+	// privilege on every platform Thane runs on: Linux wants
+	// CAP_NET_BIND_SERVICE or the unprivileged-port sysctl, and macOS
+	// refuses ports below 1024 to ordinary users outright. Where Thane
+	// runs unprivileged, bind a high port and redirect 443 to it with the
+	// OS packet filter, then set PublicPort so redirects name the port
+	// clients actually use.
 	HTTPS TLSListenConfig `yaml:"https"`
 
 	// HTTP is the plain listener that answers every request with a
@@ -830,8 +834,22 @@ type TLSConfig struct {
 type TLSListenConfig struct {
 	// Address is the bind address; empty means all interfaces.
 	Address string `yaml:"address"`
-	// Port is the TCP port. Default: 443.
+	// Port is the TCP port Thane binds. Default: 443.
 	Port int `yaml:"port"`
+	// PublicPort is the port clients reach the listener on when a packet
+	// filter or port map sits in front of it (Thane bound to 8443, the
+	// OS redirecting 443 to it). It is what the plain-HTTP redirect names
+	// in its Location; zero means the same as Port.
+	PublicPort int `yaml:"public_port"`
+}
+
+// EffectivePublicPort is the port clients use: PublicPort when set,
+// otherwise Port.
+func (l TLSListenConfig) EffectivePublicPort() int {
+	if l.PublicPort != 0 {
+		return l.PublicPort
+	}
+	return l.Port
 }
 
 // TLSRedirectConfig is the bind for the redirect-only HTTP listener.

--- a/internal/platform/config/tls.go
+++ b/internal/platform/config/tls.go
@@ -48,6 +48,9 @@ func (c *Config) validateTLS() error {
 	if t.HTTPS.Port < 1 || t.HTTPS.Port > 65535 {
 		return fmt.Errorf("tls.https.port %d out of range (1-65535)", t.HTTPS.Port)
 	}
+	if t.HTTPS.PublicPort < 0 || t.HTTPS.PublicPort > 65535 {
+		return fmt.Errorf("tls.https.public_port %d out of range (0-65535)", t.HTTPS.PublicPort)
+	}
 	if !t.HTTP.Disabled && (t.HTTP.Port < 1 || t.HTTP.Port > 65535) {
 		return fmt.Errorf("tls.http.port %d out of range (1-65535)", t.HTTP.Port)
 	}

--- a/internal/platform/config/tls_test.go
+++ b/internal/platform/config/tls_test.go
@@ -115,6 +115,8 @@ func TestValidateTLS(t *testing.T) {
 		{"valid", func(c *Config) {}, ""},
 		{"disabled skips checks", func(c *Config) { c.TLS.Enabled = false; c.TLS.Hostnames = nil }, ""},
 		{"https port out of range", func(c *Config) { c.TLS.HTTPS.Port = 70000 }, "tls.https.port"},
+		{"public port out of range", func(c *Config) { c.TLS.HTTPS.PublicPort = 70000 }, "tls.https.public_port"},
+		{"public port set", func(c *Config) { c.TLS.HTTPS.Port = 8443; c.TLS.HTTPS.PublicPort = 443 }, ""},
 		{"http port out of range", func(c *Config) { c.TLS.HTTP.Port = 0 }, "tls.http.port"},
 		{"http disabled ignores its port", func(c *Config) { c.TLS.HTTP.Disabled = true; c.TLS.HTTP.Port = 0 }, ""},
 		{"http and https collide", func(c *Config) { c.TLS.HTTP.Port = 443 }, "cannot share port"},

--- a/internal/platform/config/tls_test.go
+++ b/internal/platform/config/tls_test.go
@@ -116,6 +116,8 @@ func TestValidateTLS(t *testing.T) {
 		{"disabled skips checks", func(c *Config) { c.TLS.Enabled = false; c.TLS.Hostnames = nil }, ""},
 		{"https port out of range", func(c *Config) { c.TLS.HTTPS.Port = 70000 }, "tls.https.port"},
 		{"public port out of range", func(c *Config) { c.TLS.HTTPS.PublicPort = 70000 }, "tls.https.public_port"},
+		{"public port negative", func(c *Config) { c.TLS.HTTPS.PublicPort = -1 }, "tls.https.public_port"},
+		{"public port zero is the bound-port fallback", func(c *Config) { c.TLS.HTTPS.PublicPort = 0 }, ""},
 		{"public port set", func(c *Config) { c.TLS.HTTPS.Port = 8443; c.TLS.HTTPS.PublicPort = 443 }, ""},
 		{"http port out of range", func(c *Config) { c.TLS.HTTP.Port = 0 }, "tls.http.port"},
 		{"http disabled ignores its port", func(c *Config) { c.TLS.HTTP.Disabled = true; c.TLS.HTTP.Port = 0 }, ""},

--- a/internal/server/edge/edge.go
+++ b/internal/server/edge/edge.go
@@ -268,8 +268,10 @@ func (s *Server) hsts(next http.Handler) http.Handler {
 }
 
 // redirect answers every plain-HTTP request with a permanent redirect to
-// the same hostname and path over HTTPS, carrying the HTTPS port when it
-// is not the default.
+// the same hostname and path over HTTPS, carrying the port clients reach
+// the HTTPS listener on when it is not the default. That is the public
+// port, not necessarily the bound one: an unprivileged Thane behind a
+// packet-filter redirect binds 8443 while clients use 443.
 func (s *Server) redirect() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		host := hostOnly(r.Host)
@@ -277,8 +279,8 @@ func (s *Server) redirect() http.Handler {
 			writeJSONError(w, http.StatusBadRequest, "missing host")
 			return
 		}
-		if s.cfg.HTTPS.Port != 443 {
-			host = net.JoinHostPort(host, strconv.Itoa(s.cfg.HTTPS.Port))
+		if port := s.cfg.HTTPS.EffectivePublicPort(); port != 443 {
+			host = net.JoinHostPort(host, strconv.Itoa(port))
 		}
 		target := "https://" + host + r.URL.RequestURI()
 		http.Redirect(w, r, target, http.StatusPermanentRedirect)

--- a/internal/server/edge/edge_test.go
+++ b/internal/server/edge/edge_test.go
@@ -169,21 +169,25 @@ func TestNewRefusesHostnameToMissingSurface(t *testing.T) {
 func TestRedirectTargetsHTTPS(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name      string
-		httpsPort int
-		host      string
-		path      string
-		want      string
+		name       string
+		httpsPort  int
+		publicPort int
+		host       string
+		path       string
+		want       string
 	}{
-		{"default port omitted", 443, "thane.example.net", "/v1/version?x=1", "https://thane.example.net/v1/version?x=1"},
-		{"request port dropped", 443, "thane.example.net:80", "/", "https://thane.example.net/"},
-		{"non-default https port carried", 8443, "thane.example.net", "/docs", "https://thane.example.net:8443/docs"},
+		{"default port omitted", 443, 0, "thane.example.net", "/v1/version?x=1", "https://thane.example.net/v1/version?x=1"},
+		{"request port dropped", 443, 0, "thane.example.net:80", "/", "https://thane.example.net/"},
+		{"non-default https port carried", 8443, 0, "thane.example.net", "/docs", "https://thane.example.net:8443/docs"},
+		{"public port wins over bound port", 8443, 443, "thane.example.net", "/docs", "https://thane.example.net/docs"},
+		{"non-default public port carried", 8443, 9443, "thane.example.net", "/", "https://thane.example.net:9443/"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			cfg := testConfig(t, t.TempDir())
 			cfg.HTTPS.Port = tc.httpsPort
+			cfg.HTTPS.PublicPort = tc.publicPort
 			s, err := New(Options{Config: cfg, Surfaces: testSurfaces(), Logger: slog.New(slog.DiscardHandler)})
 			if err != nil {
 				t.Fatalf("New: %v", err)


### PR DESCRIPTION
## macOS does not let Thane bind 443, and the docs said it would

Pre-validating the production cutover on the operator's macOS host found that an ordinary user cannot bind any port below 1024 there: Python and Perl both get Permission denied on 444 while 8444 binds fine, and the only process holding 443 today is an Apple-signed ssh forwarder whose entitlement Thane will never carry. #1500 and the deployment guide asserted the opposite, on the strength of a remembered macOS release note that does not hold on this system. So the front door will run behind a packet-filter redirect, bound to a high port with the OS carrying 443 and 80, and that needs one thing the code did not have.

## What lands

**`tls.https.public_port`.** The HTTP redirect listener names the port clients actually use in its Location header. Until now that was the bound port, so a Thane on 8443 behind a redirect from 443 would have sent browsers to `:8443`, bypassing the very redirect that makes 443 work. `public_port` is what the redirect names; zero means the bound port, so existing configs are unchanged. Validated for range.

**The privileged-port guidance is corrected.** Ports 80 and 443 need privilege on every platform, and Thane should not hold it. Linux keeps its capability recipe. macOS gets the truth and a `pf` anchor example: bind 8443 and 8880, set `public_port: 443`, redirect once as root, verify with `pfctl -s nat`. The configuration guide points at it.

## Test plan

- [x] `just ci` passes locally.
- [x] Redirect tests: public port wins over the bound port, a non-default public port is carried, existing cases unchanged.
- [x] Config validation: public_port range, bound 8443 with public 443 accepted.
- [ ] Prod cutover: `pf` redirect installed, `public_port: 443`, `curl -I http://aimee.nugget.info/` lands on `https://aimee.nugget.info/` with no port.

Refs #1499, #1500

🤖 Generated with [Claude Code](https://claude.com/claude-code)
