### PR TITLE
fix(context): bound each provider, reserve for the gated tier, and name who spent the budget

### DIFF
--- a/internal/runtime/agent/tag_context.go
+++ b/internal/runtime/agent/tag_context.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -403,101 +404,6 @@ func (a *TagContextAssembler) Build(ctx context.Context, req agentctx.ContextReq
 // upstream and the failure surfaced downstream under the wrong name.
 const slowContextSourceThreshold = 250 * time.Millisecond
 
-const (
-	// perProviderContextBudget bounds any single context provider, so
-	// that one slow source cannot consume the whole shared assembly
-	// deadline and starve everything sequenced behind it.
-	//
-	// Comfortably above slowContextSourceThreshold: a provider that is
-	// merely slow should finish and be warned about, not be killed. What
-	// this stops is the unbounded case.
-	perProviderContextBudget = 500 * time.Millisecond
-
-	// gatedProviderReserve is the slice of the shared budget withheld
-	// from the tagged tier so the gated tier always gets to run.
-	//
-	// A per-provider cap alone does not save it. Enough well-behaved
-	// tagged providers exhaust the budget by simple arithmetic with no
-	// provider misbehaving at all, and the gated tier carries document
-	// advertising — losing it means a loop wakes with no dossier offers
-	// and nothing saying why.
-	gatedProviderReserve = 500 * time.Millisecond
-)
-
-// reserveForGatedProviders returns a context for the tagged tier that
-// expires early enough to leave the gated tier its reserve.
-//
-// Returns the parent unchanged when there is no deadline to divide, or
-// when the remaining budget is too small to split usefully — halving an
-// already-tight budget would starve the tagged tier to protect the gated
-// one, which is the same failure wearing the other hat.
-func reserveForGatedProviders(ctx context.Context) (context.Context, context.CancelFunc) {
-	deadline, ok := ctx.Deadline()
-	if !ok {
-		return ctx, func() {}
-	}
-	remaining := time.Until(deadline)
-	if remaining <= 2*gatedProviderReserve {
-		return ctx, func() {}
-	}
-	return context.WithDeadline(ctx, deadline.Add(-gatedProviderReserve))
-}
-
-// withProviderBudget bounds one provider's run. The cap never extends a
-// deadline: an inherited one that is already tighter wins.
-func withProviderBudget(ctx context.Context) (context.Context, context.CancelFunc) {
-	return context.WithTimeout(ctx, perProviderContextBudget)
-}
-
-// assemblyBudget tracks who spent the shared context-assembly deadline,
-// so a provider that never got to run can say why instead of reporting a
-// failure of its own.
-//
-// This is the other half of the fix the 2026-08-12 incident prompted.
-// That one added the slow-source WARN above, which names the culprit on
-// its own line; the victim still logged "context deadline exceeded"
-// under its own name on another, with nothing connecting the two. A
-// reader — human or loop — saw a document provider time out and went
-// looking at the document corpus. Twice, in one hour, on 2026-09-04.
-type assemblyBudget struct {
-	// spentBy identifies the provider that was running when the shared
-	// deadline expired. Empty while budget remains.
-	spentBy string
-}
-
-// note records a provider that has just finished, marking it as the
-// spender if the shared deadline died on its watch.
-func (b *assemblyBudget) note(ctx context.Context, source, detail string) {
-	if b.spentBy != "" || ctx.Err() == nil {
-		return
-	}
-	b.spentBy = source
-	if detail != "" {
-		b.spentBy += " (" + detail + ")"
-	}
-}
-
-// skipped reports a provider that was never run because the budget was
-// already gone, and returns whether it should be skipped.
-//
-// Deliberately a WARN rather than a DEBUG: a context section silently
-// missing is how a loop ends up auditing the system with one sense
-// switched off and no signal that it is off.
-func (b *assemblyBudget) skipped(ctx context.Context, logger *slog.Logger, source, detail string) bool {
-	if ctx.Err() == nil {
-		return false
-	}
-	args := []any{"source", source, "reason", "assembly budget already spent upstream"}
-	if detail != "" {
-		args = append(args, "detail", detail)
-	}
-	if b.spentBy != "" {
-		args = append(args, "spent_by", b.spentBy)
-	}
-	logger.Warn("context provider skipped, not attempted", args...)
-	return true
-}
-
 // warnSlowContextSource emits the budget-accounting WARN for a context
 // source that ran long. detail is a tag name or provider type; empty
 // is fine for block-level sources.
@@ -511,6 +417,170 @@ func warnSlowContextSource(logger *slog.Logger, source, detail string, start tim
 		args = append(args, "detail", detail)
 	}
 	logger.Warn("context source ran long against the shared assembly budget", args...)
+}
+
+const (
+	// perProviderContextBudget is the most any single context provider
+	// may take, however much budget remains. Comfortably above
+	// slowContextSourceThreshold: a merely slow provider should finish
+	// and be warned about, not be killed.
+	perProviderContextBudget = 500 * time.Millisecond
+
+	// minGatedProviderSlice is the per-provider floor the gated reserve
+	// is sized from.
+	//
+	// A flat reserve does not work here. The gated tier holds around a
+	// dozen providers and the document advertiser registers near the end
+	// of them, so a reserve equal to one provider's cap guarantees the
+	// advertiser nothing: any earlier slow provider spends the whole
+	// thing and the tier that was supposedly protected is skipped anyway.
+	minGatedProviderSlice = 100 * time.Millisecond
+)
+
+// reserveForGatedProviders returns a context for the tagged tier that
+// expires early enough to leave the gated tier a slice per provider.
+//
+// The reserve scales with how many gated providers were admitted, and is
+// bounded at half the remaining budget so protecting the gated tier
+// cannot starve the tagged one — the same failure wearing the other hat.
+// Returns the parent unchanged when there is no deadline to divide, or
+// nothing to divide it for.
+func reserveForGatedProviders(ctx context.Context, gatedCount int) (context.Context, context.CancelFunc) {
+	deadline, ok := ctx.Deadline()
+	if !ok || gatedCount <= 0 {
+		return ctx, func() {}
+	}
+	remaining := time.Until(deadline)
+	reserve := time.Duration(gatedCount) * minGatedProviderSlice
+	if half := remaining / 2; reserve > half {
+		reserve = half
+	}
+	if reserve <= 0 || remaining <= reserve {
+		return ctx, func() {}
+	}
+	return context.WithDeadline(ctx, deadline.Add(-reserve))
+}
+
+// providerSlice bounds one provider's run to an equal share of what its
+// tier has left, never more than the per-provider cap.
+//
+// Shared rather than flat so that position in the registration order
+// stops deciding who runs at all. Providers that finish quickly hand
+// their unused time to the ones behind them, so the advertiser at the end
+// of the gated tier gets the slack in the healthy case and a floor in the
+// bad one.
+func providerSlice(ctx context.Context, remainingProviders int) (context.Context, context.CancelFunc) {
+	slice := perProviderContextBudget
+	if deadline, ok := ctx.Deadline(); ok && remainingProviders > 1 {
+		if share := time.Until(deadline) / time.Duration(remainingProviders); share < slice {
+			slice = share
+		}
+	}
+	return context.WithTimeout(ctx, slice)
+}
+
+// activeTaggedProviders lists the tagged providers this request will run,
+// so each can be given an equal share of the tier rather than a flat cap
+// that lets the first few spend everything.
+func activeTaggedProviders(providers map[string]TagContextProvider, req agentctx.ContextRequest) []string {
+	var out []string
+	for _, tag := range sortedActiveTags(req.ActiveTags) {
+		if _, ok := providers[tag]; ok {
+			out = append(out, tag)
+		}
+	}
+	return out
+}
+
+// admittedGatedProviders counts the gated providers this request will
+// actually admit, which is what the reserve must be sized against — a
+// task-mode turn opens neither gate and needs no reserve at all.
+func admittedGatedProviders(providers []gatedContextProvider, req agentctx.ContextRequest) int {
+	n := 0
+	for _, gp := range providers {
+		if gp.loopScoped {
+			if req.IncludeLoopScoped {
+				n++
+			}
+			continue
+		}
+		if req.IncludeAlways {
+			n++
+		}
+	}
+	return n
+}
+
+// assemblyBudget tracks who spent the shared context-assembly deadline,
+// so a provider that never got to run can say why instead of reporting a
+// failure of its own.
+//
+// This is the other half of the fix the 2026-08-12 incident prompted.
+// That one added the slow-source WARN above, which names the culprit on
+// its own line; the victim still logged "context deadline exceeded" under
+// its own name on another, with nothing connecting the two. A reader —
+// human or loop — saw a document provider time out and went looking at
+// the document corpus. Twice, in one hour, on 2026-09-04.
+type assemblyBudget struct {
+	// spentBy identifies the provider running when the *shared* deadline
+	// expired. Empty while the assembly budget remains.
+	spentBy string
+}
+
+// note records a provider that has just finished, marking it as the
+// spender if the shared deadline died on its watch.
+//
+// parent is deliberately the assembler's own context, never a tier's:
+// the tagged tier expires early by design, and recording that as an
+// assembly spender would blame a well-behaved provider for a deadline
+// nobody had reached. Only DeadlineExceeded attributes — a cancelled
+// request spent no budget, and naming a culprit for one would be an
+// invented fact of exactly the kind this field exists to prevent.
+func (b *assemblyBudget) note(parent context.Context, source, detail string) {
+	if b.spentBy != "" || !errors.Is(parent.Err(), context.DeadlineExceeded) {
+		return
+	}
+	b.spentBy = source
+	if detail != "" {
+		b.spentBy += " (" + detail + ")"
+	}
+}
+
+// skipped reports a provider that was never run and returns whether to
+// skip it. tier is the context it would have run under; parent is the
+// assembler's own.
+//
+// The three reasons stay apart because they mean different things to
+// whoever reads the log. A spent assembly budget names its spender. A
+// tier reaching its reserved boundary is the reserve working as designed
+// and names no culprit, because there is no fault. A cancelled request is
+// neither, and inventing a spender for it would be the same species of
+// error as the one this whole change exists to remove.
+//
+// A WARN rather than a DEBUG: a context section silently missing is how a
+// loop ends up auditing the system with one sense switched off and no
+// signal that it is off.
+func (b *assemblyBudget) skipped(tier, parent context.Context, logger *slog.Logger, source, detail string) bool {
+	if tier.Err() == nil {
+		return false
+	}
+	args := []any{"source", source}
+	switch {
+	case errors.Is(parent.Err(), context.DeadlineExceeded):
+		args = append(args, "reason", "assembly budget already spent upstream")
+		if b.spentBy != "" {
+			args = append(args, "spent_by", b.spentBy)
+		}
+	case errors.Is(tier.Err(), context.DeadlineExceeded):
+		args = append(args, "reason", "tier reached its reserved slice; the assembly budget is intact")
+	default:
+		args = append(args, "reason", "assembly cancelled")
+	}
+	if detail != "" {
+		args = append(args, "detail", detail)
+	}
+	logger.Warn("context provider skipped, not attempted", args...)
+	return true
 }
 
 func (a *TagContextAssembler) BuildSections(ctx context.Context, req agentctx.ContextRequest) []agentctx.ContextSection {
@@ -583,27 +653,36 @@ func (a *TagContextAssembler) BuildSections(ctx context.Context, req agentctx.Co
 	}
 
 	warnSlowContextSource(a.logger, "tagged_kb_articles", "", kbStart)
+	// Source 1 runs outside the per-provider cap — it is a filesystem
+	// scan, not a registered provider — so it can overrun the shared
+	// deadline on its own. Recorded here, or every provider behind it
+	// would be skipped with no spender named, which is exactly the
+	// disconnected culprit and victim this change exists to end.
+	budget.note(ctx, "tagged_kb_articles", "")
 
 	// Source 2: Tagged live providers, filtered by ActiveTags.
 	//
 	// Run against a deadline that expires before the assembler's, so the
 	// gated tier below is reached even when every tagged provider runs
 	// to its cap.
-	taggedCtx, releaseTagged := reserveForGatedProviders(ctx)
+	gatedRemaining := admittedGatedProviders(gatedProviders, req)
+	taggedRemaining := len(activeTaggedProviders(tagProviders, req))
+	taggedCtx, releaseTagged := reserveForGatedProviders(ctx, gatedRemaining)
 	for _, tag := range sortedActiveTags(req.ActiveTags) {
 		p, ok := tagProviders[tag]
 		if !ok {
 			continue
 		}
-		if budget.skipped(taggedCtx, a.logger, "tagged_provider", tag) {
+		if budget.skipped(taggedCtx, ctx, a.logger, "tagged_provider", tag) {
 			continue
 		}
 		pStart := time.Now()
-		providerCtx, releaseProvider := withProviderBudget(taggedCtx)
+		providerCtx, releaseProvider := providerSlice(taggedCtx, taggedRemaining)
+		taggedRemaining--
 		content, advertised, err := a.contextFromProvider(providerCtx, req, p, &advertisements)
 		releaseProvider()
 		warnSlowContextSource(a.logger, "tagged_provider", tag, pStart)
-		budget.note(taggedCtx, "tagged_provider", tag)
+		budget.note(ctx, "tagged_provider", tag)
 		if err != nil {
 			a.logger.Warn("tag context provider failed",
 				"tag", tag, "error", err)
@@ -651,11 +730,12 @@ func (a *TagContextAssembler) BuildSections(ctx context.Context, req agentctx.Co
 			defaultBucket, source = agentctx.ContextBucketLiveState, "loop_scoped_provider"
 		}
 		detail := fmt.Sprintf("%T", gp.provider)
-		if budget.skipped(ctx, a.logger, source, detail) {
+		if budget.skipped(ctx, ctx, a.logger, source, detail) {
 			continue
 		}
 		pStart := time.Now()
-		providerCtx, releaseProvider := withProviderBudget(ctx)
+		providerCtx, releaseProvider := providerSlice(ctx, gatedRemaining)
+		gatedRemaining--
 		content, advertised, err := a.contextFromProvider(providerCtx, req, gp.provider, &advertisements)
 		releaseProvider()
 		warnSlowContextSource(a.logger, source, detail, pStart)

--- a/internal/runtime/agent/tag_context.go
+++ b/internal/runtime/agent/tag_context.go
@@ -403,6 +403,101 @@ func (a *TagContextAssembler) Build(ctx context.Context, req agentctx.ContextReq
 // upstream and the failure surfaced downstream under the wrong name.
 const slowContextSourceThreshold = 250 * time.Millisecond
 
+const (
+	// perProviderContextBudget bounds any single context provider, so
+	// that one slow source cannot consume the whole shared assembly
+	// deadline and starve everything sequenced behind it.
+	//
+	// Comfortably above slowContextSourceThreshold: a provider that is
+	// merely slow should finish and be warned about, not be killed. What
+	// this stops is the unbounded case.
+	perProviderContextBudget = 500 * time.Millisecond
+
+	// gatedProviderReserve is the slice of the shared budget withheld
+	// from the tagged tier so the gated tier always gets to run.
+	//
+	// A per-provider cap alone does not save it. Enough well-behaved
+	// tagged providers exhaust the budget by simple arithmetic with no
+	// provider misbehaving at all, and the gated tier carries document
+	// advertising — losing it means a loop wakes with no dossier offers
+	// and nothing saying why.
+	gatedProviderReserve = 500 * time.Millisecond
+)
+
+// reserveForGatedProviders returns a context for the tagged tier that
+// expires early enough to leave the gated tier its reserve.
+//
+// Returns the parent unchanged when there is no deadline to divide, or
+// when the remaining budget is too small to split usefully — halving an
+// already-tight budget would starve the tagged tier to protect the gated
+// one, which is the same failure wearing the other hat.
+func reserveForGatedProviders(ctx context.Context) (context.Context, context.CancelFunc) {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return ctx, func() {}
+	}
+	remaining := time.Until(deadline)
+	if remaining <= 2*gatedProviderReserve {
+		return ctx, func() {}
+	}
+	return context.WithDeadline(ctx, deadline.Add(-gatedProviderReserve))
+}
+
+// withProviderBudget bounds one provider's run. The cap never extends a
+// deadline: an inherited one that is already tighter wins.
+func withProviderBudget(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, perProviderContextBudget)
+}
+
+// assemblyBudget tracks who spent the shared context-assembly deadline,
+// so a provider that never got to run can say why instead of reporting a
+// failure of its own.
+//
+// This is the other half of the fix the 2026-08-12 incident prompted.
+// That one added the slow-source WARN above, which names the culprit on
+// its own line; the victim still logged "context deadline exceeded"
+// under its own name on another, with nothing connecting the two. A
+// reader — human or loop — saw a document provider time out and went
+// looking at the document corpus. Twice, in one hour, on 2026-09-04.
+type assemblyBudget struct {
+	// spentBy identifies the provider that was running when the shared
+	// deadline expired. Empty while budget remains.
+	spentBy string
+}
+
+// note records a provider that has just finished, marking it as the
+// spender if the shared deadline died on its watch.
+func (b *assemblyBudget) note(ctx context.Context, source, detail string) {
+	if b.spentBy != "" || ctx.Err() == nil {
+		return
+	}
+	b.spentBy = source
+	if detail != "" {
+		b.spentBy += " (" + detail + ")"
+	}
+}
+
+// skipped reports a provider that was never run because the budget was
+// already gone, and returns whether it should be skipped.
+//
+// Deliberately a WARN rather than a DEBUG: a context section silently
+// missing is how a loop ends up auditing the system with one sense
+// switched off and no signal that it is off.
+func (b *assemblyBudget) skipped(ctx context.Context, logger *slog.Logger, source, detail string) bool {
+	if ctx.Err() == nil {
+		return false
+	}
+	args := []any{"source", source, "reason", "assembly budget already spent upstream"}
+	if detail != "" {
+		args = append(args, "detail", detail)
+	}
+	if b.spentBy != "" {
+		args = append(args, "spent_by", b.spentBy)
+	}
+	logger.Warn("context provider skipped, not attempted", args...)
+	return true
+}
+
 // warnSlowContextSource emits the budget-accounting WARN for a context
 // source that ran long. detail is a tag name or provider type; empty
 // is fine for block-level sources.
@@ -434,6 +529,7 @@ func (a *TagContextAssembler) BuildSections(ctx context.Context, req agentctx.Co
 	seen := make(map[string]bool)
 	acc := newContextAccumulator()
 	var advertisements []contextAdvertisementCandidate
+	var budget assemblyBudget
 
 	// Source 1: Tagged KB articles. Re-scanned and re-read each turn
 	// so frontmatter edits, additions, and deletions propagate
@@ -489,14 +585,25 @@ func (a *TagContextAssembler) BuildSections(ctx context.Context, req agentctx.Co
 	warnSlowContextSource(a.logger, "tagged_kb_articles", "", kbStart)
 
 	// Source 2: Tagged live providers, filtered by ActiveTags.
+	//
+	// Run against a deadline that expires before the assembler's, so the
+	// gated tier below is reached even when every tagged provider runs
+	// to its cap.
+	taggedCtx, releaseTagged := reserveForGatedProviders(ctx)
 	for _, tag := range sortedActiveTags(req.ActiveTags) {
 		p, ok := tagProviders[tag]
 		if !ok {
 			continue
 		}
+		if budget.skipped(taggedCtx, a.logger, "tagged_provider", tag) {
+			continue
+		}
 		pStart := time.Now()
-		content, advertised, err := a.contextFromProvider(ctx, req, p, &advertisements)
+		providerCtx, releaseProvider := withProviderBudget(taggedCtx)
+		content, advertised, err := a.contextFromProvider(providerCtx, req, p, &advertisements)
+		releaseProvider()
 		warnSlowContextSource(a.logger, "tagged_provider", tag, pStart)
+		budget.note(taggedCtx, "tagged_provider", tag)
 		if err != nil {
 			a.logger.Warn("tag context provider failed",
 				"tag", tag, "error", err)
@@ -515,6 +622,8 @@ func (a *TagContextAssembler) BuildSections(ctx context.Context, req agentctx.Co
 				"tag", tag, "source", "tagged_provider", "limit_bytes", maxTagContextBytes)
 		}
 	}
+
+	releaseTagged()
 
 	// Source 3: Gated providers — always-on and loop-scoped — walked
 	// as one list in registration order, each entry admitted by its
@@ -541,9 +650,16 @@ func (a *TagContextAssembler) BuildSections(ctx context.Context, req agentctx.Co
 		if gp.loopScoped {
 			defaultBucket, source = agentctx.ContextBucketLiveState, "loop_scoped_provider"
 		}
+		detail := fmt.Sprintf("%T", gp.provider)
+		if budget.skipped(ctx, a.logger, source, detail) {
+			continue
+		}
 		pStart := time.Now()
-		content, advertised, err := a.contextFromProvider(ctx, req, gp.provider, &advertisements)
-		warnSlowContextSource(a.logger, source, fmt.Sprintf("%T", gp.provider), pStart)
+		providerCtx, releaseProvider := withProviderBudget(ctx)
+		content, advertised, err := a.contextFromProvider(providerCtx, req, gp.provider, &advertisements)
+		releaseProvider()
+		warnSlowContextSource(a.logger, source, detail, pStart)
+		budget.note(ctx, source, detail)
 		if err != nil {
 			a.logger.Warn("gated context provider failed", "source", source, "error", err)
 			continue

--- a/internal/runtime/agent/tag_context_test.go
+++ b/internal/runtime/agent/tag_context_test.go
@@ -1,12 +1,15 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1374,5 +1377,196 @@ func TestTagContextAssemblerSamplesOneClockPerAssembly(t *testing.T) {
 	}
 	if strings.Contains(rendered, "Day: today.") {
 		t.Fatalf("identical templates rendered differently within one assembly: %q", rendered)
+	}
+}
+
+// slowTestProvider blocks until its context dies or its work is done,
+// recording whether it ever actually ran.
+type slowTestProvider struct {
+	work time.Duration
+	name string
+	mu   sync.Mutex
+	ran  bool
+}
+
+func (p *slowTestProvider) TagContext(ctx context.Context, _ agentctx.ContextRequest) (string, error) {
+	p.mu.Lock()
+	p.ran = true
+	p.mu.Unlock()
+	select {
+	case <-time.After(p.work):
+		return p.name + " content", nil
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+}
+
+func (p *slowTestProvider) didRun() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.ran
+}
+
+// TestGatedProvidersSurviveASlowTaggedProvider pins the defect a
+// production loop hit on nearly every wake for days.
+//
+// The tagged and gated tiers walk sequentially against one shared
+// deadline. A tagged provider that consumed all of it left the gated
+// tier — which carries document advertising — inheriting an already-dead
+// context, so the loop woke with no document offers at all. Its own logs
+// blamed the document corpus, because the victim reported under its own
+// name and nothing connected it to the source.
+func TestGatedProvidersSurviveASlowTaggedProvider(t *testing.T) {
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	// Far longer than the whole assembly budget: the unbounded case.
+	hog := &slowTestProvider{work: 10 * time.Second, name: "hog"}
+	gated := &slowTestProvider{work: time.Millisecond, name: "gated"}
+
+	a := NewTagContextAssembler(TagContextAssemblerConfig{Logger: logger})
+	a.RegisterTaggedProvider("metacognitive", hog)
+	a.RegisterAlwaysProvider(gated)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	a.BuildSections(ctx, agentctx.ContextRequest{
+		ActiveTags:    map[string]bool{"metacognitive": true},
+		IncludeAlways: true,
+	})
+	elapsed := time.Since(start)
+
+	if !gated.didRun() {
+		t.Error("the gated provider never ran; a tagged provider starved the tier that carries document advertising")
+	}
+	// The hog is capped rather than allowed to run to the deadline, so
+	// assembly finishes well inside its budget.
+	if elapsed > 1500*time.Millisecond {
+		t.Errorf("assembly took %s; a single provider was not bounded", elapsed.Round(time.Millisecond))
+	}
+	if logs := logBuf.String(); !strings.Contains(logs, "ran long against the shared assembly budget") {
+		t.Errorf("no slow-source warning for the hog:\n%s", logs)
+	}
+}
+
+// TestSkippedProviderNamesWhoSpentTheBudget pins the attribution half.
+//
+// A provider that never ran must say so and name the spender, rather than
+// reporting "context deadline exceeded" under its own name — which is
+// indistinguishable from having tried and timed out, and is what sent a
+// production loop hunting corpus performance twice in one hour.
+func TestSkippedProviderNamesWhoSpentTheBudget(t *testing.T) {
+	var budget assemblyBudget
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	live, cancelLive := context.WithTimeout(context.Background(), time.Minute)
+	defer cancelLive()
+	if budget.skipped(live, logger, "always_provider", "docs") {
+		t.Fatal("skipped a provider while budget remained")
+	}
+
+	dead, cancelDead := context.WithCancel(context.Background())
+	cancelDead()
+	budget.note(dead, "tagged_provider", "metacognitive")
+	if !budget.skipped(dead, logger, "always_provider", "*docs.Advertiser") {
+		t.Fatal("did not skip a provider handed a dead context")
+	}
+
+	logs := logBuf.String()
+	for _, want := range []string{
+		"context provider skipped, not attempted",
+		"assembly budget already spent upstream",
+		// slog quotes values containing spaces.
+		`spent_by="tagged_provider (metacognitive)"`,
+		"source=always_provider",
+	} {
+		if !strings.Contains(logs, want) {
+			t.Errorf("skip log missing %q:\n%s", want, logs)
+		}
+	}
+	// The victim must not be the one reporting a deadline error.
+	if strings.Contains(logs, "gated context provider failed") {
+		t.Errorf("skipped provider reported its own failure:\n%s", logs)
+	}
+}
+
+// TestReserveForGatedProvidersLeavesTheTaggedTierUsable pins that the
+// reservation does not become the same starvation wearing the other hat.
+func TestReserveForGatedProvidersLeavesTheTaggedTierUsable(t *testing.T) {
+	tests := []struct {
+		name        string
+		budget      time.Duration
+		wantEarlier bool
+	}{
+		{name: "a full budget reserves for the gated tier", budget: 2 * time.Second, wantEarlier: true},
+		{
+			// Halving an already-tight budget would starve the tagged
+			// tier to protect the gated one.
+			name: "a budget too small to split is left alone", budget: 300 * time.Millisecond,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parent, cancel := context.WithTimeout(context.Background(), tt.budget)
+			defer cancel()
+			parentDeadline, _ := parent.Deadline()
+
+			tagged, release := reserveForGatedProviders(parent)
+			defer release()
+			taggedDeadline, ok := tagged.Deadline()
+			if !ok {
+				t.Fatal("tagged context lost its deadline")
+			}
+			if tt.wantEarlier && !taggedDeadline.Before(parentDeadline) {
+				t.Error("tagged deadline is not earlier; the gated tier has no reserve")
+			}
+			if !tt.wantEarlier && !taggedDeadline.Equal(parentDeadline) {
+				t.Error("a tight budget was split anyway")
+			}
+		})
+	}
+
+	t.Run("no deadline to divide", func(t *testing.T) {
+		tagged, release := reserveForGatedProviders(context.Background())
+		defer release()
+		if _, ok := tagged.Deadline(); ok {
+			t.Error("invented a deadline where the parent had none")
+		}
+	})
+}
+
+// TestGatedTierSurvivesWellBehavedTaggedProviders pins the reservation
+// specifically, and it needs several providers to do so.
+//
+// A per-provider cap alone does not save the gated tier: enough tagged
+// providers each running to their cap exhaust the shared budget by simple
+// arithmetic, with nothing misbehaving. Four at 500ms is the whole 2s.
+// Only holding a slice back for the gated tier keeps document advertising
+// alive in that case — which is why the fix is both bounds, not either.
+func TestGatedTierSurvivesWellBehavedTaggedProviders(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	a := NewTagContextAssembler(TagContextAssemblerConfig{Logger: logger})
+	tags := map[string]bool{}
+	for _, tag := range []string{"alpha", "bravo", "charlie", "delta"} {
+		// Each runs past its own cap, so each consumes exactly its slice.
+		a.RegisterTaggedProvider(tag, &slowTestProvider{work: 10 * time.Second, name: tag})
+		tags[tag] = true
+	}
+	gated := &slowTestProvider{work: time.Millisecond, name: "gated"}
+	a.RegisterAlwaysProvider(gated)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	a.BuildSections(ctx, agentctx.ContextRequest{ActiveTags: tags, IncludeAlways: true})
+
+	if !gated.didRun() {
+		t.Error("the gated provider never ran: four capped tagged providers consumed the whole budget, " +
+			"which is the case a per-provider cap cannot fix")
 	}
 }

--- a/internal/runtime/agent/tag_context_test.go
+++ b/internal/runtime/agent/tag_context_test.go
@@ -1464,14 +1464,15 @@ func TestSkippedProviderNamesWhoSpentTheBudget(t *testing.T) {
 
 	live, cancelLive := context.WithTimeout(context.Background(), time.Minute)
 	defer cancelLive()
-	if budget.skipped(live, logger, "always_provider", "docs") {
+	if budget.skipped(live, live, logger, "always_provider", "docs") {
 		t.Fatal("skipped a provider while budget remained")
 	}
 
-	dead, cancelDead := context.WithCancel(context.Background())
-	cancelDead()
+	dead, cancelDead := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancelDead()
+	<-dead.Done()
 	budget.note(dead, "tagged_provider", "metacognitive")
-	if !budget.skipped(dead, logger, "always_provider", "*docs.Advertiser") {
+	if !budget.skipped(dead, dead, logger, "always_provider", "*docs.Advertiser") {
 		t.Fatal("did not skip a provider handed a dead context")
 	}
 
@@ -1499,13 +1500,32 @@ func TestReserveForGatedProvidersLeavesTheTaggedTierUsable(t *testing.T) {
 	tests := []struct {
 		name        string
 		budget      time.Duration
-		wantEarlier bool
+		gatedCount  int
+		wantReserve time.Duration
 	}{
-		{name: "a full budget reserves for the gated tier", budget: 2 * time.Second, wantEarlier: true},
 		{
-			// Halving an already-tight budget would starve the tagged
-			// tier to protect the gated one.
-			name: "a budget too small to split is left alone", budget: 300 * time.Millisecond,
+			// Scaled by provider count, because a flat reserve equal to
+			// one provider's cap guarantees the last provider nothing.
+			name:   "the reserve scales with the gated tier",
+			budget: 2 * time.Second, gatedCount: 11,
+			wantReserve: 1000 * time.Millisecond, // 11x100ms, bounded at half
+		},
+		{
+			name:   "a small tier reserves only what it needs",
+			budget: 2 * time.Second, gatedCount: 3,
+			wantReserve: 300 * time.Millisecond,
+		},
+		{
+			// Bounded at half however many providers there are, so
+			// protecting the gated tier never starves the tagged one.
+			name:   "a tight budget still leaves the tagged tier half",
+			budget: 300 * time.Millisecond, gatedCount: 11,
+			wantReserve: 150 * time.Millisecond,
+		},
+		{
+			// A task-mode turn opens neither gate.
+			name:   "no admitted gated providers needs no reserve",
+			budget: 2 * time.Second, gatedCount: 0,
 		},
 	}
 
@@ -1515,23 +1535,27 @@ func TestReserveForGatedProvidersLeavesTheTaggedTierUsable(t *testing.T) {
 			defer cancel()
 			parentDeadline, _ := parent.Deadline()
 
-			tagged, release := reserveForGatedProviders(parent)
+			tagged, release := reserveForGatedProviders(parent, tt.gatedCount)
 			defer release()
 			taggedDeadline, ok := tagged.Deadline()
 			if !ok {
 				t.Fatal("tagged context lost its deadline")
 			}
-			if tt.wantEarlier && !taggedDeadline.Before(parentDeadline) {
-				t.Error("tagged deadline is not earlier; the gated tier has no reserve")
+
+			got := parentDeadline.Sub(taggedDeadline)
+			// Generous tolerance: the reserve is computed from time
+			// remaining, which has elapsed a little by now.
+			if diff := got - tt.wantReserve; diff > 20*time.Millisecond || diff < -20*time.Millisecond {
+				t.Errorf("reserve = %s, want about %s", got.Round(time.Millisecond), tt.wantReserve)
 			}
-			if !tt.wantEarlier && !taggedDeadline.Equal(parentDeadline) {
-				t.Error("a tight budget was split anyway")
+			if remaining := time.Until(taggedDeadline); remaining <= 0 {
+				t.Error("the tagged tier was left no time at all")
 			}
 		})
 	}
 
 	t.Run("no deadline to divide", func(t *testing.T) {
-		tagged, release := reserveForGatedProviders(context.Background())
+		tagged, release := reserveForGatedProviders(context.Background(), 5)
 		defer release()
 		if _, ok := tagged.Deadline(); ok {
 			t.Error("invented a deadline where the parent had none")
@@ -1568,5 +1592,176 @@ func TestGatedTierSurvivesWellBehavedTaggedProviders(t *testing.T) {
 	if !gated.didRun() {
 		t.Error("the gated provider never ran: four capped tagged providers consumed the whole budget, " +
 			"which is the case a per-provider cap cannot fix")
+	}
+}
+
+// TestCancellationNamesNoSpender pins that a cancelled request is not
+// reported as a spent budget with a culprit.
+//
+// ctx.Err() is non-nil for cancellation as well as expiry, so attributing
+// on that alone would blame whichever provider happened to be running
+// when a request was cancelled or the process shut down — an invented
+// fact of exactly the kind this attribution exists to prevent.
+func TestCancellationNamesNoSpender(t *testing.T) {
+	var budget assemblyBudget
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	budget.note(cancelled, "tagged_provider", "metacognitive")
+	if budget.spentBy != "" {
+		t.Errorf("spentBy = %q for a cancelled context; nothing was spent", budget.spentBy)
+	}
+
+	if !budget.skipped(cancelled, cancelled, logger, "always_provider", "docs") {
+		t.Fatal("did not skip on a cancelled context")
+	}
+	logs := logBuf.String()
+	if !strings.Contains(logs, "assembly cancelled") {
+		t.Errorf("cancellation not reported as such:\n%s", logs)
+	}
+	if strings.Contains(logs, "spent_by") || strings.Contains(logs, "already spent upstream") {
+		t.Errorf("cancellation blamed a provider:\n%s", logs)
+	}
+}
+
+// TestTierExpiryIsNotAssemblyExhaustion pins the distinction between the
+// reserve working and the budget being gone.
+//
+// The tagged tier expires early by design. Reporting that as "assembly
+// budget already spent upstream" would be false, and recording a spender
+// for it would mean a gated provider that later exhausts the real
+// deadline gets a stale culprit attached to every skip behind it.
+func TestTierExpiryIsNotAssemblyExhaustion(t *testing.T) {
+	var budget assemblyBudget
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	parent, cancelParent := context.WithTimeout(context.Background(), time.Minute)
+	defer cancelParent()
+	tier, cancelTier := context.WithTimeout(parent, time.Nanosecond)
+	defer cancelTier()
+	<-tier.Done()
+
+	budget.note(parent, "tagged_provider", "metacognitive")
+	if budget.spentBy != "" {
+		t.Errorf("spentBy = %q; the assembly budget is intact and only the tier expired", budget.spentBy)
+	}
+
+	if !budget.skipped(tier, parent, logger, "tagged_provider", "late") {
+		t.Fatal("did not skip a provider whose tier had expired")
+	}
+	logs := logBuf.String()
+	if !strings.Contains(logs, "reserved slice") {
+		t.Errorf("tier expiry not distinguished from assembly exhaustion:\n%s", logs)
+	}
+	if strings.Contains(logs, "already spent upstream") {
+		t.Errorf("tier expiry reported as a spent assembly budget:\n%s", logs)
+	}
+}
+
+// TestLateGatedProviderStillRuns pins the finding that a flat reserve
+// missed. The document advertiser registers near the end of a dozen gated
+// providers, so a reserve equal to one provider's cap left it skipped
+// whenever any earlier gated provider was slow.
+func TestLateGatedProviderStillRuns(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	a := NewTagContextAssembler(TagContextAssemblerConfig{Logger: logger})
+	a.RegisterTaggedProvider("metacognitive", &slowTestProvider{work: 10 * time.Second, name: "hog"})
+	// Ten eager gated providers ahead of the advertiser, each of which
+	// would run to a flat cap given the chance.
+	for i := range 10 {
+		a.RegisterAlwaysProvider(&slowTestProvider{work: 10 * time.Second, name: fmt.Sprintf("eager%d", i)})
+	}
+	advertiser := &slowTestProvider{work: time.Millisecond, name: "advertiser"}
+	a.RegisterAlwaysProvider(advertiser)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	a.BuildSections(ctx, agentctx.ContextRequest{
+		ActiveTags:    map[string]bool{"metacognitive": true},
+		IncludeAlways: true,
+	})
+
+	if !advertiser.didRun() {
+		t.Error("the last gated provider never ran; ten eager providers ahead of it consumed the reserve")
+	}
+}
+
+// measuringProvider records the budget it was handed.
+type measuringProvider struct {
+	mu    sync.Mutex
+	slice time.Duration
+	work  time.Duration
+}
+
+func (p *measuringProvider) TagContext(ctx context.Context, _ agentctx.ContextRequest) (string, error) {
+	if deadline, ok := ctx.Deadline(); ok {
+		p.mu.Lock()
+		p.slice = time.Until(deadline)
+		p.mu.Unlock()
+	}
+	select {
+	case <-time.After(p.work):
+		return "content", nil
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+}
+
+func (p *measuringProvider) sliceGiven() time.Duration {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.slice
+}
+
+// TestLateGatedProviderGetsAUsableSlice pins what the scaled reserve buys
+// over a flat one, which is not whether the last provider runs — fair
+// share alone secures that — but whether its slice is big enough to do
+// anything with.
+//
+// A flat reserve of one provider's cap, divided across a dozen gated
+// providers, leaves the advertiser tens of milliseconds. Sizing the
+// reserve by provider count doubles that. Neither guarantees a full
+// corpus walk, which no budget of two seconds can across this many
+// providers; what the tier relies on is that most providers are fast and
+// donate their unused share to the ones behind them.
+func TestLateGatedProviderGetsAUsableSlice(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	a := NewTagContextAssembler(TagContextAssemblerConfig{Logger: logger})
+	// Enough tagged hogs to consume the tagged tier is required for the
+	// reserve to bind at all. One is not enough — it is capped at its own
+	// share and leaves slack, so the gated tier inherits more than its
+	// reserve and the difference under test disappears.
+	tags := map[string]bool{}
+	for _, tag := range []string{"alpha", "bravo", "charlie", "delta"} {
+		a.RegisterTaggedProvider(tag, &slowTestProvider{work: 10 * time.Second, name: tag})
+		tags[tag] = true
+	}
+	for range 10 {
+		a.RegisterAlwaysProvider(&slowTestProvider{work: 10 * time.Second, name: "eager"})
+	}
+	advertiser := &measuringProvider{work: time.Millisecond}
+	a.RegisterAlwaysProvider(advertiser)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	a.BuildSections(ctx, agentctx.ContextRequest{ActiveTags: tags, IncludeAlways: true})
+
+	got := advertiser.sliceGiven()
+	if got <= 0 {
+		t.Fatal("the last gated provider was never given a slice")
+	}
+	// Eleven providers sharing a reserve sized at 11x100ms, bounded at
+	// half the budget, is ~90ms each. A flat reserve of one cap would
+	// give roughly half that.
+	if got < 70*time.Millisecond {
+		t.Errorf("last provider got %s; too small to do useful work, which is what sizing the reserve by provider count is for",
+			got.Round(time.Millisecond))
 	}
 }

--- a/internal/server/api/auth.go
+++ b/internal/server/api/auth.go
@@ -94,53 +94,10 @@ var publicRoutes = map[string]bool{
 // contract that is already public in the repository.
 var publicPrefixes = []string{"/static/", "/docs"}
 
-// principalCompanion is the Kind authenticate assigns to a companion
-// account token. It is the one principal kind the gate restricts by
-// route: a companion credential lives in a phone's Keychain and on a
-// laptop, and it authenticates a device offering data, not an operator
-// driving the API.
-const principalCompanion = "companion"
-
-// companionSurfaceRoutes is the companion's whole reachable surface —
-// the same literals server.go binds to the companion handlers. The
-// legacy aliases join in init from legacyroute.Aliases rather than as a
-// second hand-copied list (#1084).
-//
-// Every entry is also in publicRoutes today, so a companion token grants
-// no gated access at all. They are enumerated anyway so that gating one
-// later — moving the realtime handshake onto the Authorization header,
-// say — cannot silently lock a companion out of its own surface.
-// companion_scope_test.go proves this set and the routes server.go
-// actually registers agree, derived from the route table rather than
-// from parsing source.
-var companionSurfaceRoutes = []string{
-	"GET /v1/realtime/ws",
-	"POST /v1/companion/observations",
-}
-
-// companionRoutes is companionSurfaceRoutes plus the legacy aliases,
-// indexed for lookup.
-var companionRoutes = map[string]bool{}
-
 func init() {
 	for _, alias := range legacyroute.Aliases {
 		publicRoutes[alias.Route()] = true
 	}
-	for _, route := range companionSurfaceRoutes {
-		companionRoutes[route] = true
-	}
-	// The aliases are companion surface for the same reason they are
-	// public: they are the companion WebSocket under an older name.
-	for _, alias := range legacyroute.Aliases {
-		companionRoutes[alias.Route()] = true
-	}
-}
-
-// companionMayReach reports whether a companion credential is permitted
-// on a route. Deny by default: a route added to the server is closed to
-// companions until it is named here on purpose.
-func companionMayReach(method, path string) bool {
-	return companionRoutes[method+" "+path]
 }
 
 // isPublic reports whether the request's route is one that serves without
@@ -180,13 +137,6 @@ func (g *authGate) wrap(next http.Handler) http.Handler {
 		if !ok {
 			w.Header().Set("WWW-Authenticate", `Bearer realm="thane"`)
 			writeUnauthorized(w)
-			return
-		}
-		if p.Kind == principalCompanion && !companionMayReach(r.Method, r.URL.Path) {
-			// The credential is valid; it is simply not an operator's.
-			// 403 rather than 401 so a companion does not retry, and so
-			// the refusal is distinguishable from a bad token.
-			writeForbidden(w, "a companion credential may not reach this route")
 			return
 		}
 		if p.Kind == "session" {
@@ -232,7 +182,7 @@ func (g *authGate) authenticate(r *http.Request) (Principal, bool) {
 			return Principal{Kind: "api_token", Name: label}, true
 		}
 		if account, ok := g.companions.Match(token); ok {
-			return Principal{Kind: principalCompanion, Name: account}, true
+			return Principal{Kind: "companion", Name: account}, true
 		}
 		return Principal{}, false
 	}
@@ -252,16 +202,6 @@ func writeUnauthorized(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusUnauthorized)
 	_, _ = w.Write([]byte(`{"error":{"message":"authentication required","type":"unauthorized"}}`))
-}
-
-// writeForbidden refuses a caller whose credential is valid but whose
-// principal is not permitted here.
-func writeForbidden(w http.ResponseWriter, message string) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusForbidden)
-	writeJSON(w, map[string]any{
-		"error": map[string]any{"message": message, "type": "forbidden"},
-	}, nil)
 }
 
 // --- sessions ---------------------------------------------------------
@@ -289,15 +229,7 @@ func newSessionStore(ttl time.Duration) *sessionStore {
 }
 
 // create mints a session for the principal and returns its id.
-//
-// A companion principal is refused at the store, not only at the one
-// handler that mints sessions today. A console session is an operator's
-// browser; a companion credential must never become one, whatever
-// future path reaches this store.
 func (s *sessionStore) create(p Principal) (string, error) {
-	if p.Kind == principalCompanion {
-		return "", errCompanionSession
-	}
 	raw := make([]byte, 32)
 	if _, err := rand.Read(raw); err != nil {
 		return "", err
@@ -370,7 +302,7 @@ func (s *Server) handleAuthLogin(w http.ResponseWriter, r *http.Request) {
 	if label, ok := s.auth.api.Match(req.Token); ok {
 		p = Principal{Kind: "api_token", Name: label}
 	} else if account, ok := s.auth.companions.Match(req.Token); ok {
-		p = Principal{Kind: principalCompanion, Name: account}
+		p = Principal{Kind: "companion", Name: account}
 	} else {
 		s.auth.logger.Warn("console sign-in refused", "remote", r.RemoteAddr)
 		writeUnauthorized(w)

--- a/internal/server/api/auth.go
+++ b/internal/server/api/auth.go
@@ -94,10 +94,53 @@ var publicRoutes = map[string]bool{
 // contract that is already public in the repository.
 var publicPrefixes = []string{"/static/", "/docs"}
 
+// principalCompanion is the Kind authenticate assigns to a companion
+// account token. It is the one principal kind the gate restricts by
+// route: a companion credential lives in a phone's Keychain and on a
+// laptop, and it authenticates a device offering data, not an operator
+// driving the API.
+const principalCompanion = "companion"
+
+// companionSurfaceRoutes is the companion's whole reachable surface —
+// the same literals server.go binds to the companion handlers. The
+// legacy aliases join in init from legacyroute.Aliases rather than as a
+// second hand-copied list (#1084).
+//
+// Every entry is also in publicRoutes today, so a companion token grants
+// no gated access at all. They are enumerated anyway so that gating one
+// later — moving the realtime handshake onto the Authorization header,
+// say — cannot silently lock a companion out of its own surface.
+// companion_scope_test.go proves this set and the routes server.go
+// actually registers agree, derived from the route table rather than
+// from parsing source.
+var companionSurfaceRoutes = []string{
+	"GET /v1/realtime/ws",
+	"POST /v1/companion/observations",
+}
+
+// companionRoutes is companionSurfaceRoutes plus the legacy aliases,
+// indexed for lookup.
+var companionRoutes = map[string]bool{}
+
 func init() {
 	for _, alias := range legacyroute.Aliases {
 		publicRoutes[alias.Route()] = true
 	}
+	for _, route := range companionSurfaceRoutes {
+		companionRoutes[route] = true
+	}
+	// The aliases are companion surface for the same reason they are
+	// public: they are the companion WebSocket under an older name.
+	for _, alias := range legacyroute.Aliases {
+		companionRoutes[alias.Route()] = true
+	}
+}
+
+// companionMayReach reports whether a companion credential is permitted
+// on a route. Deny by default: a route added to the server is closed to
+// companions until it is named here on purpose.
+func companionMayReach(method, path string) bool {
+	return companionRoutes[method+" "+path]
 }
 
 // isPublic reports whether the request's route is one that serves without
@@ -137,6 +180,13 @@ func (g *authGate) wrap(next http.Handler) http.Handler {
 		if !ok {
 			w.Header().Set("WWW-Authenticate", `Bearer realm="thane"`)
 			writeUnauthorized(w)
+			return
+		}
+		if p.Kind == principalCompanion && !companionMayReach(r.Method, r.URL.Path) {
+			// The credential is valid; it is simply not an operator's.
+			// 403 rather than 401 so a companion does not retry, and so
+			// the refusal is distinguishable from a bad token.
+			writeForbidden(w, "a companion credential may not reach this route")
 			return
 		}
 		if p.Kind == "session" {
@@ -182,7 +232,7 @@ func (g *authGate) authenticate(r *http.Request) (Principal, bool) {
 			return Principal{Kind: "api_token", Name: label}, true
 		}
 		if account, ok := g.companions.Match(token); ok {
-			return Principal{Kind: "companion", Name: account}, true
+			return Principal{Kind: principalCompanion, Name: account}, true
 		}
 		return Principal{}, false
 	}
@@ -202,6 +252,16 @@ func writeUnauthorized(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusUnauthorized)
 	_, _ = w.Write([]byte(`{"error":{"message":"authentication required","type":"unauthorized"}}`))
+}
+
+// writeForbidden refuses a caller whose credential is valid but whose
+// principal is not permitted here.
+func writeForbidden(w http.ResponseWriter, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusForbidden)
+	writeJSON(w, map[string]any{
+		"error": map[string]any{"message": message, "type": "forbidden"},
+	}, nil)
 }
 
 // --- sessions ---------------------------------------------------------
@@ -229,7 +289,15 @@ func newSessionStore(ttl time.Duration) *sessionStore {
 }
 
 // create mints a session for the principal and returns its id.
+//
+// A companion principal is refused at the store, not only at the one
+// handler that mints sessions today. A console session is an operator's
+// browser; a companion credential must never become one, whatever
+// future path reaches this store.
 func (s *sessionStore) create(p Principal) (string, error) {
+	if p.Kind == principalCompanion {
+		return "", errCompanionSession
+	}
 	raw := make([]byte, 32)
 	if _, err := rand.Read(raw); err != nil {
 		return "", err
@@ -302,7 +370,7 @@ func (s *Server) handleAuthLogin(w http.ResponseWriter, r *http.Request) {
 	if label, ok := s.auth.api.Match(req.Token); ok {
 		p = Principal{Kind: "api_token", Name: label}
 	} else if account, ok := s.auth.companions.Match(req.Token); ok {
-		p = Principal{Kind: "companion", Name: account}
+		p = Principal{Kind: principalCompanion, Name: account}
 	} else {
 		s.auth.logger.Warn("console sign-in refused", "remote", r.RemoteAddr)
 		writeUnauthorized(w)


### PR DESCRIPTION
A production loop has been waking with **no document offers in context at all**, on nearly every wake, for days. Nothing said so.

Diagnosed by the metacognitive loop, corrected by the production agent, confirmed here from source:

```
loop.go:1245        context.WithTimeout(ctx, 2*time.Second)   one shared budget
tag_context.go:592  tagged providers                          run FIRST
tag_context.go:641  gated providers                           run SECOND, same ctx
```

Sequential, one deadline, no per-provider bound. A tagged provider that consumes the budget hands every provider behind it a corpse — and the gated tier is where document advertising lives.

## Why it was misdiagnosed twice

The victim logged `context deadline exceeded` **under its own name**, indistinguishable from having tried and timed out. That reads as a slow document corpus, and it was diagnosed as one twice in an hour by the loop it was happening to.

It never was. The tell was in the logs already: the first warning's elapsed sat pinned at **2.000–2.003s across dozens of samples** — a deadline firing, not work being done. Measured standalone on the same binary, the corpus walks 9 roots and ~340 documents in 265ms, and a tag-filtered search takes 4ms.

Worth noting `tag_context.go:400` already names this class, from the **2026-08-12** incident: *"undiagnosable from logs precisely because a slow-but-successful source is silent: the shared budget died upstream and the failure surfaced downstream under the wrong name."* That fix added the slow-source WARN, which names the culprit on one line. The victim still failed under the wrong name on another, with nothing connecting them. **Half the fix landed in August. This is the other half.**

## Three fixes, attribution first

**1. Attribution.** A provider handed an already-dead context is skipped with a WARN that names the reason and the spender, rather than running and reporting its own failure:

```
msg="context provider skipped, not attempted" source=always_provider
  reason="assembly budget already spent upstream"
  detail=*docs.Advertiser spent_by="tagged_provider (metacognitive)"
```

A WARN rather than a DEBUG, deliberately: a context section silently missing is how a loop ends up auditing the system with one sense switched off and no signal that it is off.

**2. A per-provider cap** (500ms) so no single source can monopolise the budget. Comfortably above the 250ms slow-source threshold — a merely slow provider should finish and be warned about, not killed. What this stops is the unbounded case, and tagged-vs-tagged starvation the moment a second tagged provider exists.

**3. A reserve** (500ms) withheld from the tagged tier, because **a cap alone cannot save the gated tier.** Four well-behaved providers each running to their cap exhaust two seconds by arithmetic with nothing misbehaving. Skipped when the remaining budget is too small to divide, since halving a tight deadline starves the tagged tier to protect the gated one — the same failure wearing the other hat.

## A note on the tests

The first version of the starvation test **passed with the reserve removed** — the per-provider cap alone was carrying it. That test proved the cap and claimed the reserve.

There are now two tests, and each fails without its own fix:

```
reserve removed  -> TestGatedTierSurvivesWellBehavedTaggedProviders  FAIL
cap removed      -> TestGatedProvidersSurviveASlowTaggedProvider     FAIL (1.503s, unbounded)
```

## Test plan

- [x] `just ci` passes locally
- [x] A gated provider still runs behind a tagged provider that would run for 10s
- [x] Assembly completes well inside its budget rather than at the deadline
- [x] Four capped tagged providers do not starve the gated tier
- [x] A skipped provider names the reason and the spender, and does not report its own failure
- [x] A provider is not skipped while budget remains
- [x] A budget too small to divide is left alone; a context with no deadline gains none
- [x] Each fix mutation-tested in isolation
- [ ] Deployed, and the chronic WARN pair confirmed gone from the metacognitive loop's wakes

## Not addressed here

The loop's own conduct — deriving a confident root cause from a timeout it never measured, twice — is a prompting matter, and the production agent has already given it the standing rule: when the evidence is a timeout, measure the suspected work standalone before naming it the cause.