### PR TITLE
fix(carddav): log the responses that never reach the CardDAV handler

### DIFF
--- a/internal/server/carddav/server.go
+++ b/internal/server/carddav/server.go
@@ -178,24 +178,31 @@ func (s *Server) tryRebind() {
 	}
 }
 
-// buildHandler creates the HTTP handler chain: security headers → auth
-// → logging → cross-origin guard → carddav.Handler. The guard sits after
-// auth because the forgery it stops is a browser replaying cached Basic
-// credentials on a cross-site request; the credentials pass, the origin
-// does not.
+// buildHandler creates the HTTP handler chain: logging → security
+// headers → auth → cross-origin guard → carddav.Handler.
 //
-// The headers sit outermost, ahead of auth, because two responses leave
-// this server without reaching it: the 401 challenge and the unauthed
-// .well-known discovery redirect. A response a browser reads before it
-// has credentials is exactly the one that must already say what may be
-// done with it.
+// Two responses leave this server without ever reaching the CardDAV
+// handler: the 401 challenge and the unauthenticated .well-known
+// discovery redirect. Logging is outermost so both are accounted for.
+// Auth used to sit outside logging, which meant a run of guessed
+// credentials against /carddav/ produced no access-log line at all — the
+// one traffic pattern an access log most needs to show, missing from the
+// surface that answers to a password rather than to a bearer token.
+//
+// The headers sit ahead of auth for the same reason: a response a
+// browser reads before it has credentials is exactly the one that must
+// already say what may be done with it.
+//
+// The cross-origin guard sits after auth because the forgery it stops is
+// a browser replaying cached Basic credentials on a cross-site request;
+// the credentials pass, the origin does not.
 func (s *Server) buildHandler() http.Handler {
 	davHandler := &libcarddav.Handler{
 		Backend: s.backend,
 		Prefix:  "/carddav",
 	}
-	return listen.SecurityHeaders(listen.PostureAPI,
-		s.withAuth(s.withLogging(listen.RejectCrossOriginWrites(s.logger, davHandler))))
+	return s.withLogging(listen.SecurityHeaders(listen.PostureAPI,
+		s.withAuth(listen.RejectCrossOriginWrites(s.logger, davHandler))))
 }
 
 // withAuth wraps a handler with HTTP Basic Auth.  The .well-known

--- a/internal/server/carddav/server_test.go
+++ b/internal/server/carddav/server_test.go
@@ -1,10 +1,14 @@
 package carddav
 
 import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/nugget/thane-ai-agent/internal/platform/logging"
 	"github.com/nugget/thane-ai-agent/internal/server/listen"
 )
 
@@ -144,6 +148,86 @@ func TestServer_SecurityHeadersOnEveryResponse(t *testing.T) {
 				if got := rr.Header().Get(name); got != want[0] {
 					t.Errorf("%s = %q, want %q", name, got, want[0])
 				}
+			}
+		})
+	}
+}
+
+// TestServer_EveryResponseIsLogged covers the responses this server
+// produces on its own rather than by serving contacts: the 401 challenge
+// and the unauthenticated .well-known discovery redirect. Both return
+// from inside withAuth, so while auth sat outside logging neither
+// appeared in the access log — a run of guessed credentials against
+// /carddav/ was invisible on the one surface that answers to a password.
+func TestServer_EveryResponseIsLogged(t *testing.T) {
+	tests := []struct {
+		name       string
+		build      func() *http.Request
+		wantMethod string
+		wantPath   string
+		wantStatus int
+	}{
+		{
+			name:       "unauthenticated challenge",
+			build:      func() *http.Request { return httptest.NewRequest("PROPFIND", "/carddav/", nil) },
+			wantMethod: "PROPFIND",
+			wantPath:   "/carddav/",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "wrong credentials",
+			build: func() *http.Request {
+				req := httptest.NewRequest("PROPFIND", "/carddav/", nil)
+				req.SetBasicAuth("user", "wrong")
+				return req
+			},
+			wantMethod: "PROPFIND",
+			wantPath:   "/carddav/",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "discovery redirect",
+			build:      func() *http.Request { return httptest.NewRequest("GET", "/.well-known/carddav", nil) },
+			wantMethod: "GET",
+			wantPath:   "/.well-known/carddav",
+			wantStatus: http.StatusMovedPermanently,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := newTestBackend(t)
+
+			var buf bytes.Buffer
+			s := NewServer(nil, "user", "pass", b, slog.New(slog.NewJSONHandler(&buf, nil)))
+			s.handler = s.buildHandler()
+			s.handler.ServeHTTP(httptest.NewRecorder(), tt.build())
+
+			var line struct {
+				Kind   string `json:"kind"`
+				Server string `json:"server"`
+				Method string `json:"method"`
+				Path   string `json:"path"`
+				Status int    `json:"status"`
+				Remote string `json:"remote"`
+			}
+			if err := json.NewDecoder(&buf).Decode(&line); err != nil {
+				t.Fatalf("no access-log line for this response: %v", err)
+			}
+
+			if line.Kind != logging.KindHTTPAccess || line.Server != "carddav" {
+				t.Errorf("kind/server = %q/%q, want %q/carddav", line.Kind, line.Server, logging.KindHTTPAccess)
+			}
+			if line.Method != tt.wantMethod || line.Path != tt.wantPath {
+				t.Errorf("method/path = %q/%q, want %q/%q", line.Method, line.Path, tt.wantMethod, tt.wantPath)
+			}
+			if line.Status != tt.wantStatus {
+				t.Errorf("status = %d, want %d", line.Status, tt.wantStatus)
+			}
+			// The peer is what makes a run of failures actionable
+			// rather than merely visible.
+			if line.Remote == "" {
+				t.Error("access-log line names no peer")
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Found while addressing review on #1513, deliberately left out of that PR because it is a behavior change rather than a header fix.

CardDAV composed its chain as `auth → logging → guard → handler`. Two responses return from inside `withAuth` and so never reached the logging wrapper:

- the `401` challenge, on every request without valid credentials
- the unauthenticated `/.well-known/carddav` discovery redirect

A run of guessed credentials against `/carddav/` therefore left **no trace at all** — no access-log line, no status, no peer. That is the one traffic pattern an access log most needs to show, and it was missing from the only surface Thane exposes that answers to a password rather than to a bearer token, which is exactly where guessing is a strategy rather than a waste of time.

## The change

Logging moves outermost, which is the shape the native API and both compat shims already had:

```
logging → security headers → auth → cross-origin guard → carddav.Handler
```

Auth still runs ahead of the cross-origin guard. The forgery that guard stops is a browser replaying cached Basic credentials on a cross-site request, so the credentials have to pass before the origin becomes the interesting question. The security headers stay ahead of auth for the reason #1513 put them there: a response a browser reads before it has credentials is the one that must already say what may be done with it.

## Test plan

- [x] `just ci` passes locally (exit 0)
- [x] `TestServer_EveryResponseIsLogged` walks the 401 challenge, a wrong-credentials attempt, and the discovery redirect, asserting each produces an access-log line carrying its method, path, status, and peer
- [x] Mutation-verified: restoring the previous ordering makes all three subtests fail with `no access-log line for this response: EOF` — no line was written at all
- [x] `TestServer_SecurityHeadersOnEveryResponse` still passes, so the #1513 guarantee survives the reordering

Refs #1513, #1499

🤖 Generated with [Claude Code](https://claude.com/claude-code)