### PR TITLE
feat(loops): tell a pull-based loop how far behind it is

### DIFF
--- a/internal/app/loop_queue_tools.go
+++ b/internal/app/loop_queue_tools.go
@@ -19,7 +19,22 @@ import (
 const (
 	queuePullDefaultLimit = 5
 	queuePullMaxLimit     = 25
-	archivistPullLimit    = 3
+	// The archivist's steady-state batch. Deliberately smaller than the
+	// general default: each item is a subject whose dossier synthesis
+	// wants care rather than throughput.
+	archivistPullDefaultLimit = 3
+	// Its ceiling, which the default no longer equals. The two were the
+	// same number, so the batch size could not be raised by any prompt
+	// and a backlog could only ever drain three subjects per wake. A
+	// ceiling above the default lets a loop that can see its own depth
+	// take a bigger bite when it is behind, and change nothing when it
+	// is not.
+	//
+	// Twelve rather than the general 25: each subject pulls a session
+	// transcript into context, and a batch large enough to push one call
+	// past a local model's window would route that turn to a cloud
+	// provider — fixing the backlog by quietly paying more for it.
+	archivistPullMaxLimit = 12
 )
 
 // buildLoopQueueTools returns the loop-private work-queue tools for one
@@ -44,7 +59,8 @@ func buildLoopQueueTools(store *loopqueue.Store, loopName string) []looppkg.Runt
 			Description: "Pull a batch of pending work items from your queue, highest priority first then oldest. " +
 				"Each item gives a subject (the key you pass to queue_ack), its source, a short summary, priority, and age — not the full payload. " +
 				"Exactly one batch may be pulled per loop iteration. Items stay queued until you queue_ack them, so an interrupted iteration just re-serves them next time. " +
-				"Finish this batch, persist your state, and sleep; remaining work belongs to the next iteration.",
+				"Finish this batch, persist your state, and sleep; remaining work belongs to the next iteration. " +
+				"The result reports `remaining` — the depth still queued behind this batch — and `oldest_wait`. Use them: pull nearer the cap and sleep short when the queue is deep or its oldest item has been waiting a long time, and take the default batch with a long sleep when it is shallow.",
 			SkipContentResolve: true,
 			Parameters: map[string]any{
 				"type": "object",
@@ -89,7 +105,25 @@ func buildLoopQueueTools(store *loopqueue.Store, loopName string) []looppkg.Runt
 						Age:      promptfmt.FormatDeltaOnly(it.EnqueuedAt, now),
 					})
 				}
-				return toQueueJSON(queuePullResult{Count: len(views), Items: views})
+				result := queuePullResult{Count: len(views), Items: views}
+				// Measured after the peek, and reported as depth beyond
+				// this batch: peeked items stay pending until acked, so
+				// the raw count still includes the ones just handed over.
+				// A failed probe leaves remaining at zero rather than
+				// failing the pull, which would trade the whole
+				// iteration for a number.
+				if pending, oldest, err := store.PendingFor(ctx, loopName); err == nil {
+					if beyond := pending - len(views); beyond > 0 {
+						result.Remaining = beyond
+						if !oldest.IsZero() {
+							result.OldestWait = promptfmt.FormatDeltaOnly(oldest, now)
+						}
+					}
+				} else {
+					logging.Logger(ctx).Warn("queue_pull: could not measure remaining depth",
+						"loop", loopName, "error", err)
+				}
+				return toQueueJSON(result)
 			},
 		},
 		{
@@ -221,7 +255,7 @@ func buildLoopQueueTools(store *loopqueue.Store, loopName string) []looppkg.Runt
 
 func queuePullLimits(loopName string) (defaultLimit, maxLimit int) {
 	if strings.TrimSpace(loopName) == archivist.DefinitionName {
-		return archivistPullLimit, archivistPullLimit
+		return archivistPullDefaultLimit, archivistPullMaxLimit
 	}
 	return queuePullDefaultLimit, queuePullMaxLimit
 }
@@ -303,8 +337,20 @@ type queueItemView struct {
 }
 
 type queuePullResult struct {
-	Count int             `json:"count"`
-	Items []queueItemView `json:"items"`
+	Count int `json:"count"`
+	// Remaining is how much work is still queued beyond this batch.
+	//
+	// It exists because a pull that hands back three items looked
+	// identical whether the queue held three or three hundred, so a loop
+	// choosing how long to sleep was doing it blind and a backlog could
+	// grow indefinitely behind a cadence that looked reasonable.
+	Remaining int `json:"remaining"`
+	// OldestWait is how long the oldest still-queued item has waited,
+	// omitted when nothing remains. Depth alone does not distinguish a
+	// burst that just arrived from a backlog that has been losing ground
+	// for days, and those call for different sleeps.
+	OldestWait string          `json:"oldest_wait,omitempty"`
+	Items      []queueItemView `json:"items"`
 }
 
 // projectQueuePayload extracts the model-facing source + summary from a

--- a/internal/app/loop_queue_tools.go
+++ b/internal/app/loop_queue_tools.go
@@ -60,7 +60,7 @@ func buildLoopQueueTools(store *loopqueue.Store, loopName string) []looppkg.Runt
 				"Each item gives a subject (the key you pass to queue_ack), its source, a short summary, priority, and age — not the full payload. " +
 				"Exactly one batch may be pulled per loop iteration. Items stay queued until you queue_ack them, so an interrupted iteration just re-serves them next time. " +
 				"Finish this batch, persist your state, and sleep; remaining work belongs to the next iteration. " +
-				"The result reports `remaining` — the depth still queued behind this batch — and `oldest_wait`. Use them: pull nearer the cap and sleep short when the queue is deep or its oldest item has been waiting a long time, and take the default batch with a long sleep when it is shallow.",
+				"The result reports `remaining`, the number of items still queued behind this batch, and `oldest_wait`, how long the oldest of those has waited — neither counts what this batch handed you. A null `remaining` means the depth could not be measured, which is not the same as an empty queue. Together they say whether you are keeping up; your loop definition says what to do about it.",
 			SkipContentResolve: true,
 			Parameters: map[string]any{
 				"type": "object",
@@ -106,18 +106,17 @@ func buildLoopQueueTools(store *loopqueue.Store, loopName string) []looppkg.Runt
 					})
 				}
 				result := queuePullResult{Count: len(views), Items: views}
-				// Measured after the peek, and reported as depth beyond
-				// this batch: peeked items stay pending until acked, so
-				// the raw count still includes the ones just handed over.
-				// A failed probe leaves remaining at zero rather than
-				// failing the pull, which would trade the whole
-				// iteration for a number.
-				if pending, oldest, err := store.PendingFor(ctx, loopName); err == nil {
-					if beyond := pending - len(views); beyond > 0 {
-						result.Remaining = beyond
-						if !oldest.IsZero() {
-							result.OldestWait = promptfmt.FormatDeltaOnly(oldest, now)
-						}
+				// Measured over the rows after this batch in drain order,
+				// so neither the count nor the age describes work already
+				// in hand. A failed probe leaves remaining null rather
+				// than zero: the pull still succeeds, because trading a
+				// whole iteration for a number would be the worse
+				// bargain, but the loop is told the depth is unknown
+				// instead of being told the queue is empty.
+				if pending, oldest, err := store.PendingBeyond(ctx, loopName, len(views)); err == nil {
+					result.Remaining = &pending
+					if pending > 0 && !oldest.IsZero() {
+						result.OldestWait = promptfmt.FormatDeltaOnly(oldest, now)
 					}
 				} else {
 					logging.Logger(ctx).Warn("queue_pull: could not measure remaining depth",
@@ -338,13 +337,19 @@ type queueItemView struct {
 
 type queuePullResult struct {
 	Count int `json:"count"`
-	// Remaining is how much work is still queued beyond this batch.
+	// Remaining is how much work is still queued beyond this batch, and
+	// is null when the depth could not be measured.
 	//
 	// It exists because a pull that hands back three items looked
 	// identical whether the queue held three or three hundred, so a loop
 	// choosing how long to sleep was doing it blind and a backlog could
 	// grow indefinitely behind a cadence that looked reasonable.
-	Remaining int `json:"remaining"`
+	//
+	// Nullable for that same reason one layer down: a failed probe
+	// reporting 0 would be indistinguishable from a drained queue, which
+	// is the exact confusion this field was added to end. Null means not
+	// measured; 0 means measured and empty.
+	Remaining *int `json:"remaining"`
 	// OldestWait is how long the oldest still-queued item has waited,
 	// omitted when nothing remains. Depth alone does not distinguish a
 	// burst that just arrived from a backlog that has been losing ground

--- a/internal/app/loop_queue_tools_test.go
+++ b/internal/app/loop_queue_tools_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -61,7 +62,12 @@ func TestArchivistQueuePullEnforcesWakeBatchLimit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, subject := range []string{"session:one", "session:two", "session:three", "session:four", "session:five"} {
+	// Enough to exercise the ceiling, which is now above the default.
+	subjects := make([]string, 0, archivistPullMaxLimit+3)
+	for i := range archivistPullMaxLimit + 3 {
+		subjects = append(subjects, fmt.Sprintf("session:%02d", i))
+	}
+	for _, subject := range subjects {
 		if err := store.Enqueue(t.Context(), "archivist", subject, 0, []byte(`{}`)); err != nil {
 			t.Fatal(err)
 		}
@@ -80,11 +86,19 @@ func TestArchivistQueuePullEnforcesWakeBatchLimit(t *testing.T) {
 
 	for _, tc := range []struct {
 		name      string
+		want      int
 		requestID string
 		args      map[string]any
 	}{
-		{name: "omitted limit", requestID: "r_default", args: map[string]any{}},
-		{name: "oversized limit", requestID: "r_oversized", args: map[string]any{"limit": 25}},
+		{name: "omitted limit takes the default", requestID: "r_default", args: map[string]any{}, want: archivistPullDefaultLimit},
+		{
+			// Previously this clamped to the default too, because the
+			// default and the ceiling were the same number. They are not
+			// any more: a loop that can see it is behind may ask for a
+			// bigger batch, up to the ceiling.
+			name:      "oversized limit clamps to the ceiling, not the default",
+			requestID: "r_oversized", args: map[string]any{"limit": 25}, want: archivistPullMaxLimit,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			out, err := pull(logging.WithRequestID(t.Context(), tc.requestID), tc.args)
@@ -95,8 +109,8 @@ func TestArchivistQueuePullEnforcesWakeBatchLimit(t *testing.T) {
 			if err := json.Unmarshal([]byte(out), &result); err != nil {
 				t.Fatalf("decode queue_pull: %v", err)
 			}
-			if result.Count != archivistPullLimit || len(result.Items) != archivistPullLimit {
-				t.Fatalf("queue_pull result = %#v, want %d items", result, archivistPullLimit)
+			if result.Count != tc.want || len(result.Items) != tc.want {
+				t.Fatalf("queue_pull result count = %d (%d items), want %d", result.Count, len(result.Items), tc.want)
 			}
 		})
 	}
@@ -284,5 +298,116 @@ func TestQueueAckToolDiscardsCompletedReceiptBeforeKeyRecreation(t *testing.T) {
 	items, err := store.Peek(t.Context(), "archivist", 1)
 	if err != nil || len(items) != 1 || string(items[0].Payload) != `{"v":2}` {
 		t.Fatalf("recreated item was not retained: items=%#v err=%v", items, err)
+	}
+}
+
+// TestQueuePullReportsRemainingDepth pins the signal a self-paced loop
+// needs and did not have. A pull that hands back three items looked
+// identical whether the queue held three or three hundred, so a loop
+// choosing its own sleep was choosing it blind — and the archivist's
+// backlog grew to 266 behind a four-hour nap that looked entirely
+// reasonable from where it was standing.
+func TestQueuePullReportsRemainingDepth(t *testing.T) {
+	pullOnce := func(t *testing.T, enqueued, limit int) queuePullResult {
+		t.Helper()
+
+		db, err := database.OpenMemory()
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = db.Close() })
+		store, err := loopqueue.NewStore(db, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range enqueued {
+			subject := fmt.Sprintf("session:%03d", i)
+			if err := store.Enqueue(t.Context(), "archivist", subject, 0, []byte(`{}`)); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		var pull func(context.Context, map[string]any) (string, error)
+		for _, tool := range buildLoopQueueTools(store, "archivist") {
+			if tool.Name == "queue_pull" {
+				pull = tool.Handler
+			}
+		}
+		raw, err := pull(logging.WithRequestID(t.Context(), "r1"), map[string]any{"limit": limit})
+		if err != nil {
+			t.Fatalf("pull: %v", err)
+		}
+		var got queuePullResult
+		if err := json.Unmarshal([]byte(raw), &got); err != nil {
+			t.Fatalf("decode %s: %v", raw, err)
+		}
+		return got
+	}
+
+	tests := []struct {
+		name          string
+		enqueued      int
+		limit         int
+		wantCount     int
+		wantRemaining int
+	}{
+		{
+			// The case that motivated this: a full batch, and a great
+			// deal more behind it.
+			name: "a deep queue says how deep", enqueued: 266, limit: 3,
+			wantCount: 3, wantRemaining: 263,
+		},
+		{
+			// Peeked items stay pending until acked, so remaining has to
+			// exclude the batch in hand or it would double-count it.
+			name: "remaining excludes the batch in hand", enqueued: 5, limit: 5,
+			wantCount: 5, wantRemaining: 0,
+		},
+		{name: "an exhausted queue reports nothing behind it", enqueued: 2, limit: 3, wantCount: 2, wantRemaining: 0},
+		{name: "an empty queue", enqueued: 0, limit: 3, wantCount: 0, wantRemaining: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pullOnce(t, tt.enqueued, tt.limit)
+			if got.Count != tt.wantCount {
+				t.Errorf("count = %d, want %d", got.Count, tt.wantCount)
+			}
+			if got.Remaining != tt.wantRemaining {
+				t.Errorf("remaining = %d, want %d", got.Remaining, tt.wantRemaining)
+			}
+			// Depth alone cannot tell a burst that just arrived from a
+			// backlog losing ground for days, and those want different
+			// sleeps — so the wait is reported whenever anything remains.
+			if tt.wantRemaining > 0 && got.OldestWait == "" {
+				t.Error("remaining work reported with no oldest_wait")
+			}
+			if tt.wantRemaining == 0 && got.OldestWait != "" {
+				t.Errorf("oldest_wait = %q with nothing remaining", got.OldestWait)
+			}
+		})
+	}
+}
+
+// TestArchivistPullCeilingExceedsItsDefault pins that a backlog can
+// actually be worked through. The default and the maximum were the same
+// number, so no prompt could ask for a bigger batch and a queue could
+// only ever drain three subjects per wake however far behind it fell.
+// The default is unchanged: steady state should still be three careful
+// subjects, not twelve rushed ones.
+func TestArchivistPullCeilingExceedsItsDefault(t *testing.T) {
+	def, max := queuePullLimits("archivist")
+	if def != archivistPullDefaultLimit {
+		t.Errorf("default = %d, want %d", def, archivistPullDefaultLimit)
+	}
+	if max <= def {
+		t.Errorf("max = %d and default = %d; a backlog cannot be worked down when they are equal", max, def)
+	}
+	// Each subject pulls a session transcript into context. A ceiling
+	// large enough to push one call past a local model's window would
+	// route that turn to a cloud provider, which fixes the backlog by
+	// quietly paying more for it.
+	if max > queuePullMaxLimit {
+		t.Errorf("max = %d exceeds the general ceiling %d", max, queuePullMaxLimit)
 	}
 }

--- a/internal/app/loop_queue_tools_test.go
+++ b/internal/app/loop_queue_tools_test.go
@@ -373,8 +373,11 @@ func TestQueuePullReportsRemainingDepth(t *testing.T) {
 			if got.Count != tt.wantCount {
 				t.Errorf("count = %d, want %d", got.Count, tt.wantCount)
 			}
-			if got.Remaining != tt.wantRemaining {
-				t.Errorf("remaining = %d, want %d", got.Remaining, tt.wantRemaining)
+			if got.Remaining == nil {
+				t.Fatalf("remaining = null, want it measured as %d", tt.wantRemaining)
+			}
+			if *got.Remaining != tt.wantRemaining {
+				t.Errorf("remaining = %d, want %d", *got.Remaining, tt.wantRemaining)
 			}
 			// Depth alone cannot tell a burst that just arrived from a
 			// backlog losing ground for days, and those want different
@@ -409,5 +412,82 @@ func TestArchivistPullCeilingExceedsItsDefault(t *testing.T) {
 	// quietly paying more for it.
 	if max > queuePullMaxLimit {
 		t.Errorf("max = %d exceeds the general ceiling %d", max, queuePullMaxLimit)
+	}
+}
+
+// TestQueuePullOldestWaitDescribesWhatIsLeft pins that the reported age
+// belongs to the backlog, not to the batch in hand.
+//
+// Drain order is oldest-first within a priority, so an aggregate over the
+// whole partition necessarily returns an item this pull just handed over.
+// A loop reading that would size its sleep against the age of work it had
+// already picked up — precisely backwards.
+func TestQueuePullOldestWaitDescribesWhatIsLeft(t *testing.T) {
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store, err := loopqueue.NewStore(db, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Four items, of which the three that a batch would take are made
+	// genuinely older. Enqueueing in a loop is not enough: the rows land
+	// inside the same second and their timestamps tie, which hides the
+	// very difference this test exists to detect.
+	for i := range 4 {
+		if err := store.Enqueue(t.Context(), "archivist", fmt.Sprintf("session:%d", i), 0, []byte(`{}`)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := db.ExecContext(t.Context(),
+		`UPDATE loop_queue SET enqueued_at = datetime(enqueued_at, '-1 hour')
+		 WHERE dedup_key IN ('session:0','session:1','session:2')`); err != nil {
+		t.Fatalf("backdate: %v", err)
+	}
+
+	pending, oldest, err := store.PendingBeyond(t.Context(), "archivist", 3)
+	if err != nil {
+		t.Fatalf("PendingBeyond: %v", err)
+	}
+	if pending != 1 {
+		t.Fatalf("pending beyond 3 = %d, want 1", pending)
+	}
+
+	all, wholePartitionOldest, err := store.PendingBeyond(t.Context(), "archivist", 0)
+	if err != nil {
+		t.Fatalf("PendingBeyond(0): %v", err)
+	}
+	if all != 4 {
+		t.Fatalf("pending beyond 0 = %d, want 4", all)
+	}
+	if !oldest.After(wholePartitionOldest) {
+		t.Errorf("oldest beyond the batch (%s) is not newer than the partition's oldest (%s); the batch in hand is being described",
+			oldest, wholePartitionOldest)
+	}
+}
+
+// TestQueuePullUnmeasuredDepthIsNullNotZero pins the result shape for a
+// failed probe. Reporting 0 would be indistinguishable from a drained
+// queue — the same absent-signal-reads-as-healthy failure this whole
+// change exists to remove, one layer down.
+func TestQueuePullUnmeasuredDepthIsNullNotZero(t *testing.T) {
+	unmeasured, err := json.Marshal(queuePullResult{Count: 1, Items: []queueItemView{{Subject: "session:x"}}})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(unmeasured), `"remaining":null`) {
+		t.Errorf("unmeasured depth serialized as %s, want an explicit null", unmeasured)
+	}
+
+	zero := 0
+	measured, err := json.Marshal(queuePullResult{Count: 1, Remaining: &zero, Items: []queueItemView{{Subject: "session:x"}}})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(measured), `"remaining":0`) {
+		t.Errorf("a measured empty queue serialized as %s, want remaining 0", measured)
 	}
 }

--- a/internal/app/new_channels.go
+++ b/internal/app/new_channels.go
@@ -534,9 +534,9 @@ func (a *App) initChannels(s *newState) error {
 		LiveRegistry:     a.loopRegistry,
 	})
 	a.loop.Tools().ConfigureLoopRuntimeTools(tools.LoopRuntimeToolDeps{
-		Registry:       a.loopRegistry,
-		LaunchLoop:     a.launchLoop,
-		MailboxPending: a.loopQueue.PendingCounts,
+		Registry:     a.loopRegistry,
+		LaunchLoop:   a.launchLoop,
+		QueuePending: a.loopQueue.PendingCounts,
 	})
 	a.initMessageBus()
 	a.loop.Tools().ConfigureMessageTools(tools.MessageToolDeps{

--- a/internal/runtime/loop/loop_view.go
+++ b/internal/runtime/loop/loop_view.go
@@ -125,10 +125,10 @@ type LoopView struct {
 	WakeReasons24h map[string]int `json:"wake_reasons_24h,omitempty"`
 
 	// ---- economics (%CPU / %MEM / TIME) ----
-	// MailboxPending is the loop's durable mailbox depth: work-queue
+	// QueuePending is the loop's durable work-queue depth: work-queue
 	// items enqueued for it and not yet acked. 0 is a real "nothing
 	// pending"; null means depth was not measured for this projection.
-	MailboxPending    *int `json:"mailbox_pending"`
+	QueuePending      *int `json:"queue_pending"`
 	Iterations        *int `json:"iterations"`
 	Attempts          *int `json:"attempts"`
 	TotalInputTokens  *int `json:"total_input_tokens"`
@@ -274,24 +274,24 @@ type LoopPolicyInfo struct {
 // not per row. Construct one with NewLoopViewResolver, then call FromStatus
 // for each loop.
 type LoopViewResolver struct {
-	nameByID       map[string]string
-	parentByID     map[string]string
-	childCount     map[string]int
-	policyByName   map[string]LoopPolicyInfo
-	mailboxPending map[string]int
-	now            time.Time
+	nameByID     map[string]string
+	parentByID   map[string]string
+	childCount   map[string]int
+	policyByName map[string]LoopPolicyInfo
+	queuePending map[string]int
+	now          time.Time
 }
 
-// WithMailboxPending joins durable mailbox depth (pending work-queue
+// WithQueuePending joins durable work-queue depth (pending work-queue
 // items keyed by loop name) onto every projected row. When the join is
 // wired, a loop absent from the map reports an explicit 0 — a real
 // "nothing pending" datum; when it is not wired, rows report null,
 // meaning depth was not measured for this projection.
-func (r LoopViewResolver) WithMailboxPending(byName map[string]int) LoopViewResolver {
+func (r LoopViewResolver) WithQueuePending(byName map[string]int) LoopViewResolver {
 	if byName == nil {
 		byName = map[string]int{}
 	}
-	r.mailboxPending = byName
+	r.queuePending = byName
 	return r
 }
 
@@ -432,9 +432,9 @@ func (r LoopViewResolver) FromStatus(s Status) LoopView {
 	}
 
 	applyLiveTelemetry(&v, s, r.now)
-	if r.mailboxPending != nil {
-		pending := r.mailboxPending[s.Name]
-		v.MailboxPending = &pending
+	if r.queuePending != nil {
+		pending := r.queuePending[s.Name]
+		v.QueuePending = &pending
 	}
 	return v
 }

--- a/internal/state/loopqueue/queue_stats.go
+++ b/internal/state/loopqueue/queue_stats.go
@@ -52,8 +52,28 @@ func (s *Store) PendingStats(ctx context.Context) ([]ConsumerPending, error) {
 	return stats, rows.Err()
 }
 
+// PendingFor returns one consumer's live backlog: how many items are
+// pending and when the oldest was enqueued. A partition with no pending
+// work reports zero and a zero time.
+//
+// Separate from [Store.PendingStats] because the hot caller is a single
+// loop asking about itself on every pull, and scanning every partition
+// to answer that would make the common case pay for the census.
+func (s *Store) PendingFor(ctx context.Context, consumer string) (pending int, oldest time.Time, err error) {
+	var oldestRaw any
+	row := s.db.QueryRowContext(ctx, `
+		SELECT COUNT(*), MIN(enqueued_at)
+		FROM loop_queue
+		WHERE status = ? AND consumer_loop = ?
+	`, StatusPending, strings.TrimSpace(consumer))
+	if err := row.Scan(&pending, &oldestRaw); err != nil {
+		return 0, time.Time{}, fmt.Errorf("loopqueue: pending for %q: %w", consumer, err)
+	}
+	return pending, parseQueueTimestamp(oldestRaw), nil
+}
+
 // PendingCounts returns pending depth keyed by consumer partition —
-// the join shape loop views use to attach mailbox depth to a loop row.
+// the join shape loop views use to attach queue depth to a loop row.
 // Partitions with no pending work are absent from the map.
 func (s *Store) PendingCounts(ctx context.Context) (map[string]int, error) {
 	stats, err := s.PendingStats(ctx)

--- a/internal/state/loopqueue/queue_stats.go
+++ b/internal/state/loopqueue/queue_stats.go
@@ -52,22 +52,40 @@ func (s *Store) PendingStats(ctx context.Context) ([]ConsumerPending, error) {
 	return stats, rows.Err()
 }
 
-// PendingFor returns one consumer's live backlog: how many items are
-// pending and when the oldest was enqueued. A partition with no pending
-// work reports zero and a zero time.
+// PendingBeyond returns what is still queued for one consumer after the
+// first skip items in drain order: how many, and when the oldest of them
+// was enqueued. A partition with nothing behind that point reports zero
+// and a zero time.
+//
+// The offset is the whole point. Peeked items stay pending until acked,
+// so a plain aggregate over the partition counts the batch the caller is
+// already holding — and because drain order is oldest-first within a
+// priority, MIN(enqueued_at) over that set always describes an item in
+// hand rather than one still waiting. A loop deciding how long to sleep
+// would be reading the age of work it had just picked up.
+//
+// The ordering here must stay identical to the one [Store.Peek] uses, or
+// the offset skips the wrong rows.
 //
 // Separate from [Store.PendingStats] because the hot caller is a single
-// loop asking about itself on every pull, and scanning every partition
-// to answer that would make the common case pay for the census.
-func (s *Store) PendingFor(ctx context.Context, consumer string) (pending int, oldest time.Time, err error) {
+// loop asking about itself on every pull, and scanning every partition to
+// answer that would make the common case pay for the census.
+func (s *Store) PendingBeyond(ctx context.Context, consumer string, skip int) (pending int, oldest time.Time, err error) {
+	if skip < 0 {
+		skip = 0
+	}
 	var oldestRaw any
 	row := s.db.QueryRowContext(ctx, `
-		SELECT COUNT(*), MIN(enqueued_at)
-		FROM loop_queue
-		WHERE status = ? AND consumer_loop = ?
-	`, StatusPending, strings.TrimSpace(consumer))
+		SELECT COUNT(*), MIN(enqueued_at) FROM (
+			SELECT enqueued_at
+			FROM loop_queue
+			WHERE consumer_loop = ? AND status = ?
+			ORDER BY priority DESC, enqueued_at ASC, dedup_key ASC
+			LIMIT -1 OFFSET ?
+		)
+	`, strings.TrimSpace(consumer), StatusPending, skip)
 	if err := row.Scan(&pending, &oldestRaw); err != nil {
-		return 0, time.Time{}, fmt.Errorf("loopqueue: pending for %q: %w", consumer, err)
+		return 0, time.Time{}, fmt.Errorf("loopqueue: pending beyond %d for %q: %w", skip, consumer, err)
 	}
 	return pending, parseQueueTimestamp(oldestRaw), nil
 }

--- a/internal/tools/loop_runtime_tools.go
+++ b/internal/tools/loop_runtime_tools.go
@@ -25,10 +25,10 @@ const (
 type LoopRuntimeToolDeps struct {
 	Registry   *looppkg.Registry
 	LaunchLoop func(context.Context, looppkg.Launch) (looppkg.LaunchResult, error)
-	// MailboxPending reports durable mailbox depth by loop name, joined
-	// onto loop_status rows as mailbox_pending. Optional: unwired, rows
+	// QueuePending reports durable work-queue depth by loop name, joined
+	// onto loop_status rows as queue_pending. Optional: unwired, rows
 	// report null (depth not measured) rather than a fake zero.
-	MailboxPending func(context.Context) (map[string]int, error)
+	QueuePending func(context.Context) (map[string]int, error)
 }
 
 // ConfigureLoopRuntimeTools stores the runtime dependencies needed by the
@@ -36,7 +36,7 @@ type LoopRuntimeToolDeps struct {
 func (r *Registry) ConfigureLoopRuntimeTools(deps LoopRuntimeToolDeps) {
 	r.liveLoopRegistry = deps.Registry
 	r.launchLoop = deps.LaunchLoop
-	r.mailboxPendingCounts = deps.MailboxPending
+	r.queuePendingCounts = deps.QueuePending
 	r.registerLoopRuntimeTools()
 	r.registerLoopContainers()
 }
@@ -165,11 +165,11 @@ func (r *Registry) handleLoopStatus(ctx context.Context, args map[string]any) (s
 	// per row) plus the definition-policy join, so every row is the canonical
 	// LoopView — the same rich shape every loop-data tool emits.
 	resolver := looppkg.NewLoopViewResolver(statuses, r.loopPolicyByName(), time.Now())
-	// Join durable mailbox depth when the queue is wired. A failed probe
+	// Join durable work-queue depth when the queue is wired. A failed probe
 	// leaves depth null (not measured) rather than failing the census.
-	if r.mailboxPendingCounts != nil {
-		if counts, err := r.mailboxPendingCounts(ctx); err == nil {
-			resolver = resolver.WithMailboxPending(counts)
+	if r.queuePendingCounts != nil {
+		if counts, err := r.queuePendingCounts(ctx); err == nil {
+			resolver = resolver.WithQueuePending(counts)
 		}
 	}
 	filtered := make([]looppkg.LoopView, 0, len(statuses))

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -106,7 +106,7 @@ type Registry struct {
 	launchLoopDefinition                       func(context.Context, string, looppkg.Launch) (looppkg.LaunchResult, error)
 	liveLoopRegistry                           *looppkg.Registry
 	launchLoop                                 func(context.Context, looppkg.Launch) (looppkg.LaunchResult, error)
-	mailboxPendingCounts                       func(context.Context) (map[string]int, error)
+	queuePendingCounts                         func(context.Context) (map[string]int, error)
 	messageBus                                 *messages.Bus
 	loopIntentDeps                             LoopIntentToolDeps
 


### PR DESCRIPTION
The archivist's queue reached **266 subjects** behind a four-hour sleep. The sleep was not the bug — it was a reasonable choice given what the loop could see, which was nothing.

`queue_pull` returned only what it handed over. A pull of three items read identically whether the queue held three or three hundred:

```json
{"count": 3, "items": [...]}
```

Same shape as every other defect this week: **the absent signal reads as the healthy value.**

## What changes

`queue_pull` now reports depth beyond the batch in hand, plus how long the oldest item has waited:

```json
{"count": 3, "remaining": 263, "oldest_wait": "-4d", "items": [...]}
```

`oldest_wait` earns its place because depth alone cannot separate a burst that just arrived from a backlog losing ground for days, and those call for different sleeps. Both land where the decision is actually made — no extra tool call, no new context source.

Peeked items stay pending until acked, so `remaining` deliberately excludes the batch in hand; reporting the raw count would double-count what the loop is already holding.

## The ceiling that was not one

```go
// before
func queuePullLimits(name string) (default, max int) {
    if name == archivist { return archivistPullLimit, archivistPullLimit }   // 3, 3
```

Default and maximum were the same number, so **no prompt could ask for a bigger batch.** Editing the loop definition's `limit: 3` to say 10 would have silently clamped back to 3, and a backlog could only ever drain three subjects per wake however far behind it fell.

Now `(3, 12)`. The default is unchanged on purpose — steady state should stay three careful subjects rather than twelve rushed ones, since dossier synthesis is the product. A loop that can see it is behind may take a bigger bite.

**Twelve rather than the general 25** because each subject pulls a session transcript into context. A batch large enough to push one call past a local model's window routes that turn to a cloud provider, which fixes the backlog by quietly paying more for it. At twelve on the current four-hour cadence that is 72/day — 266 drains in under four days with no cadence change at all.

## The rename

`mailbox_pending` becomes `queue_pending`. It was wired to `loopQueue.PendingCounts` while its own Godoc read *"durable mailbox depth: work-queue items"* — contradicting itself inside one sentence. That naming is why a 266-deep work queue was read as notification noise.

The ambiguity is not hypothetical. `mailbox` already means IMAP folder in `email_tools.go`, and the archivist will be processing email in time. `queue_*` now consistently means the durable work queue, matching `queue_pull`, `queue_ack`, `loopqueue`, and the loop definitions that already call it that. The genuine notification `Mailbox` keeps its name.

## Test plan

- [x] `just ci` passes locally
- [x] A deep queue reports its depth; 266 enqueued and 3 pulled gives `remaining: 263`
- [x] `remaining` excludes the batch in hand rather than double-counting it
- [x] An exhausted or empty queue reports nothing behind it and omits `oldest_wait`
- [x] Anything remaining always carries `oldest_wait`
- [x] The archivist ceiling now exceeds its default, and stays within the general ceiling
- [x] An omitted limit still takes the default of 3; an oversized limit clamps to 12 rather than 3
- [x] A failed depth probe leaves `remaining` at zero and warns, rather than failing the pull and trading a whole iteration for a number
- [ ] Deployed, and the archivist observed choosing a shorter sleep against a deep queue

## Not in this PR

The loop definition prose still says *"Call `queue_pull` exactly once with `limit: 3`"*. That is operator-signed content in the core docroot, and it is what teaches the archivist to use these two new numbers. Happy to stage that edit separately for signing.