### PR TITLE
fix(api): the Ollama surface stops asserting the operator's identity

### DIFF
--- a/docs/understanding/trust-architecture.md
+++ b/docs/understanding/trust-architecture.md
@@ -87,6 +87,27 @@ Trust zones determine:
 - Notification priority and rate limits
 - Response depth and effort
 
+### Owner Assertion
+
+**Status: Implemented**
+
+The `owner` tag is protected: it carries the operator's own tools, and the
+model cannot activate it. It is pinned by the runtime for a conversation
+whose channel binding says the caller is the operator — and that flag is
+set in exactly one place, where a contact lookup resolves the caller to the
+operator's contact record.
+
+A surface does not confer it. Reaching a port is not an identity, so a
+listener that cannot identify its callers produces a binding that names the
+channel and claims nothing else. The Ollama-compatible surface is the case
+that made this explicit: it set the owner flag for every conversation until
+#1503, which meant Home Assistant, Open WebUI, and any host on the network
+segment all spoke as the operator. It now runs at the trust its caller has
+established, which for an unauthenticated caller is none.
+
+The general form of this rule — one resolver that reads attestation state,
+sender trust zone, and loop tier at the execution chokepoint — is #1268.
+
 ### Orchestrator Tool Gating
 
 **Status: Implemented**

--- a/internal/runtime/agent/channel_tags_test.go
+++ b/internal/runtime/agent/channel_tags_test.go
@@ -919,3 +919,64 @@ func TestResetCapabilities_DropsOnlyVoluntaryTags(t *testing.T) {
 		}
 	}
 }
+
+// TestSessionOrigin_UnidentifiedOwuBindingDoesNotPinOwner is the
+// consequence half of #1503. The Ollama-compatible surface has no
+// credential that could tell Home Assistant from Open WebUI from any
+// other host on the segment, so the binding it produces names the
+// channel and nothing else. A binding like that must not reach the
+// protected owner tag: the tools that tag carries are the operator's,
+// and the caller has not been shown to be the operator.
+func TestSessionOrigin_UnidentifiedOwuBindingDoesNotPinOwner(t *testing.T) {
+	mock := &mockLLM{
+		responses: []*llm.ChatResponse{
+			{
+				Model:        "test-model",
+				Message:      llm.Message{Role: "assistant", Content: "Done."},
+				InputTokens:  100,
+				OutputTokens: 10,
+			},
+		},
+	}
+
+	loop := buildTestLoop(mock, []string{"owner_tool", "chat_tool"})
+	loop.SetCapabilityTags(map[string]config.CapabilityTagConfig{
+		"owner": {
+			Description: "Owner-scoped privileged tools.",
+			Tools:       []string{"owner_tool"},
+			Protected:   true,
+		},
+		"chat": {
+			Description: "Ordinary conversation tools.",
+			Tools:       []string{"chat_tool"},
+		},
+	}, nil)
+	loop.SetChannelTags(map[string][]string{
+		"owu": {"chat"},
+	})
+
+	_, err := loop.Run(context.Background(), &Request{
+		Messages:       []Message{{Role: "user", Content: "turn on the garage lights"}},
+		RoutingFactors: map[string]string{"source": "owu", "channel": "ollama"},
+		ChannelBinding: &memory.ChannelBinding{Channel: "owu"},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	names := toolNames(mock.calls[0].Tools)
+	if !hasName(names, "chat_tool") {
+		t.Fatalf("chat_tool should be available from the channel's own tags: %v", names)
+	}
+	if hasName(names, "owner_tool") {
+		t.Fatalf("owner_tool was offered to an unidentified owu caller: %v", names)
+	}
+
+	originCtx := parseSessionOriginContext(t, mock.calls[0].Messages[0].Content)
+	if containsString(originCtx.Tags, "owner") {
+		t.Fatalf("origin tags = %#v, want no owner tag for an unidentified caller", originCtx.Tags)
+	}
+	if rule, ok := appliedRuleBySource(originCtx.Applied, "channel_binding"); ok {
+		t.Fatalf("a binding with no identity applied a channel_binding rule: %#v", rule)
+	}
+}

--- a/internal/server/api/ollama_hardening_test.go
+++ b/internal/server/api/ollama_hardening_test.go
@@ -244,13 +244,21 @@ func TestOllamaHandlerClaimsNoOwnership(t *testing.T) {
 	// The handler reads the router's quality ceiling off the loop and
 	// otherwise routes through the tracker, so a zero-value loop (nil
 	// router, quality floor default) is all this path needs.
-	go handleOllamaChatShared(rec, req, &agent.Loop{}, tracker, slog.Default())
+	//
+	// Called on the test's own goroutine: the recording runner's channel
+	// is buffered, so nothing here deadlocks, and the handler is finished
+	// before the assertions and before cleanup cancels the tracker.
+	handleOllamaChatShared(rec, req, &agent.Loop{}, tracker, slog.Default())
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d (%s), want the request to complete", rec.Code, rec.Body.String())
+	}
 
 	var got loop.Request
 	select {
 	case got = <-runner.requests:
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for the request to reach the loop")
+	default:
+		t.Fatal("the handler returned without the request reaching the loop")
 	}
 
 	if got.ChannelBinding == nil {

--- a/internal/server/api/ollama_hardening_test.go
+++ b/internal/server/api/ollama_hardening_test.go
@@ -13,7 +13,9 @@ import (
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/platform/buildinfo"
+	"github.com/nugget/thane-ai-agent/internal/platform/events"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agent"
+	"github.com/nugget/thane-ai-agent/internal/runtime/loop"
 )
 
 func TestOllamaAuth(t *testing.T) {
@@ -204,5 +206,65 @@ func TestOpenAIAuth(t *testing.T) {
 				t.Fatalf("error envelope = %+v, want invalid_api_key/invalid_request_error", body.Error)
 			}
 		})
+	}
+}
+
+// TestOllamaHandlerClaimsNoOwnership drives a chat request through the
+// handler exactly as Home Assistant or Open WebUI does — no credential,
+// no identity, nothing but a body — and pins that the binding reaching
+// the loop claims only the surface it arrived on.
+//
+// This surface used to set the owner flag here (#1503), which meant the
+// protected owner tag was pinned for any caller who could open a socket
+// to port 11434. The tag has to come from a caller identified as the
+// operator's contact, and nothing on this surface can identify anyone.
+func TestOllamaHandlerClaimsNoOwnership(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	registry := loop.NewRegistry()
+	t.Cleanup(func() {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer shutdownCancel()
+		registry.ShutdownAll(shutdownCtx)
+	})
+
+	runner := &owuRecordingRunner{requests: make(chan loop.Request, 1)}
+	tracker, err := NewOWUTracker(ctx, registry, events.New(), runner, slog.Default())
+	if err != nil {
+		t.Fatalf("NewOWUTracker: %v", err)
+	}
+
+	body := bytes.NewBufferString(`{"model":"thane:latest","stream":false,` +
+		`"messages":[{"role":"system","content":"You are a helpful assistant for David."},` +
+		`{"role":"user","content":"turn on the garage lights"}]}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/chat", body)
+	rec := httptest.NewRecorder()
+
+	// The handler reads the router's quality ceiling off the loop and
+	// otherwise routes through the tracker, so a zero-value loop (nil
+	// router, quality floor default) is all this path needs.
+	go handleOllamaChatShared(rec, req, &agent.Loop{}, tracker, slog.Default())
+
+	var got loop.Request
+	select {
+	case got = <-runner.requests:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the request to reach the loop")
+	}
+
+	if got.ChannelBinding == nil {
+		t.Fatal("ChannelBinding = nil, want the surface to be named")
+	}
+	if got.ChannelBinding.Channel != "owu" {
+		t.Errorf("Channel = %q, want owu", got.ChannelBinding.Channel)
+	}
+	if got.ChannelBinding.IsOwner {
+		t.Error("IsOwner = true for a caller that presented no identity")
+	}
+	// Nothing else on the binding was established either, which is the
+	// honest description of an anonymous caller.
+	if got.ChannelBinding.ContactID != "" || got.ChannelBinding.ContactName != "" || got.ChannelBinding.TrustZone != "" {
+		t.Errorf("binding claims an identity it never verified: %#v", got.ChannelBinding)
 	}
 }

--- a/internal/server/api/owu_tracker.go
+++ b/internal/server/api/owu_tracker.go
@@ -109,14 +109,22 @@ func (t *OWUTracker) Dispatch(ctx context.Context, req *agent.Request, streamCal
 		resp, err := t.run(ctx, loopReq, loopStreamFromAgent(streamCallback))
 		return agentResponseFromLoop(resp), err
 	}
+	// The binding records which surface the request arrived on, and that
+	// is all this surface knows. It used to set IsOwner here — on the
+	// binding it created and on any binding that named the owu channel —
+	// which asserted the operator's identity from the fact that a request
+	// reached port 11434. That is not a fact about who is calling: the
+	// same port answers Home Assistant, Open WebUI, and every host on the
+	// network segment, and the surface has no credential that could tell
+	// them apart. The owner flag belongs to a binding whose contact was
+	// actually resolved to the operator (see isOwnerContact in
+	// internal/app/adapters.go); until this surface can identify a
+	// caller, its conversations run at the trust the caller has
+	// established, which is none. See #1503.
 	if loopReq.ChannelBinding == nil {
-		loopReq.ChannelBinding = (&memory.ChannelBinding{Channel: "owu", IsOwner: true}).Normalize()
-	} else {
-		loopReq.ChannelBinding = loopReq.ChannelBinding.Normalize()
-		if loopReq.ChannelBinding != nil && loopReq.ChannelBinding.Channel == "owu" {
-			loopReq.ChannelBinding.IsOwner = true
-		}
+		loopReq.ChannelBinding = &memory.ChannelBinding{Channel: "owu"}
 	}
+	loopReq.ChannelBinding = loopReq.ChannelBinding.Normalize()
 	if req != nil {
 		req.ChannelBinding = loopReq.ChannelBinding
 	}

--- a/internal/server/api/owu_tracker_test.go
+++ b/internal/server/api/owu_tracker_test.go
@@ -110,13 +110,16 @@ func TestOWUTrackerDispatchRoutesThroughTurnBuilder(t *testing.T) {
 	if len(gotReq.InitialTags) != 1 || gotReq.InitialTags[0] != "owu" {
 		t.Fatalf("InitialTags = %#v, want [owu]", gotReq.InitialTags)
 	}
-	if gotReq.ChannelBinding == nil || gotReq.ChannelBinding.Channel != "owu" || !gotReq.ChannelBinding.IsOwner {
+	// The binding names the surface and claims nothing about the caller.
+	// It carried IsOwner until #1503, asserted from the port the request
+	// arrived on rather than from any identity.
+	if gotReq.ChannelBinding == nil || gotReq.ChannelBinding.Channel != "owu" || gotReq.ChannelBinding.IsOwner {
 		t.Fatalf("ChannelBinding = %#v", gotReq.ChannelBinding)
 	}
-	if req.ChannelBinding == nil || req.ChannelBinding.Channel != "owu" || !req.ChannelBinding.IsOwner {
+	if req.ChannelBinding == nil || req.ChannelBinding.Channel != "owu" || req.ChannelBinding.IsOwner {
 		t.Fatalf("original request ChannelBinding = %#v", req.ChannelBinding)
 	}
-	if boundConvID != "owu-chat-1" || bound == nil || bound.Channel != "owu" || !bound.IsOwner {
+	if boundConvID != "owu-chat-1" || bound == nil || bound.Channel != "owu" || bound.IsOwner {
 		t.Fatalf("bound conversation = %q %#v", boundConvID, bound)
 	}
 	if len(gotReq.Messages) != 1 || len(gotReq.Messages[0].Images) != 1 || gotReq.Messages[0].Images[0].MediaType != "image/png" {


### PR DESCRIPTION
## Summary

Closes #1503. Every conversation on the Ollama-compatible surface ran as the operator.

`OWUTracker.Dispatch` set `IsOwner` on the binding it created *and* on any binding already naming the `owu` channel. The loop pins the protected `owner` tag whenever a binding carries that flag, and the session-origin policy honours it. Nothing between the socket and the tag asked who was calling — because nothing on that surface can. Port 11434 answers Home Assistant, Open WebUI, and every host on the segment alike, with no credential that could tell them apart.

The binding now records which surface a request arrived on and claims nothing else. The owner flag belongs to a binding whose contact was resolved to the operator, which happens in exactly one place (`isOwnerContact`, `internal/app/adapters.go`), and no transport can shortcut it.

## What this changes in practice

Prod's access log for the last two days shows three callers on this surface: `spark-a23e` (18 requests, 8 of them `/api/chat` — presumably Open WebUI), `homeassistant` (3), and the host itself (9). All three were running as the operator. After this, all three run as what they've actually established, which is nothing.

Open WebUI is the client whose experience changes — it loses operator-grade context here.

## The honest way back, and a correction to #1499

The charter says Home Assistant "can't send bearer". That was true once and isn't now: HA's Ollama config flow has an API key field that builds `Authorization: Bearer <key>`, and multiple config entries are allowed as long as the URLs differ.

So a caller on this surface *can* identify itself, and mapping a key to a contact would give the binding a real identity. It is per-caller, not per-user — HA's user id lives in `llm_context`, is used locally for tool execution, and never crosses the wire (checked against `ollama/entity.py`: the request carries `model`, `messages`, `tools`, `stream`, `keep_alive`, `options`, `think`, `format`, and nothing else). Worth noting `SessionOrigin` already has `HAUserID`, `Person`, `DeviceID`, and `PipelineID` slots that no producer fills.

That is a follow-up slice, not this change.

## Test plan

- [x] `just ci` passes locally (exit 0)
- [x] **Handler end**: a chat request driven through `handleOllamaChatShared` exactly as HA sends one — no credential, no identity, just a body — produces a binding naming the channel with no owner flag, no contact, and no trust zone
- [x] **Loop end**: a loop run with that binding shape is not offered the `owner` tag's tools and applies no `channel_binding` origin rule
- [x] Mutation-verified: restoring the flag fails both new tests (`IsOwner = true for a caller that presented no identity`)
- [x] The existing tracker test asserted the old behaviour in three places; it now asserts the new one
- [x] `docs/understanding/trust-architecture.md` gains the rule it was missing — the owner tag is pinned from a resolved contact, never conferred by a surface

Note the same file's "literally cannot" claim about orchestrator tool gating stays overclaimed until `tag_activate` consults the resolver; that is phase 2 (#1268), not this slice.

Closes #1503
Refs #1499, #1502, #1268

🤖 Generated with [Claude Code](https://claude.com/claude-code)