### PR TITLE
feat(agent): pin a conversation to one model from inside the conversation

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -73,6 +73,7 @@ These tools load on every turn regardless of active tags.
 | Tool | Description |
 |------|-------------|
 | `conversation_reset` | Reset the current conversation's message history. |
+| `conversation_model_pin` | Hold the current conversation to one model deployment, or clear the hold. Outranks channel and client model selection; memory-only, cleared by restart. |
 | `session_checkpoint` | Save current session state as a checkpoint. |
 | `session_close` | Close the current session with carry-forward context. |
 | `session_split` | Fork the current session. |
@@ -580,6 +581,10 @@ tools for Signal-specific workflows.
 | `model_route_explain` | Dry-run a routing decision with the router's rationale. |
 | `model_deployment_set_policy` | Update deployment-level routing policy. |
 | `model_resource_set_policy` | Update resource-level routing policy. |
+
+Policy here is fleet-wide and survives restart. Holding one conversation
+to one model is a `session` decision (`conversation_model_pin`, above),
+and pinning a loop definition is `loop_definition_update` under `loops`.
 
 ## `diagnostics` — operational visibility
 

--- a/internal/app/new_channels.go
+++ b/internal/app/new_channels.go
@@ -709,6 +709,7 @@ func (a *App) initChannels(s *newState) error {
 	a.loop.Tools().SetArchiveStore(a.archiveStore)
 	a.loop.Tools().SetConversationResetter(a.loop)
 	a.loop.Tools().SetSessionManager(a.loop)
+	a.loop.Tools().SetConversationModelPinner(a.loop)
 
 	// --- Embeddings ---
 	// Optional semantic search over fact and contact stores. When enabled,

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -66,6 +66,7 @@ func (a *App) initServers(s *newState) error {
 	}
 	server.SetAuth(cfg.Listen.Auth, companionTokens)
 	server.SetMemoryStore(a.mem)
+	server.SetConversationModelPins(a.loop)
 	server.SetArchiveStore(a.archiveStore)
 	server.UseContactStore(a.contactStore)
 	if a.archivistDefinitionEnabled() {

--- a/internal/model/toolcatalog/catalog.go
+++ b/internal/model/toolcatalog/catalog.go
@@ -154,6 +154,7 @@ var builtinToolSpecs = map[string]BuiltinToolSpec{
 	"ha_call_service":               {CanonicalID: "native:ha_call_service", Source: NativeToolSource, Tags: []string{"ha"}},
 	"task_cancel":                   {CanonicalID: "native:task_cancel", Source: NativeToolSource, Tags: []string{"scheduler"}},
 	"ha_control_device":             {CanonicalID: "native:ha_control_device", Source: NativeToolSource, Tags: []string{"ha"}},
+	"conversation_model_pin":        {CanonicalID: "native:conversation_model_pin", Source: NativeToolSource, Tags: []string{"session"}},
 	"conversation_reset":            {CanonicalID: "native:conversation_reset", Source: NativeToolSource, Tags: []string{"session"}},
 	"cost_summary":                  {CanonicalID: "native:cost_summary", Source: NativeToolSource, Tags: []string{"diagnostics"}},
 	"doc_activity":                  {CanonicalID: "native:doc_activity", Source: NativeToolSource, Tags: []string{"diagnostics"}},

--- a/internal/runtime/agent/conversation_model_pin.go
+++ b/internal/runtime/agent/conversation_model_pin.go
@@ -46,18 +46,22 @@ func (p *conversationModelPins) clear(conversationID string) (tools.Conversation
 	return pin, ok
 }
 
-// recordFallback notes that the pin on conversationID could not serve a
-// turn and model answered instead. A pin that was cleared meanwhile is
-// left alone.
-func (p *conversationModelPins) recordFallback(conversationID, model, reason string, at time.Time) {
+// recordFallback notes that observed, the pin a turn read at its start,
+// could not serve that turn and model answered instead. The turn ran
+// outside the lock, so the conversation may have been re-pinned or
+// cleared meanwhile; the record is written only while the live entry is
+// still the pin the turn actually judged (same deployment, same
+// PinnedAt), so a replacement pin never inherits a verdict about its
+// predecessor.
+func (p *conversationModelPins) recordFallback(observed tools.ConversationModelPin, model, reason string, at time.Time) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	pin, ok := p.pins[conversationID]
-	if !ok {
+	pin, ok := p.pins[observed.ConversationID]
+	if !ok || pin.Model != observed.Model || !pin.PinnedAt.Equal(observed.PinnedAt) {
 		return
 	}
 	pin.LastFallback = &tools.ConversationModelPinFallback{At: at, Model: model, Reason: reason}
-	p.pins[conversationID] = pin
+	p.pins[observed.ConversationID] = pin
 }
 
 // PinConversationModel resolves ref against the live model catalog and

--- a/internal/runtime/agent/conversation_model_pin.go
+++ b/internal/runtime/agent/conversation_model_pin.go
@@ -1,0 +1,143 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/model/fleet"
+	"github.com/nugget/thane-ai-agent/internal/tools"
+)
+
+// conversationModelPins is the in-process set of conversation model
+// pins. It is memory-only on purpose: a pin is an operator's in-the-moment
+// steer for one conversation, and the recovery path for a bad steer is a
+// restart, not a hunt through storage. Router cooldowns follow the same
+// rule for the same reason.
+type conversationModelPins struct {
+	mu   sync.Mutex
+	pins map[string]tools.ConversationModelPin
+}
+
+func (p *conversationModelPins) get(conversationID string) (tools.ConversationModelPin, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	pin, ok := p.pins[conversationID]
+	return pin, ok
+}
+
+func (p *conversationModelPins) set(pin tools.ConversationModelPin) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.pins == nil {
+		p.pins = make(map[string]tools.ConversationModelPin)
+	}
+	p.pins[pin.ConversationID] = pin
+}
+
+func (p *conversationModelPins) clear(conversationID string) (tools.ConversationModelPin, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	pin, ok := p.pins[conversationID]
+	if ok {
+		delete(p.pins, conversationID)
+	}
+	return pin, ok
+}
+
+// recordFallback notes that the pin on conversationID could not serve a
+// turn and model answered instead. A pin that was cleared meanwhile is
+// left alone.
+func (p *conversationModelPins) recordFallback(conversationID, model, reason string, at time.Time) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	pin, ok := p.pins[conversationID]
+	if !ok {
+		return
+	}
+	pin.LastFallback = &tools.ConversationModelPinFallback{At: at, Model: model, Reason: reason}
+	p.pins[conversationID] = pin
+}
+
+// PinConversationModel resolves ref against the live model catalog and
+// holds conversationID to that deployment from its next turn. It
+// implements [tools.ConversationModelPinner].
+//
+// Only references that would fail every turn are refused here: unknown
+// or ambiguous names, deployments made inactive by operator policy, and
+// deployments that cannot call tools. Anything narrower (no vision, a
+// small window) is judged per turn, where the runtime routes around the
+// pin for that turn instead of failing it.
+func (l *Loop) PinConversationModel(conversationID, ref, reason string) (tools.ConversationModelPin, error) {
+	conversationID = strings.TrimSpace(conversationID)
+	if conversationID == "" {
+		return tools.ConversationModelPin{}, fmt.Errorf("conversation id is required to pin a model")
+	}
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return tools.ConversationModelPin{}, fmt.Errorf("model is required: pass a deployment id or model name from model_registry_list")
+	}
+	cat := l.currentModelCatalog()
+	if cat == nil {
+		return tools.ConversationModelPin{}, fmt.Errorf("the model catalog is unavailable, so %q cannot be resolved to a deployment", ref)
+	}
+	dep, err := cat.ResolveDeploymentRef(ref)
+	if err != nil {
+		if fleet.IsUnknownModel(err) {
+			return tools.ConversationModelPin{}, fmt.Errorf("unknown model %q; pass a deployment id or unique model name as listed by model_registry_list (activate the models tag), or clear=true to return to the router", ref)
+		}
+		return tools.ConversationModelPin{}, err
+	}
+	if dep.PolicyState == fleet.DeploymentPolicyStateInactive || dep.ResourcePolicyState == fleet.DeploymentPolicyStateInactive {
+		return tools.ConversationModelPin{}, fmt.Errorf("deployment %q is inactive by operator policy and would fail every turn; choose another deployment, or re-enable it with model_deployment_set_policy first", dep.ID)
+	}
+	switch {
+	case !dep.ProviderSupportsTools:
+		return tools.ConversationModelPin{}, fmt.Errorf("deployment %q cannot serve conversation turns: its provider does not support tool use; choose a tool-capable deployment from model_registry_list", dep.ID)
+	case !dep.SupportsTools:
+		return tools.ConversationModelPin{}, fmt.Errorf("deployment %q cannot serve conversation turns: it is configured without tool support; choose a tool-capable deployment from model_registry_list", dep.ID)
+	}
+
+	pin := tools.ConversationModelPin{
+		ConversationID:    conversationID,
+		Model:             dep.ID,
+		Provider:          dep.Provider,
+		Resource:          dep.ResourceID,
+		SupportsTools:     dep.SupportsTools,
+		SupportsImages:    dep.SupportsImages,
+		SupportsStreaming: dep.SupportsStreaming,
+		ContextWindow:     dep.ContextWindow,
+		Reason:            strings.TrimSpace(reason),
+		PinnedAt:          l.now(),
+	}
+	l.conversationPins.set(pin)
+	l.logger.Info("conversation model pinned",
+		"conversation_id", conversationID,
+		"model", dep.ID,
+		"provider", dep.Provider,
+		"resource", dep.ResourceID,
+		"reason", pin.Reason,
+	)
+	return pin, nil
+}
+
+// ClearConversationModelPin removes the pin on conversationID and returns
+// it. It implements [tools.ConversationModelPinner].
+func (l *Loop) ClearConversationModelPin(conversationID string) (tools.ConversationModelPin, bool) {
+	pin, ok := l.conversationPins.clear(strings.TrimSpace(conversationID))
+	if ok {
+		l.logger.Info("conversation model pin cleared",
+			"conversation_id", pin.ConversationID,
+			"model", pin.Model,
+		)
+	}
+	return pin, ok
+}
+
+// ConversationModelPin reports the live pin on conversationID. It
+// implements [tools.ConversationModelPinner] and serves the API's
+// conversation view.
+func (l *Loop) ConversationModelPin(conversationID string) (tools.ConversationModelPin, bool) {
+	return l.conversationPins.get(strings.TrimSpace(conversationID))
+}

--- a/internal/runtime/agent/conversation_model_pin_test.go
+++ b/internal/runtime/agent/conversation_model_pin_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/model/llm"
 	"github.com/nugget/thane-ai-agent/internal/model/router"
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
+	"github.com/nugget/thane-ai-agent/internal/tools"
 	"gopkg.in/yaml.v3"
 )
 
@@ -301,5 +302,76 @@ func TestRun_ConversationPinWithoutRouterFailsLikeExplicitModel(t *testing.T) {
 	}
 	if len(mock.calls) != 0 {
 		t.Fatalf("llm calls = %d, want 0", len(mock.calls))
+	}
+}
+
+func TestRun_ConversationPinRoutesAroundDeploymentDeactivatedAfterPinning(t *testing.T) {
+	mock := &mockLLM{responses: okResponses(2)}
+	loop, registry := newPinTestLoop(t, mock)
+	const conv = "signal-alice"
+
+	if _, err := loop.PinConversationModel(conv, "qwen3:8b", "local please"); err != nil {
+		t.Fatalf("PinConversationModel: %v", err)
+	}
+	runTextTurn(t, loop, conv, "", "still local?")
+	if got := mock.calls[0].Model; got != "qwen3:8b" {
+		t.Fatalf("pinned turn model = %q, want qwen3:8b", got)
+	}
+
+	// Operator policy switches the pinned deployment off after the pin was
+	// accepted. The router sees it through a config sync; the pin must see
+	// it through preflight on its next turn.
+	if err := registry.ApplyDeploymentPolicy("qwen3:8b", fleet.DeploymentPolicy{State: fleet.DeploymentPolicyStateInactive, Reason: "maintenance"}, time.Now()); err != nil {
+		t.Fatalf("ApplyDeploymentPolicy: %v", err)
+	}
+	loop.router.UpdateConfig(registry.Catalog().RouterConfig(32))
+
+	runTextTurn(t, loop, conv, "", "and now?")
+	if got := mock.calls[1].Model; got != "claude-sonnet-4-20250514" {
+		t.Fatalf("turn after deactivation model = %q, want the router's replacement", got)
+	}
+	if prompt := systemPromptOf(t, mock.calls[1]); !strings.Contains(prompt, "pinned qwen3:8b skipped this turn: this deployment is currently inactive by operator policy") {
+		t.Fatalf("context line does not explain the deactivated pin:\n%s", prompt)
+	}
+	pin, ok := loop.ConversationModelPin(conv)
+	if !ok || pin.LastFallback == nil || !strings.Contains(pin.LastFallback.Reason, "inactive") {
+		t.Fatalf("pin after deactivation = %+v, %v; want it kept with the inactive fallback recorded", pin, ok)
+	}
+}
+
+func TestConversationModelPins_FallbackOnlyLandsOnTheObservedPin(t *testing.T) {
+	var pins conversationModelPins
+	t0 := time.Date(2026, 9, 3, 15, 0, 0, 0, time.UTC)
+	first := tools.ConversationModelPin{ConversationID: "signal-alice", Model: "qwen3:8b", PinnedAt: t0}
+	pins.set(first)
+
+	// A turn observed `first`; meanwhile the conversation was re-pinned.
+	replacement := tools.ConversationModelPin{ConversationID: "signal-alice", Model: "claude-sonnet-4-20250514", PinnedAt: t0.Add(time.Minute)}
+	pins.set(replacement)
+	pins.recordFallback(first, "claude-sonnet-4-20250514", "it does not support image inputs", t0.Add(2*time.Minute))
+	if got, _ := pins.get("signal-alice"); got.LastFallback != nil {
+		t.Fatalf("replacement pin inherited a fallback from its predecessor: %+v", got.LastFallback)
+	}
+
+	// The same deployment re-pinned later is a different pin too.
+	repinned := tools.ConversationModelPin{ConversationID: "signal-alice", Model: "qwen3:8b", PinnedAt: t0.Add(3 * time.Minute)}
+	pins.set(repinned)
+	pins.recordFallback(first, "claude-sonnet-4-20250514", "stale", t0.Add(4*time.Minute))
+	if got, _ := pins.get("signal-alice"); got.LastFallback != nil {
+		t.Fatalf("re-pinned deployment inherited a stale fallback: %+v", got.LastFallback)
+	}
+
+	// The live pin's own verdict lands.
+	pins.recordFallback(repinned, "claude-sonnet-4-20250514", "it does not support image inputs", t0.Add(5*time.Minute))
+	got, _ := pins.get("signal-alice")
+	if got.LastFallback == nil || got.LastFallback.Model != "claude-sonnet-4-20250514" {
+		t.Fatalf("live pin fallback = %+v, want it recorded", got.LastFallback)
+	}
+
+	// A cleared pin records nothing.
+	pins.clear("signal-alice")
+	pins.recordFallback(repinned, "x", "y", t0.Add(6*time.Minute))
+	if _, ok := pins.get("signal-alice"); ok {
+		t.Fatal("recordFallback resurrected a cleared pin")
 	}
 }

--- a/internal/runtime/agent/conversation_model_pin_test.go
+++ b/internal/runtime/agent/conversation_model_pin_test.go
@@ -1,0 +1,305 @@
+package agent
+
+import (
+	"context"
+	"encoding/base64"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/model/fleet"
+	"github.com/nugget/thane-ai-agent/internal/model/llm"
+	"github.com/nugget/thane-ai-agent/internal/model/router"
+	"github.com/nugget/thane-ai-agent/internal/platform/config"
+	"gopkg.in/yaml.v3"
+)
+
+// pinTestConfig describes a fleet where the router, left alone, prefers
+// the local text-only model and only the cloud model can see images.
+func pinTestConfig() *config.Config {
+	return &config.Config{
+		Models: config.ModelsConfig{
+			Default:    "qwen3:8b",
+			LocalFirst: true,
+			Resources: map[string]config.ModelServerConfig{
+				"local": {URL: "http://localhost:11434", Provider: "ollama"},
+				"cloud": {URL: "https://api.anthropic.com", Provider: "anthropic"},
+			},
+			Available: []config.ModelConfig{
+				{Name: "qwen3:8b", Resource: "local", SupportsTools: true, ContextWindow: 32768, Speed: 10, Quality: 7, CostTier: 0},
+				{Name: "claude-sonnet-4-20250514", Resource: "cloud", SupportsTools: true, ContextWindow: 200000, Speed: 4, Quality: 9, CostTier: 3},
+			},
+		},
+	}
+}
+
+func newPinTestLoop(t *testing.T, mock *mockLLM) (*Loop, *fleet.Registry) {
+	t.Helper()
+	loop := buildTestLoop(mock, nil)
+	registry := testModelRegistryFromConfig(t, pinTestConfig())
+	loop.UseModelRegistry(registry)
+	loop.router = router.NewRouter(slog.Default(), registry.Catalog().RouterConfig(32))
+	return loop, registry
+}
+
+func okResponses(n int) []*llm.ChatResponse {
+	out := make([]*llm.ChatResponse, n)
+	for i := range out {
+		out[i] = &llm.ChatResponse{Message: llm.Message{Role: "assistant", Content: "ok"}}
+	}
+	return out
+}
+
+func runTextTurn(t *testing.T, loop *Loop, convID, model, text string) {
+	t.Helper()
+	if _, err := loop.Run(context.Background(), &Request{
+		ConversationID: convID,
+		Model:          model,
+		Messages:       []Message{{Role: "user", Content: text}},
+	}, nil); err != nil {
+		t.Fatalf("Run(%q, model=%q): %v", convID, model, err)
+	}
+}
+
+func systemPromptOf(t *testing.T, call mockLLMCall) string {
+	t.Helper()
+	if len(call.Messages) == 0 || call.Messages[0].Role != "system" {
+		t.Fatalf("first LLM message is not a system prompt: %+v", call.Messages)
+	}
+	return call.Messages[0].Content
+}
+
+func TestPinConversationModel_ResolvesAndRefuses(t *testing.T) {
+	loop, registry := newPinTestLoop(t, &mockLLM{})
+
+	t.Run("resolves a model name to its deployment", func(t *testing.T) {
+		pin, err := loop.PinConversationModel("signal-alice", "claude-sonnet-4-20250514", "compare minds")
+		if err != nil {
+			t.Fatalf("PinConversationModel: %v", err)
+		}
+		if pin.Model != "claude-sonnet-4-20250514" || pin.Provider != "anthropic" || pin.Resource != "cloud" {
+			t.Fatalf("pin = %+v, want claude on anthropic/cloud", pin)
+		}
+		if !pin.SupportsTools || !pin.SupportsImages || pin.ContextWindow != 200000 {
+			t.Fatalf("pin capabilities = %+v, want tools+images and the configured window", pin)
+		}
+		if pin.Reason != "compare minds" || pin.PinnedAt.IsZero() {
+			t.Fatalf("pin metadata = %+v, want reason and pinned_at recorded", pin)
+		}
+		got, ok := loop.ConversationModelPin("signal-alice")
+		if !ok || got.Model != pin.Model {
+			t.Fatalf("ConversationModelPin = %+v, %v; want the pin just set", got, ok)
+		}
+	})
+
+	t.Run("replacing a pin keeps one per conversation", func(t *testing.T) {
+		if _, err := loop.PinConversationModel("signal-alice", "qwen3:8b", ""); err != nil {
+			t.Fatalf("PinConversationModel: %v", err)
+		}
+		got, _ := loop.ConversationModelPin("signal-alice")
+		if got.Model != "qwen3:8b" {
+			t.Fatalf("pin after replace = %q, want qwen3:8b", got.Model)
+		}
+		prev, had := loop.ClearConversationModelPin("signal-alice")
+		if !had || prev.Model != "qwen3:8b" {
+			t.Fatalf("ClearConversationModelPin = %+v, %v; want the replaced pin", prev, had)
+		}
+		if _, ok := loop.ConversationModelPin("signal-alice"); ok {
+			t.Fatal("pin survived ClearConversationModelPin")
+		}
+		if _, had := loop.ClearConversationModelPin("signal-alice"); had {
+			t.Fatal("second clear reported a pin")
+		}
+	})
+
+	refusals := []struct {
+		name string
+		conv string
+		ref  string
+		want string
+	}{
+		{name: "unknown model names the discovery tool", conv: "signal-alice", ref: "nope", want: "model_registry_list"},
+		{name: "empty model", conv: "signal-alice", ref: "  ", want: "model is required"},
+		{name: "empty conversation", conv: "", ref: "qwen3:8b", want: "conversation id is required"},
+	}
+	for _, tc := range refusals {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := loop.PinConversationModel(tc.conv, tc.ref, "")
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want it to contain %q", err, tc.want)
+			}
+		})
+	}
+
+	t.Run("inactive deployment is refused with the policy tool named", func(t *testing.T) {
+		if err := registry.ApplyDeploymentPolicy("qwen3:8b", fleet.DeploymentPolicy{State: fleet.DeploymentPolicyStateInactive, Reason: "test"}, time.Now()); err != nil {
+			t.Fatalf("ApplyDeploymentPolicy: %v", err)
+		}
+		t.Cleanup(func() {
+			_ = registry.ApplyDeploymentPolicy("qwen3:8b", fleet.DeploymentPolicy{State: fleet.DeploymentPolicyStateActive, Reason: "test"}, time.Now())
+		})
+		_, err := loop.PinConversationModel("signal-alice", "qwen3:8b", "")
+		if err == nil || !strings.Contains(err.Error(), "inactive") || !strings.Contains(err.Error(), "model_deployment_set_policy") {
+			t.Fatalf("error = %v, want inactive refusal naming model_deployment_set_policy", err)
+		}
+	})
+}
+
+func TestPinConversationModel_RefusesToollessAndAmbiguous(t *testing.T) {
+	loop := buildTestLoop(&mockLLM{}, nil)
+	// YAML rather than a struct literal: an explicit supports_tools: false
+	// is a configured override, while a zero-valued struct field reads as
+	// "unset" and inherits the provider's capability.
+	var cfg config.Config
+	raw := `
+models:
+  default: toolless
+  resources:
+    a:
+      url: http://a.example:11434
+      provider: ollama
+    b:
+      url: http://b.example:11434
+      provider: ollama
+  available:
+    - name: toolless
+      resource: a
+      supports_tools: false
+      context_window: 8192
+    - name: twin
+      resource: a
+      supports_tools: true
+      context_window: 8192
+    - name: twin
+      resource: b
+      supports_tools: true
+      context_window: 8192
+`
+	if err := yaml.Unmarshal([]byte(raw), &cfg); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	loop.UseModelRegistry(testModelRegistryFromConfig(t, &cfg))
+
+	if _, err := loop.PinConversationModel("owu-1", "toolless", ""); err == nil || !strings.Contains(err.Error(), "tool") {
+		t.Fatalf("toolless pin error = %v, want a tool-support refusal", err)
+	}
+	_, err := loop.PinConversationModel("owu-1", "twin", "")
+	if err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("ambiguous pin error = %v, want the candidates listed", err)
+	}
+	if _, ok := loop.ConversationModelPin("owu-1"); ok {
+		t.Fatal("a refused pin was stored")
+	}
+}
+
+func TestRun_ConversationPinOutranksRouterAndRequestModel(t *testing.T) {
+	mock := &mockLLM{responses: okResponses(6)}
+	loop, _ := newPinTestLoop(t, mock)
+	const conv = "signal-alice"
+
+	runTextTurn(t, loop, conv, "", "what is the status")
+	if got := mock.calls[0].Model; got != "qwen3:8b" {
+		t.Fatalf("unpinned turn model = %q, want the router's local pick qwen3:8b", got)
+	}
+
+	if _, err := loop.PinConversationModel(conv, "claude-sonnet-4-20250514", "user asked for sonnet"); err != nil {
+		t.Fatalf("PinConversationModel: %v", err)
+	}
+
+	runTextTurn(t, loop, conv, "", "and now?")
+	if got := mock.calls[1].Model; got != "claude-sonnet-4-20250514" {
+		t.Fatalf("pinned turn model = %q, want claude-sonnet-4-20250514", got)
+	}
+	if prompt := systemPromptOf(t, mock.calls[1]); !strings.Contains(prompt, "claude-sonnet-4-20250514 (pinned -") {
+		t.Fatalf("pinned turn context line missing pin marker:\n%s", prompt)
+	}
+
+	runTextTurn(t, loop, conv, "qwen3:8b", "explicit request model")
+	if got := mock.calls[2].Model; got != "claude-sonnet-4-20250514" {
+		t.Fatalf("pin vs request model: got %q, want the pin to win", got)
+	}
+
+	runTextTurn(t, loop, "owu-bob", "", "a different conversation")
+	if got := mock.calls[3].Model; got != "qwen3:8b" {
+		t.Fatalf("other conversation model = %q, want it unaffected by the pin", got)
+	}
+
+	if _, had := loop.ClearConversationModelPin(conv); !had {
+		t.Fatal("ClearConversationModelPin found nothing to clear")
+	}
+	runTextTurn(t, loop, conv, "", "back to automatic")
+	if got := mock.calls[4].Model; got != "qwen3:8b" {
+		t.Fatalf("cleared turn model = %q, want the router back in charge", got)
+	}
+	if prompt := systemPromptOf(t, mock.calls[4]); strings.Contains(prompt, "pinned") {
+		t.Fatalf("cleared turn context line still mentions a pin:\n%s", prompt)
+	}
+}
+
+func TestRun_ConversationPinFallsBackWhenTurnNeedsImages(t *testing.T) {
+	mock := &mockLLM{responses: okResponses(2)}
+	loop, _ := newPinTestLoop(t, mock)
+	const conv = "signal-alice"
+
+	if _, err := loop.PinConversationModel(conv, "qwen3:8b", "local only please"); err != nil {
+		t.Fatalf("PinConversationModel: %v", err)
+	}
+
+	image := llm.ImageContent{
+		Data:      base64.StdEncoding.EncodeToString([]byte("not really a png")),
+		MediaType: "image/png",
+	}
+	if _, err := loop.Run(context.Background(), &Request{
+		ConversationID: conv,
+		Messages:       []Message{{Role: "user", Content: "what is this", Images: []llm.ImageContent{image}}},
+	}, nil); err != nil {
+		t.Fatalf("Run with image: %v", err)
+	}
+	if got := mock.calls[0].Model; got != "claude-sonnet-4-20250514" {
+		t.Fatalf("image turn model = %q, want the router's vision-capable pick", got)
+	}
+	prompt := systemPromptOf(t, mock.calls[0])
+	if !strings.Contains(prompt, "pinned qwen3:8b skipped this turn: it does not support image inputs") {
+		t.Fatalf("fallback turn context line does not explain the skipped pin:\n%s", prompt)
+	}
+
+	pin, ok := loop.ConversationModelPin(conv)
+	if !ok {
+		t.Fatal("pin was dropped by the fallback; it must survive")
+	}
+	if pin.LastFallback == nil || pin.LastFallback.Model != "claude-sonnet-4-20250514" || !strings.Contains(pin.LastFallback.Reason, "image") {
+		t.Fatalf("pin.LastFallback = %+v, want the routed model and the image reason", pin.LastFallback)
+	}
+
+	runTextTurn(t, loop, conv, "", "thanks, text again")
+	if got := mock.calls[1].Model; got != "qwen3:8b" {
+		t.Fatalf("text turn after fallback model = %q, want the pin honored again", got)
+	}
+	if prompt := systemPromptOf(t, mock.calls[1]); !strings.Contains(prompt, "qwen3:8b (pinned -") {
+		t.Fatalf("post-fallback context line missing pin marker:\n%s", prompt)
+	}
+}
+
+func TestRun_ConversationPinWithoutRouterFailsLikeExplicitModel(t *testing.T) {
+	mock := &mockLLM{responses: okResponses(1)}
+	loop := buildTestLoop(mock, nil)
+	loop.UseModelRegistry(testModelRegistryFromConfig(t, pinTestConfig()))
+	const conv = "signal-alice"
+
+	if _, err := loop.PinConversationModel(conv, "qwen3:8b", ""); err != nil {
+		t.Fatalf("PinConversationModel: %v", err)
+	}
+	_, err := loop.Run(context.Background(), &Request{
+		ConversationID: conv,
+		Messages: []Message{{Role: "user", Content: "look", Images: []llm.ImageContent{{
+			Data: base64.StdEncoding.EncodeToString([]byte("x")), MediaType: "image/png",
+		}}}},
+	}, nil)
+	if err == nil || !strings.Contains(err.Error(), "image") {
+		t.Fatalf("Run error = %v, want the explicit-model incompatibility with no router to fall back to", err)
+	}
+	if len(mock.calls) != 0 {
+		t.Fatalf("llm calls = %d, want 0", len(mock.calls))
+	}
+}

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -2043,9 +2043,11 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 	// or client model field. It outranks the request model. It is read
 	// here, after tool gating and before routing, so preflight judges it
 	// on the tool surface this turn will actually expose.
+	var pinned tools.ConversationModelPin
 	pinnedModel := ""
 	pinSkipReason := ""
 	if pin, ok := l.conversationPins.get(convID); ok {
+		pinned = pin
 		pinnedModel = pin.Model
 		model = pin.Model
 		usageInfo.ModelPinAge = l.now().Sub(pin.PinnedAt)
@@ -2094,8 +2096,13 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 				"pinned_model", pinnedModel,
 				"reason", pinSkipReason,
 			)
+			// Route on the same full request size (messages plus tool
+			// schemas) the pin was just judged on. A messages-only figure
+			// could hand the router the very deployment the window check
+			// rejected, and the routed re-check below measures messages
+			// alone, so nothing later would catch it.
 			var routeErr error
-			model, routerDecision, routeErr = routeWithContextSize(estimateLLMMessagesContextTokens(llmMessages))
+			model, routerDecision, routeErr = routeWithContextSize(contextSize)
 			if routeErr != nil {
 				return nil, routeErr
 			}
@@ -2138,7 +2145,7 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 	case pinnedModel != "" && pinSkipReason != "":
 		usageInfo.ModelPinSkipped = pinnedModel
 		usageInfo.ModelPinSkipReason = pinSkipReason
-		l.conversationPins.recordFallback(convID, model, pinSkipReason, l.now())
+		l.conversationPins.recordFallback(pinned, model, pinSkipReason, l.now())
 	case pinnedModel != "":
 		usageInfo.ModelPinned = true
 	}

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -313,6 +313,12 @@ type Loop struct {
 	modelRegistry       *fleet.Registry
 	modelRuntime        *fleet.Runtime
 
+	// conversationPins holds the live conversation model pins. One Loop
+	// serves every conversation, so this is the one place a pin set by a
+	// tool in turn N is guaranteed to be seen by turn N+1 whichever
+	// bridge or API surface builds it. See [Loop.PinConversationModel].
+	conversationPins conversationModelPins
+
 	// Capability tags — per-Run tool/talent filtering.
 	//
 	// Each Run() creates its own capabilityScope (stored in context)
@@ -2032,7 +2038,20 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 	model := req.Model
 	var routerDecision *router.Decision
 
-	log.Debug("model selection start", "req_model", req.Model, "default_model", l.model)
+	// A conversation pin is the most specific model intent there is:
+	// set from inside this conversation, later than any channel config
+	// or client model field. It outranks the request model. It is read
+	// here, after tool gating and before routing, so preflight judges it
+	// on the tool surface this turn will actually expose.
+	pinnedModel := ""
+	pinSkipReason := ""
+	if pin, ok := l.conversationPins.get(convID); ok {
+		pinnedModel = pin.Model
+		model = pin.Model
+		usageInfo.ModelPinAge = l.now().Sub(pin.PinnedAt)
+	}
+
+	log.Debug("model selection start", "req_model", req.Model, "pinned_model", pinnedModel, "default_model", l.model)
 
 	if model == "" || model == "thane" {
 		if l.router != nil {
@@ -2056,15 +2075,31 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 		// so that wanting room to answer never makes a servable request look
 		// incompatible here.
 		contextSize = estimateRequestContextTokens(llmMessages, visibleTools.List())
-		if _, prepErr := l.maybePrepareExplicitModel(ctx, model, needsTools, needsStreaming, needsImages, contextSize); prepErr != nil {
-			return nil, prepErr
+		resolvedModel, explicitErr := l.selectExplicitModel(ctx, model, needsTools, needsStreaming, needsImages, contextSize)
+		switch {
+		case explicitErr == nil:
+			model = resolvedModel
+			log.Debug("model specified in request, skipping router", "model", model, "pinned", pinnedModel != "")
+		case pinnedModel == "" || l.router == nil:
+			return nil, explicitErr
+		default:
+			// The pin cannot serve this turn. A conversation's needs change
+			// from turn to turn (an image arrives, the prompt grows) and a
+			// pin that turned every such turn into an error would be a trap
+			// rather than a preference. Route this one turn, keep the pin,
+			// and tell the next turn what happened through the context line.
+			pinSkipReason = explicitModelSkipReason(explicitErr)
+			log.Warn("conversation model pin skipped for this turn; routing instead",
+				"conversation_id", convID,
+				"pinned_model", pinnedModel,
+				"reason", pinSkipReason,
+			)
+			var routeErr error
+			model, routerDecision, routeErr = routeWithContextSize(estimateLLMMessagesContextTokens(llmMessages))
+			if routeErr != nil {
+				return nil, routeErr
+			}
 		}
-		resolvedModel, err := l.preflightExplicitModel(model, needsTools, needsStreaming, needsImages, contextSize)
-		if err != nil {
-			return nil, err
-		}
-		model = resolvedModel
-		log.Debug("model specified in request, skipping router", "model", model)
 	}
 
 	for routedPromptChecks := 0; routerDecision != nil; routedPromptChecks++ {
@@ -2099,6 +2134,14 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 
 	usageInfo.Model = model
 	usageInfo.Routed = routerDecision != nil
+	switch {
+	case pinnedModel != "" && pinSkipReason != "":
+		usageInfo.ModelPinSkipped = pinnedModel
+		usageInfo.ModelPinSkipReason = pinSkipReason
+		l.conversationPins.recordFallback(convID, model, pinSkipReason, l.now())
+	case pinnedModel != "":
+		usageInfo.ModelPinned = true
+	}
 	if cat := l.currentModelCatalog(); cat != nil {
 		if dep, err := cat.ResolveDeploymentRef(model); err == nil && dep.ContextWindow > 0 {
 			usageInfo.ContextWindow = dep.ContextWindow

--- a/internal/runtime/agent/model_selection.go
+++ b/internal/runtime/agent/model_selection.go
@@ -111,6 +111,14 @@ func (l *Loop) preflightExplicitModel(ref string, needsTools, needsStreaming, ne
 	}
 
 	var reasons []string
+	// Operator policy is judged here, per turn, and not only where a
+	// reference is first accepted: a deployment or resource switched off
+	// after a conversation pinned it must stop receiving that
+	// conversation's traffic, the same as it stops receiving routed
+	// traffic (see fleet routingEligible).
+	if dep.PolicyState == fleet.DeploymentPolicyStateInactive {
+		reasons = append(reasons, "this deployment is currently inactive by operator policy")
+	}
 	if dep.ResourcePolicyState == fleet.DeploymentPolicyStateInactive {
 		reasons = append(reasons, "its resource is currently inactive by operator policy")
 	}
@@ -153,7 +161,7 @@ func (l *Loop) maybePrepareExplicitModel(ctx context.Context, ref string, needsT
 	if err != nil {
 		return false, nil
 	}
-	if dep.ResourcePolicyState == fleet.DeploymentPolicyStateInactive {
+	if dep.PolicyState == fleet.DeploymentPolicyStateInactive || dep.ResourcePolicyState == fleet.DeploymentPolicyStateInactive {
 		return false, nil
 	}
 	// contextSize is what the request requires; the window worth loading for

--- a/internal/runtime/agent/model_selection.go
+++ b/internal/runtime/agent/model_selection.go
@@ -71,6 +71,29 @@ func (l *Loop) currentModelCatalog() *fleet.Catalog {
 	return l.usageCatalog
 }
 
+// selectExplicitModel prepares and preflights an explicit deployment
+// reference for one request and returns the resolved deployment ID. Both
+// a request model and a conversation pin come through here, so the two
+// are judged by exactly the same rules.
+func (l *Loop) selectExplicitModel(ctx context.Context, ref string, needsTools, needsStreaming, needsImages bool, contextSize int) (string, error) {
+	if _, err := l.maybePrepareExplicitModel(ctx, ref, needsTools, needsStreaming, needsImages, contextSize); err != nil {
+		return "", err
+	}
+	return l.preflightExplicitModel(ref, needsTools, needsStreaming, needsImages, contextSize)
+}
+
+// explicitModelSkipReason renders why an explicit deployment could not
+// serve a turn in the shortest form that still teaches: the preflight
+// reasons alone when the verdict was a capability mismatch, the whole
+// error otherwise.
+func explicitModelSkipReason(err error) string {
+	var incompatible *IncompatibleModelError
+	if errors.As(err, &incompatible) && len(incompatible.Reasons) > 0 {
+		return strings.Join(incompatible.Reasons, "; ")
+	}
+	return err.Error()
+}
+
 func (l *Loop) preflightExplicitModel(ref string, needsTools, needsStreaming, needsImages bool, contextSize int) (string, error) {
 	ref = strings.TrimSpace(ref)
 	if ref == "" || ref == "thane" {

--- a/internal/server/api/conversation_model_pin_test.go
+++ b/internal/server/api/conversation_model_pin_test.go
@@ -1,0 +1,92 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/tools"
+)
+
+type stubConversationModelPins map[string]tools.ConversationModelPin
+
+func (s stubConversationModelPins) ConversationModelPin(conversationID string) (tools.ConversationModelPin, bool) {
+	pin, ok := s[conversationID]
+	return pin, ok
+}
+
+func getConversation(t *testing.T, s *Server, id string) (*httptest.ResponseRecorder, map[string]any) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/v1/conversations/"+id, nil)
+	req.SetPathValue("id", id)
+	rr := httptest.NewRecorder()
+	s.handleConversationGet(rr, req)
+	var body map[string]any
+	if rr.Code == http.StatusOK {
+		if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode body: %v (raw=%s)", err, rr.Body.String())
+		}
+	}
+	return rr, body
+}
+
+func TestHandleConversationGetCarriesModelPin(t *testing.T) {
+	s, store := newConvTestServer(t)
+	addConv(t, store, "signal-alice", 2, nil)
+	addConv(t, store, "signal-bob", 1, nil)
+	s.SetConversationModelPins(stubConversationModelPins{
+		"signal-alice": {
+			ConversationID: "signal-alice",
+			Model:          "claude-opus-4-8",
+			Provider:       "anthropic",
+			Reason:         "compare",
+			PinnedAt:       time.Date(2026, 9, 3, 15, 4, 5, 0, time.UTC),
+			LastFallback: &tools.ConversationModelPinFallback{
+				At:     time.Date(2026, 9, 3, 15, 10, 0, 0, time.UTC),
+				Model:  "qwen3:8b",
+				Reason: "it does not support image inputs",
+			},
+		},
+	})
+
+	rr, body := getConversation(t, s, "signal-alice")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rr.Code, rr.Body.String())
+	}
+	if body["id"] != "signal-alice" {
+		t.Fatalf("id = %v, want signal-alice (stored record fields must still flatten)", body["id"])
+	}
+	if msgs, _ := body["messages"].([]any); len(msgs) != 2 {
+		t.Fatalf("messages = %v, want the 2 stored messages", body["messages"])
+	}
+	pin, _ := body["model_pin"].(map[string]any)
+	if pin["model"] != "claude-opus-4-8" || pin["provider"] != "anthropic" || pin["reason"] != "compare" {
+		t.Fatalf("model_pin = %v, want the pin's deployment, provider, and reason", body["model_pin"])
+	}
+	if fb, _ := pin["last_fallback"].(map[string]any); fb["model"] != "qwen3:8b" {
+		t.Fatalf("model_pin.last_fallback = %v, want the routed replacement", pin["last_fallback"])
+	}
+
+	rr, body = getConversation(t, s, "signal-bob")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rr.Code, rr.Body.String())
+	}
+	if _, present := body["model_pin"]; present {
+		t.Fatalf("unpinned conversation body = %v, want model_pin omitted", body)
+	}
+}
+
+func TestHandleConversationGetWithoutPinReader(t *testing.T) {
+	s, store := newConvTestServer(t)
+	addConv(t, store, "signal-alice", 1, nil)
+
+	rr, body := getConversation(t, s, "signal-alice")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rr.Code, rr.Body.String())
+	}
+	if _, present := body["model_pin"]; present {
+		t.Fatalf("body = %v, want model_pin omitted when no reader is wired", body)
+	}
+}

--- a/internal/server/api/server.go
+++ b/internal/server/api/server.go
@@ -34,6 +34,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/server/openapi"
 	"github.com/nugget/thane-ai-agent/internal/state/contacts"
 	"github.com/nugget/thane-ai-agent/internal/state/memory"
+	"github.com/nugget/thane-ai-agent/internal/tools"
 )
 
 // WebServerRegistrar is implemented by types that can register HTTP
@@ -104,6 +105,7 @@ type Server struct {
 	schedulerReader                    SchedulerReader
 	capSurface                         func() []toolcatalog.CapabilitySurface
 	usageStore                         *usage.Store
+	conversationPins                   ConversationModelPinReader
 	persistModelRegistryPolicy         func(string, fleet.DeploymentPolicy) error
 	deleteModelRegistryPolicy          func(string) error
 	persistModelRegistryResourcePolicy func(string, fleet.ResourcePolicy) error
@@ -444,6 +446,27 @@ func NewServer(
 // SetCheckpointer configures the checkpointer for checkpoint API endpoints.
 func (s *Server) SetCheckpointer(cp *checkpoint.Checkpointer) {
 	s.checkpointer = cp
+}
+
+// ConversationModelPinReader exposes the live conversation model pins so
+// the conversation view can show which deployment a conversation is
+// held to. Implemented by agent.Loop.
+type ConversationModelPinReader interface {
+	ConversationModelPin(conversationID string) (tools.ConversationModelPin, bool)
+}
+
+// SetConversationModelPins configures where GET /v1/conversations/{id}
+// reads a conversation's model pin from. Nil leaves the field off.
+func (s *Server) SetConversationModelPins(r ConversationModelPinReader) {
+	s.conversationPins = r
+}
+
+// conversationDetail is the GET /v1/conversations/{id} body: the stored
+// conversation plus the runtime-only model pin, which lives in process
+// memory rather than in the store and so cannot ride the record itself.
+type conversationDetail struct {
+	*memory.Conversation
+	ModelPin *tools.ConversationModelPin `json:"model_pin,omitempty"`
 }
 
 // SetMemoryStore configures the memory store for history API endpoints.
@@ -1592,8 +1615,15 @@ func (s *Server) handleConversationGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	detail := conversationDetail{Conversation: conv}
+	if s.conversationPins != nil {
+		if pin, ok := s.conversationPins.ConversationModelPin(id); ok {
+			detail.ModelPin = &pin
+		}
+	}
+
 	w.Header().Set("Content-Type", "application/json")
-	writeJSON(w, conv, s.logger)
+	writeJSON(w, detail, s.logger)
 }
 
 func (s *Server) handleSessionStats(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/openapi/native.yaml
+++ b/internal/server/openapi/native.yaml
@@ -3191,6 +3191,84 @@ components:
           link_source: exact
           is_owner: false
 
+    ConversationModelPin:
+      type: object
+      description: >-
+        A model override requested from inside one conversation. While it
+        stands, every turn of that conversation bypasses the router and runs
+        on the named deployment; a turn the deployment cannot serve routes
+        normally and is recorded in last_fallback. Pins live in process
+        memory only and clear when Thane restarts.
+      required: [conversation_id, model, pinned_at]
+      properties:
+        conversation_id:
+          type: string
+          readOnly: true
+          description: The conversation the pin applies to.
+          example: signal-alice
+        model:
+          type: string
+          readOnly: true
+          description: Resolved deployment ID the conversation is held to.
+          example: claude-opus-4-8
+        provider:
+          type: string
+          readOnly: true
+          description: Provider serving the pinned deployment.
+          example: anthropic
+        resource:
+          type: string
+          readOnly: true
+          description: Model resource the pinned deployment runs on.
+          example: cloud
+        supports_tools:
+          type: boolean
+          readOnly: true
+          description: Whether the pinned deployment can call tools.
+        supports_images:
+          type: boolean
+          readOnly: true
+          description: Whether the pinned deployment accepts image input. A turn carrying images falls back to the router when false.
+        supports_streaming:
+          type: boolean
+          readOnly: true
+          description: Whether the pinned deployment can stream responses.
+        context_window:
+          type: integer
+          readOnly: true
+          description: Configured context window of the pinned deployment, in tokens.
+          example: 200000
+        reason:
+          type: string
+          readOnly: true
+          description: Free-text justification recorded when the pin was set.
+          example: "user asked to compare opus on this thread"
+        pinned_at:
+          type: string
+          format: date-time
+          readOnly: true
+          description: RFC3339 timestamp for when the pin was set.
+          example: "2026-09-03T15:04:05Z"
+        last_fallback:
+          type: object
+          readOnly: true
+          description: The most recent turn the pin could not serve; omitted until that happens.
+          required: [at, model, reason]
+          properties:
+            at:
+              type: string
+              format: date-time
+              description: RFC3339 timestamp of the turn that routed around the pin.
+              example: "2026-09-03T15:10:00Z"
+            model:
+              type: string
+              description: Deployment the router chose for that turn instead.
+              example: qwen3:8b
+            reason:
+              type: string
+              description: The preflight verdict that ruled the pinned deployment out for that turn.
+              example: it does not support image inputs
+
     ConversationSummary:
       type: object
       description: >-
@@ -3389,6 +3467,12 @@ components:
         metadata:
           $ref: "#/components/schemas/ConversationMetadata"
           description: Typed conversation metadata; omitted when none is set.
+        model_pin:
+          $ref: "#/components/schemas/ConversationModelPin"
+          description: >-
+            The live model pin holding this conversation to one deployment;
+            omitted when the conversation routes normally. Runtime state, not
+            part of the stored record: it clears when Thane restarts.
         created_at:
           type: string
           format: date-time

--- a/internal/state/awareness/context_usage.go
+++ b/internal/state/awareness/context_usage.go
@@ -19,6 +19,19 @@ type ContextUsageInfo struct {
 	Model string
 	// Routed indicates whether a router is configured (actual model may differ).
 	Routed bool
+	// ModelPinned marks Model as a conversation pin that was honored
+	// this turn. ModelPinAge is how long the pin has stood; it renders
+	// as an exact-second delta so the model never divides a duration.
+	ModelPinned bool
+	ModelPinAge time.Duration
+	// ModelPinSkipped names a conversation pin the runtime could not
+	// honor this turn, with ModelPinSkipReason saying why. Model then
+	// holds the routed replacement. The next turn is the reader: it has
+	// to know the pin still stands and why this answer came from
+	// elsewhere, or it will re-pin or apologize for a switch it never
+	// made.
+	ModelPinSkipped    string
+	ModelPinSkipReason string
 	// TokenCount is the estimated token count of the active conversation.
 	TokenCount int
 	// ContextWindow is the context window size of the default model.
@@ -47,7 +60,16 @@ func FormatContextUsage(info ContextUsageInfo) string {
 	// Model segment.
 	if info.Model != "" {
 		m := info.Model
-		if info.Routed {
+		switch {
+		case info.ModelPinned:
+			m += " (pinned " + formatPinAge(info.ModelPinAge) + ")"
+		case info.ModelPinSkipped != "":
+			qualifier := "routed; pinned " + info.ModelPinSkipped + " skipped this turn"
+			if info.ModelPinSkipReason != "" {
+				qualifier += ": " + info.ModelPinSkipReason
+			}
+			m += " (" + qualifier + ")"
+		case info.Routed:
 			m += " (routed)"
 		}
 		parts = append(parts, m)
@@ -107,4 +129,15 @@ func FormatContextUsage(info ContextUsageInfo) string {
 	}
 
 	return result
+}
+
+// formatPinAge renders how long a pin has stood as the signed delta the
+// rest of the prompt uses for time ("-120s", "-3h15m"), so the model
+// reads it the same way it reads every other timestamp it is shown.
+func formatPinAge(age time.Duration) string {
+	if age < 0 {
+		age = 0
+	}
+	var epoch time.Time
+	return promptfmt.FormatDeltaOnly(epoch, epoch.Add(age))
 }

--- a/internal/state/awareness/context_usage_pin_test.go
+++ b/internal/state/awareness/context_usage_pin_test.go
@@ -1,0 +1,109 @@
+package awareness
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFormatContextUsage_ConversationModelPin(t *testing.T) {
+	tests := []struct {
+		name     string
+		info     ContextUsageInfo
+		contains []string
+		excludes []string
+	}{
+		{
+			name: "honored pin shows the deployment and its age as a delta",
+			info: ContextUsageInfo{
+				Model:         "claude-opus-4-8",
+				ModelPinned:   true,
+				ModelPinAge:   2 * time.Minute,
+				TokenCount:    1000,
+				ContextWindow: 200000,
+			},
+			contains: []string{"claude-opus-4-8 (pinned -120s)"},
+			excludes: []string{"routed", "skipped"},
+		},
+		{
+			name: "honored pin outranks the routed marker",
+			info: ContextUsageInfo{
+				Model:         "claude-opus-4-8",
+				Routed:        true,
+				ModelPinned:   true,
+				ModelPinAge:   3*time.Hour + 15*time.Minute,
+				TokenCount:    1000,
+				ContextWindow: 200000,
+			},
+			contains: []string{"claude-opus-4-8 (pinned -3h15m)"},
+			excludes: []string{"(routed)"},
+		},
+		{
+			name: "skipped pin names the pin, the reason, and the routed replacement",
+			info: ContextUsageInfo{
+				Model:              "claude-sonnet-4-20250514",
+				Routed:             true,
+				ModelPinSkipped:    "qwen3:8b",
+				ModelPinSkipReason: "it does not support image inputs",
+				TokenCount:         1000,
+				ContextWindow:      200000,
+			},
+			contains: []string{"claude-sonnet-4-20250514 (routed; pinned qwen3:8b skipped this turn: it does not support image inputs)"},
+			excludes: []string{"(routed)"},
+		},
+		{
+			name: "skipped pin without a reason still reads cleanly",
+			info: ContextUsageInfo{
+				Model:           "claude-sonnet-4-20250514",
+				Routed:          true,
+				ModelPinSkipped: "qwen3:8b",
+				TokenCount:      1000,
+				ContextWindow:   200000,
+			},
+			contains: []string{"(routed; pinned qwen3:8b skipped this turn)"},
+		},
+		{
+			name: "no pin leaves the routed marker alone",
+			info: ContextUsageInfo{
+				Model:         "qwen3:8b",
+				Routed:        true,
+				TokenCount:    1000,
+				ContextWindow: 32768,
+			},
+			contains: []string{"qwen3:8b (routed)"},
+			excludes: []string{"pinned"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := FormatContextUsage(tc.info)
+			for _, want := range tc.contains {
+				if !strings.Contains(got, want) {
+					t.Errorf("FormatContextUsage() = %q, want it to contain %q", got, want)
+				}
+			}
+			for _, bad := range tc.excludes {
+				if strings.Contains(got, bad) {
+					t.Errorf("FormatContextUsage() = %q, must not contain %q", got, bad)
+				}
+			}
+		})
+	}
+}
+
+func TestFormatPinAge(t *testing.T) {
+	tests := []struct {
+		age  time.Duration
+		want string
+	}{
+		{age: 0, want: "-0s"},
+		{age: -5 * time.Second, want: "-0s"},
+		{age: 45 * time.Second, want: "-45s"},
+		{age: 90 * time.Minute, want: "-1h30m"},
+	}
+	for _, tc := range tests {
+		if got := formatPinAge(tc.age); got != tc.want {
+			t.Errorf("formatPinAge(%v) = %q, want %q", tc.age, got, tc.want)
+		}
+	}
+}

--- a/internal/tools/conversation_model_tools.go
+++ b/internal/tools/conversation_model_tools.go
@@ -1,0 +1,151 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// ConversationModelPin is the live record of a model override requested
+// from inside one conversation. The agent runtime owns the set of pins
+// and honors them at turn time; this package defines the shape because
+// the pin tool renders it to the model and the API renders it to the
+// console.
+//
+// A pin is deliberately not durable. It lives in process memory, so it
+// holds across turns and sessions of its conversation and clears when
+// Thane restarts. A poor choice is always one restart from undone, and
+// nothing about it has to be found and deleted from storage.
+type ConversationModelPin struct {
+	ConversationID string `json:"conversation_id"`
+	// Model is the resolved deployment ID the conversation is held to.
+	Model    string `json:"model"`
+	Provider string `json:"provider,omitempty"`
+	Resource string `json:"resource,omitempty"`
+	// Capability facts the turn-time preflight judges the pin on. A
+	// turn the deployment cannot serve routes normally instead of
+	// failing, so the model can see in advance which turns those are.
+	SupportsTools     bool `json:"supports_tools"`
+	SupportsImages    bool `json:"supports_images"`
+	SupportsStreaming bool `json:"supports_streaming"`
+	ContextWindow     int  `json:"context_window,omitempty"`
+	// Reason is the free-text justification recorded with the pin.
+	Reason   string    `json:"reason,omitempty"`
+	PinnedAt time.Time `json:"pinned_at"`
+	// LastFallback records the most recent turn the runtime could not
+	// honor the pin and routed instead. Nil until that happens.
+	LastFallback *ConversationModelPinFallback `json:"last_fallback,omitempty"`
+}
+
+// ConversationModelPinFallback describes one turn that a pinned
+// deployment could not serve.
+type ConversationModelPinFallback struct {
+	At time.Time `json:"at"`
+	// Model is the deployment the router chose for that turn instead.
+	Model string `json:"model"`
+	// Reason is the preflight verdict, in the same words the runtime
+	// uses for an explicit request model.
+	Reason string `json:"reason"`
+}
+
+// ConversationModelPinner manages conversation model pins. Implemented by
+// agent.Loop, which resolves references against the live model catalog
+// and honors pins when selecting a turn's model.
+type ConversationModelPinner interface {
+	// PinConversationModel resolves model (a deployment ID or unique
+	// model name) and holds conversationID to it from the next turn.
+	// Replaces any existing pin for that conversation.
+	PinConversationModel(conversationID, model, reason string) (ConversationModelPin, error)
+	// ClearConversationModelPin removes the pin for conversationID and
+	// returns it. The boolean is false when nothing was pinned.
+	ClearConversationModelPin(conversationID string) (ConversationModelPin, bool)
+	// ConversationModelPin reports the current pin for conversationID.
+	ConversationModelPin(conversationID string) (ConversationModelPin, bool)
+}
+
+// conversationModelPinClearValues are the model arguments that mean
+// "return this conversation to the router". Models asked to unpin reach
+// for these at least as often as for the clear flag.
+var conversationModelPinClearValues = map[string]bool{
+	"auto":   true,
+	"router": true,
+	"thane":  true,
+	"none":   true,
+	"clear":  true,
+}
+
+// SetConversationModelPinner adds the conversation_model_pin tool to the
+// registry.
+func (r *Registry) SetConversationModelPinner(pinner ConversationModelPinner) {
+	r.Register(&Tool{
+		Name: "conversation_model_pin",
+		Description: "Hold the current conversation to one model deployment, bypassing the router on every later turn, or clear that hold. " +
+			"Use when the user asks to talk to a specific model (\"switch this chat to opus\", \"use the local model for now\", \"go back to automatic\"). " +
+			"model accepts a deployment id or unique model name as listed by model_registry_list; pass clear=true (or model \"auto\") to return the conversation to router selection. " +
+			"The pin outranks the channel's configured model and any client-selected model, takes effect from the next turn, holds across turns and sessions of this conversation, and is deliberately dropped when Thane restarts. " +
+			"A turn the pinned deployment cannot serve (an image arrives and it lacks vision, the prompt outgrows its window) routes normally for that one turn and the Context line reports the skipped pin. " +
+			"This is not fleet policy: to disable or promote a deployment for everyone use model_deployment_set_policy; to pin a loop definition use loop_definition_update.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"model": map[string]any{
+					"type":        "string",
+					"description": "Deployment id or unique model name to pin (from model_registry_list). \"auto\" clears the pin.",
+				},
+				"clear": map[string]any{
+					"type":        "boolean",
+					"description": "When true, remove the pin and return the conversation to the router. model is ignored.",
+				},
+				"reason": map[string]any{
+					"type":        "string",
+					"description": "Why this conversation is being pinned, in the user's words where possible. Recorded with the pin and shown to whoever inspects it.",
+				},
+			},
+		},
+		Handler: func(ctx context.Context, args map[string]any) (string, error) {
+			// Turns without an ID share the runtime's "default"
+			// conversation, and the helper says so; a pin set from one
+			// of them holds that shared conversation, which is exactly
+			// what its memory and session state already do.
+			convID := ConversationIDFromContext(ctx)
+
+			model := strings.TrimSpace(stringArg(args, "model"))
+			clear, _ := args["clear"].(bool)
+			if model != "" && conversationModelPinClearValues[strings.ToLower(model)] {
+				clear = true
+			}
+			if clear {
+				prev, had := pinner.ClearConversationModelPin(convID)
+				if !had {
+					return mrMarshalToolJSON(map[string]any{
+						"status":          "not_pinned",
+						"conversation_id": convID,
+						"model_selection": "router",
+					})
+				}
+				return mrMarshalToolJSON(map[string]any{
+					"status":          "cleared",
+					"conversation_id": convID,
+					"previous_model":  prev.Model,
+					"model_selection": "router",
+					"applies":         "next turn",
+				})
+			}
+			if model == "" {
+				return "", fmt.Errorf("model is required: pass a deployment id or model name from model_registry_list, or clear=true to return to the router")
+			}
+
+			pin, err := pinner.PinConversationModel(convID, model, strings.TrimSpace(stringArg(args, "reason")))
+			if err != nil {
+				return "", err
+			}
+			return mrMarshalToolJSON(map[string]any{
+				"status":     "pinned",
+				"pin":        pin,
+				"applies":    "next turn",
+				"cleared_by": "conversation_model_pin with clear=true, or a Thane restart",
+			})
+		},
+	})
+}

--- a/internal/tools/conversation_model_tools_test.go
+++ b/internal/tools/conversation_model_tools_test.go
@@ -1,0 +1,171 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+type mockConversationModelPinner struct {
+	pins    map[string]ConversationModelPin
+	pinErr  error
+	lastPin struct{ conv, model, reason string }
+}
+
+func newMockConversationModelPinner() *mockConversationModelPinner {
+	return &mockConversationModelPinner{pins: make(map[string]ConversationModelPin)}
+}
+
+func (m *mockConversationModelPinner) PinConversationModel(conversationID, model, reason string) (ConversationModelPin, error) {
+	m.lastPin.conv, m.lastPin.model, m.lastPin.reason = conversationID, model, reason
+	if m.pinErr != nil {
+		return ConversationModelPin{}, m.pinErr
+	}
+	pin := ConversationModelPin{
+		ConversationID: conversationID,
+		Model:          model,
+		Provider:       "anthropic",
+		Resource:       "cloud",
+		SupportsTools:  true,
+		SupportsImages: true,
+		Reason:         reason,
+		PinnedAt:       time.Date(2026, 9, 3, 15, 4, 5, 0, time.UTC),
+	}
+	m.pins[conversationID] = pin
+	return pin, nil
+}
+
+func (m *mockConversationModelPinner) ClearConversationModelPin(conversationID string) (ConversationModelPin, bool) {
+	pin, ok := m.pins[conversationID]
+	delete(m.pins, conversationID)
+	return pin, ok
+}
+
+func (m *mockConversationModelPinner) ConversationModelPin(conversationID string) (ConversationModelPin, bool) {
+	pin, ok := m.pins[conversationID]
+	return pin, ok
+}
+
+func conversationModelPinTool(t *testing.T, pinner ConversationModelPinner) *Tool {
+	t.Helper()
+	reg := NewEmptyRegistry()
+	reg.SetConversationModelPinner(pinner)
+	tool := reg.Get("conversation_model_pin")
+	if tool == nil {
+		t.Fatal("conversation_model_pin not registered")
+	}
+	return tool
+}
+
+func decodeToolJSON(t *testing.T, raw string) map[string]any {
+	t.Helper()
+	var out map[string]any
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		t.Fatalf("decode tool result %q: %v", raw, err)
+	}
+	return out
+}
+
+func TestConversationModelPin_PinsCurrentConversation(t *testing.T) {
+	pinner := newMockConversationModelPinner()
+	tool := conversationModelPinTool(t, pinner)
+	ctx := WithConversationID(context.Background(), "signal-alice")
+
+	raw, err := tool.Handler(ctx, map[string]any{"model": " claude-opus-4-8 ", "reason": "user asked"})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if pinner.lastPin.conv != "signal-alice" || pinner.lastPin.model != "claude-opus-4-8" || pinner.lastPin.reason != "user asked" {
+		t.Fatalf("pinner received %+v, want trimmed model and reason for signal-alice", pinner.lastPin)
+	}
+	out := decodeToolJSON(t, raw)
+	if out["status"] != "pinned" || out["applies"] != "next turn" {
+		t.Fatalf("result = %v, want status pinned applying next turn", out)
+	}
+	pin, _ := out["pin"].(map[string]any)
+	if pin["model"] != "claude-opus-4-8" || pin["conversation_id"] != "signal-alice" || pin["provider"] != "anthropic" {
+		t.Fatalf("result pin = %v, want the resolved deployment echoed with provider", pin)
+	}
+	if _, ok := out["cleared_by"]; !ok {
+		t.Fatalf("result = %v, want cleared_by guidance", out)
+	}
+}
+
+func TestConversationModelPin_ClearSemantics(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       map[string]any
+		wantStatus string
+	}{
+		{name: "clear flag", args: map[string]any{"clear": true}, wantStatus: "cleared"},
+		{name: "clear flag ignores model", args: map[string]any{"clear": true, "model": "claude-opus-4-8"}, wantStatus: "cleared"},
+		{name: "auto model clears", args: map[string]any{"model": "auto"}, wantStatus: "cleared"},
+		{name: "router model clears", args: map[string]any{"model": "Router"}, wantStatus: "cleared"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pinner := newMockConversationModelPinner()
+			pinner.pins["signal-alice"] = ConversationModelPin{ConversationID: "signal-alice", Model: "claude-opus-4-8"}
+			tool := conversationModelPinTool(t, pinner)
+			ctx := WithConversationID(context.Background(), "signal-alice")
+
+			raw, err := tool.Handler(ctx, tc.args)
+			if err != nil {
+				t.Fatalf("handler: %v", err)
+			}
+			out := decodeToolJSON(t, raw)
+			if out["status"] != tc.wantStatus || out["previous_model"] != "claude-opus-4-8" || out["model_selection"] != "router" {
+				t.Fatalf("result = %v, want %s with previous_model and router selection", out, tc.wantStatus)
+			}
+			if _, still := pinner.pins["signal-alice"]; still {
+				t.Fatal("pin survived clear")
+			}
+			if pinner.lastPin.conv != "" {
+				t.Fatalf("clear reached PinConversationModel with %+v", pinner.lastPin)
+			}
+		})
+	}
+
+	t.Run("clearing nothing reports not_pinned", func(t *testing.T) {
+		tool := conversationModelPinTool(t, newMockConversationModelPinner())
+		raw, err := tool.Handler(WithConversationID(context.Background(), "signal-alice"), map[string]any{"clear": true})
+		if err != nil {
+			t.Fatalf("handler: %v", err)
+		}
+		if out := decodeToolJSON(t, raw); out["status"] != "not_pinned" {
+			t.Fatalf("result = %v, want not_pinned", out)
+		}
+	})
+}
+
+func TestConversationModelPin_ErrorsTeachTheNextMove(t *testing.T) {
+	t.Run("turn without an id pins the shared default conversation", func(t *testing.T) {
+		pinner := newMockConversationModelPinner()
+		tool := conversationModelPinTool(t, pinner)
+		if _, err := tool.Handler(context.Background(), map[string]any{"model": "claude-opus-4-8"}); err != nil {
+			t.Fatalf("handler: %v", err)
+		}
+		if pinner.lastPin.conv != "default" {
+			t.Fatalf("pinned conversation = %q, want the runtime's shared default", pinner.lastPin.conv)
+		}
+	})
+	t.Run("missing model", func(t *testing.T) {
+		tool := conversationModelPinTool(t, newMockConversationModelPinner())
+		_, err := tool.Handler(WithConversationID(context.Background(), "signal-alice"), map[string]any{})
+		if err == nil || !strings.Contains(err.Error(), "model_registry_list") || !strings.Contains(err.Error(), "clear=true") {
+			t.Fatalf("error = %v, want both next moves named", err)
+		}
+	})
+	t.Run("pinner refusal passes through verbatim", func(t *testing.T) {
+		pinner := newMockConversationModelPinner()
+		pinner.pinErr = errors.New(`unknown model "nope"; pass a deployment id`)
+		tool := conversationModelPinTool(t, pinner)
+		_, err := tool.Handler(WithConversationID(context.Background(), "signal-alice"), map[string]any{"model": "nope"})
+		if !errors.Is(err, pinner.pinErr) {
+			t.Fatalf("error = %v, want the pinner's error unchanged", err)
+		}
+	})
+}

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=72
-interfaces=89
+interfaces=91
 large_files=61
-set_mutators=125
+set_mutators=127
 database_opens=9

--- a/talents/models.md
+++ b/talents/models.md
@@ -1,0 +1,81 @@
+---
+kind: doctrine
+tags: [models]
+---
+
+# Models
+
+These tools look at the fleet of minds Thane can think with, and at
+the router that chooses among them. The craft is telling three
+different questions apart before touching anything: *what is
+available right now*, *why did (or would) the router choose what it
+chose*, and *who should be steered, for how long, by which lever*.
+Most model work goes wrong by answering the third with a tool built
+for the first.
+
+Start with `model_registry_summary`. It is one cheap call that returns
+the live picture: generation, counts, the default deployment, degraded
+resources, cooldowns, policy totals, promoted discoveries. Read it
+before listing anything; the summary usually says whether a deeper
+call is warranted at all. `model_registry_list` is the next step when
+you need a specific shape of model (image-capable, tool-capable,
+routable, on one resource) and takes filters so you never page through
+the whole fleet. `model_registry_get` is depth on one deployment or
+resource: capabilities, policy state, health, experience. Names here
+are deployment IDs; a bare model name resolves only when exactly one
+deployment carries it, and an ambiguous name comes back with the
+candidates rather than a guess.
+
+Routing is intent, not names. The router scores every routable
+deployment against a turn's hints (quality floor, local-only, speed,
+mission, context size, required capabilities) and picks the best fit,
+so "which model will answer" is a question with a computed answer, not
+a configured one. `model_route_explain` is the dry run: give it the
+hypothetical request and it returns the chosen deployment, every
+rejected candidate, and the rules that fired, using live cooldown and
+reachability state and mutating nothing. Reach for it before concluding
+a model is "not being used"; most such reports are a rule doing its
+job (a resource marked unreachable, a context window too small, a
+local-first bonus) and the explanation names it.
+
+Steering has three levers, and they differ in scope and in how long
+they hold. Choose by asking who should be affected and what should
+survive a restart:
+
+- **The whole fleet, durably.** `model_deployment_set_policy` and
+  `model_resource_set_policy` are operator policy: flag, deactivate, or
+  promote a deployment (`routable=true` is how a discovered model
+  becomes eligible at all), or switch a whole resource off. Policy
+  persists across restarts and applies to every conversation and loop.
+  It is the right lever for "this model is broken" or "this server is
+  down for maintenance", and the wrong one for "use opus in this chat".
+- **One loop definition, durably.** `loop_definition_update` with
+  `model` pins a persistent loop definition to a deployment; it lives in
+  the loops overlay and survives restart. That tool rides the `loops`
+  tag.
+- **One conversation, until restart.** `conversation_model_pin` holds
+  the conversation you are in to one deployment from the next turn on,
+  outranking the channel's configured model and any client-selected
+  model. It is deliberately not durable: it clears when Thane restarts,
+  so a poor choice is always one restart from undone. It rides the
+  `session` tag with the other conversation-lifecycle tools, because
+  that is what it is. The Context line at the top of your prompt shows
+  `(pinned -Ns)` while a pin is honored and names the pin as skipped on
+  a turn the deployment could not serve; a skipped pin still stands,
+  so do not re-pin, and do not apologize for a switch you did not make.
+
+Pinning is not a way to fix a broken router decision. If
+`model_route_explain` shows the router rejecting a model for a reason
+that is wrong (a stale capability flag, a resource wrongly marked
+down), the fix is the registry or the policy, and it helps every
+conversation at once. Pin when the *user* has a preference for this
+thread, or when you are deliberately comparing minds on the same work.
+
+Two cautions carry across all of it. Policy mutations are broad and
+durable, so read the summary first and say what you changed in the
+turn that changed it; a deployment silently deactivated is a mystery
+for the next operator. And capability flags describe what a deployment
+is *believed* to do, not what it was seen doing; a preflight that
+routes around a pin because "it does not support image inputs" is
+reading that flag, and `model_registry_get` will show whether the
+belief came from config or from observation.

--- a/talents/operations-trailhead.md
+++ b/talents/operations-trailhead.md
@@ -25,7 +25,8 @@ Choose the next move deliberately:
   `diagnostics`. Its `system_health` is the one-call annunciator panel;
   start there when you only know "something is off".
 - If the question is about model registry, routing, or policy, activate
-  `models`.
+  `models`. Steering one conversation to one model is a `session`
+  decision (`conversation_model_pin`), not a policy one.
 - If the work is about scheduled tasks or timing policy, activate
   `scheduler`.
 - If you need loop definitions, loop policy, or loop launches —

--- a/talents/session.md
+++ b/talents/session.md
@@ -1,15 +1,17 @@
 ---
 name: session
 tags: [session]
-teaser: "Open for conversation-lifecycle decisions — reset, close, checkpoint, or split."
+teaser: "Open for conversation-lifecycle decisions — reset, close, checkpoint, split, or pin this conversation to one model."
 ---
 
 # Session
 
-Four tools, each genuinely distinct. The names sound similar enough
-that the model demonstrably mis-routes between them; the differences
-matter because some are destructive and some aren't, some preserve
-continuity and some sever it.
+Five tools, each genuinely distinct. Four shape the conversation's
+lifecycle; the names sound similar enough that the model demonstrably
+mis-routes between them, and the differences matter because some are
+destructive and some aren't, some preserve continuity and some sever
+it. The fifth, `conversation_model_pin`, shapes *which mind answers*
+this conversation and touches no history at all.
 
 ## The single most important disambiguation
 
@@ -41,6 +43,7 @@ current session; two do not.
 | `session_close` | Closes current session, opens a fresh one with a carry-forward handoff injected. | **Yes** (but with continuity) |
 | `session_checkpoint` | Snapshots state. Current session continues uninterrupted. | No |
 | `session_split` | Archives early messages, keeps recent ones in the current session. | No (the current session keeps going) |
+| `conversation_model_pin` | Holds this conversation to one model deployment, or clears the hold. Touches no messages. | No |
 
 When in doubt about destructiveness, look at this table first.
 
@@ -161,6 +164,57 @@ Use this when:
 Distinguish from `session_close`: split keeps you *in* the current
 session (no carry-forward needed, no handoff). It's "compact this
 session" rather than "transition to a new session."
+
+## conversation_model_pin — steer which mind answers
+
+**Hold this conversation to one model deployment, from the next turn
+on, until cleared or until Thane restarts.** The user asks for it in
+model terms: "switch this chat to opus," "use the local model for
+now," "go back to automatic."
+
+```json
+{
+  "model": "claude-opus-4-8",
+  "reason": "user wants to compare opus on this thread"
+}
+```
+
+To clear:
+
+```json
+{
+  "clear": true
+}
+```
+
+`model` is a deployment id or a unique model name; the `models` tag's
+`model_registry_list` is where those come from, and an unknown or
+ambiguous name errors with the next move rather than guessing. The
+pin outranks the channel's configured model and any model a client
+picked in a dropdown, and it holds across turns, sessions, splits, and
+checkpoints of this conversation. Nothing about it is durable: it is
+process memory, so a restart drops it. That is the recovery path for a
+bad choice, by design.
+
+Three things to hold in mind while a pin stands:
+
+- **It applies from the next turn.** The turn that sets the pin has
+  already chosen its model. Say so when you confirm.
+- **The Context line tells you the state.** `(pinned -Ns)` after the
+  model name means the pin was honored this turn. `pinned X skipped
+  this turn: <reason>` means the deployment could not serve this one
+  turn (an image arrived and it lacks vision, the prompt outgrew its
+  window) and the router answered instead. The pin still stands; do
+  not re-pin, and do not apologize for a switch you did not make.
+- **It is not policy.** To take a deployment away from *everyone*, or
+  promote a discovered one, that is `model_deployment_set_policy`
+  under `models`. To pin a persistent loop definition, that is
+  `loop_definition_update` under `loops`. This tool is for this
+  conversation and this conversation only.
+
+Pin on the user's request or for a deliberate comparison. Do not pin
+on your own initiative because a turn felt weak; the router's choice is
+explainable (`model_route_explain`) and usually right for a reason.
 
 ## Choosing the right one
 


### PR DESCRIPTION
## Steering one conversation to one mind, without making it policy

Thane already knows how to bypass the router: a request that names a model skips scoring and runs a preflight instead, a loop definition can pin its model through `loop_definition_update`, and the Signal channel can pin every sender at once through `signal.routing.model`. What it could not do was let the operator say, from inside a conversation, "use opus for this thread" and have that stick. The client-side model dropdown covers Open WebUI; Signal and the companions have no such control, and the conversation loops those bridges spawn are not definitions, so the loop pin verb cannot reach them either.

This PR adds `conversation_model_pin`, a `session`-tag tool that holds the current conversation to one deployment from its next turn on. The pin is read at the one seam every turn passes through, after tool gating and before routing, so it is judged by exactly the preflight an explicit request model gets. It outranks the request model, which means it beats both the channel-wide Signal config and a client-selected model: it is the most specific and most recent intent there is. Delegates still route on their own.

Two decisions shape the rest. The pin is deliberately memory-only. It lives on the shared agent loop keyed by conversation ID, holds across turns and sessions of that conversation, and clears when Thane restarts. That is the recovery path for a bad choice, and it costs no schema, no boot-time wipe, and nothing to hunt down in storage; router cooldowns already follow the same rule for the same reason. And a pinned deployment that cannot serve a particular turn is routed around for that turn rather than failing it. A conversation's needs change turn to turn (an image arrives, the prompt outgrows a window) and a pin that turned every such turn into a hard error would be a trap rather than a preference. The pin stands, the fallback is recorded on it, and the Context line at the top of the prompt names the skipped pin and the reason, so the next turn knows the pin still holds and does not re-pin or apologize for a switch it never made. Pins that would fail every turn (unknown or ambiguous names, deployments made inactive by policy, deployments that cannot call tools) are refused at pin time with the next move named.

`GET /v1/conversations/{id}` now carries the live pin as `model_pin`, including the last fallback, so the console can show which mind a conversation is held to.

The second change closes a gap found on the way. The operations trailhead has told the model to activate a `models` tag for registry, routing, and policy questions, and the tag activates fine because the tools declare it, but no talent in the repo or in prod's core talents taught it. `talents/models.md` now does: summary first, list with filters, explain before concluding the router is wrong, and the three steering levers distinguished by scope and durability (fleet policy survives restart, a loop-definition pin survives restart, a conversation pin does not). The session talent teaches the new tool in the same register as its four siblings, and the trailhead now says which of the two tags a "use this model for this chat" request belongs to.

Turns without a conversation ID share the runtime's `default` conversation, and a pin set from one of them holds that shared conversation, which is what their memory and session state already do.

## Test plan

- [x] `just ci` passes locally (fmt, lint, race tests, architecture baseline regenerated for the two new interfaces and two new setters)
- [x] Agent: pin resolves a model name to its deployment; unknown, empty, ambiguous, inactive, and toolless references are refused with the next move named
- [x] Agent: a pin outranks both the router's local-first pick and an explicit request model, leaves other conversations alone, and clearing returns the router
- [x] Agent: a pinned text-only model routes around an image turn, records the fallback on the pin, explains it in the Context line, and is honored again on the next text turn
- [x] Agent: with no router to fall back to, a pin fails the same way an explicit request model does
- [x] Tool: pin, clear (`clear=true`, `model: auto`, `model: router`), not-pinned, missing-model error, and pinner errors passing through verbatim
- [x] Context line: `(pinned -120s)`, the skipped-pin form, and the untouched routed form
- [x] API: `model_pin` present with `last_fallback` on a pinned conversation, omitted on an unpinned one and when no reader is wired
- [x] Talent corpus tests: `models.md` and the session edits reference only real tools and resolvable tags
- [ ] Prod: after deploy, pin a Signal thread from the conversation, confirm the next reply's model in the console, send an image, confirm the fallback line, restart, confirm the pin is gone
- [ ] Prod: backport `talents/models.md`, `talents/session.md`, and `talents/operations-trailhead.md` to core/talents (deploy does not push talents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
