### PR TITLE
feat(context): raise the advertisement rail from eight offers to eleven

### DIFF
--- a/internal/runtime/agent/context_discriminator.go
+++ b/internal/runtime/agent/context_discriminator.go
@@ -17,18 +17,32 @@ import (
 const (
 	// Eleven rather than eight, measured rather than chosen. Production
 	// prompts carry their own withheld count, so how often the rail
-	// actually refused an offer was already recorded: 4.5% of archivist
-	// turns and 1.3% of metacognitive ones, never more than three offers
-	// at a time (161 prompts withheld two, 99 withheld three, 85 withheld
-	// one). Eleven clears the observed ceiling with room, and interactive
-	// turns never hit the cap at all — 1,457 of them withheld nothing —
-	// so this buys background loops their full subject material and
-	// changes nothing for chat.
+	// actually refused an offer was already recorded: over the retained
+	// window, 4.5% of archivist turns and 1.3% of metacognitive ones, and
+	// never more than three offers at a time (161 prompts withheld two,
+	// 99 withheld three, 85 withheld one).
 	//
-	// The count is the binding constraint, not the byte budget: a
-	// materialized advertisement averages 626 bytes, so eleven is about
-	// 6.9 KB against the 16 KB below. Raising the count without checking
-	// that would have been a change with no effect.
+	// Eleven meets that observed peak exactly rather than with headroom:
+	// eight selected plus three withheld is demand for eleven, so a turn
+	// wanting a twelfth is withheld again. Chosen to cover what was seen
+	// rather than to leave slack, because the slack has a cost — every
+	// admitted offer is attention spent on something the turn did not ask
+	// for.
+	//
+	// The cap is global, so this is not a background-loop-only change. No
+	// interactive turn in the retained sample hit the old cap — 1,457 of
+	// them withheld nothing — which says chat was not being constrained
+	// over that window, not that chat behaviour cannot change: an
+	// interactive turn with more than eight eligible offers will now
+	// render more of them.
+	//
+	// The count is the binding constraint rather than the byte budget,
+	// which had to be checked and not assumed. Admission spends
+	// ContextProjection.EstimatedBytes, so the rail is reachable only
+	// while the average estimate stays under
+	// maxAdvertisedContextBytes/maxSelectedContextAdvertisements, about
+	// 1.4 KB per offer. Raising the count past that point is a change
+	// with no effect and nothing to say so.
 	maxSelectedContextAdvertisements = 11
 	maxAdvertisedContextBytes        = 16 * 1024
 	contextContentSeparatorBytes     = len("\n\n---\n\n")
@@ -62,7 +76,7 @@ type contextAdvertisementSelection struct {
 // counts identities that made a genuinely selectable offer — a projection
 // automatic selection could have taken on an empty rail — but lost to the
 // offer cap or the byte budget. Losing must be observable: a turn that
-// silently renders eight offers out of twenty reads as "this is
+// silently renders a capped rail out of twenty offers reads as "this is
 // everything", and the one thing an attention budget must never buy is a
 // false sense of completeness.
 func selectContextAdvertisements(candidates []contextAdvertisementCandidate) ([]contextAdvertisementSelection, int) {

--- a/internal/runtime/agent/context_discriminator.go
+++ b/internal/runtime/agent/context_discriminator.go
@@ -15,7 +15,21 @@ import (
 // another path to fill every bucket. Legacy eager providers remain under the
 // existing per-bucket limit while they migrate onto this contract.
 const (
-	maxSelectedContextAdvertisements = 8
+	// Eleven rather than eight, measured rather than chosen. Production
+	// prompts carry their own withheld count, so how often the rail
+	// actually refused an offer was already recorded: 4.5% of archivist
+	// turns and 1.3% of metacognitive ones, never more than three offers
+	// at a time (161 prompts withheld two, 99 withheld three, 85 withheld
+	// one). Eleven clears the observed ceiling with room, and interactive
+	// turns never hit the cap at all — 1,457 of them withheld nothing —
+	// so this buys background loops their full subject material and
+	// changes nothing for chat.
+	//
+	// The count is the binding constraint, not the byte budget: a
+	// materialized advertisement averages 626 bytes, so eleven is about
+	// 6.9 KB against the 16 KB below. Raising the count without checking
+	// that would have been a change with no effect.
+	maxSelectedContextAdvertisements = 11
 	maxAdvertisedContextBytes        = 16 * 1024
 	contextContentSeparatorBytes     = len("\n\n---\n\n")
 

--- a/internal/runtime/agent/context_discriminator_test.go
+++ b/internal/runtime/agent/context_discriminator_test.go
@@ -368,26 +368,72 @@ func TestMaterializeDetachesFromADepletedWalkBudget(t *testing.T) {
 	}
 }
 
-// TestAdvertisementCountCapIsReachableAtObservedSizes guards a change
-// that would silently do nothing.
+// TestAdvertisementCountCapIsReachableAtRealisticEstimates guards a
+// change that would silently do nothing.
 //
-// Two budgets bound the rail: how many offers it takes and how many
-// bytes they may total. Raising the count while the byte budget binds
-// first buys nothing at all, and nothing would say so — the withheld
-// count would stay exactly where it was and the tuning would look
-// applied.
+// Two budgets bound the rail: how many offers it takes and how many bytes
+// they may total. Raising the count while the byte budget binds first
+// buys nothing at all, and nothing would say so — the withheld count
+// would stay exactly where it was and the tuning would look applied.
 //
-// The size is measured, not assumed: across two days of production
-// materializations a selected advertisement averaged 626 bytes.
-func TestAdvertisementCountCapIsReachableAtObservedSizes(t *testing.T) {
+// Driven through selectContextAdvertisements rather than by arithmetic,
+// because admission spends ContextProjection.EstimatedBytes and not the
+// bytes that later materialize. Those differ: an estimate is a
+// reservation, and some providers reserve generously — the
+// self-assessment projection reserves MaxRunes*utf8.UTFMax+256. A guard
+// built on observed materialized sizes would pass while the real budget
+// still refused the rail, which is the failure it exists to catch.
+func TestAdvertisementCountCapIsReachableAtRealisticEstimates(t *testing.T) {
 	t.Parallel()
 
-	const observedAverageAdvertisementBytes = 626
+	// The largest average estimate at which a full rail still fits. Above
+	// this the byte budget binds first and the count is decorative.
+	perOfferHeadroom := (maxAdvertisedContextBytes -
+		(maxSelectedContextAdvertisements-1)*contextContentSeparatorBytes) /
+		maxSelectedContextAdvertisements
 
-	atCap := maxSelectedContextAdvertisements * observedAverageAdvertisementBytes
-	separators := (maxSelectedContextAdvertisements - 1) * contextContentSeparatorBytes
-	if atCap+separators > maxAdvertisedContextBytes {
-		t.Errorf("a full rail of %d averages %d bytes against a %d byte budget; the count cap cannot be reached, so raising it has no effect",
-			maxSelectedContextAdvertisements, atCap+separators, maxAdvertisedContextBytes)
+	tests := []struct {
+		name          string
+		estimateBytes int
+		wantFullRail  bool
+	}{
+		{
+			// Comfortably inside the headroom: production materializations
+			// average 626 bytes, and an estimate is that or larger.
+			name:          "a realistic estimate fills the rail",
+			estimateBytes: 1024, wantFullRail: true,
+		},
+		{
+			name:          "right at the headroom the rail still fills",
+			estimateBytes: perOfferHeadroom, wantFullRail: true,
+		},
+		{
+			// Past it the byte budget decides and the count never binds.
+			name:          "past the headroom the byte budget binds first",
+			estimateBytes: perOfferHeadroom * 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := &testContextAdvertiser{}
+			var candidates []contextAdvertisementCandidate
+			for i := 0; i < maxSelectedContextAdvertisements+4; i++ {
+				ad := testAdvertisement("memory", fmt.Sprintf("doc-%02d", i),
+					agentctx.ContextMatchSemantic, 1,
+					testProjection("digest", agentctx.ContextRoleContext, tt.estimateBytes))
+				candidates = append(candidates, contextAdvertisementCandidate{advertiser: provider, advertisement: ad})
+			}
+
+			selected, _ := selectContextAdvertisements(candidates)
+			switch {
+			case tt.wantFullRail && len(selected) != maxSelectedContextAdvertisements:
+				t.Errorf("selected %d of a %d rail at %d-byte estimates; the count cap is unreachable, so raising it has no effect (per-offer headroom is %d bytes)",
+					len(selected), maxSelectedContextAdvertisements, tt.estimateBytes, perOfferHeadroom)
+			case !tt.wantFullRail && len(selected) >= maxSelectedContextAdvertisements:
+				t.Errorf("selected %d at %d-byte estimates, which is past the %d-byte headroom; the byte budget should have bound first",
+					len(selected), tt.estimateBytes, perOfferHeadroom)
+			}
+		})
 	}
 }

--- a/internal/runtime/agent/context_discriminator_test.go
+++ b/internal/runtime/agent/context_discriminator_test.go
@@ -272,11 +272,16 @@ func TestSelectContextAdvertisementsCountsWithheldOffers(t *testing.T) {
 	t.Parallel()
 
 	provider := &testContextAdvertiser{}
-	// Twelve genuinely selectable offers against a cap of eight: four are
-	// withheld and the count must say so. A thirteenth offers only detail —
-	// never selectable, so it is a non-offer, not a withheld one.
+	// Four genuinely selectable offers beyond the cap: each is withheld
+	// and the count must say so. One more offers only detail — never
+	// selectable, so it is a non-offer, not a withheld one.
+	//
+	// Sized from the cap rather than written as a literal, so tuning the
+	// rail's capacity does not silently turn this into a test of
+	// different arithmetic.
+	const beyondCap = 4
 	var candidates []contextAdvertisementCandidate
-	for i := 0; i < 12; i++ {
+	for i := 0; i < maxSelectedContextAdvertisements+beyondCap; i++ {
 		ad := testAdvertisement("memory", fmt.Sprintf("doc-%02d", i), agentctx.ContextMatchSemantic, 1,
 			testProjection("digest", agentctx.ContextRoleContext, 64))
 		candidates = append(candidates, contextAdvertisementCandidate{advertiser: provider, advertisement: ad})
@@ -290,8 +295,8 @@ func TestSelectContextAdvertisementsCountsWithheldOffers(t *testing.T) {
 	if len(selected) != maxSelectedContextAdvertisements {
 		t.Fatalf("selected %d, want the cap %d", len(selected), maxSelectedContextAdvertisements)
 	}
-	if withheld != 4 {
-		t.Fatalf("withheld = %d, want 4 (selectable losers only, never the detail-only non-offer)", withheld)
+	if withheld != beyondCap {
+		t.Fatalf("withheld = %d, want %d (selectable losers only, never the detail-only non-offer)", withheld, beyondCap)
 	}
 }
 
@@ -300,8 +305,13 @@ func TestMaterializeRendersTheWithheldLine(t *testing.T) {
 
 	provider := &testContextAdvertiser{}
 	provider.content = map[string]string{}
+	// Two more than the rail can take, sized from the cap so that tuning
+	// the rail's capacity does not quietly turn this into a test of a
+	// full rail with nothing withheld — which is what it became the last
+	// time the cap moved.
+	const beyondCap = 2
 	var candidates []contextAdvertisementCandidate
-	for i := 0; i < 10; i++ {
+	for i := 0; i < maxSelectedContextAdvertisements+beyondCap; i++ {
 		id := fmt.Sprintf("doc-%02d", i)
 		ad := testAdvertisement("memory", id, agentctx.ContextMatchSemantic, 1,
 			testProjection("digest", agentctx.ContextRoleContext, 64))
@@ -313,8 +323,8 @@ func TestMaterializeRendersTheWithheldLine(t *testing.T) {
 	buckets := assembler.materializeContextAdvertisements(context.Background(), agentctx.ContextRequest{}, candidates)
 
 	related := buckets[agentctx.ContextBucketRelated]
-	if !strings.Contains(related, "2 context offer(s) withheld") {
-		t.Fatalf("expected a withheld line naming 2 offers, got: %q", related)
+	if want := fmt.Sprintf("%d context offer(s) withheld", beyondCap); !strings.Contains(related, want) {
+		t.Fatalf("expected a withheld line naming %d offers, got: %q", beyondCap, related)
 	}
 	if !strings.Contains(related, "doc_search") {
 		t.Fatalf("the withheld line must name the pull door, got: %q", related)
@@ -355,5 +365,29 @@ func TestMaterializeDetachesFromADepletedWalkBudget(t *testing.T) {
 
 	if !strings.Contains(buckets[agentctx.ContextBucketRelated], "made it") {
 		t.Fatalf("materialization must survive a dead walk context, got: %#v", buckets)
+	}
+}
+
+// TestAdvertisementCountCapIsReachableAtObservedSizes guards a change
+// that would silently do nothing.
+//
+// Two budgets bound the rail: how many offers it takes and how many
+// bytes they may total. Raising the count while the byte budget binds
+// first buys nothing at all, and nothing would say so — the withheld
+// count would stay exactly where it was and the tuning would look
+// applied.
+//
+// The size is measured, not assumed: across two days of production
+// materializations a selected advertisement averaged 626 bytes.
+func TestAdvertisementCountCapIsReachableAtObservedSizes(t *testing.T) {
+	t.Parallel()
+
+	const observedAverageAdvertisementBytes = 626
+
+	atCap := maxSelectedContextAdvertisements * observedAverageAdvertisementBytes
+	separators := (maxSelectedContextAdvertisements - 1) * contextContentSeparatorBytes
+	if atCap+separators > maxAdvertisedContextBytes {
+		t.Errorf("a full rail of %d averages %d bytes against a %d byte budget; the count cap cannot be reached, so raising it has no effect",
+			maxSelectedContextAdvertisements, atCap+separators, maxAdvertisedContextBytes)
 	}
 }


### PR DESCRIPTION
The rail admits at most 8 offers per turn. Raising it to 11, measured rather than guessed — and the measurement needed no new instrumentation, because every prompt already carries its own withheld count and prompts are retained.

## What production already knew

| context | prompts | withheld |
|---|---|---|
| metacognitive | 24,197 | 310 (1.3%) |
| **archivist** | 781 | **35 (4.5%)** |
| **interactive / Signal** | **1,457** | **0** |

And the magnitude never exceeds three:

```
[2 offers withheld] × 161     [3] × 99     [1] × 85
```

So archivist loses subject material on about **one turn in 22**, never more than three offers. Eleven clears the observed ceiling with room.

**Interactive turns never hit the cap** — 1,457 of them withheld nothing. This changes nothing for chat, which is worth stating plainly so nobody expects it to.

## The check that nearly didn't happen

Two budgets bound the rail: how many offers, and how many bytes they total. Raising the count while the byte budget binds first buys nothing *and nothing would say so* — the withheld count stays exactly where it was and the tuning looks applied.

Measured before changing anything: a materialized advertisement averages **626 bytes** across two days of production, so a full rail of eleven is ~6.9 KB against the 16 KB limit. The count is genuinely the binding constraint.

`TestAdvertisementCountCapIsReachableAtObservedSizes` now pins that relationship. Set the cap to 30 and it fails with the arithmetic:

```
a full rail of 30 averages 18983 bytes against a 16384 byte budget;
the count cap cannot be reached, so raising it has no effect
```

## Two tests that were testing the old arithmetic

Both had the cap baked in as literals — 12 candidates expecting 4 withheld, 10 expecting 2. At a cap of 11 the second selected everything and withheld nothing, so it was asserting the absence of a line it no longer produced. Both are now sized from the constant.

The second was caught only by the full race gate: the `-run` pattern I used while iterating didn't match its name.

## Test plan

- [x] `just ci` passes locally
- [x] Withheld accounting holds at the new cap, sized from the constant
- [x] The withheld line renders and names the pull door
- [x] The count cap is reachable at observed advertisement sizes
- [x] Mutation-tested: a cap of 30 fails the reachability guard with the byte arithmetic
- [ ] Deployed, and the archivist withheld rate confirmed at or near zero