### PR TITLE
feat(context): root the presence block in contacts, and stop calling a transition a duration

### DIFF
--- a/internal/app/adapters.go
+++ b/internal/app/adapters.go
@@ -161,8 +161,28 @@ type contactChannelBindingResolver struct {
 // channel/address pair. It always returns a channel-scoped binding when
 // the inputs are non-empty, even if no contact match is found.
 func (r *contactChannelBindingResolver) ResolveChannelBinding(channel, address string) *memory.ChannelBinding {
-	operatorConfigured := r.operatorContactID != uuid.Nil || strings.TrimSpace(r.legacyOwnerContactName) != ""
-	return resolveChannelBinding(r.store, channel, address, operatorConfigured, r.resolvedOperatorContactID())
+	return resolveChannelBinding(r.store, channel, address, r.operatorConfigured(), r.resolvedOperatorContactID())
+}
+
+// operatorConfigured reports whether either operator selector is set.
+// Both are: identity.operator_contact_id names a UUID directly, and the
+// legacy identity.owner_contact_name names a contact to look up.
+func (r *contactChannelBindingResolver) operatorConfigured() bool {
+	if r == nil {
+		return false
+	}
+	return r.operatorContactID != uuid.Nil || strings.TrimSpace(r.legacyOwnerContactName) != ""
+}
+
+// isOperator reports whether the given contact is the configured
+// operator. It routes through resolvedOperatorContactID so the legacy
+// name selector resolves to a UUID rather than failing closed, and so
+// every surface pins the same contact from the same cache.
+func (r *contactChannelBindingResolver) isOperator(contact *contacts.Contact) bool {
+	if r == nil {
+		return false
+	}
+	return isOwnerContact(r.store, contact, r.operatorConfigured(), r.resolvedOperatorContactID())
 }
 
 // contactNameLookup resolves contact names to rich context profiles for

--- a/internal/app/adapters_test.go
+++ b/internal/app/adapters_test.go
@@ -329,6 +329,56 @@ func TestContactChannelBindingResolverCachesLegacyConfiguredContactName(t *testi
 	}
 }
 
+// TestContactBindingResolverOperatorUnderLegacyName pins the legacy
+// identity.owner_contact_name selector against isOperator, the path the
+// contact-rooted presence block uses to decide is_operator.
+//
+// Passing the raw config values to isOwnerContact fails closed here:
+// the selector counts as configured, so the single-admin fallback is
+// skipped, but the name was never resolved to a UUID, leaving the
+// comparison against uuid.Nil. Only resolvedOperatorContactID makes the
+// legacy configuration mark anyone as the operator.
+func TestContactBindingResolverOperatorUnderLegacyName(t *testing.T) {
+	db, err := database.Open(t.TempDir() + "/contacts.db")
+	if err != nil {
+		t.Fatalf("database.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store, err := contacts.NewStore(db, slog.Default())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	tools := contacts.NewTools(store, nil)
+	for _, name := range []string{"Aimee", "Blake"} {
+		if _, err := tools.SaveContact(`{"name":"` + name + `","kind":"individual"}`); err != nil {
+			t.Fatalf("SaveContact %s: %v", name, err)
+		}
+	}
+	operator, err := store.FindByName("Aimee")
+	if err != nil {
+		t.Fatalf("FindByName: %v", err)
+	}
+	other, err := store.FindByName("Blake")
+	if err != nil {
+		t.Fatalf("FindByName: %v", err)
+	}
+
+	resolver := &contactChannelBindingResolver{
+		store:                  store,
+		legacyOwnerContactName: "Aimee",
+	}
+	if !resolver.isOperator(operator) {
+		t.Error("isOperator(operator) = false under identity.owner_contact_name, want true")
+	}
+	if resolver.isOperator(other) {
+		t.Error("isOperator(other) = true, want false")
+	}
+	if resolver.isOperator(nil) {
+		t.Error("isOperator(nil) = true, want false")
+	}
+}
+
 func TestContactChannelBindingResolverUsesConfiguredOperatorID(t *testing.T) {
 	configured := uuid.New()
 	resolver := &contactChannelBindingResolver{operatorContactID: configured}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/google/uuid"
 	"github.com/nugget/thane-ai-agent/internal/channels/email"
 	"github.com/nugget/thane-ai-agent/internal/channels/messages"
 	sigcli "github.com/nugget/thane-ai-agent/internal/channels/messaging/signal"
@@ -87,6 +88,11 @@ type App struct {
 	// contactBindingsConfigOwned records the verified startup decision so
 	// CardDAV cannot reinterpret an ignored unverified config later.
 	contactBindingsConfigOwned bool
+	// Operator identity, resolved in initChannels and read by later
+	// stages. initAwareness runs after channels, so the presence
+	// contact resolver can rely on these being set.
+	operatorContactID      uuid.UUID
+	legacyOwnerContactName string
 
 	// LLM clients
 	llmClient             llm.Client

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -14,7 +14,6 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/google/uuid"
 	"github.com/nugget/thane-ai-agent/internal/channels/email"
 	"github.com/nugget/thane-ai-agent/internal/channels/messages"
 	sigcli "github.com/nugget/thane-ai-agent/internal/channels/messaging/signal"
@@ -88,11 +87,12 @@ type App struct {
 	// contactBindingsConfigOwned records the verified startup decision so
 	// CardDAV cannot reinterpret an ignored unverified config later.
 	contactBindingsConfigOwned bool
-	// Operator identity, resolved in initChannels and read by later
-	// stages. initAwareness runs after channels, so the presence
-	// contact resolver can rely on these being set.
-	operatorContactID      uuid.UUID
-	legacyOwnerContactName string
+	// Operator identity, built in initChannels and read by later stages.
+	// initAwareness runs after channels, so the presence contact
+	// resolver can rely on this being set. Shared with the Signal
+	// bridge so both surfaces pin the same contact as operator,
+	// including under the legacy identity.owner_contact_name selector.
+	contactBindingResolver *contactChannelBindingResolver
 
 	// LLM clients
 	llmClient             llm.Client

--- a/internal/app/new_awareness.go
+++ b/internal/app/new_awareness.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/nugget/thane-ai-agent/internal/channels/notifications"
 	"github.com/nugget/thane-ai-agent/internal/connwatch"
 	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
@@ -330,19 +329,28 @@ func (a *App) initAwareness(s *newState) error {
 		var presenceOpts []contacts.PresenceOption
 		if a.contactStore != nil {
 			store := a.contactStore
+			bindings := a.contactBindingResolver
 			presenceOpts = append(presenceOpts, contacts.WithContactResolver(
 				func(entityID string) (contacts.ContactIdentity, bool) {
 					contact, err := store.FindByHAPersonEntity(entityID)
-					if err != nil || contact == nil {
+					if err != nil {
+						// An unclaimed entity is (nil, nil) and degrades
+						// silently by design. A store failure degrades
+						// identically but is not routine: it strips
+						// contact_id and operator status out of an
+						// always-on block, so say so.
+						logger.Warn("presence contact resolution failed, rendering entity-only",
+							"entity_id", entityID, "error", err)
 						return contacts.ContactIdentity{}, false
 					}
-					operatorConfigured := a.operatorContactID != uuid.Nil ||
-						strings.TrimSpace(a.legacyOwnerContactName) != ""
+					if contact == nil {
+						return contacts.ContactIdentity{}, false
+					}
 					return contacts.ContactIdentity{
 						ID:         contact.ID.String(),
 						Name:       contact.FormattedName,
 						TrustZone:  contact.TrustZone,
-						IsOperator: isOwnerContact(store, contact, operatorConfigured, a.operatorContactID),
+						IsOperator: bindings.isOperator(contact),
 					}, true
 				}))
 		}

--- a/internal/app/new_awareness.go
+++ b/internal/app/new_awareness.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/nugget/thane-ai-agent/internal/channels/notifications"
 	"github.com/nugget/thane-ai-agent/internal/connwatch"
 	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
@@ -321,7 +322,31 @@ func (a *App) initAwareness(s *newState) error {
 	// after construction when HA is available. Initialize is idempotent,
 	// so a redundant call from OnReady is harmless.
 	if len(cfg.Person.Track) > 0 {
-		s.personTracker = contacts.NewPresenceTracker(cfg.Person.Track, cfg.Timezone, logger)
+		// Contact-rooted presence: the model reasons about people, and
+		// without a contact id here it cannot chain into
+		// contact_whereabouts on a turn with no counterparty binding.
+		// Resolved per render, so a contact bound to a person entity
+		// after startup is picked up without a restart.
+		var presenceOpts []contacts.PresenceOption
+		if a.contactStore != nil {
+			store := a.contactStore
+			presenceOpts = append(presenceOpts, contacts.WithContactResolver(
+				func(entityID string) (contacts.ContactIdentity, bool) {
+					contact, err := store.FindByHAPersonEntity(entityID)
+					if err != nil || contact == nil {
+						return contacts.ContactIdentity{}, false
+					}
+					operatorConfigured := a.operatorContactID != uuid.Nil ||
+						strings.TrimSpace(a.legacyOwnerContactName) != ""
+					return contacts.ContactIdentity{
+						ID:         contact.ID.String(),
+						Name:       contact.FormattedName,
+						TrustZone:  contact.TrustZone,
+						IsOperator: isOwnerContact(store, contact, operatorConfigured, a.operatorContactID),
+					}, true
+				}))
+		}
+		s.personTracker = contacts.NewPresenceTracker(cfg.Person.Track, cfg.Timezone, logger, presenceOpts...)
 		s.personTracker.OnIngestEntitiesChange(seedPresenceIngestFloor)
 		s.personTracker.OnLinkedTrackersChange(func(entityIDs []string) {
 			if a.ha == nil || len(entityIDs) == 0 {

--- a/internal/app/new_channels.go
+++ b/internal/app/new_channels.go
@@ -139,10 +139,13 @@ func (a *App) initChannels(s *newState) error {
 		return err
 	}
 	a.contactBindingsConfigOwned = contactIdentity.configOwnsHAPersonBindings
-	a.operatorContactID = contactIdentity.operatorContactID
-	a.legacyOwnerContactName = contactIdentity.legacyOwnerContactName
 	operatorContactID := contactIdentity.operatorContactID
 	legacyOwnerContactName := contactIdentity.legacyOwnerContactName
+	a.contactBindingResolver = &contactChannelBindingResolver{
+		store:                  contactStore,
+		operatorContactID:      operatorContactID,
+		legacyOwnerContactName: legacyOwnerContactName,
+	}
 
 	// Wire summarizer → contact interaction tracking now that the
 	// contact store is available. Register the callback before Start()
@@ -834,17 +837,13 @@ func (a *App) initChannels(s *newState) error {
 			a.onCloseErr("signal", signalClient.Close)
 
 			bridge := sigcli.NewBridge(sigcli.BridgeConfig{
-				Client:        signalClient,
-				Runner:        &loopAdapter{agentLoop: a.loop, router: a.rtr, capSurface: a.capSurfaceGetter()},
-				Logger:        a.logger,
-				RateLimit:     a.cfg.Signal.RateLimitPerMinute,
-				HandleTimeout: a.cfg.Signal.HandleTimeout,
-				Routing:       a.cfg.Signal.Routing,
-				Resolver: &contactChannelBindingResolver{
-					store:                  contactStore,
-					operatorContactID:      operatorContactID,
-					legacyOwnerContactName: legacyOwnerContactName,
-				},
+				Client:           signalClient,
+				Runner:           &loopAdapter{agentLoop: a.loop, router: a.rtr, capSurface: a.capSurfaceGetter()},
+				Logger:           a.logger,
+				RateLimit:        a.cfg.Signal.RateLimitPerMinute,
+				HandleTimeout:    a.cfg.Signal.HandleTimeout,
+				Routing:          a.cfg.Signal.Routing,
+				Resolver:         a.contactBindingResolver,
 				BindConversation: a.mem.BindConversationChannel,
 				Attachments: sigcli.AttachmentConfig{
 					SourceDir: a.cfg.Signal.AttachmentSourceDir,

--- a/internal/app/new_channels.go
+++ b/internal/app/new_channels.go
@@ -139,6 +139,8 @@ func (a *App) initChannels(s *newState) error {
 		return err
 	}
 	a.contactBindingsConfigOwned = contactIdentity.configOwnsHAPersonBindings
+	a.operatorContactID = contactIdentity.operatorContactID
+	a.legacyOwnerContactName = contactIdentity.legacyOwnerContactName
 	operatorContactID := contactIdentity.operatorContactID
 	legacyOwnerContactName := contactIdentity.legacyOwnerContactName
 

--- a/internal/state/contacts/presence.go
+++ b/internal/state/contacts/presence.go
@@ -234,29 +234,48 @@ func (t *PresenceTracker) TagContextBucket() agentctx.ContextBucket {
 // tracked. Implements [agent.TagContextProvider]; registered via
 // RegisterAlwaysContextProvider.
 //
-// People with known state are formatted as compact JSON with delta-
-// annotated timestamps following #458 conventions. People with unknown
-// or unset state are rendered as plain markdown text.
+// Every row is compact JSON with delta-annotated timestamps following
+// #458 conventions, including people whose state is unknown or unset —
+// those carry state "unknown" and no state_since.
+//
+// Live state is snapshotted under the read lock and the lock is released
+// before contact resolution, which reaches the contacts database and
+// would otherwise hold presence writers behind SQLite's busy wait.
 func (t *PresenceTracker) TagContext(_ context.Context, _ agentctx.ContextRequest) (string, error) {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-
-	if len(t.order) == 0 {
+	rows := t.presenceRows(time.Now())
+	if len(rows) == 0 {
 		return "", nil
 	}
-
-	now := time.Now()
 
 	var sb strings.Builder
 	sb.WriteString("### People & Presence\n\n")
 
+	for i := range rows {
+		if t.contactResolver != nil {
+			if c, ok := t.contactResolver(rows[i].EntityID); ok {
+				rows[i].Contact = &c
+			}
+		}
+		sb.WriteString(FormatPersonPresence(rows[i]))
+		sb.WriteByte('\n')
+	}
+
+	return sb.String(), nil
+}
+
+// presenceRows copies the tracked people into render inputs. It takes the
+// read lock and performs no I/O, so applyPersonState reclaims the write
+// lock without waiting on contact resolution.
+func (t *PresenceTracker) presenceRows(now time.Time) []PersonPresenceInput {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	rows := make([]PersonPresenceInput, 0, len(t.order))
 	for _, id := range t.order {
 		p := t.people[id]
-		displayName := TitleCase(p.FriendlyName)
-
 		in := PersonPresenceInput{
 			EntityID:     p.EntityID,
-			Name:         displayName,
+			Name:         TitleCase(p.FriendlyName),
 			State:        p.State,
 			StateSince:   p.Since,
 			Room:         p.Room,
@@ -264,11 +283,6 @@ func (t *PresenceTracker) TagContext(_ context.Context, _ agentctx.ContextReques
 			RoomSource:   p.RoomSource,
 			RoomConflict: p.roomConflict,
 			Now:          now,
-		}
-		if t.contactResolver != nil {
-			if c, ok := t.contactResolver(p.EntityID); ok {
-				in.Contact = &c
-			}
 		}
 		// Unknown renders as JSON too. It used to be a markdown bullet
 		// carrying only a display name, so on the one turn the model most
@@ -279,11 +293,9 @@ func (t *PresenceTracker) TagContext(_ context.Context, _ agentctx.ContextReques
 			in.Room, in.RoomProvider, in.RoomSource = "", "", ""
 			in.RoomConflict = false
 		}
-		sb.WriteString(FormatPersonPresence(in))
-		sb.WriteByte('\n')
+		rows = append(rows, in)
 	}
-
-	return sb.String(), nil
+	return rows
 }
 
 // SetDeviceMACs configures the MAC addresses associated with a tracked

--- a/internal/state/contacts/presence.go
+++ b/internal/state/contacts/presence.go
@@ -2,7 +2,6 @@ package contacts
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"strings"
 	"sync"
@@ -18,46 +17,91 @@ import (
 // person in context output. Richer than the default entity JSON
 // because the tracker has provider-attributed room data.
 type PersonPresenceContext struct {
-	Entity       string `json:"entity"`
-	Name         string `json:"name"`
-	State        string `json:"state"`
-	Since        string `json:"since"`
+	// Contact identity first: the model reasons about people, and
+	// ContactID is what lets it chain into contact_whereabouts without
+	// gambling on name resolution.
+	Contact    string `json:"contact,omitempty"`
+	ContactID  string `json:"contact_id,omitempty"`
+	TrustZone  string `json:"trust_zone,omitempty"`
+	IsOperator bool   `json:"is_operator,omitempty"`
+
+	Entity string `json:"entity"`
+	Name   string `json:"name"`
+	State  string `json:"state"`
+	// StateSince is when this person entity last changed state. While
+	// away that is when they left home — it is not how long they have
+	// been wherever they are now. It was named "since", which invited
+	// exactly that misreading in an always-on block with no tool call to
+	// blame and no hedge available.
+	StateSince   string `json:"state_since,omitempty"`
 	Room         string `json:"room,omitempty"`
 	RoomProvider string `json:"room_provider,omitempty"`
 	RoomSource   string `json:"room_source,omitempty"`
 	RoomConflict bool   `json:"room_conflict,omitempty"`
 }
 
+// ContactIdentity is the contact a tracked person entity resolves to.
+// The tracker holds no contact store; app wiring supplies a resolver so
+// the projection can be contact-rooted without the dependency.
+type ContactIdentity struct {
+	ID         string
+	Name       string
+	TrustZone  string
+	IsOperator bool
+}
+
+// PersonPresenceInput is the state of one tracked person.
+//
+// A struct rather than a parameter list: the previous signature took
+// eight positional primitives, and contact identity would have made it
+// twelve.
+type PersonPresenceInput struct {
+	EntityID     string
+	Name         string
+	State        string
+	StateSince   time.Time
+	Room         string
+	RoomProvider string
+	RoomSource   string
+	RoomConflict bool
+	Contact      *ContactIdentity
+	Now          time.Time
+}
+
 // FormatPersonPresence formats a tracked person as compact JSON with
 // delta-annotated timestamps.
-func FormatPersonPresence(
-	entityID, name, state string,
-	since time.Time,
-	room, roomProvider, roomSource string,
-	roomConflict bool,
-	now time.Time,
-) string {
-	displayState := state
-	if strings.EqualFold(state, "not_home") {
+func FormatPersonPresence(in PersonPresenceInput) string {
+	displayState := in.State
+	if strings.EqualFold(in.State, "not_home") {
 		displayState = "away"
 	}
-	if !strings.EqualFold(state, "home") || roomConflict {
+	room, roomProvider, roomSource := in.Room, in.RoomProvider, in.RoomSource
+	roomConflict := in.RoomConflict
+	if !strings.EqualFold(in.State, "home") || roomConflict {
 		room = ""
 		roomProvider = ""
 		roomSource = ""
 	}
-	if !strings.EqualFold(state, "home") {
+	if !strings.EqualFold(in.State, "home") {
 		roomConflict = false
 	}
 	pc := PersonPresenceContext{
-		Entity:       entityID,
-		Name:         name,
+		Entity:       in.EntityID,
+		Name:         in.Name,
 		State:        displayState,
-		Since:        promptfmt.FormatDeltaOnly(since, now),
 		Room:         room,
 		RoomProvider: roomProvider,
 		RoomSource:   roomSource,
 		RoomConflict: roomConflict,
+	}
+	if !in.StateSince.IsZero() {
+		pc.StateSince = promptfmt.FormatDeltaOnly(in.StateSince, in.Now)
+	}
+	if c := in.Contact; c != nil {
+		pc.Contact = c.Name
+		pc.ContactID = c.ID
+		pc.TrustZone = c.TrustZone
+		pc.IsOperator = c.IsOperator
 	}
 	return promptfmt.MarshalCompact(pc)
 }
@@ -101,6 +145,11 @@ type PresenceTracker struct {
 	order     []string           // insertion order for deterministic output
 	observers []RoomObserver     // called on room changes
 
+	// contactResolver maps a person entity to the contact it belongs to.
+	// Supplied by app wiring; nil in tests and in deployments with no
+	// contact store, where the block degrades to entity-only.
+	contactResolver func(entityID string) (ContactIdentity, bool)
+
 	linkedByPerson  map[string][]string
 	ownersByTracker map[string][]string
 	trackerPlatform map[string]string
@@ -115,11 +164,25 @@ type PresenceTracker struct {
 	logger *slog.Logger
 }
 
+// PresenceOption configures a tracker at construction.
+//
+// An option rather than a setter: the resolver is wiring, fixed for the
+// tracker's life, and the architecture baseline counts mutator growth
+// deliberately. Variadic so the existing call sites are untouched.
+type PresenceOption func(*PresenceTracker)
+
+// WithContactResolver supplies the entity-to-contact projection that
+// makes the presence block contact-rooted. Omitted, the block renders
+// entity-only rather than inventing an identity.
+func WithContactResolver(fn func(entityID string) (ContactIdentity, bool)) PresenceOption {
+	return func(t *PresenceTracker) { t.contactResolver = fn }
+}
+
 // NewPresenceTracker creates a person tracker for the given entity IDs. All
 // entities start in "Unknown" state until Initialize is called. The
 // timezone is an IANA location string (e.g., "America/Chicago"); an
 // empty or invalid timezone falls back to the system local timezone.
-func NewPresenceTracker(entityIDs []string, timezone string, logger *slog.Logger) *PresenceTracker {
+func NewPresenceTracker(entityIDs []string, timezone string, logger *slog.Logger, opts ...PresenceOption) *PresenceTracker {
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -145,7 +208,7 @@ func NewPresenceTracker(entityIDs []string, timezone string, logger *slog.Logger
 		order = append(order, id)
 	}
 
-	return &PresenceTracker{
+	t := &PresenceTracker{
 		people:          people,
 		order:           order,
 		linkedByPerson:  make(map[string][]string),
@@ -155,6 +218,10 @@ func NewPresenceTracker(entityIDs []string, timezone string, logger *slog.Logger
 		loc:             loc,
 		logger:          logger,
 	}
+	for _, opt := range opts {
+		opt(t)
+	}
+	return t
 }
 
 // TagContextBucket places current person presence in live state.
@@ -187,15 +254,33 @@ func (t *PresenceTracker) TagContext(_ context.Context, _ agentctx.ContextReques
 		p := t.people[id]
 		displayName := TitleCase(p.FriendlyName)
 
-		if p.State == "Unknown" || p.Since.IsZero() {
-			fmt.Fprintf(&sb, "- **%s**: unknown\n", displayName)
-		} else {
-			sb.WriteString(FormatPersonPresence(
-				p.EntityID, displayName, p.State, p.Since,
-				p.Room, p.RoomProvider, p.RoomSource, p.roomConflict, now,
-			))
-			sb.WriteByte('\n')
+		in := PersonPresenceInput{
+			EntityID:     p.EntityID,
+			Name:         displayName,
+			State:        p.State,
+			StateSince:   p.Since,
+			Room:         p.Room,
+			RoomProvider: p.RoomProvider,
+			RoomSource:   p.RoomSource,
+			RoomConflict: p.roomConflict,
+			Now:          now,
 		}
+		if t.contactResolver != nil {
+			if c, ok := t.contactResolver(p.EntityID); ok {
+				in.Contact = &c
+			}
+		}
+		// Unknown renders as JSON too. It used to be a markdown bullet
+		// carrying only a display name, so on the one turn the model most
+		// needs a handle it had nothing to chain into.
+		if p.State == "Unknown" || p.Since.IsZero() {
+			in.State = "unknown"
+			in.StateSince = time.Time{}
+			in.Room, in.RoomProvider, in.RoomSource = "", "", ""
+			in.RoomConflict = false
+		}
+		sb.WriteString(FormatPersonPresence(in))
+		sb.WriteByte('\n')
 	}
 
 	return sb.String(), nil

--- a/internal/state/contacts/presence_test.go
+++ b/internal/state/contacts/presence_test.go
@@ -51,8 +51,13 @@ func TestNewPresenceTracker(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetContext: %v", err)
 	}
-	if !strings.Contains(result, ": unknown") {
+	// Unknown renders as JSON now, not a markdown bullet: the model needs
+	// a chainable handle on the turn it knows least.
+	if !strings.Contains(result, `"state":"unknown"`) {
 		t.Errorf("expected unknown state in initial context, got:\n%s", result)
+	}
+	if !strings.Contains(result, `"entity":"person.alice"`) {
+		t.Errorf("expected unknown rows to stay chainable, got:\n%s", result)
 	}
 }
 
@@ -126,9 +131,9 @@ func TestTracker_Initialize_PartialFailure(t *testing.T) {
 	if !strings.Contains(result, `"name":"Alice"`) || !strings.Contains(result, `"state":"home"`) {
 		t.Errorf("expected Alice with state:home, got:\n%s", result)
 	}
-	// Bob should show unknown.
-	if !strings.Contains(result, "- **Bob**: unknown") {
-		t.Errorf("expected Bob: unknown, got:\n%s", result)
+	// Bob should show unknown, as JSON like everyone else.
+	if !strings.Contains(result, `{"entity":"person.bob","name":"Bob","state":"unknown"}`) {
+		t.Errorf("expected Bob unknown as JSON, got:\n%s", result)
 	}
 }
 
@@ -165,8 +170,8 @@ func TestTracker_HandleStateChange_IgnoresUntracked(t *testing.T) {
 	tracker.HandleStateChange("light.kitchen", "off", "on", "")
 
 	result, _ := tracker.TagContext(context.Background(), agentctx.ContextRequest{UserMessage: ""})
-	if !strings.Contains(result, "- **Alice**: unknown") {
-		t.Errorf("expected Alice: unknown unchanged, got:\n%s", result)
+	if !strings.Contains(result, `{"entity":"person.alice","name":"Alice","state":"unknown"}`) {
+		t.Errorf("expected Alice unknown unchanged, got:\n%s", result)
 	}
 }
 
@@ -270,8 +275,10 @@ func TestTracker_GetContext(t *testing.T) {
 	if !strings.Contains(result, `"entity":"person.alice"`) || !strings.Contains(result, `"state":"home"`) {
 		t.Errorf("expected JSON format with entity and state, got:\n%s", result)
 	}
-	if !strings.Contains(result, `"since":"-`) {
-		t.Errorf("expected delta since field, got:\n%s", result)
+	// state_since, not since: it is when the entity last changed state,
+	// which while away is when they left home.
+	if !strings.Contains(result, `"state_since":"-`) {
+		t.Errorf("expected delta state_since field, got:\n%s", result)
 	}
 
 	// Verify Alice comes before Bob (insertion order).
@@ -773,5 +780,78 @@ func TestPresenceSnapshot(t *testing.T) {
 	}
 	if _, ok := tracker.Snapshot("person.nobody"); ok {
 		t.Error("untracked entity reported as tracked")
+	}
+}
+
+// TestPresenceIsContactRooted pins the projection the model depends on.
+//
+// Without contact_id in this block the model cannot chain into
+// contact_whereabouts on a turn with no counterparty binding — it has
+// only a friendly name and has to gamble on resolution.
+func TestPresenceIsContactRooted(t *testing.T) {
+	tracker := NewPresenceTracker([]string{"person.alice"}, "UTC", nil, WithContactResolver(func(entityID string) (ContactIdentity, bool) {
+		if entityID != "person.alice" {
+			return ContactIdentity{}, false
+		}
+		return ContactIdentity{
+			ID:         "019c76e4-2ff1-7918-8d6f-6c2488f5098d",
+			Name:       "Alice",
+			TrustZone:  "owner",
+			IsOperator: true,
+		}, true
+	}))
+	tracker.HandleStateChange("person.alice", "not_home", "home", "")
+
+	out, err := tracker.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	for _, want := range []string{
+		`"contact":"Alice"`,
+		`"contact_id":"019c76e4-2ff1-7918-8d6f-6c2488f5098d"`,
+		`"trust_zone":"owner"`,
+		`"is_operator":true`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("presence block missing %s, got:\n%s", want, out)
+		}
+	}
+}
+
+// TestPresenceDegradesWithoutContactStore keeps the block honest where no
+// contact claims the entity: entity-only, never an invented identity.
+func TestPresenceDegradesWithoutContactStore(t *testing.T) {
+	tracker := NewPresenceTracker([]string{"person.alice"}, "UTC", nil)
+	tracker.HandleStateChange("person.alice", "not_home", "home", "")
+
+	out, err := tracker.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	if strings.Contains(out, "contact_id") || strings.Contains(out, "trust_zone") {
+		t.Errorf("unbound entity should carry no contact identity, got:\n%s", out)
+	}
+	if !strings.Contains(out, `"entity":"person.alice"`) {
+		t.Errorf("entity row should still render, got:\n%s", out)
+	}
+}
+
+// TestStateSinceIsNotDwellTime documents the semantics the rename exists
+// for: while away this is when they left home, not how long they have
+// been anywhere.
+func TestStateSinceIsNotDwellTime(t *testing.T) {
+	now := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	out := FormatPersonPresence(PersonPresenceInput{
+		EntityID:   "person.alice",
+		Name:       "Alice",
+		State:      "not_home",
+		StateSince: now.Add(-3*time.Hour - 44*time.Minute),
+		Now:        now,
+	})
+	if !strings.Contains(out, `"state_since":"-3h44m"`) {
+		t.Errorf("expected state_since delta, got: %s", out)
+	}
+	if strings.Contains(out, `"since"`) {
+		t.Errorf("bare `since` invites reading this as dwell time, got: %s", out)
 	}
 }

--- a/internal/state/contacts/room_presence_test.go
+++ b/internal/state/contacts/room_presence_test.go
@@ -198,10 +198,17 @@ func TestRoomObservationEvidenceKeepsBermudaIdentityPrivate(t *testing.T) {
 
 func TestFormatPersonPresenceConflictSuppressesResolvedRoom(t *testing.T) {
 	now := time.Date(2026, 8, 30, 12, 0, 0, 0, time.UTC)
-	rendered := FormatPersonPresence(
-		"person.alice", "Alice", "home", now.Add(-time.Hour),
-		"office", "unifi", "ap-office", true, now,
-	)
+	rendered := FormatPersonPresence(PersonPresenceInput{
+		EntityID:     "person.alice",
+		Name:         "Alice",
+		State:        "home",
+		StateSince:   now.Add(-time.Hour),
+		Room:         "office",
+		RoomProvider: "unifi",
+		RoomSource:   "ap-office",
+		RoomConflict: true,
+		Now:          now,
+	})
 	if !strings.Contains(rendered, `"room_conflict":true`) || strings.Contains(rendered, `"room":`) {
 		t.Fatalf("conflict context = %s, want conflict without resolved room", rendered)
 	}


### PR DESCRIPTION
Items 1 and 2 from the agent-facing surface design. Same code path, and everything downstream needs `contact_id`.

## `since` never meant what it said

`person.Since` is assigned only inside `if stateChanged` (`ha_presence.go:224-228`), so it is the moment the entity last **transitioned** — while away, that is when they left home, not how long they have been anywhere.

It shipped in an always-on block under the name `since`. A model asked *"how long have I been here?"* reads `since: "-3h44m"` and answers "about three and three-quarter hours" — wrong, every time, with no tool call to attribute it to and no hedge available. Renamed `state_since`.

## The block is contact-rooted now

```json
{"contact":"Nugget","contact_id":"019c76e4-…","trust_zone":"owner","is_operator":true,"entity":"person.nugget","name":"Nugget","state":"away","state_since":"-3h44m"}
```

Without `contact_id` the model could not chain from this block into `contact_whereabouts` — it had a friendly name and had to gamble on name resolution. That was the concrete obstacle to the person, rather than the device, being the thing the agent reasons about.

Unknown rows render as JSON too. They were a bare markdown bullet with only a display name, so on the turn the model knows least it had nothing chainable at all.

## Degradation, on purpose

Resolution runs per render rather than cached at wiring, so a contact bound to a person entity after startup is picked up without a restart. Where no contact claims the entity the row stays entity-only rather than inventing an identity, and a deployment with no contact store behaves exactly as before.

## Two structural notes

`FormatPersonPresence` takes a struct. It took eight positional primitives; contact identity would have made it twelve.

Wiring is a **construction option, not a setter**. `SetContactResolver` tripped `architecture-check` — `set_mutators` 128 → 129 — and that baseline exists to make setter growth a conscious decision. A variadic `PresenceOption` leaves all 48 existing `NewPresenceTracker` call sites untouched and makes the resolver fixed for the tracker's life, which is what it should be.

## Test plan

- [x] `just ci` passes — 74 packages ok, 0 FAIL, architecture baseline held at 128
- [x] Contact projection lands: `contact`, `contact_id`, `trust_zone`, `is_operator`
- [x] An entity no contact claims degrades to entity-only, never a fabricated identity
- [x] `state_since` renders as a delta and a bare `since` key is gone
- [x] Unknown rows stay chainable
- [x] **Mutation-verified** — dropping the contact projection fails the contact-rooted test; renaming `state_since` back to `since` fails both the semantics test and the pre-existing context test

## Next in the sequence

`ContextRequest` carrying a counterparty (prerequisite for pre-filling whereabouts on counterparty channels), then the `ios.system-context` reader, then `contact_recent_places`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
