### PR TITLE
feat(listen): a source allowlist for the compat shims, now that the address on the socket is the callers own

### DIFF
--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -525,12 +525,14 @@ ollama_api:
   address: ""
   port: 11434
   api_key: ""        # optional bearer token; HA's Ollama integration cannot send one
+  allowed_sources: []   # e.g. [192.168.1.0/24, 192.168.1.44]
 
 openai_api:
   enabled: true
   address: ""
   port: 8081
   api_key: ""        # optional bearer token; OpenAI clients send it natively
+  allowed_sources: []
 ```
 
 Network binding for the API servers. `listen:` binds the native Thane
@@ -560,6 +562,35 @@ no tokens configured the API is open, as it was before this block existed.
 Each token is compared as a SHA-256 digest in constant time and the
 plaintext is not retained after load; `label` is what logs and the session
 endpoint report.
+
+`allowed_sources` says which hosts may speak to a compat shim. With the
+list empty or omitted, as it ships, the surface is open to anything that
+can reach the port; with entries, a request from any other address is
+refused with `403` and a JSON error body before it reaches the routes,
+and the refusal is logged at WARN with the surface and the peer. Entries
+are CIDR prefixes (`192.168.1.0/24`, `2001:db8::/32`); a bare address
+(`192.168.1.44`) is shorthand for the single host. An entry that does not
+parse fails `thane validate` and the boot gate, naming the block and the
+offending entry, so a typo cannot quietly admit or refuse everyone.
+
+A source is the address on the socket — the peer of the TCP connection,
+or of the TLS connection under the front door — and never a forwarded
+header, which any client can write and none can be trusted to write
+honestly. That address only became visible to Thane when the front door
+replaced the reverse proxy; before the cutover every request appeared to
+come from the proxy. On a dual-stack listener an IPv4 client may arrive
+as an IPv4-mapped IPv6 address, which is unmapped before matching, so
+`192.168.1.0/24` covers it and there is no need to write the mapped form.
+
+The list matters most on `ollama_api`, the one surface that cannot ask
+for a credential: Home Assistant's Ollama integration sends no bearer
+token, so `api_key` is unusable exactly where the surface drives the full
+agent loop — tools, memory, delegation — for whoever reaches the port. On
+`openai_api`, whose clients do send keys, the list is a second lock; it is
+checked before `api_key`, so a key from an address outside the list is
+never compared. The native API under `listen:` has no such field: it has
+bearer authentication with a pinned public-route set, and `listen.address`
+already confines it to a network when a deployment wants that.
 
 Every listener refuses state-changing requests (`POST`, `PUT`, `DELETE`,
 `PATCH`) that a browser marks as cross-origin, using the `Sec-Fetch-Site`

--- a/docs/operating/deployment.md
+++ b/docs/operating/deployment.md
@@ -206,7 +206,13 @@ the privilege to bind them (the Linux capability above); on macOS, and on
 any host where Thane stays unprivileged, keep the high binds and set
 `https.public_port: 443` with the packet-filter redirect above carrying
 443 and 80. Thane's own access log now records real client addresses where
-the proxy reported its own.
+the proxy reported its own, and `allowed_sources` on the compat shims is
+what makes those addresses actionable: the proxy's access policy, if it
+had one, moves into `ollama_api.allowed_sources` and
+`openai_api.allowed_sources` (see
+[Configuration](configuration.md#listen-addresses)). Read the access log
+first and let it tell you which hosts actually call each shim, then write
+the list from what you find.
 
 Thane also needs outbound access to:
 - Your Home Assistant instance (REST + WebSocket)

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -56,6 +56,14 @@ ollama_api:
   # this only for token-capable clients (e.g. Open WebUI) or when HA
   # connects through a proxy that injects the header.
   api_key: ""
+  # AllowedSources, when non-empty, admits only callers whose address
+  # falls inside one of the listed CIDR prefixes; a bare address is a
+  # single host. A caller's address is the peer on the socket, never a
+  # forwarded header. This is the admission control for the one
+  # surface that cannot ask for a credential, so it is where an
+  # operator says which hosts may drive the agent loop through it.
+  # Empty leaves the surface open to anything that can reach the port.
+  allowed_sources: []
 # OpenAIAPI configures the optional OpenAI-compatible API server,
 # serving the frozen OpenAI shim on its own port (separate from the
 # Thane-native /v1 API on the primary listen port).
@@ -70,6 +78,14 @@ openai_api:
   # delegation — so leaving it empty (open) is appropriate only when
   # every host that can reach the port is trusted.
   api_key: ""
+  # AllowedSources, when non-empty, admits only callers whose address
+  # falls inside one of the listed CIDR prefixes; a bare address is a
+  # single host. A caller's address is the peer on the socket, never a
+  # forwarded header. Clients of this shim can send a bearer key, so
+  # here the list is a second lock rather than the only one, and it is
+  # checked first: a refused caller never reaches the key comparison.
+  # Empty leaves the surface open.
+  allowed_sources: []
 # TLS configures the optional HTTPS front door: in-process TLS
 # termination with certificates from certmagic, routing each
 # configured hostname to one of the surfaces above.

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -237,7 +237,11 @@ func (a *App) initServers(s *newState) error {
 	// Home Assistant's Ollama integration connects here, allowing Thane
 	// to serve as a drop-in replacement for a standalone Ollama instance.
 	if cfg.OllamaAPI.Enabled {
-		a.ollamaServer = api.NewOllamaServer(cfg.OllamaAPI.Address, cfg.OllamaAPI.Port, cfg.OllamaAPI.APIKey, a.loop, logger)
+		allowedSources, err := cfg.OllamaAPI.AllowedPrefixes()
+		if err != nil {
+			return fmt.Errorf("ollama api: %w", err)
+		}
+		a.ollamaServer = api.NewOllamaServer(cfg.OllamaAPI.Address, cfg.OllamaAPI.Port, cfg.OllamaAPI.APIKey, allowedSources, a.loop, logger)
 		a.ollamaServer.SetOWUTracker(owuTracker)
 	}
 
@@ -246,7 +250,11 @@ func (a *App) initServers(s *newState) error {
 	// (/v1/chat/completions, /v1/models) on its own port, keeping the
 	// Thane-native /v1 API on the primary port free of foreign shapes.
 	if cfg.OpenAIAPI.Enabled {
-		a.openaiServer = api.NewOpenAIServer(cfg.OpenAIAPI.Address, cfg.OpenAIAPI.Port, cfg.OpenAIAPI.APIKey, a.server, logger)
+		allowedSources, err := cfg.OpenAIAPI.AllowedPrefixes()
+		if err != nil {
+			return fmt.Errorf("openai api: %w", err)
+		}
+		a.openaiServer = api.NewOpenAIServer(cfg.OpenAIAPI.Address, cfg.OpenAIAPI.Port, cfg.OpenAIAPI.APIKey, allowedSources, a.server, logger)
 	}
 
 	// --- Companion app endpoint ---

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -811,6 +811,14 @@ type OllamaAPIConfig struct {
 	// this only for token-capable clients (e.g. Open WebUI) or when HA
 	// connects through a proxy that injects the header.
 	APIKey string `yaml:"api_key"`
+	// AllowedSources, when non-empty, admits only callers whose address
+	// falls inside one of the listed CIDR prefixes; a bare address is a
+	// single host. A caller's address is the peer on the socket, never a
+	// forwarded header. This is the admission control for the one
+	// surface that cannot ask for a credential, so it is where an
+	// operator says which hosts may drive the agent loop through it.
+	// Empty leaves the surface open to anything that can reach the port.
+	AllowedSources []string `yaml:"allowed_sources"`
 }
 
 // OpenAIAPIConfig configures the optional OpenAI-compatible API server.
@@ -828,6 +836,14 @@ type OpenAIAPIConfig struct {
 	// delegation — so leaving it empty (open) is appropriate only when
 	// every host that can reach the port is trusted.
 	APIKey string `yaml:"api_key"`
+	// AllowedSources, when non-empty, admits only callers whose address
+	// falls inside one of the listed CIDR prefixes; a bare address is a
+	// single host. A caller's address is the peer on the socket, never a
+	// forwarded header. Clients of this shim can send a bearer key, so
+	// here the list is a second lock rather than the only one, and it is
+	// checked first: a refused caller never reaches the key comparison.
+	// Empty leaves the surface open.
+	AllowedSources []string `yaml:"allowed_sources"`
 }
 
 // TLSConfig configures Thane's HTTPS front door: one TLS listener that
@@ -3438,6 +3454,9 @@ func (c *Config) Validate() error {
 		return err
 	}
 	if err := c.validateListenAuth(); err != nil {
+		return err
+	}
+	if err := c.validateListenSources(); err != nil {
 		return err
 	}
 	if c.CardDAV.Enabled {

--- a/internal/platform/config/listen_sources.go
+++ b/internal/platform/config/listen_sources.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"fmt"
+	"net/netip"
+	"strings"
+)
+
+// AllowedPrefixes parses ollama_api.allowed_sources into the prefixes the
+// shim's source guard matches a caller against.
+func (c OllamaAPIConfig) AllowedPrefixes() ([]netip.Prefix, error) {
+	return parseSourcePrefixes("ollama_api", c.AllowedSources)
+}
+
+// AllowedPrefixes parses openai_api.allowed_sources into the prefixes the
+// shim's source guard matches a caller against.
+func (c OpenAIAPIConfig) AllowedPrefixes() ([]netip.Prefix, error) {
+	return parseSourcePrefixes("openai_api", c.AllowedSources)
+}
+
+// validateListenSources fails a config whose source lists cannot be
+// parsed. The work happens at load, not on the first request, so a typo
+// stops `thane validate` and the boot gate rather than silently admitting
+// or refusing everyone once traffic arrives.
+func (c *Config) validateListenSources() error {
+	if _, err := c.OllamaAPI.AllowedPrefixes(); err != nil {
+		return err
+	}
+	if _, err := c.OpenAIAPI.AllowedPrefixes(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// parseSourcePrefixes converts one allowed_sources list into prefixes,
+// naming the block and the offending entry when one does not parse.
+func parseSourcePrefixes(block string, entries []string) ([]netip.Prefix, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	prefixes := make([]netip.Prefix, 0, len(entries))
+	for i, entry := range entries {
+		prefix, err := parseSourcePrefix(strings.TrimSpace(entry))
+		if err != nil {
+			return nil, fmt.Errorf("%s.allowed_sources[%d] %q: %w", block, i, entry, err)
+		}
+		prefixes = append(prefixes, prefix)
+	}
+	return prefixes, nil
+}
+
+// parseSourcePrefix reads one entry as a CIDR prefix, or as a bare
+// address standing for the single-host prefix that covers exactly it.
+// Prefixes are masked so an entry written with host bits set (192.168.1.5/24)
+// means the network the operator plainly intended.
+func parseSourcePrefix(entry string) (netip.Prefix, error) {
+	if strings.Contains(entry, "/") {
+		prefix, err := netip.ParsePrefix(entry)
+		if err != nil {
+			return netip.Prefix{}, fmt.Errorf("not a CIDR prefix: %w", err)
+		}
+		return prefix.Masked(), nil
+	}
+	addr, err := netip.ParseAddr(entry)
+	if err != nil {
+		return netip.Prefix{}, fmt.Errorf("not an address or CIDR prefix: %w", err)
+	}
+	addr = addr.Unmap()
+	return netip.PrefixFrom(addr, addr.BitLen()), nil
+}

--- a/internal/platform/config/listen_sources_test.go
+++ b/internal/platform/config/listen_sources_test.go
@@ -1,0 +1,114 @@
+package config
+
+import (
+	"net/netip"
+	"strings"
+	"testing"
+)
+
+func TestValidateListenSources(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		mutate  func(c *Config)
+		wantErr string
+	}{
+		{"absent lists leave both surfaces open", func(c *Config) {}, ""},
+		{"empty list is valid", func(c *Config) { c.OllamaAPI.AllowedSources = []string{} }, ""},
+		{"CIDR prefixes", func(c *Config) {
+			c.OllamaAPI.AllowedSources = []string{"192.168.1.0/24", "10.0.0.0/8", "2001:db8::/32"}
+		}, ""},
+		{"bare addresses", func(c *Config) {
+			c.OllamaAPI.AllowedSources = []string{"192.168.1.44", "::1"}
+		}, ""},
+		{"surrounding whitespace is tolerated", func(c *Config) {
+			c.OllamaAPI.AllowedSources = []string{"  192.168.1.0/24  "}
+		}, ""},
+		{"unparseable ollama entry names the block and the entry", func(c *Config) {
+			c.OllamaAPI.AllowedSources = []string{"192.168.1.0/24", "192.168.1"}
+		}, `ollama_api.allowed_sources[1] "192.168.1"`},
+		{"bad ollama mask names the block", func(c *Config) {
+			c.OllamaAPI.AllowedSources = []string{"192.168.1.0/33"}
+		}, `ollama_api.allowed_sources[0] "192.168.1.0/33"`},
+		{"empty ollama entry is refused", func(c *Config) {
+			c.OllamaAPI.AllowedSources = []string{""}
+		}, `ollama_api.allowed_sources[0] ""`},
+		{"hostnames are not sources", func(c *Config) {
+			c.OllamaAPI.AllowedSources = []string{"homeassistant.example.net"}
+		}, "not an address or CIDR prefix"},
+		{"unparseable openai entry names its own block", func(c *Config) {
+			c.OpenAIAPI.AllowedSources = []string{"not-an-address"}
+		}, `openai_api.allowed_sources[0] "not-an-address"`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := &Config{}
+			tc.mutate(cfg)
+			err := cfg.validateListenSources()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateListenSources: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("err = %v, want containing %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestAllowedPrefixes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a bare address becomes a single-host prefix", func(t *testing.T) {
+		t.Parallel()
+		got, err := OllamaAPIConfig{AllowedSources: []string{"192.168.1.44", "2001:db8::5"}}.AllowedPrefixes()
+		if err != nil {
+			t.Fatalf("AllowedPrefixes: %v", err)
+		}
+		want := []netip.Prefix{
+			netip.MustParsePrefix("192.168.1.44/32"),
+			netip.MustParsePrefix("2001:db8::5/128"),
+		}
+		if len(got) != len(want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("prefix %d = %v, want %v", i, got[i], want[i])
+			}
+		}
+	})
+
+	t.Run("an IPv4-mapped bare address names the IPv4 host it means", func(t *testing.T) {
+		t.Parallel()
+		got, err := OpenAIAPIConfig{AllowedSources: []string{"::ffff:192.168.1.44"}}.AllowedPrefixes()
+		if err != nil {
+			t.Fatalf("AllowedPrefixes: %v", err)
+		}
+		if want := netip.MustParsePrefix("192.168.1.44/32"); got[0] != want {
+			t.Fatalf("prefix = %v, want %v", got[0], want)
+		}
+	})
+
+	t.Run("host bits in a prefix are masked away", func(t *testing.T) {
+		t.Parallel()
+		got, err := OllamaAPIConfig{AllowedSources: []string{"192.168.1.5/24"}}.AllowedPrefixes()
+		if err != nil {
+			t.Fatalf("AllowedPrefixes: %v", err)
+		}
+		if want := netip.MustParsePrefix("192.168.1.0/24"); got[0] != want {
+			t.Fatalf("prefix = %v, want %v", got[0], want)
+		}
+	})
+
+	t.Run("an absent list yields no prefixes", func(t *testing.T) {
+		t.Parallel()
+		got, err := OllamaAPIConfig{}.AllowedPrefixes()
+		if err != nil || got != nil {
+			t.Fatalf("AllowedPrefixes = (%v, %v), want (nil, nil)", got, err)
+		}
+	})
+}

--- a/internal/server/api/compat_sources_test.go
+++ b/internal/server/api/compat_sources_test.go
@@ -1,0 +1,92 @@
+package api
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"testing"
+)
+
+// homeLAN is the prefix the wiring tests admit from; the refused peers
+// below sit outside it.
+var homeLAN = []netip.Prefix{netip.MustParsePrefix("192.168.1.0/24")}
+
+// TestOllamaServerRestrictsSources pins the guard onto the Ollama shim's
+// handler chain: this is the surface whose callers cannot present a
+// credential, so the address list is the whole of its admission policy.
+func TestOllamaServerRestrictsSources(t *testing.T) {
+	t.Parallel()
+
+	handler := NewOllamaServer("", 11434, "", homeLAN, nil, slog.Default()).Handler()
+
+	t.Run("peer outside the list is refused", func(t *testing.T) {
+		t.Parallel()
+		rec := serveFrom(handler, http.MethodGet, "/api/version", "203.0.113.9:52000", "")
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want 403 (body: %s)", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("peer inside the list reaches the routes", func(t *testing.T) {
+		t.Parallel()
+		rec := serveFrom(handler, http.MethodGet, "/api/version", "192.168.1.44:52000", "")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("an unset list leaves the surface open", func(t *testing.T) {
+		t.Parallel()
+		open := NewOllamaServer("", 11434, "", nil, nil, slog.Default()).Handler()
+		rec := serveFrom(open, http.MethodGet, "/api/version", "203.0.113.9:52000", "")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+		}
+	})
+}
+
+// TestOpenAIServerRestrictsSourcesBeforeAuth pins both the guard's
+// presence on the OpenAI shim and its position: a caller outside the list
+// is refused with 403 without its bearer key ever being compared, so a
+// correct key from a disallowed host gets no different an answer than a
+// wrong one.
+func TestOpenAIServerRestrictsSourcesBeforeAuth(t *testing.T) {
+	t.Parallel()
+
+	handler := NewOpenAIServer("", 8081, "sekrit", homeLAN, &Server{}, slog.Default()).Handler()
+
+	tests := []struct {
+		name     string
+		remote   string
+		auth     string
+		wantCode int
+	}{
+		{"disallowed peer without a key", "203.0.113.9:52000", "", http.StatusForbidden},
+		{"disallowed peer with the correct key", "203.0.113.9:52000", "Bearer sekrit", http.StatusForbidden},
+		{"allowed peer without a key still needs one", "192.168.1.44:52000", "", http.StatusUnauthorized},
+		{"allowed peer with the correct key is served", "192.168.1.44:52000", "Bearer sekrit", http.StatusOK},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rec := serveFrom(handler, http.MethodGet, "/health", tc.remote, tc.auth)
+			if rec.Code != tc.wantCode {
+				t.Fatalf("status = %d, want %d (body: %s)", rec.Code, tc.wantCode, rec.Body.String())
+			}
+		})
+	}
+}
+
+// serveFrom drives one request at handler as though it arrived from
+// remote, which is what net/http fills RemoteAddr with on a real socket.
+func serveFrom(handler http.Handler, method, path, remote, auth string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, path, nil)
+	req.RemoteAddr = remote
+	if auth != "" {
+		req.Header.Set("Authorization", auth)
+	}
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	return rec
+}

--- a/internal/server/api/ollama_server.go
+++ b/internal/server/api/ollama_server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/netip"
 	"sync"
 	"time"
 
@@ -21,9 +22,11 @@ import (
 // port (e.g., for Home Assistant integration). For single-port setups, use
 // Server.RegisterOllamaRoutes instead.
 type OllamaServer struct {
-	address     string
-	port        int
-	apiKey      string
+	address        string
+	port           int
+	apiKey         string
+	allowedSources []netip.Prefix
+
 	loop        *agent.Loop
 	owuTracker  *OWUTracker
 	logger      *slog.Logger
@@ -44,17 +47,20 @@ func (s *OllamaServer) SetOWUTracker(t *OWUTracker) {
 //   - port: Port to listen on (typically 11434 for Ollama compatibility)
 //   - apiKey: When non-empty, every request must present this value as a
 //     bearer token; empty leaves the surface unauthenticated
+//   - allowedSources: When non-empty, only callers inside one of these
+//     prefixes are served; empty leaves the surface open to the network
 //   - loop: The agent loop that processes requests
 //   - logger: Logger for request and error logging
 //
 // The server is created but not started. Call Start to begin serving requests.
-func NewOllamaServer(address string, port int, apiKey string, loop *agent.Loop, logger *slog.Logger) *OllamaServer {
+func NewOllamaServer(address string, port int, apiKey string, allowedSources []netip.Prefix, loop *agent.Loop, logger *slog.Logger) *OllamaServer {
 	return &OllamaServer{
-		address: address,
-		port:    port,
-		apiKey:  apiKey,
-		loop:    loop,
-		logger:  logger,
+		address:        address,
+		port:           port,
+		apiKey:         apiKey,
+		allowedSources: allowedSources,
+		loop:           loop,
+		logger:         logger,
 	}
 }
 
@@ -114,9 +120,12 @@ func (s *OllamaServer) buildHandler() http.Handler {
 	mux.HandleFunc("HEAD /{$}", s.handleHead)
 	mux.HandleFunc("GET /{$}", s.handleHealth)
 
-	// Auth and the cross-origin guard sit inside logging so rejected
-	// requests still produce access-log lines with their 401/403 status.
-	return s.withLogging(listen.RejectCrossOriginWrites(s.logger, ollamaAuth(s.apiKey, mux)))
+	// The guards sit inside logging so rejected requests still produce
+	// access-log lines with their 401/403 status. The source allowlist
+	// goes first: a caller the operator has not admitted costs one log
+	// line and nothing else.
+	return s.withLogging(listen.RestrictSources(s.logger, "ollama", s.allowedSources,
+		listen.RejectCrossOriginWrites(s.logger, ollamaAuth(s.apiKey, mux))))
 }
 
 // Shutdown gracefully stops the server.

--- a/internal/server/api/openai_server.go
+++ b/internal/server/api/openai_server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/netip"
 	"sync"
 	"time"
 
@@ -19,9 +20,11 @@ import (
 // mirroring the OllamaServer split. The handlers live on *Server; this type
 // owns only the listener and route registration.
 type OpenAIServer struct {
-	address     string
-	apiKey      string // bearer token required when non-empty; see openaiAuth
-	port        int
+	address        string
+	apiKey         string // bearer token required when non-empty; see openaiAuth
+	allowedSources []netip.Prefix
+	port           int
+
 	api         *Server
 	logger      *slog.Logger
 	server      *http.Server
@@ -37,15 +40,24 @@ type OpenAIServer struct {
 //   - port: Port to listen on (default 8081)
 //   - apiKey: bearer token every request must present; empty leaves the
 //     surface open (see config.OpenAIAPIConfig.APIKey)
+//   - allowedSources: When non-empty, only callers inside one of these
+//     prefixes are served; empty leaves the surface open to the network
 //   - apiServer: The native Server whose OpenAI-compatible handlers are served
 //   - logger: Logger for request and error logging
 //
 // The server is created but not started. Call Start to begin serving requests.
-func NewOpenAIServer(address string, port int, apiKey string, apiServer *Server, logger *slog.Logger) *OpenAIServer {
+func NewOpenAIServer(address string, port int, apiKey string, allowedSources []netip.Prefix, apiServer *Server, logger *slog.Logger) *OpenAIServer {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &OpenAIServer{address: address, port: port, apiKey: apiKey, api: apiServer, logger: logger}
+	return &OpenAIServer{
+		address:        address,
+		port:           port,
+		apiKey:         apiKey,
+		allowedSources: allowedSources,
+		api:            apiServer,
+		logger:         logger,
+	}
 }
 
 // Start begins serving the OpenAI-compatible surface and blocks until the
@@ -82,7 +94,10 @@ func (s *OpenAIServer) Handler() http.Handler {
 	s.handlerOnce.Do(func() {
 		mux := http.NewServeMux()
 		s.api.RegisterOpenAIRoutes(mux)
-		s.handler = s.withLogging(listen.RejectCrossOriginWrites(s.logger, openaiAuth(s.apiKey, listen.LimitRequestBody(compatMaxBodyBytes, mux))))
+		// The source allowlist runs ahead of the bearer gate, so a key is
+		// only ever compared for a caller the operator admitted.
+		s.handler = s.withLogging(listen.RestrictSources(s.logger, "openai", s.allowedSources,
+			listen.RejectCrossOriginWrites(s.logger, openaiAuth(s.apiKey, listen.LimitRequestBody(compatMaxBodyBytes, mux)))))
 	})
 	return s.handler
 }

--- a/internal/server/edge/inherit_test.go
+++ b/internal/server/edge/inherit_test.go
@@ -172,6 +172,17 @@ func TestInheritedListenersServeAndNameThePort(t *testing.T) {
 	cfg.HTTPS.Port = 8443
 	cfg.HTTPS.PublicPort = 9999 // must lose to the inherited socket's port
 	cfg.HTTP.Disabled = true    // an inherited http socket still serves
+	// This is the only edge test that calls Start, which is the only path
+	// that reaches ManageAsync. With hostnames to manage, that goroutine
+	// goes off to an ACME directory and writes account keys and lock files
+	// into storage on its own schedule — past cancel, past Shutdown, which
+	// stops the cache's maintenance loop but has no handle on an obtain
+	// already in flight. A write landing after the test returns races
+	// t.TempDir()'s RemoveAll and fails the test with "directory not
+	// empty". Nothing here needs a certificate: the subject is which port
+	// an inherited socket makes the redirect name, and redirect() never
+	// consults the routing table. Manage nothing, and there is no writer.
+	cfg.Hostnames = nil
 	s, err := New(Options{
 		Config:    cfg,
 		Surfaces:  testSurfaces(),

--- a/internal/server/listen/sources.go
+++ b/internal/server/listen/sources.go
@@ -1,0 +1,82 @@
+package listen
+
+import (
+	"log/slog"
+	"net"
+	"net/http"
+	"net/netip"
+)
+
+// RestrictSources refuses a request whose caller is not inside one of the
+// allowed prefixes. It is the admission control for the surfaces that
+// cannot ask their callers for a credential: Home Assistant's Ollama
+// integration sends no bearer token and never will, so on that shim an
+// address policy is the only policy there is.
+//
+// The source is the peer on the socket — r.RemoteAddr, which is the TLS
+// connection's peer under the front door and the TCP peer on the
+// plaintext listeners — and never a forwarded header. Thane no longer
+// sits behind anything that would set one honestly, and a header any
+// client can write is a claim, not a source. An IPv4-mapped IPv6 peer is
+// unmapped before matching, so a dual-stack listener behaves the way an
+// operator expects when they write 192.168.1.0/24, and a zone is dropped
+// so a link-local peer matches the prefix that covers it.
+//
+// An empty prefix list leaves the surface open, which is the shipped
+// default: the field is opt-in and a deployment that never writes it
+// sees no change. A peer that does not parse is refused, because a
+// source policy that cannot see the source admits nobody.
+//
+// The guard does not consult the mTLS principal the front door extracts
+// from a client certificate. When that principal becomes an admission
+// input, a certificate-bearing peer should be admitted regardless of
+// address, and that judgement belongs to a resolver that can weigh both,
+// not to a guard that only knows addresses.
+func RestrictSources(logger *slog.Logger, surface string, allowed []netip.Prefix, next http.Handler) http.Handler {
+	if len(allowed) == 0 {
+		return next
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		peer, ok := peerAddr(r.RemoteAddr)
+		if !ok || !containsAddr(allowed, peer) {
+			logger.Warn("refused request from disallowed source",
+				"surface", surface,
+				"method", r.Method,
+				"path", r.URL.Path,
+				"peer", r.RemoteAddr,
+			)
+			writeJSONError(w, http.StatusForbidden, "source address not allowed")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// peerAddr extracts the comparable address from an http.Request's
+// RemoteAddr, which net/http fills with "host:port" for TCP listeners.
+// The address is unmapped and stripped of any zone so it compares
+// against prefixes written the way operators write them.
+func peerAddr(remoteAddr string) (netip.Addr, bool) {
+	host := remoteAddr
+	if h, _, err := net.SplitHostPort(remoteAddr); err == nil {
+		host = h
+	}
+	addr, err := netip.ParseAddr(host)
+	if err != nil {
+		return netip.Addr{}, false
+	}
+	return addr.Unmap().WithZone(""), true
+}
+
+// containsAddr reports whether any prefix covers addr.
+func containsAddr(allowed []netip.Prefix, addr netip.Addr) bool {
+	for _, prefix := range allowed {
+		if prefix.Contains(addr) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/server/listen/sources.go
+++ b/internal/server/listen/sources.go
@@ -20,7 +20,9 @@ import (
 // client can write is a claim, not a source. An IPv4-mapped IPv6 peer is
 // unmapped before matching, so a dual-stack listener behaves the way an
 // operator expects when they write 192.168.1.0/24, and a zone is dropped
-// so a link-local peer matches the prefix that covers it.
+// so a link-local peer matches the prefix that covers it. A refusal logs
+// that matched form, so the address an operator reads out of the log is
+// the one they can add to the list.
 //
 // An empty prefix list leaves the surface open, which is the shipped
 // default: the field is opt-in and a deployment that never writes it
@@ -42,11 +44,18 @@ func RestrictSources(logger *slog.Logger, surface string, allowed []netip.Prefix
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		peer, ok := peerAddr(r.RemoteAddr)
 		if !ok || !containsAddr(allowed, peer) {
+			// peer is the address the guard actually matched, so an
+			// operator can paste it straight into allowed_sources;
+			// remote_addr keeps the raw socket string beside it, port and
+			// all, for anyone correlating with the access dataset. An
+			// unparseable peer logs as "invalid IP" and remote_addr shows
+			// what arrived.
 			logger.Warn("refused request from disallowed source",
 				"surface", surface,
 				"method", r.Method,
 				"path", r.URL.Path,
-				"peer", r.RemoteAddr,
+				"peer", peer.String(),
+				"remote_addr", r.RemoteAddr,
 			)
 			writeJSONError(w, http.StatusForbidden, "source address not allowed")
 			return

--- a/internal/server/listen/sources_test.go
+++ b/internal/server/listen/sources_test.go
@@ -1,0 +1,114 @@
+package listen
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"testing"
+)
+
+func mustPrefixes(t *testing.T, entries ...string) []netip.Prefix {
+	t.Helper()
+	prefixes := make([]netip.Prefix, 0, len(entries))
+	for _, entry := range entries {
+		prefix, err := netip.ParsePrefix(entry)
+		if err != nil {
+			t.Fatalf("ParsePrefix(%q): %v", entry, err)
+		}
+		prefixes = append(prefixes, prefix)
+	}
+	return prefixes
+}
+
+func TestRestrictSources(t *testing.T) {
+	t.Parallel()
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	tests := []struct {
+		name     string
+		allowed  []string
+		remote   string
+		wantCode int
+	}{
+		{"empty list leaves the surface open", nil, "203.0.113.9:52000", http.StatusOK},
+		{"peer inside the prefix admitted", []string{"192.168.1.0/24"}, "192.168.1.44:52000", http.StatusOK},
+		{"peer outside every prefix refused", []string{"192.168.1.0/24"}, "192.168.2.44:52000", http.StatusForbidden},
+		{"second prefix admits", []string{"192.168.1.0/24", "10.0.0.0/8"}, "10.9.9.9:52000", http.StatusOK},
+		{"single-host prefix admits exactly that host", []string{"192.168.1.44/32"}, "192.168.1.44:52000", http.StatusOK},
+		{"single-host prefix refuses the neighbour", []string{"192.168.1.44/32"}, "192.168.1.45:52000", http.StatusForbidden},
+		{"loopback prefix admits loopback", []string{"127.0.0.0/8"}, "127.0.0.1:52000", http.StatusOK},
+		{"IPv4-mapped IPv6 peer matches an IPv4 prefix", []string{"192.168.1.0/24"}, "[::ffff:192.168.1.44]:52000", http.StatusOK},
+		{"IPv4-mapped IPv6 peer outside the prefix refused", []string{"192.168.1.0/24"}, "[::ffff:192.168.2.44]:52000", http.StatusForbidden},
+		{"IPv6 peer matches an IPv6 prefix", []string{"2001:db8::/32"}, "[2001:db8::5]:52000", http.StatusOK},
+		{"IPv6 peer does not match an IPv4 prefix", []string{"0.0.0.0/0"}, "[2001:db8::5]:52000", http.StatusForbidden},
+		{"link-local peer with a zone matches its prefix", []string{"fe80::/10"}, "[fe80::1%en0]:52000", http.StatusOK},
+		{"bare address without a port is still read", []string{"192.168.1.0/24"}, "192.168.1.44", http.StatusOK},
+		{"unparseable peer refused", []string{"192.168.1.0/24"}, "/var/run/thane.sock", http.StatusForbidden},
+		{"empty peer refused", []string{"192.168.1.0/24"}, "", http.StatusForbidden},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequest(http.MethodPost, "/api/chat", nil)
+			req.RemoteAddr = tc.remote
+			rec := httptest.NewRecorder()
+			RestrictSources(nil, "ollama", mustPrefixes(t, tc.allowed...), next).ServeHTTP(rec, req)
+			if rec.Code != tc.wantCode {
+				t.Fatalf("status = %d, want %d (body: %s)", rec.Code, tc.wantCode, rec.Body.String())
+			}
+			if tc.wantCode != http.StatusForbidden {
+				return
+			}
+			if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+				t.Fatalf("Content-Type = %q, want application/json", ct)
+			}
+			if body := rec.Body.String(); body != `{"error":"source address not allowed"}` {
+				t.Fatalf("body = %s, want the shared JSON error envelope", body)
+			}
+		})
+	}
+}
+
+// TestRestrictSourcesGuardsSafeMethods pins that the source policy is not
+// the cross-origin guard: a GET is state-changing enough on a surface
+// that runs the agent loop, and every method is subject to the list.
+func TestRestrictSourcesGuardsSafeMethods(t *testing.T) {
+	t.Parallel()
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	for _, method := range []string{http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodPost} {
+		req := httptest.NewRequest(method, "/api/tags", nil)
+		req.RemoteAddr = "203.0.113.9:52000"
+		rec := httptest.NewRecorder()
+		RestrictSources(nil, "ollama", mustPrefixes(t, "192.168.1.0/24"), next).ServeHTTP(rec, req)
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("%s status = %d, want 403", method, rec.Code)
+		}
+	}
+}
+
+// TestRestrictSourcesEmptyListSkipsTheWrapper pins the zero-cost default:
+// with no prefixes configured the guard returns the next handler itself,
+// so an open surface carries no per-request work.
+func TestRestrictSourcesEmptyListSkipsTheWrapper(t *testing.T) {
+	t.Parallel()
+
+	var next comparableHandler
+	if got := RestrictSources(nil, "ollama", nil, next); got != http.Handler(next) {
+		t.Fatalf("RestrictSources with no prefixes wrapped the handler")
+	}
+}
+
+// comparableHandler is an http.Handler that == compares, which an
+// http.HandlerFunc does not.
+type comparableHandler struct{}
+
+func (comparableHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}

--- a/internal/server/listen/sources_test.go
+++ b/internal/server/listen/sources_test.go
@@ -1,6 +1,9 @@
 package listen
 
 import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/netip"
@@ -111,4 +114,53 @@ type comparableHandler struct{}
 
 func (comparableHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
+}
+
+// TestRestrictSourcesLogsTheMatchedAddress pins what a refusal writes: an
+// operator reading the log must be able to paste peer into
+// allowed_sources unedited, so it carries the address the guard matched —
+// no port, unmapped, no zone — with the raw socket string beside it.
+func TestRestrictSourcesLogsTheMatchedAddress(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		remote         string
+		wantPeer       string
+		wantRemoteAddr string
+	}{
+		{"port stripped", "203.0.113.9:52000", "203.0.113.9", "203.0.113.9:52000"},
+		{"IPv4-mapped peer logged as the IPv4 host", "[::ffff:203.0.113.9]:52000", "203.0.113.9", "[::ffff:203.0.113.9]:52000"},
+		{"zone stripped", "[fe80::1%en0]:52000", "fe80::1", "[fe80::1%en0]:52000"},
+		{"unparseable peer says so and keeps the raw string", "/var/run/thane.sock", "invalid IP", "/var/run/thane.sock"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+			req := httptest.NewRequest(http.MethodPost, "/api/chat", nil)
+			req.RemoteAddr = tc.remote
+			RestrictSources(logger, "ollama", mustPrefixes(t, "192.168.1.0/24"), comparableHandler{}).
+				ServeHTTP(httptest.NewRecorder(), req)
+
+			var line struct {
+				Level      string `json:"level"`
+				Surface    string `json:"surface"`
+				Peer       string `json:"peer"`
+				RemoteAddr string `json:"remote_addr"`
+			}
+			if err := json.Unmarshal(buf.Bytes(), &line); err != nil {
+				t.Fatalf("log line %q: %v", buf.String(), err)
+			}
+			if line.Level != "WARN" || line.Surface != "ollama" {
+				t.Fatalf("level/surface = %q/%q, want WARN/ollama", line.Level, line.Surface)
+			}
+			if line.Peer != tc.wantPeer || line.RemoteAddr != tc.wantRemoteAddr {
+				t.Fatalf("peer/remote_addr = %q/%q, want %q/%q", line.Peer, line.RemoteAddr, tc.wantPeer, tc.wantRemoteAddr)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

`allowed_sources` on `ollama_api` and `openai_api`: a list of CIDR prefixes, with a bare address as shorthand for the single host that covers it, saying which hosts may speak to a surface that cannot authenticate its callers. The Ollama shim is where this matters — Home Assistant's Ollama integration sends no bearer token and never will, so `api_key` is unusable exactly where the surface drives the full agent loop for whoever reaches the port. Until the front door landed, the only address Thane could see on that socket was the reverse proxy's container gateway, which made a source policy impossible to express and is why the security charter deferred this slice; the cutover changed the fact on the ground.

## What it does

`listen.RestrictSources` is one guard in the shared `listen` package, beside the cross-origin guard. It reads the peer from `RemoteAddr` — the TLS connection's peer under the front door, the TCP peer on the plaintext listeners — and never a forwarded header, which any client can write and none can be trusted to write honestly. An IPv4-mapped IPv6 peer is unmapped and a zone is dropped before matching, so a dual-stack listener behaves the way an operator expects when they write `192.168.1.0/24`. A peer outside every prefix, or one that does not parse, is refused with 403 and the shared JSON envelope, logged at WARN with the surface and the peer so it lands in the events dataset beside the cross-origin refusals; the access log still records the 403. The logged `peer` is the matched form, not the raw socket string, so the address an operator reads out of a refusal is the one they can add to the list — the raw string rides alongside as `remote_addr`.

Entries are parsed at config load, not on the first request, so a typo fails `thane validate` and the boot gate with a message naming the block and the offending entry. An empty or omitted list leaves the surface open, as today, and returns the next handler unwrapped, so the shipped default carries no per-request work. The guard sits inside access logging and ahead of the cross-origin guard and bearer auth: a refused caller costs one log line and nothing else, and a key from a disallowed address is never compared.

The native API is deliberately excluded — it has bearer auth with a pinned public-route set, and `listen.address` already confines it to a network. The guard does not consult the mTLS principal the front door extracts from a client certificate; when that becomes an admission input, weighing it against an address belongs to a resolver, not here.

## Test plan

- [x] `just ci` passes locally (clean, exit 0)
- [x] Guard: admit, refuse, second-prefix, single-host, IPv4-mapped-IPv6 both ways, IPv6, zoned link-local, portless peer, unparseable peer, empty peer, empty list, every method
- [x] Config validation: CIDR and bare entries, whitespace tolerance, bad mask, empty entry, hostname, both blocks named in their own errors
- [x] Parsing: bare address becomes a /32 or /128, mapped literal names the IPv4 host, host bits masked away, absent list yields nil
- [x] Wiring: Ollama shim admits/refuses/open-when-unset; OpenAI shim refuses ahead of the bearer gate, so a correct key from a disallowed host gets the same 403 as none
- [x] Refusal log: `peer` is the matched form an operator can paste into `allowed_sources` (port stripped, unmapped, zone stripped), with the raw `remote_addr` beside it
- [x] `examples/config.example.yaml` regenerated
- [ ] Prod: set `ollama_api.allowed_sources` after reading the access dataset for what actually calls 11434

## One unrelated commit rides along

`35eb8b9f` fixes a flake in `TestInheritedListenersServeAndNameThePort` (`internal/server/edge`), which arrived with #1507 and is reproducible on `main` — roughly two runs in three with `-race`. It is the only edge test that calls `Start`, the only path reaching certmagic's `ManageAsync`; that goroutine writes account keys and lock files into storage past the context cancel and past `Shutdown`, and a late write recreates a directory inside `t.TempDir()`'s `RemoveAll`, which fails with "directory not empty". The test needs no certificate — its subject is which port an inherited socket makes the redirect name, and `redirect()` never consults the routing table — so it now manages no hostnames. 25 consecutive `-race` runs clean, no storage left behind.

It is here only because this branch could not go green without it; it is happy to be split out if you would rather land it separately.

Closes #1508
Refs #1499, #1501

🤖 Generated with [Claude Code](https://claude.com/claude-code)


