### PR TITLE
fix(api): a companion token is a device credential, not an operator's

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -34,8 +34,19 @@ token. Clients send `Authorization: Bearer <token>`; an operator token
 authenticates as its label, a companion account token
 (`companion.providers.<account>.tokens`) as that account, and a client
 certificate the HTTPS front door verified as its subject. A missing or wrong
-credential gets `401` with `WWW-Authenticate: Bearer realm="thane"`. The
-routes that serve without a credential are exactly: `GET /health`,
+credential gets `401` with `WWW-Authenticate: Bearer realm="thane"`.
+
+A companion account token is not an operator credential. It authenticates a
+device offering data, and it reaches the companion surface — `/v1/realtime/ws`
+and its aliases, `POST /v1/companion/observations` — and nothing else gated:
+every other gated route answers `403` with an error of type `forbidden`.
+The allowlist is deny-by-default, so a route added later is closed to
+companions until it is named on purpose, and a test derives the companion
+surface from the route table to keep the two in step. Public routes are
+unaffected, being public to everyone. This matters because that credential
+lives in a phone's Keychain and travels further than an operator token.
+
+The routes that serve without a credential are exactly: `GET /health`,
 `GET /v1/version`, `GET /v1/identity`, the console shell and `/static/*`,
 `/docs*`, the three `/v1/auth/*` endpoints, and the companion endpoints
 (`/v1/realtime/ws` and its aliases, `POST /v1/companion/observations`),
@@ -45,7 +56,7 @@ route is neither gated nor listed as public on purpose.
 | Method | Path | Purpose |
 | --- | --- | --- |
 | `GET` | `/v1/auth/session` | Whether a credential is required and whether the caller has one; names the principal. |
-| `POST` | `/v1/auth/login` | Exchange a token for an HttpOnly, SameSite=Strict `thane_session` cookie (the console's sign-in). |
+| `POST` | `/v1/auth/login` | Exchange an **operator** token for an HttpOnly, SameSite=Strict `thane_session` cookie (the console's sign-in). A companion token is refused with `403`: a device credential cannot become an operator's browser session. |
 | `POST` | `/v1/auth/logout` | Revoke the session and clear the cookie. |
 
 The console never stores a token: it exchanges one at sign-in for the

--- a/docs/understanding/trust-architecture.md
+++ b/docs/understanding/trust-architecture.md
@@ -116,7 +116,10 @@ A companion account token authenticates a device offering data, not an
 operator driving the API. The native gate enforces that: a request whose
 principal is `companion` may reach the companion surface — the realtime
 WebSocket, its legacy aliases, and observation ingestion — and is refused
-with 403 everywhere else. The allowlist is deny-by-default, so a route
+with 403 on every *gated* route outside it. Public routes are unchanged:
+`/health`, `/v1/identity` and `/v1/auth/session` serve without a
+credential for anyone, so presenting a companion token there is neither
+better nor worse than presenting none. The allowlist is deny-by-default, so a route
 added to the server is closed to companions until it is named on purpose,
 and a test derives the companion surface from the route table at runtime
 so the two cannot drift.

--- a/docs/understanding/trust-architecture.md
+++ b/docs/understanding/trust-architecture.md
@@ -108,6 +108,34 @@ established, which for an unauthenticated caller is none.
 The general form of this rule — one resolver that reads attestation state,
 sender trust zone, and loop tier at the execution chokepoint — is #1268.
 
+### Companion Credential Scope
+
+**Status: Implemented**
+
+A companion account token authenticates a device offering data, not an
+operator driving the API. The native gate enforces that: a request whose
+principal is `companion` may reach the companion surface — the realtime
+WebSocket, its legacy aliases, and observation ingestion — and is refused
+with 403 everywhere else. The allowlist is deny-by-default, so a route
+added to the server is closed to companions until it is named on purpose,
+and a test derives the companion surface from the route table at runtime
+so the two cannot drift.
+
+A companion credential also cannot become a console session. `/v1/auth/login`
+refuses it, and the session store refuses it again beneath the handler, so a
+future caller cannot reopen the exchange.
+
+This matters because of where the credential lives. It sits in a phone's
+Keychain and on a laptop, travels further than an operator token, and is
+held by software the operator does not read. Before this, it authorized
+every gated native route — contact deletion, checkpoint restore, session
+reset — and could be traded for a browser session.
+
+Note the precondition: the gate exists only when operator API tokens are
+configured. With none configured it is nil and every route serves without a
+credential, so this scope is a restriction on an authenticated deployment,
+not a floor under an unauthenticated one.
+
 ### Orchestrator Tool Gating
 
 **Status: Implemented**

--- a/internal/server/api/auth.go
+++ b/internal/server/api/auth.go
@@ -258,11 +258,19 @@ func writeUnauthorized(w http.ResponseWriter) {
 // writeForbidden refuses a caller whose credential is valid but whose
 // principal is not permitted here.
 func writeForbidden(w http.ResponseWriter, message string) {
+	// Marshal before writing anything, and carry no logger: writeJSON
+	// dereferences its logger when encoding fails (server.go:51-54), and
+	// the gate has no logger to hand it on every path. A client that
+	// disconnects mid-response must not panic the middleware.
+	body, err := json.Marshal(map[string]any{
+		"error": map[string]any{"message": message, "type": "forbidden"},
+	})
+	if err != nil {
+		body = []byte(`{"error":{"message":"forbidden","type":"forbidden"}}`)
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusForbidden)
-	writeJSON(w, map[string]any{
-		"error": map[string]any{"message": message, "type": "forbidden"},
-	}, nil)
+	_, _ = w.Write(body)
 }
 
 // --- sessions ---------------------------------------------------------

--- a/internal/server/api/auth.go
+++ b/internal/server/api/auth.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -94,10 +95,53 @@ var publicRoutes = map[string]bool{
 // contract that is already public in the repository.
 var publicPrefixes = []string{"/static/", "/docs"}
 
+// principalCompanion is the Kind authenticate assigns to a companion
+// account token. It is the one principal kind the gate restricts by
+// route: a companion credential lives in a phone's Keychain and on a
+// laptop, and it authenticates a device offering data, not an operator
+// driving the API.
+const principalCompanion = "companion"
+
+// companionSurfaceRoutes is the companion's whole reachable surface —
+// the same literals server.go binds to the companion handlers. The
+// legacy aliases join in init from legacyroute.Aliases rather than as a
+// second hand-copied list (#1084).
+//
+// Every entry is also in publicRoutes today, so a companion token grants
+// no gated access at all. They are enumerated anyway so that gating one
+// later — moving the realtime handshake onto the Authorization header,
+// say — cannot silently lock a companion out of its own surface.
+// companion_scope_test.go proves this set and the routes server.go
+// actually registers agree, derived from the route table rather than
+// from parsing source.
+var companionSurfaceRoutes = []string{
+	"GET /v1/realtime/ws",
+	"POST /v1/companion/observations",
+}
+
+// companionRoutes is companionSurfaceRoutes plus the legacy aliases,
+// indexed for lookup.
+var companionRoutes = map[string]bool{}
+
 func init() {
 	for _, alias := range legacyroute.Aliases {
 		publicRoutes[alias.Route()] = true
 	}
+	for _, route := range companionSurfaceRoutes {
+		companionRoutes[route] = true
+	}
+	// The aliases are companion surface for the same reason they are
+	// public: they are the companion WebSocket under an older name.
+	for _, alias := range legacyroute.Aliases {
+		companionRoutes[alias.Route()] = true
+	}
+}
+
+// companionMayReach reports whether a companion credential is permitted
+// on a route. Deny by default: a route added to the server is closed to
+// companions until it is named here on purpose.
+func companionMayReach(method, path string) bool {
+	return companionRoutes[method+" "+path]
 }
 
 // isPublic reports whether the request's route is one that serves without
@@ -137,6 +181,13 @@ func (g *authGate) wrap(next http.Handler) http.Handler {
 		if !ok {
 			w.Header().Set("WWW-Authenticate", `Bearer realm="thane"`)
 			writeUnauthorized(w)
+			return
+		}
+		if p.Kind == principalCompanion && !companionMayReach(r.Method, r.URL.Path) {
+			// The credential is valid; it is simply not an operator's.
+			// 403 rather than 401 so a companion does not retry, and so
+			// the refusal is distinguishable from a bad token.
+			writeForbidden(w, "a companion credential may not reach this route")
 			return
 		}
 		if p.Kind == "session" {
@@ -182,7 +233,7 @@ func (g *authGate) authenticate(r *http.Request) (Principal, bool) {
 			return Principal{Kind: "api_token", Name: label}, true
 		}
 		if account, ok := g.companions.Match(token); ok {
-			return Principal{Kind: "companion", Name: account}, true
+			return Principal{Kind: principalCompanion, Name: account}, true
 		}
 		return Principal{}, false
 	}
@@ -204,12 +255,26 @@ func writeUnauthorized(w http.ResponseWriter) {
 	_, _ = w.Write([]byte(`{"error":{"message":"authentication required","type":"unauthorized"}}`))
 }
 
+// writeForbidden refuses a caller whose credential is valid but whose
+// principal is not permitted here.
+func writeForbidden(w http.ResponseWriter, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusForbidden)
+	writeJSON(w, map[string]any{
+		"error": map[string]any{"message": message, "type": "forbidden"},
+	}, nil)
+}
+
 // --- sessions ---------------------------------------------------------
 
 type session struct {
 	principal Principal
 	expires   time.Time
 }
+
+// errCompanionSession refuses a console session for a companion
+// credential.
+var errCompanionSession = errors.New("a companion credential cannot open a console session")
 
 // sessionStore holds console sessions in memory. Losing them on restart
 // costs one sign-in and buys a store with no persistence, no secret key,
@@ -229,7 +294,15 @@ func newSessionStore(ttl time.Duration) *sessionStore {
 }
 
 // create mints a session for the principal and returns its id.
+//
+// A companion principal is refused at the store, not only at the one
+// handler that mints sessions today. A console session is an operator's
+// browser; a companion credential must never become one, whatever
+// future path reaches this store.
 func (s *sessionStore) create(p Principal) (string, error) {
+	if p.Kind == principalCompanion {
+		return "", errCompanionSession
+	}
 	raw := make([]byte, 32)
 	if _, err := rand.Read(raw); err != nil {
 		return "", err
@@ -302,7 +375,13 @@ func (s *Server) handleAuthLogin(w http.ResponseWriter, r *http.Request) {
 	if label, ok := s.auth.api.Match(req.Token); ok {
 		p = Principal{Kind: "api_token", Name: label}
 	} else if account, ok := s.auth.companions.Match(req.Token); ok {
-		p = Principal{Kind: "companion", Name: account}
+		// A companion token authenticates a device offering data, not an
+		// operator. Refuse before minting rather than relying on the
+		// store's backstop, so the caller gets a reason.
+		s.auth.logger.Warn("console sign-in refused for companion credential",
+			"account", account, "remote", r.RemoteAddr)
+		s.errorResponse(w, http.StatusForbidden, errCompanionSession.Error())
+		return
 	} else {
 		s.auth.logger.Warn("console sign-in refused", "remote", r.RemoteAddr)
 		writeUnauthorized(w)

--- a/internal/server/api/auth_test.go
+++ b/internal/server/api/auth_test.go
@@ -69,7 +69,7 @@ func TestAuthGateCredentials(t *testing.T) {
 		{"no credential refused", "", http.StatusUnauthorized, "", ""},
 		{"operator token accepted", "Bearer alice-token", http.StatusOK, "api_token", "alice"},
 		{"second operator token accepted", "Bearer bob-token", http.StatusOK, "api_token", "bob-cli"},
-		{"companion token accepted as account", "Bearer companion-token", http.StatusOK, "companion", "phone"},
+		{"companion token refused on an operator route", "Bearer companion-token", http.StatusForbidden, "", ""},
 		{"wrong token refused", "Bearer nope", http.StatusUnauthorized, "", ""},
 		{"prefix of token refused", "Bearer alice-tok", http.StatusUnauthorized, "", ""},
 		{"basic scheme refused", "Basic alice-token", http.StatusUnauthorized, "", ""},
@@ -89,6 +89,15 @@ func TestAuthGateCredentials(t *testing.T) {
 			if tc.wantCode == http.StatusUnauthorized {
 				if got := rec.Header().Get("WWW-Authenticate"); !strings.HasPrefix(got, "Bearer") {
 					t.Fatalf("WWW-Authenticate = %q", got)
+				}
+				return
+			}
+			if tc.wantCode == http.StatusForbidden {
+				// The gate refuses before the handler, so no principal
+				// reaches the context. Resolution is asserted separately
+				// in TestCompanionPrincipalResolvesOnItsOwnSurface.
+				if present {
+					t.Fatalf("a refused request still reached the handler as %+v", seen)
 				}
 				return
 			}

--- a/internal/server/api/companion_scope_test.go
+++ b/internal/server/api/companion_scope_test.go
@@ -1,8 +1,10 @@
 package api
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"sort"
 	"strings"
 	"testing"
@@ -152,8 +154,14 @@ func TestSessionStoreRefusesCompanionPrincipal(t *testing.T) {
 // It is deliberately not a source scrape. A regex over server.go keys on
 // a closed set of handler names, so a third companion handler registered
 // later is invisible to it and the two sides drift silently while the
-// test stays green. The delta cannot drift: a companion route that is
-// registered appears in it by construction.
+// test stays green.
+//
+// The delta has one residual dependency of the same kind, and it is
+// covered rather than ignored: companionGatedServer has to wire the
+// companion handlers, so a third handler it does not know about would be
+// absent from both route tables and fall out of the delta unnoticed.
+// TestCompanionFixtureWiresEveryCompanionHandler fails in that case, so
+// the gap closes at the fixture instead of hiding here.
 func TestCompanionAllowlistMatchesRegisteredRoutes(t *testing.T) {
 	t.Parallel()
 
@@ -217,4 +225,70 @@ func TestCompanionPrincipalResolvesOnItsOwnSurface(t *testing.T) {
 	if seen.Kind != principalCompanion || seen.Name != "phone" {
 		t.Fatalf("principal = %+v, want %s/phone", seen, principalCompanion)
 	}
+}
+
+// TestCompanionFixtureWiresEveryCompanionHandler closes the one way the
+// route-table delta can still drift.
+//
+// The delta is only as complete as the fixture that produces it: a
+// companion handler companionGatedServer does not wire registers no
+// routes, so its surface is missing from both sides of the comparison and
+// TestCompanionAllowlistMatchesRegisteredRoutes stays green while a real
+// companion route sits outside the allowlist and 403s in production.
+//
+// Reflection rather than a hand-kept list, for the same reason the delta
+// beats a regex: a companion handler field added to Server is found here
+// whether or not anyone remembered this test existed.
+func TestCompanionFixtureWiresEveryCompanionHandler(t *testing.T) {
+	t.Parallel()
+
+	v := reflect.ValueOf(companionGatedServer(t)).Elem()
+	typ := v.Type()
+
+	found := 0
+	for i := range typ.NumField() {
+		name := typ.Field(i).Name
+		if !strings.HasPrefix(name, "companion") || !strings.HasSuffix(name, "Handler") {
+			continue
+		}
+		found++
+		if v.Field(i).IsNil() {
+			t.Errorf("Server.%s is not wired by companionGatedServer, so its routes "+
+				"are absent from the delta and the allowlist test cannot see them. "+
+				"Wire it in the fixture and add its routes to companionSurfaceRoutes.", name)
+		}
+	}
+	if found == 0 {
+		t.Fatal("no companion handler fields found; the naming convention this test " +
+			"keys on has changed and the guard is now inert")
+	}
+}
+
+// failingWriter is a ResponseWriter whose body writes fail, standing in
+// for a client that disconnected mid-response.
+type failingWriter struct{ header http.Header }
+
+func (f *failingWriter) Header() http.Header {
+	if f.header == nil {
+		f.header = http.Header{}
+	}
+	return f.header
+}
+func (f *failingWriter) Write([]byte) (int, error) { return 0, errors.New("client gone") }
+func (f *failingWriter) WriteHeader(int)           {}
+
+// TestWriteForbiddenSurvivesAClientDisconnect pins the refusal path
+// against a nil-logger panic. writeJSON logs encode failures through a
+// logger it does not nil-check, and the gate has none to give it, so the
+// 403 path writes its own bytes.
+//
+// Mutation check: restore `writeJSON(w, …, nil)` and this panics.
+func TestWriteForbiddenSurvivesAClientDisconnect(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("writeForbidden panicked on a failed write: %v", r)
+		}
+	}()
+	writeForbidden(&failingWriter{}, "a companion credential may not reach this route")
 }

--- a/internal/server/api/companion_scope_test.go
+++ b/internal/server/api/companion_scope_test.go
@@ -1,0 +1,220 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/config"
+	"github.com/nugget/thane-ai-agent/internal/server/web"
+)
+
+// companionGatedServer is gatedServer with the companion handlers wired,
+// so the companion routes and their legacy aliases are registered.
+func companionGatedServer(t *testing.T) *Server {
+	t.Helper()
+	s := &Server{logger: testAPILogger()}
+	s.SetWebServer(web.NewWebServer(web.Config{}))
+	s.SetCompanionHandler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	s.SetCompanionObservationHandler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	s.SetAuth(config.ListenAuthConfig{
+		Tokens:     []config.APIToken{{Label: "alice", Token: "alice-token"}},
+		SessionTTL: time.Hour,
+	}, map[string]string{"companion-token": "phone"})
+	return s
+}
+
+// TestCompanionCredentialRefusedOnGatedRoutes is the point of the change:
+// the token in a phone's Keychain is not an operator API credential.
+//
+// Mutation check: delete the principalCompanion branch in authGate.wrap
+// and every subtest fails with 200/404 instead of 403.
+func TestCompanionCredentialRefusedOnGatedRoutes(t *testing.T) {
+	t.Parallel()
+	h := gatedServer(t).Handler()
+
+	// Routes an operator reaches and a device must not. Two are
+	// destructive, two disclose the operator's own data.
+	for _, tc := range []struct{ method, path string }{
+		{"GET", "/v1/system"},
+		{"GET", "/v1/system/logs"},
+		{"GET", "/v1/conversations"},
+		{"GET", "/v1/contacts"},
+		{"POST", "/v1/sessions/reset"},
+	} {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			req.Header.Set("Authorization", "Bearer companion-token")
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("companion on %s %s: got %d, want 403", tc.method, tc.path, rec.Code)
+			}
+			if body := rec.Body.String(); !strings.Contains(body, "companion credential") {
+				t.Errorf("refusal should say why, got %q", body)
+			}
+		})
+	}
+}
+
+// TestOperatorCredentialStillReachesGatedRoutes guards the obvious
+// regression: scoping companions must not scope operators.
+func TestOperatorCredentialStillReachesGatedRoutes(t *testing.T) {
+	t.Parallel()
+	h := gatedServer(t).Handler()
+
+	req := httptest.NewRequest("GET", "/v1/system", nil)
+	req.Header.Set("Authorization", "Bearer alice-token")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusForbidden || rec.Code == http.StatusUnauthorized {
+		t.Fatalf("operator token refused on a gated route: %d", rec.Code)
+	}
+}
+
+// TestCompanionCredentialServesItsOwnSurface proves the scoping does not
+// lock a companion out of the routes it exists to call.
+func TestCompanionCredentialServesItsOwnSurface(t *testing.T) {
+	t.Parallel()
+	h := companionGatedServer(t).Handler()
+
+	for _, route := range []string{
+		"GET /v1/realtime/ws",
+		"POST /v1/companion/observations",
+		"GET /v1/companion/ws",
+		"GET /v1/platform/ws",
+	} {
+		t.Run(route, func(t *testing.T) {
+			method, path, _ := strings.Cut(route, " ")
+			req := httptest.NewRequest(method, path, nil)
+			req.Header.Set("Authorization", "Bearer companion-token")
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code == http.StatusForbidden {
+				t.Fatalf("companion refused on its own surface %s", route)
+			}
+		})
+	}
+}
+
+// TestCompanionTokenCannotMintConsoleSession closes the exchange that
+// made a device credential an operator's browser session.
+//
+// Mutation check: restore the `p = Principal{Kind: principalCompanion…}`
+// branch in handleAuthLogin and this fails with 200 and a Set-Cookie.
+func TestCompanionTokenCannotMintConsoleSession(t *testing.T) {
+	t.Parallel()
+	h := gatedServer(t).Handler()
+
+	req := httptest.NewRequest("POST", "/v1/auth/login",
+		strings.NewReader(`{"token":"companion-token"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("companion sign-in: got %d, want 403", rec.Code)
+	}
+	if cookies := rec.Result().Cookies(); len(cookies) > 0 {
+		t.Fatalf("a session cookie was issued to a companion: %v", cookies)
+	}
+}
+
+// TestSessionStoreRefusesCompanionPrincipal is the backstop beneath the
+// handler, so a future caller of create cannot reopen the hole.
+func TestSessionStoreRefusesCompanionPrincipal(t *testing.T) {
+	t.Parallel()
+	store := newSessionStore(time.Hour)
+
+	if _, err := store.create(Principal{Kind: principalCompanion, Name: "phone"}); err == nil {
+		t.Fatal("session store minted a session for a companion principal")
+	}
+	if _, err := store.create(Principal{Kind: "api_token", Name: "alice"}); err != nil {
+		t.Fatalf("session store refused an operator principal: %v", err)
+	}
+}
+
+// TestCompanionAllowlistMatchesRegisteredRoutes derives the companion
+// surface from the route table at runtime — the delta between a server
+// with the companion handlers wired and one without — and compares it to
+// the allowlist the gate enforces.
+//
+// It is deliberately not a source scrape. A regex over server.go keys on
+// a closed set of handler names, so a third companion handler registered
+// later is invisible to it and the two sides drift silently while the
+// test stays green. The delta cannot drift: a companion route that is
+// registered appears in it by construction.
+func TestCompanionAllowlistMatchesRegisteredRoutes(t *testing.T) {
+	t.Parallel()
+
+	base := gatedServer(t)
+	_ = base.Handler()
+	withCompanion := companionGatedServer(t)
+	_ = withCompanion.Handler()
+
+	baseRoutes := map[string]bool{}
+	for _, r := range base.routes {
+		baseRoutes[r] = true
+	}
+	var registered []string
+	for _, r := range withCompanion.routes {
+		if !baseRoutes[r] {
+			registered = append(registered, r)
+		}
+	}
+	sort.Strings(registered)
+
+	var allowed []string
+	for route := range companionRoutes {
+		allowed = append(allowed, route)
+	}
+	sort.Strings(allowed)
+
+	if len(registered) == 0 {
+		t.Fatal("no companion routes in the delta; the fixture no longer wires them")
+	}
+	if strings.Join(registered, "\n") != strings.Join(allowed, "\n") {
+		t.Errorf("companion allowlist and registered companion routes disagree\n"+
+			"registered:\n  %s\nallowlist:\n  %s\n\n"+
+			"A companion route registered without an allowlist entry 403s on the "+
+			"companion's own surface; an allowlist entry with no route grants "+
+			"nothing but claims to.",
+			strings.Join(registered, "\n  "), strings.Join(allowed, "\n  "))
+	}
+}
+
+// TestCompanionPrincipalResolvesOnItsOwnSurface keeps the coverage the
+// auth-gate table lost when its companion row became a refusal: a
+// companion token still resolves to the right principal, it is simply
+// only useful on the companion surface.
+func TestCompanionPrincipalResolvesOnItsOwnSurface(t *testing.T) {
+	t.Parallel()
+
+	g := testGate(t)
+	var seen Principal
+	var present bool
+	h := g.wrap(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		seen, present = PrincipalFromContext(r.Context())
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/companion/observations", nil)
+	req.Header.Set("Authorization", "Bearer companion-token")
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	if !present {
+		t.Fatal("companion did not reach its own surface")
+	}
+	if seen.Kind != principalCompanion || seen.Name != "phone" {
+		t.Fatalf("principal = %+v, want %s/phone", seen, principalCompanion)
+	}
+}

--- a/internal/server/openapi/native.yaml
+++ b/internal/server/openapi/native.yaml
@@ -213,14 +213,15 @@ paths:
       operationId: authLogin
       summary: Exchange a token for a console session cookie
       description: >-
-        The console's sign-in. Posts an operator or companion token once and
+        The console's sign-in. Posts an operator token once and
         receives an HttpOnly, SameSite=Strict `thane_session` cookie (marked
         Secure when the request arrived over TLS, directly or via a proxy
         reporting `X-Forwarded-Proto: https`). The token is never stored by
         the console. Sessions live in memory, expire after
         `listen.auth.session_ttl` without use, and end on restart. Returns 404
         when no operator token is configured, since there is nothing to sign
-        in to.
+        in to, and 403 for a companion account token: a device credential
+        cannot become an operator's browser session.
       security: []
       requestBody:
         description: The credential to exchange.
@@ -233,7 +234,9 @@ paths:
               properties:
                 token:
                   type: string
-                  description: An operator token or a companion account token.
+                  description: >-
+                    An operator token. A companion account token is refused
+                    with 403.
                   example: 0GxlTt1n5uP5R9M9Ck4vYkq1vHsZ6l2ZB7Q4Yw4GJ7A
       responses:
         "200":
@@ -252,6 +255,13 @@ paths:
               schema: { $ref: "#/components/schemas/Error" }
         "401":
           description: The token was not accepted.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: >-
+            A companion account token was presented. It authenticates a device,
+            not an operator, and cannot be exchanged for a console session.
           content:
             application/json:
               schema: { $ref: "#/components/schemas/Error" }
@@ -1473,7 +1483,16 @@ components:
       description: |
         Operator token from `listen.auth.tokens`, or a companion account token
         (`companion.providers.<account>.tokens`), which authenticates as that
-        account. Enforced on every operation except those marked `security: []`
+        account.
+
+        A companion token is not an operator credential. It authenticates a
+        device offering data and reaches only the companion surface —
+        `/v1/realtime/ws` and its aliases, `POST /v1/companion/observations`.
+        Every other gated operation answers `403` with an error of type
+        `forbidden`, and `POST /v1/auth/login` refuses it rather than minting a
+        session. Operations marked `security: []` are public and unaffected.
+
+        Enforced on every operation except those marked `security: []`
         whenever at least one operator token is configured; with none configured
         the API is open. The console holds no token: it exchanges one at
         `POST /v1/auth/login` for an HttpOnly, SameSite=Strict session cookie


### PR DESCRIPTION
Closes the worst finding from the companion protocol audit.

## The defect

`authGate.authenticate` resolves a companion account token to `Principal{Kind: "companion"}` and the gate then calls the handler. `Principal.Kind` is read in exactly two places server-wide — `auth.go:142` to slide a session cookie, `auth.go:343` to echo the principal back — and neither is a route guard.

So the bearer token in a phone's Keychain authorizes every gated native route: `DELETE /v1/contacts/{id}`, `POST /v1/checkpoints/{id}/restore`, `POST /v1/sessions/reset`, `GET /v1/system/logs`. And `handleAuthLogin` accepts it and mints a `thane_session` console cookie.

## The change

A companion principal reaches the companion surface and nothing else — the realtime WebSocket, its legacy aliases, and observation ingestion. Everything else is 403. Deny-by-default, so a route added later is closed to companions until named on purpose.

403 rather than 401: the credential is valid, it just isn't an operator's, and a companion should not retry.

Console sessions are refused twice — in `handleAuthLogin` before minting so the caller gets a reason, and in `sessionStore.create` beneath it so a future caller cannot reopen the exchange.

## Nothing in production loses access

- **macOS v0.1.3** (current release) calls exactly one route: `GET /v1/platform/ws`, a public legacy alias. Verified with `git ls-tree`/`git show` against the tag, not against a local branch.
- **iOS** calls `/v1/realtime/ws`, `/v1/companion/observations`, `/v1/identity` — all in `publicRoutes`.

An earlier draft carried a seven-route compatibility floor for the macOS Server window. That window exists only on an unreleased branch, so the floor would have permanently granted a phone-Keychain credential `GET /v1/system/logs` and conversation search in order to protect nothing. It is not here. When that macOS build ships it needs its own operator token — that is its PR's work, and it should be noted there.

## The allowlist test does not scrape source

It derives the companion surface from the route table at runtime: the delta between a `Server` with the companion handlers wired and one without.

A regex over `server.go` keys on a closed set of handler names, so a third companion handler added later is invisible to it — the allowlist and the registrations drift while the test stays green. The delta cannot drift, because a registered companion route appears in it by construction. It also picks up the legacy aliases without naming them.

## Test plan

- [x] `just ci` passes — 73 packages ok, 0 FAIL
- [x] Companion refused 403 on five gated routes, including two destructive and two disclosing
- [x] Operator token still reaches gated routes
- [x] Companion still reaches all four of its own routes, aliases included
- [x] Companion token cannot mint a console session, and no `Set-Cookie` is issued
- [x] `sessionStore.create` refuses a companion principal directly
- [x] **Mutation-verified** — each of these fails exactly one test:
  - remove the gate branch → `TestCompanionCredentialRefusedOnGatedRoutes`
  - restore the login mint → `TestCompanionTokenCannotMintConsoleSession`
  - register `GET /v1/companion/inventory` with no allowlist entry → `TestCompanionAllowlistMatchesRegisteredRoutes`

## Note on scope

`docs/understanding/trust-architecture.md` gains a section stating the rule, including its precondition: the gate exists only when operator API tokens are configured. With none configured it is nil and every route serves without a credential, so this is a restriction on an authenticated deployment rather than a floor under an unauthenticated one.

Refs #1499

🤖 Generated with [Claude Code](https://claude.com/claude-code)
