### PR TITLE
feat(models): let a deployment declare supports_images

### DIFF
--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -340,11 +340,12 @@ models:
       # inherits what the resource reported or what the model name
       # implies. It exists because that inference is the only one with no
       # authoritative source on a plain OpenAI-compatible endpoint: the
-      # /v1/models schema carries an id and nothing about modality, so a
-      # multimodal model whose name does not advertise itself — anything
-      # without a "vl" or "vision" in it — is invisible to Thane no matter
-      # what the server can actually do. LM Studio escapes this only
-      # because its native inventory returns a vision flag.
+      # /v1/models schema carries an id and nothing about modality, so
+      # vision is inferred from the model name alone. A multimodal model
+      # whose name matches none of the vision-name patterns that
+      # inference knows is invisible to Thane however capable the server
+      # is. LM Studio escapes this only because its native inventory
+      # returns a vision flag.
       supports_images: false
       context_window: 32768
       speed: 9
@@ -360,11 +361,12 @@ models:
       # inherits what the resource reported or what the model name
       # implies. It exists because that inference is the only one with no
       # authoritative source on a plain OpenAI-compatible endpoint: the
-      # /v1/models schema carries an id and nothing about modality, so a
-      # multimodal model whose name does not advertise itself — anything
-      # without a "vl" or "vision" in it — is invisible to Thane no matter
-      # what the server can actually do. LM Studio escapes this only
-      # because its native inventory returns a vision flag.
+      # /v1/models schema carries an id and nothing about modality, so
+      # vision is inferred from the model name alone. A multimodal model
+      # whose name matches none of the vision-name patterns that
+      # inference knows is invisible to Thane however capable the server
+      # is. LM Studio escapes this only because its native inventory
+      # returns a vision flag.
       supports_images: false
       context_window: 131072
       speed: 3

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -336,6 +336,16 @@ models:
       resource: edge
       supports_tools: true
       supports_streaming: false
+      # SupportsImages is an optional per-deployment vision override. Nil
+      # inherits what the resource reported or what the model name
+      # implies. It exists because that inference is the only one with no
+      # authoritative source on a plain OpenAI-compatible endpoint: the
+      # /v1/models schema carries an id and nothing about modality, so a
+      # multimodal model whose name does not advertise itself — anything
+      # without a "vl" or "vision" in it — is invisible to Thane no matter
+      # what the server can actually do. LM Studio escapes this only
+      # because its native inventory returns a vision flag.
+      supports_images: false
       context_window: 32768
       speed: 9
       quality: 5
@@ -346,6 +356,16 @@ models:
       resource: default
       supports_tools: true
       supports_streaming: false
+      # SupportsImages is an optional per-deployment vision override. Nil
+      # inherits what the resource reported or what the model name
+      # implies. It exists because that inference is the only one with no
+      # authoritative source on a plain OpenAI-compatible endpoint: the
+      # /v1/models schema carries an id and nothing about modality, so a
+      # multimodal model whose name does not advertise itself — anything
+      # without a "vl" or "vision" in it — is invisible to Thane no matter
+      # what the server can actually do. LM Studio escapes this only
+      # because its native inventory returns a vision flag.
+      supports_images: false
       context_window: 131072
       speed: 3
       quality: 9

--- a/internal/model/fleet/catalog.go
+++ b/internal/model/fleet/catalog.go
@@ -58,6 +58,7 @@ type Deployment struct {
 	SupportsStreaming         bool
 	ObservedSupportsStreaming bool
 	SupportsImages            bool
+	ObservedSupportsImages    bool
 	ContextWindow             int
 	ObservedContextWindow     int
 	MaxContextWindow          int
@@ -89,6 +90,7 @@ type Deployment struct {
 
 	SupportsToolsOverride     *bool
 	SupportsStreamingOverride *bool
+	SupportsImagesOverride    *bool
 	ContextWindowOverride     int
 }
 
@@ -202,6 +204,7 @@ func BuildCatalog(cfg *config.Config) (*Catalog, error) {
 		RunnerState           string
 		SupportsToolsOverride *bool
 		SupportsStreaming     *bool
+		SupportsImages        *bool
 		TrainedForToolUse     bool
 		ContextWindowOverride int
 		MaxContextWindow      int
@@ -285,6 +288,7 @@ func BuildCatalog(cfg *config.Config) (*Catalog, error) {
 				return override
 			}(),
 			SupportsStreaming:     m.SupportsStreaming,
+			SupportsImages:        m.SupportsImages,
 			TrainedForToolUse:     m.SupportsTools,
 			ContextWindowOverride: m.ContextWindow,
 			Speed:                 m.Speed,
@@ -333,17 +337,11 @@ func BuildCatalog(cfg *config.Config) (*Catalog, error) {
 			Quantization:              p.Quantization,
 			SupportsToolsOverride:     p.SupportsToolsOverride,
 			SupportsStreamingOverride: p.SupportsStreaming,
+			SupportsImagesOverride:    p.SupportsImages,
 			ContextWindowOverride:     p.ContextWindowOverride,
 		}
 		if res, ok := resourceByID[p.ResourceID]; ok {
 			applyObservedCapabilities(&dep, res.Capabilities)
-			dep.SupportsImages = modelproviders.SupportsImagesForModel(
-				dep.Provider,
-				dep.ModelName,
-				dep.Family,
-				dep.Families,
-				res.Capabilities,
-			)
 		}
 		deployments = append(deployments, dep)
 	}
@@ -406,8 +404,20 @@ func applyObservedCapabilities(dep *Deployment, caps modelproviders.Capabilities
 	if !dep.ObservedSupportsStreaming {
 		dep.ObservedSupportsStreaming = caps.SupportsStreaming
 	}
+	if !dep.ObservedSupportsImages {
+		// The name heuristic is a guess of last resort, so it only gets
+		// to speak where nothing authoritative already has.
+		dep.ObservedSupportsImages = modelproviders.SupportsImagesForModel(
+			dep.Provider,
+			dep.ModelName,
+			dep.Family,
+			dep.Families,
+			caps,
+		)
+	}
 	dep.SupportsTools = boolOverrideValue(dep.SupportsToolsOverride, dep.ObservedSupportsTools)
 	dep.SupportsStreaming = boolOverrideValue(dep.SupportsStreamingOverride, dep.ObservedSupportsStreaming)
+	dep.SupportsImages = boolOverrideValue(dep.SupportsImagesOverride, dep.ObservedSupportsImages)
 	dep.ContextWindow = effectiveContextWindow(dep)
 }
 

--- a/internal/model/fleet/catalog_test.go
+++ b/internal/model/fleet/catalog_test.go
@@ -486,7 +486,7 @@ func TestMergeDiscoveredDeployment_PreservesExistingRuntimeMetadataOnZeroValues(
 
 func TestMergeDiscoveredDeployment_PreservesExistingImageSupportWhenDiscoveryIsFalse(t *testing.T) {
 	dep := &Deployment{
-		SupportsImages: true,
+		ObservedSupportsImages: true,
 	}
 
 	mergeDiscoveredDeployment(dep, DiscoveredModel{
@@ -726,5 +726,109 @@ func TestCatalogRouterConfig_ExcludesInactiveDeploymentsAndRetargetsDefault(t *t
 	})
 	if got == "spark/gpt-oss:20b" {
 		t.Fatal("router selected inactive deployment")
+	}
+}
+
+// TestSupportsImagesOverride pins the fourth capability override. Tools,
+// streaming, and the context window could all be declared in config;
+// vision could not, and it is the one with no authoritative source on a
+// plain OpenAI-compatible endpoint — the /v1/models schema carries an id
+// and nothing about modality. A multimodal model whose name does not
+// advertise itself was therefore invisible to Thane no matter what the
+// server could actually do, and no runtime tool could correct it.
+func TestSupportsImagesOverride(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		modelName string
+		override  *bool
+		want      bool
+	}{
+		{
+			// The case that motivated this: served by vLLM, genuinely
+			// multimodal, and named nothing the heuristic recognizes.
+			name:      "an override rescues a model the name heuristic misses",
+			modelName: "Qwen/Qwen3.5-122B-A10B-FP8",
+			override:  boolPtr(true),
+			want:      true,
+		},
+		{
+			name:      "without an override that same model stays invisible",
+			modelName: "Qwen/Qwen3.5-122B-A10B-FP8",
+			want:      false,
+		},
+		{
+			// The override has to be able to say no, not only yes: a
+			// name containing "vl" is a guess, and an operator who knows
+			// better outranks it.
+			name:      "an override of false beats a vision-looking name",
+			modelName: "qwen2.5-vl:7b",
+			override:  boolPtr(false),
+			want:      false,
+		},
+		{
+			name:      "the heuristic still stands where nothing overrides it",
+			modelName: "qwen2.5-vl:7b",
+			want:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &config.Config{}
+			cfg.Models.Resources = map[string]config.ModelServerConfig{
+				"spark": {URL: "http://spark:8000", Provider: "openai_compat"},
+			}
+			cfg.Models.Available = []config.ModelConfig{
+				{Name: tt.modelName, Resource: "spark", SupportsImages: tt.override},
+			}
+
+			cat, err := BuildCatalog(cfg)
+			if err != nil {
+				t.Fatalf("BuildCatalog: %v", err)
+			}
+			var dep *Deployment
+			for i := range cat.Deployments {
+				if cat.Deployments[i].ModelName == tt.modelName {
+					dep = &cat.Deployments[i]
+					break
+				}
+			}
+			if dep == nil {
+				t.Fatalf("no deployment built for %q", tt.modelName)
+			}
+			if dep.SupportsImages != tt.want {
+				t.Errorf("SupportsImages = %v, want %v (observed=%v, override=%v)",
+					dep.SupportsImages, tt.want, dep.ObservedSupportsImages, tt.override)
+			}
+		})
+	}
+}
+
+// TestSupportsImagesOverrideSurvivesDiscovery pins the half of the
+// contract the merge path owns. Discovery ORs its own observation in, so
+// an operator who wrote supports_images: false has to keep it off however
+// loudly a runner disagrees — otherwise the override holds only until the
+// next inventory sweep.
+func TestSupportsImagesOverrideSurvivesDiscovery(t *testing.T) {
+	t.Parallel()
+
+	dep := &Deployment{
+		SupportsImagesOverride: boolPtr(false),
+	}
+
+	mergeDiscoveredDeployment(dep, DiscoveredModel{
+		Name:           "qwen-vl:latest",
+		SupportsImages: true,
+	}, modelproviders.Capabilities{SupportsImages: true})
+
+	if dep.SupportsImages {
+		t.Error("SupportsImages = true, want the operator's explicit false to survive discovery")
+	}
+	if !dep.ObservedSupportsImages {
+		t.Error("ObservedSupportsImages = false, want discovery still recorded under the override")
 	}
 }

--- a/internal/model/fleet/inventory_merge.go
+++ b/internal/model/fleet/inventory_merge.go
@@ -137,7 +137,10 @@ func mergeDiscoveredDeployment(dep *Deployment, model DiscoveredModel, caps mode
 	if model.LoadedInstanceID != "" {
 		dep.LoadedInstanceID = model.LoadedInstanceID
 	}
-	dep.SupportsImages = dep.SupportsImages || model.SupportsImages
+	// Observation, not the resolved value: an operator who wrote
+	// supports_images: false keeps it off however loudly discovery
+	// disagrees.
+	dep.ObservedSupportsImages = dep.ObservedSupportsImages || model.SupportsImages
 	if model.TrainedForToolUse {
 		dep.TrainedForToolUse = true
 	}
@@ -158,7 +161,7 @@ func newDiscoveredDeployment(base *Catalog, ri ResourceInventory, model Discover
 		ObservedSupportsTools:     observedBoolCapability(model.SupportsTools, caps.SupportsTools),
 		TrainedForToolUse:         model.TrainedForToolUse,
 		ObservedSupportsStreaming: observedBoolCapability(model.SupportsStreaming, caps.SupportsStreaming),
-		SupportsImages:            model.SupportsImages,
+		ObservedSupportsImages:    model.SupportsImages,
 		ObservedContextWindow:     firstPositiveInt(model.ContextWindow, base.ContextWindowForModel(model.Name, 0)),
 		MaxContextWindow:          model.MaxContextWindow,
 		LoadedContextWindow:       model.LoadedContextWindow,

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -1766,11 +1766,21 @@ type ModelConfig struct {
 	Resource          string `yaml:"resource"`           // Named provider resource from models.resources for this deployment
 	SupportsTools     bool   `yaml:"supports_tools"`     // Optional per-deployment tool-use override. When omitted, runtime/provider capability is used.
 	SupportsStreaming *bool  `yaml:"supports_streaming"` // Optional per-deployment streaming override. Nil inherits observed runtime/provider capability.
-	ContextWindow     int    `yaml:"context_window"`     // Optional per-deployment context-window override. Zero inherits observed runtime metadata.
-	Speed             int    `yaml:"speed"`              // Relative speed rating, 1 (slow) to 10 (fast)
-	Quality           int    `yaml:"quality"`            // Relative quality rating, 1 (low) to 10 (high)
-	CostTier          int    `yaml:"cost_tier"`          // 0=local/free, 1=cheap, 2=moderate, 3=expensive
-	MinComplexity     string `yaml:"min_complexity"`     // Minimum task complexity: simple, moderate, complex
+	// SupportsImages is an optional per-deployment vision override. Nil
+	// inherits what the resource reported or what the model name
+	// implies. It exists because that inference is the only one with no
+	// authoritative source on a plain OpenAI-compatible endpoint: the
+	// /v1/models schema carries an id and nothing about modality, so a
+	// multimodal model whose name does not advertise itself — anything
+	// without a "vl" or "vision" in it — is invisible to Thane no matter
+	// what the server can actually do. LM Studio escapes this only
+	// because its native inventory returns a vision flag.
+	SupportsImages *bool  `yaml:"supports_images"`
+	ContextWindow  int    `yaml:"context_window"` // Optional per-deployment context-window override. Zero inherits observed runtime metadata.
+	Speed          int    `yaml:"speed"`          // Relative speed rating, 1 (slow) to 10 (fast)
+	Quality        int    `yaml:"quality"`        // Relative quality rating, 1 (low) to 10 (high)
+	CostTier       int    `yaml:"cost_tier"`      // 0=local/free, 1=cheap, 2=moderate, 3=expensive
+	MinComplexity  string `yaml:"min_complexity"` // Minimum task complexity: simple, moderate, complex
 
 	supportsToolsSet bool `yaml:"-"`
 }

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -1770,11 +1770,12 @@ type ModelConfig struct {
 	// inherits what the resource reported or what the model name
 	// implies. It exists because that inference is the only one with no
 	// authoritative source on a plain OpenAI-compatible endpoint: the
-	// /v1/models schema carries an id and nothing about modality, so a
-	// multimodal model whose name does not advertise itself — anything
-	// without a "vl" or "vision" in it — is invisible to Thane no matter
-	// what the server can actually do. LM Studio escapes this only
-	// because its native inventory returns a vision flag.
+	// /v1/models schema carries an id and nothing about modality, so
+	// vision is inferred from the model name alone. A multimodal model
+	// whose name matches none of the vision-name patterns that
+	// inference knows is invisible to Thane however capable the server
+	// is. LM Studio escapes this only because its native inventory
+	// returns a vision flag.
 	SupportsImages *bool  `yaml:"supports_images"`
 	ContextWindow  int    `yaml:"context_window"` // Optional per-deployment context-window override. Zero inherits observed runtime metadata.
 	Speed          int    `yaml:"speed"`          // Relative speed rating, 1 (slow) to 10 (fast)


### PR DESCRIPTION
Three of the four capability overrides already existed. An operator who knew better than the runtime could write `supports_tools`, `supports_streaming`, or `context_window` and have it respected. Vision was the exception, and it is the capability with the least evidence behind it.

The OpenAI `/v1/models` schema carries an id and says nothing about modality. I checked the live cluster to be sure:

```
['created', 'id', 'max_model_len', 'object', 'owned_by', 'parent', 'permission', 'root']
```

No arch, no type, no modality. So for an `openai_compat` resource the sole evidence is the model's name, run through `looksLikeVisionModel`. LM Studio escapes this because its native inventory returns an authoritative `vision` boolean that [inventory.go:218](https://github.com/nugget/thane-ai-agent/blob/main/internal/model/fleet/inventory.go#L218) ORs in. There is no equivalent for a generic OpenAI endpoint and there is not going to be one.

The consequence is a model that can see, that Thane believes cannot. `Qwen/Qwen3.5-122B-A10B-FP8` is served by vLLM as `Qwen3_5MoeForConditionalGeneration`, initializes an encoder cache at startup, and accepts images right now. The heuristic wants both `qwen` and `vl` in the name and finds only the first. Nothing could correct it either: `supports_images` appears in the tool layer only as a read filter, never as a setter.

## Shape

`SupportsImages` now resolves the way its three siblings already do, rather than being assigned past the machinery that exists for exactly this:

```go
// before — computed in BuildCatalog, after applyObservedCapabilities had run
dep.SupportsImages = modelproviders.SupportsImagesForModel(...)

// after — inside applyObservedCapabilities, alongside the others
dep.SupportsTools     = boolOverrideValue(dep.SupportsToolsOverride, dep.ObservedSupportsTools)
dep.SupportsStreaming = boolOverrideValue(dep.SupportsStreamingOverride, dep.ObservedSupportsStreaming)
dep.SupportsImages    = boolOverrideValue(dep.SupportsImagesOverride, dep.ObservedSupportsImages)
```

The heuristic becomes `ObservedSupportsImages` — an observation like any other, and like the tools observation it only speaks where nothing authoritative already has. The merge path ORs discovery into the *observation* rather than into the resolved value, so an explicit `false` survives an inventory sweep that disagrees; previously any discovery reporting vision would have silently won.

## Config

```yaml
models:
  available:
    - name: Qwen/Qwen3.5-122B-A10B-FP8
      resource: spark
      supports_images: true
```

Nil inherits, exactly as `supports_streaming` does, and renders the same way in the generated example.

## A note on the changed test

`TestMergeDiscoveredDeployment_PreservesExistingImageSupportWhenDiscoveryIsFalse` hand-built a `Deployment` with only the derived field set. That is a state the resolver can no longer produce — both merge paths end in `applyObservedCapabilities`, so `SupportsImages` is always derived. The fixture now sets the observation and asserts exactly what it asserted before; the guarantee it protects is unchanged.

## Test plan

- [x] `just ci` passes locally
- [x] An override rescues a multimodal model the name heuristic misses
- [x] Without an override that same model stays invisible — negative control, so the test measures the override and not the heuristic
- [x] An override of `false` beats a vision-looking name
- [x] The heuristic still stands where nothing overrides it
- [x] An explicit `false` survives a discovery sweep reporting vision, and the discovery is still recorded underneath it
- [x] Mutation-tested: replacing the resolution with the bare observation fails exactly the two override cases and leaves the two heuristic cases passing
- [ ] Verified against the Spark cluster by sending an image to Qwen3.5-122B with `supports_images: true` in prod config