### PR TITLE
feat(listen): security response headers, three postures, no unsafe-inline on the console

### DIFF
--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -592,6 +592,25 @@ never compared. The native API under `listen:` has no such field: it has
 bearer authentication with a pinned public-route set, and `listen.address`
 already confines it to a network when a deployment wants that.
 
+Every response carries security headers, and which ones depends on what
+the surface serves. All of them send `X-Content-Type-Options: nosniff`,
+`Referrer-Policy: no-referrer`, `X-Frame-Options: DENY`, and a
+`Permissions-Policy` denying geolocation, camera, and microphone; none of
+this is configurable, because there is no deployment that wants less.
+Beyond that there are three postures. Data surfaces — the native `/v1`
+routes, both compat shims, CardDAV — send `default-src 'none'`, which
+says an API response is not a page; with `nosniff` that is what keeps a
+stored payload the server never parsed from being read back as script.
+The web console sends a policy naming only `'self'` and `'none'`, with no
+`'unsafe-inline'` and no `'unsafe-eval'` anywhere in it, which it can
+afford because it loads no external origin, evaluates no strings, and
+embeds no images. The `/docs` explorer sends the one loosened policy:
+its vendored Scalar bundle applies styles at runtime and carries its
+icons as `data:` URIs, so `style-src` and `img-src` are relaxed for that
+surface alone. Scripts are not relaxed even there. `Strict-Transport-Security`
+is not in this set; it is a claim about transport and only the HTTPS
+front door sends it.
+
 Every listener refuses state-changing requests (`POST`, `PUT`, `DELETE`,
 `PATCH`) that a browser marks as cross-origin, using the `Sec-Fetch-Site`
 and `Origin` headers browsers attach and non-browser clients do not. This

--- a/internal/server/api/ollama_server.go
+++ b/internal/server/api/ollama_server.go
@@ -124,8 +124,9 @@ func (s *OllamaServer) buildHandler() http.Handler {
 	// access-log lines with their 401/403 status. The source allowlist
 	// goes first: a caller the operator has not admitted costs one log
 	// line and nothing else.
-	return s.withLogging(listen.RestrictSources(s.logger, "ollama", s.allowedSources,
-		listen.RejectCrossOriginWrites(s.logger, ollamaAuth(s.apiKey, mux))))
+	return s.withLogging(listen.SecurityHeaders(listen.PostureAPI,
+		listen.RestrictSources(s.logger, "ollama", s.allowedSources,
+			listen.RejectCrossOriginWrites(s.logger, ollamaAuth(s.apiKey, mux)))))
 }
 
 // Shutdown gracefully stops the server.

--- a/internal/server/api/openai_server.go
+++ b/internal/server/api/openai_server.go
@@ -96,8 +96,9 @@ func (s *OpenAIServer) Handler() http.Handler {
 		s.api.RegisterOpenAIRoutes(mux)
 		// The source allowlist runs ahead of the bearer gate, so a key is
 		// only ever compared for a caller the operator admitted.
-		s.handler = s.withLogging(listen.RestrictSources(s.logger, "openai", s.allowedSources,
-			listen.RejectCrossOriginWrites(s.logger, openaiAuth(s.apiKey, listen.LimitRequestBody(compatMaxBodyBytes, mux)))))
+		s.handler = s.withLogging(listen.SecurityHeaders(listen.PostureAPI,
+			listen.RestrictSources(s.logger, "openai", s.allowedSources,
+				listen.RejectCrossOriginWrites(s.logger, openaiAuth(s.apiKey, listen.LimitRequestBody(compatMaxBodyBytes, mux))))))
 	})
 	return s.handler
 }

--- a/internal/server/api/security_headers_test.go
+++ b/internal/server/api/security_headers_test.go
@@ -1,0 +1,135 @@
+package api
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/server/listen"
+)
+
+// serveHeaders drives one request and returns the response headers.
+func serveHeaders(h http.Handler, req *http.Request) (header http.Header) {
+	rec := httptest.NewRecorder()
+	defer func() {
+		_ = recover()
+		header = rec.Header()
+	}()
+	h.ServeHTTP(rec, req)
+	return rec.Header()
+}
+
+// TestEveryRouteCarriesSecurityHeaders is the route-table test for this
+// slice, and the reason the headers go on the chain rather than on the
+// routes. It walks every pattern registered on the native mux — the API,
+// the console, and the explorer share it — and proves each answers with
+// the common set and a content policy. The companion data plane (#1509)
+// is about to add authenticated endpoints here; adding one without
+// headers should fail in this test the way adding one without an auth
+// decision already fails in TestEveryRouteIsGatedOrDeliberatelyPublic.
+func TestEveryRouteCarriesSecurityHeaders(t *testing.T) {
+	t.Parallel()
+	s := gatedServer(t)
+	h := s.Handler()
+
+	for _, pattern := range s.routes {
+		method, path, ok := strings.Cut(pattern, " ")
+		if !ok {
+			t.Fatalf("pattern %q has no method", pattern)
+		}
+		probePath := strings.NewReplacer("{$}", "", "{file...}", "app.js").Replace(path)
+		for strings.Contains(probePath, "{") {
+			start := strings.Index(probePath, "{")
+			end := strings.Index(probePath, "}")
+			probePath = probePath[:start] + "x" + probePath[end+1:]
+		}
+		t.Run(pattern, func(t *testing.T) {
+			req := httptest.NewRequest(method, probePath, strings.NewReader("{}"))
+			req.Header.Set("Authorization", "Bearer alice-token")
+			got := serveHeaders(h, req)
+			for name, want := range map[string]string{
+				"X-Content-Type-Options": "nosniff",
+				"X-Frame-Options":        "DENY",
+				"Referrer-Policy":        "no-referrer",
+			} {
+				if got.Get(name) != want {
+					t.Errorf("%s: %s = %q, want %q", pattern, name, got.Get(name), want)
+				}
+			}
+			policy := got.Values("Content-Security-Policy")
+			if len(policy) != 1 {
+				t.Fatalf("%s: got %d content policies, want exactly 1: %v", pattern, len(policy), policy)
+			}
+			if !strings.Contains(policy[0], "frame-ancestors 'none'") {
+				t.Errorf("%s: policy does not deny framing: %s", pattern, policy[0])
+			}
+		})
+	}
+}
+
+// TestSurfacePosturesAreTheRightWayRound pins which policy each part of
+// the shared mux ends up with: the console and the explorer replace the
+// API posture the chain applied on the way in, and everything else keeps
+// it. A route that forgets to choose gets the strictest one.
+func TestSurfacePosturesAreTheRightWayRound(t *testing.T) {
+	t.Parallel()
+	h := gatedServer(t).Handler()
+
+	tests := []struct {
+		name    string
+		path    string
+		want    listen.Posture
+		comment string
+	}{
+		{"console shell", "/", listen.PostureConsole, "the console is a document"},
+		{"console asset", "/static/app.js", listen.PostureConsole, "assets share the shell's origin"},
+		{"explorer", "/docs", listen.PostureDocuments, "the vendored bundle needs data: images"},
+		{"explorer asset", "/docs/scalar.js", listen.PostureDocuments, "same surface, same posture"},
+		{"native api", "/v1/version", listen.PostureAPI, "an API response is not a page"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			req.Header.Set("Authorization", "Bearer alice-token")
+			got := serveHeaders(h, req).Get("Content-Security-Policy")
+			if want := securityPolicyFor(tc.want); got != want {
+				t.Fatalf("%s (%s):\n got %s\nwant %s", tc.path, tc.comment, got, want)
+			}
+		})
+	}
+}
+
+// TestCompatShimsCarrySecurityHeaders pins the header set onto the two
+// foreign-protocol surfaces, which have their own chains rather than
+// sharing the native mux.
+func TestCompatShimsCarrySecurityHeaders(t *testing.T) {
+	t.Parallel()
+
+	shims := map[string]http.Handler{
+		"ollama": NewOllamaServer("", 11434, "", nil, nil, slog.Default()).Handler(),
+		"openai": NewOpenAIServer("", 8081, "", nil, &Server{}, slog.Default()).Handler(),
+	}
+	paths := map[string]string{"ollama": "/api/version", "openai": "/health"}
+
+	for surface, handler := range shims {
+		got := serveHeaders(handler, httptest.NewRequest(http.MethodGet, paths[surface], nil))
+		if got.Get("X-Content-Type-Options") != "nosniff" {
+			t.Errorf("%s: missing nosniff", surface)
+		}
+		if want := securityPolicyFor(listen.PostureAPI); got.Get("Content-Security-Policy") != want {
+			t.Errorf("%s: policy = %q, want the API posture %q", surface, got.Get("Content-Security-Policy"), want)
+		}
+	}
+}
+
+// securityPolicyFor reads back the policy a posture sends, so these
+// tests assert against the guard's own table rather than a copy of it
+// that could drift.
+func securityPolicyFor(posture listen.Posture) string {
+	rec := httptest.NewRecorder()
+	listen.SecurityHeaders(posture, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})).
+		ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	return rec.Header().Get("Content-Security-Policy")
+}

--- a/internal/server/api/server.go
+++ b/internal/server/api/server.go
@@ -633,7 +633,12 @@ func (s *Server) buildHandler() http.Handler {
 	// The gate sits inside the cross-origin guard, so a forged request is
 	// refused before its cookie is even consulted, and outside the body
 	// cap, so an unauthenticated caller never gets a body read at all.
-	return s.withLogging(listen.RejectCrossOriginWrites(s.logger, s.auth.wrap(listen.LimitRequestBody(nativeMaxBodyBytes, mux))))
+	// The API posture goes on the whole chain, so a route added to this
+	// mux without a thought still answers with the strictest policy
+	// rather than none; the console and explorer registrars replace it
+	// for their own sub-trees on the way out.
+	return s.withLogging(listen.SecurityHeaders(listen.PostureAPI,
+		listen.RejectCrossOriginWrites(s.logger, s.auth.wrap(listen.LimitRequestBody(nativeMaxBodyBytes, mux)))))
 }
 
 // Shutdown gracefully stops the server.

--- a/internal/server/api/uiharness.go
+++ b/internal/server/api/uiharness.go
@@ -23,6 +23,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/events"
 	"github.com/nugget/thane-ai-agent/internal/platform/logging"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/server/listen"
 )
 
 // harnessLoopReg is a static LoopStatusReader seeded with synthetic loops.
@@ -193,11 +194,18 @@ func RunUIHarness(addr, staticDir, authToken string) error {
 	mux.HandleFunc("GET /v1/loops/{id}/logs", s.handleLoopLogs)
 	mux.HandleFunc("GET /v1/requests/{id}", s.handleRequest)
 
-	// Console static assets, served live from staticDir.
-	mux.Handle("GET /static/", http.StripPrefix("/static/", http.FileServer(http.Dir(staticDir))))
-	mux.HandleFunc("GET /{$}", func(w http.ResponseWriter, r *http.Request) {
+	// Console static assets, served live from staticDir. The console
+	// posture is applied here, and the API posture to the whole handler
+	// below, exactly as production composes them — so a change to the
+	// console that its content policy would refuse fails here, while
+	// the asset is still being iterated on, rather than in prod.
+	console := func(h http.Handler) http.Handler {
+		return listen.SecurityHeaders(listen.PostureConsole, h)
+	}
+	mux.Handle("GET /static/", console(http.StripPrefix("/static/", http.FileServer(http.Dir(staticDir)))))
+	mux.Handle("GET /{$}", console(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.ServeFile(w, r, filepath.Join(staticDir, "index.html"))
-	})
+	})))
 
 	logger.Warn("ui harness listening", "addr", addr, "static", staticDir)
 	var handler http.Handler = mux
@@ -211,7 +219,7 @@ func RunUIHarness(addr, staticDir, authToken string) error {
 		mux.HandleFunc("GET /v1/auth/session", s.handleAuthSession)
 		handler = gate.wrap(mux)
 	}
-	return http.ListenAndServe(addr, handler)
+	return http.ListenAndServe(addr, listen.SecurityHeaders(listen.PostureAPI, handler))
 }
 
 // emitSyntheticActivity drives the "signal/aimee" loop through repeating turns

--- a/internal/server/carddav/server.go
+++ b/internal/server/carddav/server.go
@@ -188,7 +188,8 @@ func (s *Server) buildHandler() http.Handler {
 		Backend: s.backend,
 		Prefix:  "/carddav",
 	}
-	return s.withAuth(s.withLogging(listen.RejectCrossOriginWrites(s.logger, davHandler)))
+	return s.withAuth(s.withLogging(listen.SecurityHeaders(listen.PostureAPI,
+		listen.RejectCrossOriginWrites(s.logger, davHandler))))
 }
 
 // withAuth wraps a handler with HTTP Basic Auth.  The .well-known

--- a/internal/server/carddav/server.go
+++ b/internal/server/carddav/server.go
@@ -178,18 +178,24 @@ func (s *Server) tryRebind() {
 	}
 }
 
-// buildHandler creates the HTTP handler chain: auth → logging →
-// cross-origin guard → carddav.Handler. The guard sits after auth
-// because the forgery it stops is a browser replaying cached Basic
+// buildHandler creates the HTTP handler chain: security headers → auth
+// → logging → cross-origin guard → carddav.Handler. The guard sits after
+// auth because the forgery it stops is a browser replaying cached Basic
 // credentials on a cross-site request; the credentials pass, the origin
 // does not.
+//
+// The headers sit outermost, ahead of auth, because two responses leave
+// this server without reaching it: the 401 challenge and the unauthed
+// .well-known discovery redirect. A response a browser reads before it
+// has credentials is exactly the one that must already say what may be
+// done with it.
 func (s *Server) buildHandler() http.Handler {
 	davHandler := &libcarddav.Handler{
 		Backend: s.backend,
 		Prefix:  "/carddav",
 	}
-	return s.withAuth(s.withLogging(listen.SecurityHeaders(listen.PostureAPI,
-		listen.RejectCrossOriginWrites(s.logger, davHandler))))
+	return listen.SecurityHeaders(listen.PostureAPI,
+		s.withAuth(s.withLogging(listen.RejectCrossOriginWrites(s.logger, davHandler))))
 }
 
 // withAuth wraps a handler with HTTP Basic Auth.  The .well-known

--- a/internal/server/carddav/server_test.go
+++ b/internal/server/carddav/server_test.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/server/listen"
 )
 
 func TestServer_AuthRequired(t *testing.T) {
@@ -84,6 +86,66 @@ func TestServer_WellKnownNoAuth(t *testing.T) {
 
 	if rr.Code == http.StatusUnauthorized {
 		t.Error("well-known redirect should not require auth")
+	}
+}
+
+// TestServer_SecurityHeadersOnEveryResponse covers the two responses
+// CardDAV returns before authentication: the 401 challenge and the
+// unauthenticated .well-known discovery redirect. Both leave the server
+// without touching the CardDAV handler, so they are the responses a
+// chain that put the headers behind auth would silently omit them from.
+//
+// The expected headers are taken from the API posture itself rather than
+// written out, so this test asserts CardDAV carries that posture and
+// cannot drift from what listen defines it to be.
+func TestServer_SecurityHeadersOnEveryResponse(t *testing.T) {
+	b := newTestBackend(t)
+	s := NewServer(nil, "user", "pass", b, b.logger)
+	s.handler = s.buildHandler()
+
+	posture := httptest.NewRecorder()
+	listen.SecurityHeaders(listen.PostureAPI, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})).
+		ServeHTTP(posture, httptest.NewRequest("GET", "/", nil))
+
+	tests := []struct {
+		name  string
+		build func() *http.Request
+		want  int
+	}{
+		{
+			name:  "unauthenticated challenge",
+			build: func() *http.Request { return httptest.NewRequest("PROPFIND", "/carddav/", nil) },
+			want:  http.StatusUnauthorized,
+		},
+		{
+			name:  "discovery redirect",
+			build: func() *http.Request { return httptest.NewRequest("GET", "/.well-known/carddav", nil) },
+			want:  http.StatusMovedPermanently,
+		},
+		{
+			name: "authenticated request",
+			build: func() *http.Request {
+				req := httptest.NewRequest("PROPFIND", "/carddav/", nil)
+				req.SetBasicAuth("user", "pass")
+				return req
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			s.handler.ServeHTTP(rr, tt.build())
+
+			if tt.want != 0 && rr.Code != tt.want {
+				t.Errorf("status = %d, want %d", rr.Code, tt.want)
+			}
+			for name, want := range posture.Header() {
+				if got := rr.Header().Get(name); got != want[0] {
+					t.Errorf("%s = %q, want %q", name, got, want[0])
+				}
+			}
+		})
 	}
 }
 

--- a/internal/server/listen/headers.go
+++ b/internal/server/listen/headers.go
@@ -1,0 +1,117 @@
+package listen
+
+import "net/http"
+
+// Posture names what a surface's responses are, which is what decides
+// the content policy they carry. It is an enumeration rather than a set
+// of branches because the set grows: #1509's artifact primitive, when it
+// lands, serves arbitrary client-supplied bytes and will want a posture
+// stricter than any of these.
+type Posture int
+
+const (
+	// PostureAPI is for surfaces that answer with data: the native /v1
+	// routes, the two compat shims, CardDAV. Their responses are not
+	// documents and must never be treated as any, which matters more
+	// than it looks: a companion materialization (#1509) is opaque
+	// client-authored JSON that Thane stores without parsing and serves
+	// back from the same origin the console's session cookie lives on.
+	// Sniffing is the mechanism that would turn such a payload into
+	// script on that origin, so nosniff and default-src 'none' together
+	// are what keep stored data from becoming stored scripting.
+	PostureAPI Posture = iota
+
+	// PostureConsole is for the web console, which is a real document
+	// and can afford a real policy: the console loads no external
+	// origin, evaluates no strings, embeds no images, and reaches the
+	// server over one same-origin EventSource, so every directive below
+	// names 'self' or 'none' and none is loosened.
+	PostureConsole
+
+	// PostureDocuments is for the OpenAPI explorer at /docs, whose
+	// vendored Scalar bundle is the one asset Thane serves that it did
+	// not write. The bundle carries inline images as data: URIs and
+	// builds stylesheets at runtime, so this posture — and only this
+	// posture — loosens img-src and style-src to suit it. Keeping that
+	// looseness on its own surface is the reason postures exist at all.
+	PostureDocuments
+)
+
+// contentPolicy is the Content-Security-Policy each posture sends.
+var contentPolicy = map[Posture]string{
+	PostureAPI: "default-src 'none'; frame-ancestors 'none'; base-uri 'none'",
+
+	PostureConsole: "default-src 'none'; " +
+		"script-src 'self'; " +
+		"style-src 'self'; " +
+		"img-src 'self'; " +
+		"connect-src 'self'; " +
+		"form-action 'self'; " +
+		"frame-ancestors 'none'; " +
+		"base-uri 'none'",
+
+	// data: for the bundle's inline icons; 'unsafe-inline' for the
+	// styles it applies at runtime. Both are the vendored bundle's
+	// requirements, not Thane's, and both were verified by removing them
+	// and watching the page break: without 'unsafe-inline' the explorer
+	// renders as unstyled HTML. They stop at this surface.
+	//
+	// Scripts are NOT loosened here, which matters most on the one
+	// surface serving code Thane did not write. The bundle tries to run
+	// one inline script and is refused; the page renders and works
+	// without it, and an inline script that cannot be identified is a
+	// reason to keep refusing rather than to allowlist a hash.
+	//
+	// font-src and connect-src stay closed on purpose. The bundle
+	// reaches for fonts.scalar.com and api.scalar.com at runtime despite
+	// being vendored to render offline; those requests are refused and
+	// the page falls back to system fonts. See #1512.
+	PostureDocuments: "default-src 'none'; " +
+		"script-src 'self'; " +
+		"style-src 'self' 'unsafe-inline'; " +
+		"img-src 'self' data:; " +
+		"font-src 'self' data:; " +
+		"connect-src 'self'; " +
+		"form-action 'self'; " +
+		"frame-ancestors 'none'; " +
+		"base-uri 'none'",
+}
+
+// SecurityHeaders sets the response headers that tell a browser what it
+// may do with what Thane just sent it. Every surface takes one, so a
+// listener cannot be added without a decision about what its responses
+// are, the same way it cannot be added without the shared bounds.
+//
+// Headers are set before the handler runs, so a handler that knows
+// better can overwrite them. That is deliberate and load-bearing: the
+// native API, the console, and the explorer share one mux, so the API
+// posture is applied to the whole chain and the console and explorer
+// sub-trees replace the policy for their own routes. A route added to
+// that mux without a thought therefore gets the strictest posture rather
+// than none, which is the right way round.
+//
+// Strict-Transport-Security is deliberately absent. It is a claim about
+// transport and belongs to the surface that terminates TLS; the front
+// door sets it, and a plaintext listener asserting it would be making a
+// promise it cannot keep.
+func SecurityHeaders(posture Posture, next http.Handler) http.Handler {
+	policy := contentPolicy[posture]
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h := w.Header()
+		h.Set("Content-Security-Policy", policy)
+		// A JSON body is never sniffed into script, and a document is
+		// never reinterpreted as something else.
+		h.Set("X-Content-Type-Options", "nosniff")
+		// frame-ancestors already says this to anything current;
+		// X-Frame-Options is its legacy spelling and costs one line.
+		h.Set("X-Frame-Options", "DENY")
+		// The console links out to the project's GitHub page. Under the
+		// default policy that request would carry the deployment's
+		// hostname to a third party, and no Thane surface has a reason
+		// to send a referrer anywhere.
+		h.Set("Referrer-Policy", "no-referrer")
+		// Nothing Thane serves asks for a device.
+		h.Set("Permissions-Policy", "geolocation=(), camera=(), microphone=()")
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/server/listen/headers.go
+++ b/internal/server/listen/headers.go
@@ -94,8 +94,16 @@ var contentPolicy = map[Posture]string{
 // transport and belongs to the surface that terminates TLS; the front
 // door sets it, and a plaintext listener asserting it would be making a
 // promise it cannot keep.
+//
+// A posture with no policy of its own falls back to the API policy
+// rather than to no policy. Posture is an enumeration meant to grow, and
+// the failure mode of adding a constant without a map entry has to be
+// the strictest surface Thane serves, not the loosest.
 func SecurityHeaders(posture Posture, next http.Handler) http.Handler {
-	policy := contentPolicy[posture]
+	policy, ok := contentPolicy[posture]
+	if !ok {
+		policy = contentPolicy[PostureAPI]
+	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		h := w.Header()
 		h.Set("Content-Security-Policy", policy)

--- a/internal/server/listen/headers_test.go
+++ b/internal/server/listen/headers_test.go
@@ -1,0 +1,134 @@
+package listen
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// commonHeaders are sent by every posture; a surface cannot opt out of
+// them by choosing one posture over another.
+var commonHeaders = map[string]string{
+	"X-Content-Type-Options": "nosniff",
+	"X-Frame-Options":        "DENY",
+	"Referrer-Policy":        "no-referrer",
+	"Permissions-Policy":     "geolocation=(), camera=(), microphone=()",
+}
+
+func TestSecurityHeadersCommonSet(t *testing.T) {
+	t.Parallel()
+
+	for _, posture := range []Posture{PostureAPI, PostureConsole, PostureDocuments} {
+		rec := httptest.NewRecorder()
+		SecurityHeaders(posture, comparableHandler{}).
+			ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+		for name, want := range commonHeaders {
+			if got := rec.Header().Get(name); got != want {
+				t.Errorf("posture %d: %s = %q, want %q", posture, name, got, want)
+			}
+		}
+		if rec.Header().Get("Content-Security-Policy") == "" {
+			t.Errorf("posture %d sent no content policy", posture)
+		}
+		// HSTS is the front door's to send; a surface asserting it would
+		// be promising a transport it does not terminate.
+		if got := rec.Header().Get("Strict-Transport-Security"); got != "" {
+			t.Errorf("posture %d sent HSTS %q; that belongs to the front door", posture, got)
+		}
+	}
+}
+
+// TestConsolePolicyLoosensNothing is the test that keeps the console's
+// policy honest. The console loads no external origin, evaluates no
+// strings, and embeds no images, so every directive should name 'self'
+// or 'none'. If a future asset needs more, the choice should be to
+// change the asset, and this failing is where that conversation starts.
+func TestConsolePolicyLoosensNothing(t *testing.T) {
+	t.Parallel()
+
+	policy := contentPolicy[PostureConsole]
+	for _, banned := range []string{"'unsafe-inline'", "'unsafe-eval'", "'unsafe-hashes'", "data:", "blob:", "*", "http:", "https:"} {
+		if strings.Contains(policy, banned) {
+			t.Errorf("console policy contains %s: %s", banned, policy)
+		}
+	}
+	for _, required := range []string{
+		"default-src 'none'",
+		"script-src 'self'",
+		"style-src 'self'",
+		"connect-src 'self'",
+		"frame-ancestors 'none'",
+		"base-uri 'none'",
+	} {
+		if !strings.Contains(policy, required) {
+			t.Errorf("console policy missing %q: %s", required, policy)
+		}
+	}
+}
+
+// TestAPIPolicyIsForDataNotDocuments pins that an API response says it
+// is not a page. This is what keeps a stored companion materialization
+// (#1509) — opaque client-authored JSON served back from the origin the
+// console's session cookie lives on — from being treated as anything
+// executable.
+func TestAPIPolicyIsForDataNotDocuments(t *testing.T) {
+	t.Parallel()
+
+	policy := contentPolicy[PostureAPI]
+	if !strings.Contains(policy, "default-src 'none'") {
+		t.Fatalf("api policy must deny everything by default: %s", policy)
+	}
+	for _, banned := range []string{"'unsafe-inline'", "'unsafe-eval'", "data:", "'self'"} {
+		if strings.Contains(policy, banned) {
+			t.Errorf("api policy contains %s; an API response loads nothing: %s", banned, policy)
+		}
+	}
+}
+
+// TestDocumentsPolicyLoosensOnlyWhatTheBundleNeeds pins the blast radius
+// of the one surface that carries a vendored asset: it may relax images
+// and styles for Scalar, and nothing else, and never for scripts.
+func TestDocumentsPolicyLoosensOnlyWhatTheBundleNeeds(t *testing.T) {
+	t.Parallel()
+
+	policy := contentPolicy[PostureDocuments]
+	if !strings.Contains(policy, "script-src 'self'") || strings.Contains(policy, "'unsafe-eval'") {
+		t.Errorf("documents policy must keep scripts strict: %s", policy)
+	}
+	for _, directive := range strings.Split(policy, "; ") {
+		name, value, _ := strings.Cut(directive, " ")
+		switch name {
+		case "img-src", "font-src":
+			if strings.ReplaceAll(value, "data:", "") != "'self' " && value != "'self' data:" {
+				t.Errorf("%s = %q, want 'self' plus data: only", name, value)
+			}
+		case "style-src":
+			if value != "'self' 'unsafe-inline'" {
+				t.Errorf("style-src = %q, want 'self' 'unsafe-inline' for the bundle's runtime stylesheets", value)
+			}
+		default:
+			if strings.Contains(value, "data:") || strings.Contains(value, "'unsafe-inline'") {
+				t.Errorf("%s is loosened but is not a bundle requirement: %s", name, directive)
+			}
+		}
+	}
+}
+
+// TestSecurityHeadersAreOverridable pins the composition the native mux
+// depends on: headers are set before the handler runs, so a sub-tree
+// that knows its own posture replaces them rather than appending.
+func TestSecurityHeadersAreOverridable(t *testing.T) {
+	t.Parallel()
+
+	inner := SecurityHeaders(PostureConsole, comparableHandler{})
+	rec := httptest.NewRecorder()
+	SecurityHeaders(PostureAPI, inner).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if got := rec.Header().Values("Content-Security-Policy"); len(got) != 1 {
+		t.Fatalf("got %d content policies, want exactly 1: %v", len(got), got)
+	}
+	if got := rec.Header().Get("Content-Security-Policy"); got != contentPolicy[PostureConsole] {
+		t.Fatalf("inner posture did not win: %s", got)
+	}
+}

--- a/internal/server/listen/headers_test.go
+++ b/internal/server/listen/headers_test.go
@@ -28,8 +28,8 @@ func TestSecurityHeadersCommonSet(t *testing.T) {
 				t.Errorf("posture %d: %s = %q, want %q", posture, name, got, want)
 			}
 		}
-		if rec.Header().Get("Content-Security-Policy") == "" {
-			t.Errorf("posture %d sent no content policy", posture)
+		if got := rec.Header().Get("Content-Security-Policy"); got != contentPolicy[posture] {
+			t.Errorf("posture %d sent %q, want its own policy %q", posture, got, contentPolicy[posture])
 		}
 		// HSTS is the front door's to send; a surface asserting it would
 		// be promising a transport it does not terminate.
@@ -111,6 +111,43 @@ func TestDocumentsPolicyLoosensOnlyWhatTheBundleNeeds(t *testing.T) {
 			if strings.Contains(value, "data:") || strings.Contains(value, "'unsafe-inline'") {
 				t.Errorf("%s is loosened but is not a bundle requirement: %s", name, directive)
 			}
+		}
+	}
+}
+
+// TestUnknownPostureFailsClosed pins the fallback. Posture is exported
+// and meant to grow, so the interesting case is not a posture Thane has
+// today but the one added tomorrow with the constant written and the map
+// entry forgotten. An empty policy is the loosest thing this middleware
+// could send, on the surface most likely to be new and unexamined, so an
+// unrecognised posture answers with the API policy instead.
+func TestUnknownPostureFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	SecurityHeaders(Posture(999), comparableHandler{}).
+		ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if got := rec.Header().Get("Content-Security-Policy"); got != contentPolicy[PostureAPI] {
+		t.Errorf("unknown posture sent %q, want the API policy %q", got, contentPolicy[PostureAPI])
+	}
+	for name, want := range commonHeaders {
+		if got := rec.Header().Get(name); got != want {
+			t.Errorf("unknown posture: %s = %q, want %q", name, got, want)
+		}
+	}
+}
+
+// TestEveryPostureHasItsOwnPolicy keeps the fallback from being a place
+// postures quietly live. Falling back is the safe behaviour for a
+// mistake, not a way to declare a posture without deciding what it
+// serves, so every named posture carries its own entry.
+func TestEveryPostureHasItsOwnPolicy(t *testing.T) {
+	t.Parallel()
+
+	for _, posture := range []Posture{PostureAPI, PostureConsole, PostureDocuments} {
+		if _, ok := contentPolicy[posture]; !ok {
+			t.Errorf("posture %d has no policy of its own", posture)
 		}
 	}
 }

--- a/internal/server/openapi/assets/explorer-boot.js
+++ b/internal/server/openapi/assets/explorer-boot.js
@@ -1,0 +1,19 @@
+// Bootstraps the Scalar API reference against the embedded specs.
+//
+// A separate file rather than an inline block so /docs keeps
+// script-src 'self'. That directive matters more here than anywhere
+// else: this is the one surface serving an asset Thane did not write,
+// so the last thing its policy should permit is inline script.
+Scalar.createApiReference('#app', {
+  sources: [
+    { url: '/docs/openapi/native.yaml', title: 'Thane Native API', slug: 'native' },
+    { url: '/docs/openapi/compat.yaml', title: 'Compatibility API', slug: 'compat' },
+  ],
+  // Default the "Try it" code samples to curl — the operator's lingua
+  // franca for a self-hosted API.
+  defaultHttpClient: { targetKey: 'shell', clientKey: 'curl' },
+  // Label the auto-rendered components/schemas section "Schemas" so it no
+  // longer reads as a bare "Models" — that title collided with the
+  // "Model Routing" tag and the "Routing & Telemetry" group.
+  modelsSectionLabel: 'Schemas',
+})

--- a/internal/server/openapi/explorer.go
+++ b/internal/server/openapi/explorer.go
@@ -17,12 +17,15 @@ import (
 // Scalar standalone bundle. Vendored (not CDN-loaded) so /docs renders
 // offline.
 //
-//go:embed native.yaml compat.yaml assets/scalar.standalone.js
+//go:embed native.yaml compat.yaml assets/scalar.standalone.js assets/explorer-boot.js
 var files embed.FS
 
 // indexHTML bootstraps the Scalar API reference against the embedded specs.
-// Scalar is loaded from /docs/scalar.js (vendored) and renders both the
-// native and compatibility documents with a built-in switcher.
+// Scalar is loaded from /docs/scalar.js (vendored) and configured by
+// /docs/boot.js; both are files rather than inline blocks so the
+// explorer's content policy can keep script-src 'self'. The reference
+// renders both the native and compatibility documents with a built-in
+// switcher.
 const indexHTML = `<!doctype html>
 <html lang="en">
   <head>
@@ -33,21 +36,7 @@ const indexHTML = `<!doctype html>
   <body>
     <div id="app"></div>
     <script src="/docs/scalar.js"></script>
-    <script>
-      Scalar.createApiReference('#app', {
-        sources: [
-          { url: '/docs/openapi/native.yaml', title: 'Thane Native API', slug: 'native' },
-          { url: '/docs/openapi/compat.yaml', title: 'Compatibility API', slug: 'compat' },
-        ],
-        // Default the "Try it" code samples to curl — the operator's lingua
-        // franca for a self-hosted API.
-        defaultHttpClient: { targetKey: 'shell', clientKey: 'curl' },
-        // Label the auto-rendered components/schemas section "Schemas" so it no
-        // longer reads as a bare "Models" — that title collided with the
-        // "Model Routing" tag and the "Routing & Telemetry" group.
-        modelsSectionLabel: 'Schemas',
-      })
-    </script>
+    <script src="/docs/boot.js"></script>
   </body>
 </html>
 `
@@ -56,11 +45,18 @@ const indexHTML = `<!doctype html>
 // The surface is read-only and unauthenticated (documentation only); restrict
 // it at the reverse proxy if it should not be public.
 func RegisterRoutes(mux listen.RouteRegistrar) {
-	mux.HandleFunc("GET /docs", handleIndex)
-	mux.HandleFunc("GET /docs/", handleIndex)
-	mux.HandleFunc("GET /docs/scalar.js", serveEmbedded("assets/scalar.standalone.js", "application/javascript; charset=utf-8"))
-	mux.HandleFunc("GET /docs/openapi/native.yaml", serveEmbedded("native.yaml", "application/yaml; charset=utf-8"))
-	mux.HandleFunc("GET /docs/openapi/compat.yaml", serveEmbedded("compat.yaml", "application/yaml; charset=utf-8"))
+	// The explorer replaces the API posture with the one that suits the
+	// vendored Scalar bundle, whose data: images and runtime-built
+	// stylesheets are the only reason any directive anywhere is loosened.
+	docs := func(h http.HandlerFunc) http.Handler {
+		return listen.SecurityHeaders(listen.PostureDocuments, h)
+	}
+	mux.Handle("GET /docs", docs(handleIndex))
+	mux.Handle("GET /docs/", docs(handleIndex))
+	mux.Handle("GET /docs/scalar.js", docs(serveEmbedded("assets/scalar.standalone.js", "application/javascript; charset=utf-8")))
+	mux.Handle("GET /docs/boot.js", docs(serveEmbedded("assets/explorer-boot.js", "application/javascript; charset=utf-8")))
+	mux.Handle("GET /docs/openapi/native.yaml", docs(serveEmbedded("native.yaml", "application/yaml; charset=utf-8")))
+	mux.Handle("GET /docs/openapi/compat.yaml", docs(serveEmbedded("compat.yaml", "application/yaml; charset=utf-8")))
 }
 
 func handleIndex(w http.ResponseWriter, _ *http.Request) {

--- a/internal/server/openapi/explorer_test.go
+++ b/internal/server/openapi/explorer_test.go
@@ -25,7 +25,11 @@ func TestRegisterRoutes(t *testing.T) {
 		wantCTPart string
 		wantBody   string
 	}{
-		{"/docs", "text/html", "createApiReference"},
+		// The page bootstraps through /docs/boot.js rather than an inline
+		// block, so the explorer's content policy can keep script-src
+		// 'self' on the one surface serving a vendored bundle.
+		{"/docs", "text/html", `<script src="/docs/boot.js">`},
+		{"/docs/boot.js", "javascript", "createApiReference"},
 		{"/docs/scalar.js", "javascript", "createApiReference"},
 		{"/docs/openapi/native.yaml", "yaml", "openapi: 3.1.0"},
 		{"/docs/openapi/compat.yaml", "yaml", "openapi: 3.1.0"},

--- a/internal/server/web/server.go
+++ b/internal/server/web/server.go
@@ -96,8 +96,12 @@ func NewWebServer(cfg Config) *WebServer {
 func (s *WebServer) RegisterRoutes(mux listen.RouteRegistrar) {
 	// Exact-root match only ("/{$}"), so retired /api/* URLs and other
 	// unknown paths get a 404 instead of a 200 dashboard shell.
-	mux.HandleFunc("GET /{$}", s.handleIndex)
-	mux.HandleFunc("GET /static/{file...}", s.handleStatic)
+	// The console is a document, not data, so it replaces the API
+	// posture the native chain applied on the way in. Its policy names
+	// only 'self' and 'none': the console loads no external origin,
+	// evaluates no strings, and embeds no images.
+	mux.Handle("GET /{$}", listen.SecurityHeaders(listen.PostureConsole, http.HandlerFunc(s.handleIndex)))
+	mux.Handle("GET /static/{file...}", listen.SecurityHeaders(listen.PostureConsole, http.HandlerFunc(s.handleStatic)))
 }
 
 // handleIndex serves the single-page visualizer.

--- a/internal/server/web/static/index.html
+++ b/internal/server/web/static/index.html
@@ -5,21 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Thane - Cognition Engine</title>
   <link rel="stylesheet" href="/static/style.css">
-  <script>
-    // Apply persisted theme before first paint to avoid a flash of the
-    // default look. Mirrors static/theme.js; kept tiny and dependency-free.
-    (function () {
-      try {
-        var root = document.documentElement;
-        var m = localStorage.getItem('thane.theme.mode');
-        if (m === 'light' || m === 'dark') root.dataset.theme = m;
-        var a = localStorage.getItem('thane.theme.accent');
-        if (a && /^#[0-9a-f]{6}$/i.test(a)) {
-          root.style.setProperty('--accent', a);
-        }
-      } catch (e) { /* storage blocked — fall back to defaults */ }
-    })();
-  </script>
+  <!-- Blocking on purpose: runs before first paint, so the persisted
+       theme is applied without a flash of the default look. -->
+  <script src="/static/theme-boot.js"></script>
 </head>
 <body>
   <header class="header">
@@ -71,7 +59,7 @@
       <div id="request-detail" class="detail-content" hidden>
         <div class="detail-header">
           <h2 class="detail-name">Request Detail</h2>
-          <div style="display:flex;gap:4px;align-items:center">
+          <div class="inline-row">
             <button id="request-detail-copy" class="copy-btn" title="Copy full request as JSON">JSON</button>
             <button id="request-detail-close" class="btn btn--sm" title="Close request detail">&times;</button>
           </div>

--- a/internal/server/web/static/style.css
+++ b/internal/server/web/static/style.css
@@ -4003,3 +4003,11 @@ body.resize-col .schema-card__fade {
 }
 .auth-button:disabled { opacity: 0.6; cursor: default; }
 .auth-error { color: var(--error); font-size: 0.85rem; }
+
+/* Replaces an inline style attribute on the graph toolbar's button row,
+   so the console's content policy needs no 'unsafe-inline' for styles. */
+.inline-row {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+}

--- a/internal/server/web/static/theme-boot.js
+++ b/internal/server/web/static/theme-boot.js
@@ -1,0 +1,21 @@
+// Applies the persisted theme before first paint to avoid a flash of the
+// default look. Mirrors theme.js; kept tiny and dependency-free.
+//
+// This is a separate file rather than an inline block in index.html so
+// the console's content policy can name 'self' and nothing else. A
+// blocking <script src> in <head> runs before first paint just as an
+// inline block does, so the anti-flash property is unchanged; the cost
+// is one request against an embedded file. The alternative — a nonce —
+// would mean index.html could no longer be served as a static asset,
+// since each response would need a fresh value templated into it.
+(function () {
+  try {
+    var root = document.documentElement;
+    var m = localStorage.getItem('thane.theme.mode');
+    if (m === 'light' || m === 'dark') root.dataset.theme = m;
+    var a = localStorage.getItem('thane.theme.accent');
+    if (a && /^#[0-9a-f]{6}$/i.test(a)) {
+      root.style.setProperty('--accent', a);
+    }
+  } catch (e) { /* storage blocked — fall back to defaults */ }
+})();


### PR DESCRIPTION
## Summary

Phase 1 slice (d) of #1499. Thane sent one security header before this — HSTS, from the front door only. Everything else arrived with nothing telling the browser what it may do with it.

`listen.SecurityHeaders` takes a **posture**, not a policy, because one global header would mean every surface inherits whatever the loosest one needs — backwards, when the loosest is the one serving a vendored third-party bundle.

| Posture | Surfaces | Policy |
|---|---|---|
| API | native `/v1`, both compat shims, CardDAV | `default-src 'none'` — an API response is not a page |
| Console | `/`, `/static/*` | only `'self'` and `'none'`, nothing loosened |
| Documents | `/docs/*` | `style-src` + `img-src` relaxed for the Scalar bundle, **scripts are not** |

All three send `nosniff`, `Referrer-Policy: no-referrer`, `X-Frame-Options: DENY`, and a `Permissions-Policy` denying geolocation, camera, and microphone. None send HSTS — that is the front door's claim to make.

## How #1509 shaped this

The companion data plane is about to add authenticated endpoints, and its central move is storing **opaque client-authored JSON that Thane never parses** and serving it back from the same origin the console's session cookie lives on. Two consequences:

- **`nosniff` is load-bearing here, not hygiene.** Sniffing is exactly the mechanism that turns a stored materialization into script on that origin; `nosniff` plus `default-src 'none'` is what prevents it.
- **The headers go on the chain, never on a route.** `TestEveryRouteCarriesSecurityHeaders` walks all 69 registered patterns, so a companion endpoint added later inherits headers the way it already inherits an auth decision. Headers are set before the handler runs, so the API posture covers the whole native mux and the console/explorer registrars overwrite it for their own sub-trees — a route added without a thought gets the *strictest* posture rather than none.

The artifact primitive #1509 anticipates will want a fourth posture; `Posture` is an enumeration for that reason, and the rationale is recorded in #1511.

## Losing the nonce

Per the operator's call, the console's theme bootstrap moved to `/static/theme-boot.js` rather than growing nonce plumbing. The explorer's Scalar call needed the same treatment — `/docs/boot.js`. Both are blocking scripts in `<head>`, so neither loses the property it was inline for, and neither forces per-request templating on a static embedded asset. One flex-row `style=` attribute became a class.

## The loosening is verified, not assumed

Removing `'unsafe-inline'` from the documents posture's `style-src` renders the explorer as completely unstyled HTML. It stays, with that evidence in the comment. Scripts are not loosened even there: the bundle attempts one inline script and is refused, the page renders and works without it, and a script I could not identify is a reason to keep refusing rather than to allowlist its hash.

## What the policy found: #1512

`/docs` is documented as vendored "so /docs renders offline." It is not. The bundle fetches 14 web fonts from `fonts.scalar.com` and calls `api.scalar.com/vector/registry/*` on every load — on a deliberately public, unauthenticated route. The policy refuses both and the page falls back to system fonts, so this PR *fixes* the leak as a side effect, but the requests are still attempted and the right fix is that they stop being made. Filed as #1512; that issue explicitly does not relax this policy.

## Test plan

- [x] `just ci` passes locally (exit 0)
- [x] Guard: common set on every posture, no HSTS from any, console policy asserted free of `'unsafe-inline'`/`'unsafe-eval'`/`data:`/wildcards, API policy asserted to load nothing, documents policy asserted to loosen only `img-src`/`font-src`/`style-src`, inner posture overwrites outer
- [x] Route table: all 69 native patterns carry the common set and exactly one policy that denies framing
- [x] CardDAV: the two responses that never reach the handler — the 401 challenge and the unauthenticated `.well-known` redirect — carry the API posture, with expectations read from `listen.SecurityHeaders` rather than copied
- [x] Fail-closed: a posture with no policy of its own answers with the API policy, and every named posture is asserted to have one
- [x] Postures land the right way round on `/`, `/static/app.js`, `/docs`, `/docs/scalar.js`, `/v1/version`; both compat shims carry the API posture
- [x] **Live, console**: strict policy on document and assets, `default-src 'none'` on `/v1`, no HSTS on a plaintext listener, zero CSP violations across a full load and view switches, graph renders, SSE connects under `connect-src 'self'`, theme still applied before first paint across a reload
- [x] **Live, explorer**: fully styled, sidebar/auth panel/client libraries intact
- [x] Harness composes the same postures, so console CSP breakage surfaces during UI work
- [ ] Companion `WKWebView` dashboard against `frame-ancestors 'none'` — top-level navigation, so it should be untouched, but it is the one consumer that fails silently off-screen. Needs a deployed instance.

Closes #1511
Refs #1499, #1504, #1509

🤖 Generated with [Claude Code](https://claude.com/claude-code)

