### PR TITLE
feat(presence): let the contact store decide who is tracked

### DIFF
--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -188,14 +188,8 @@ stub with that exact ID, and start with an explicit empty
 `person.contact_bindings` is an exact contact-UUID-to-person-entity map, and
 it is what decides the presence roster: a contact is tracked because it
 carries an `ha_person_entity` binding. Every referenced contact must exist at
-startup, and a person may belong to only one active contact.
-
-`person.track` is a startup assertion rather than the roster. Every entity it
-lists must be claimed by some contact, or Thane refuses to start and names
-the unclaimed ones — which catches a config that has drifted from the contact
-graph instead of quietly shrinking the roster and taking the ingest floor,
-channel enrichment, UniFi room updates, and the MQTT AP sensors with it. It
-may be omitted entirely; the bindings alone are sufficient. When the key is present — even as `{}` — startup
+startup, and a person may belong to only one active contact. When
+`person.contact_bindings` is present — even as `{}` — startup
 atomically reconciles the stored set to config. CardDAV still emits
 `X-THANE-HA-PERSON`, but treats it as a read-only projection and preserves
 it when clients omit unknown vCard fields. An explicitly present value must
@@ -203,6 +197,13 @@ match the projection; attempting to change or clear it is rejected. Removing
 a map entry clears that binding on the next restart. A contact with a
 configured binding cannot be deleted through CardDAV until its map entry is
 removed and Thane restarts; unbound contacts remain deletable.
+
+`person.track` is a startup assertion rather than the roster. Every entity it
+lists must be claimed by some contact, or Thane refuses to start and names
+the unclaimed ones — which catches a config that has drifted from the contact
+graph instead of quietly shrinking the roster and taking the ingest floor,
+channel enrichment, UniFi room updates, and the MQTT AP sensors with it. It
+may be omitted entirely; the bindings alone are sufficient.
 
 Configs loaded through `-insecure-config` cannot declare these identity
 relationships. Thane ignores `person.contact_bindings`,

--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -171,8 +171,6 @@ identity:
   operator_contact_id: 019c76e4-2ff1-7918-8d6f-6c2488f5098d
 
 person:
-  track:
-    - person.nugget
   contact_bindings:
     019c76e4-2ff1-7918-8d6f-6c2488f5098d: person.nugget
 ```
@@ -187,10 +185,17 @@ a UUID in the signed config first, seed an `admin`-zone `Operator` contact
 stub with that exact ID, and start with an explicit empty
 `person.contact_bindings` map.
 
-`person.contact_bindings` is an exact contact-UUID-to-person-entity map.
-Every referenced contact must exist at startup, every person entity must
-also appear under `person.track`, and a person may belong to only one
-active contact. When the key is present — even as `{}` — startup
+`person.contact_bindings` is an exact contact-UUID-to-person-entity map, and
+it is what decides the presence roster: a contact is tracked because it
+carries an `ha_person_entity` binding. Every referenced contact must exist at
+startup, and a person may belong to only one active contact.
+
+`person.track` is a startup assertion rather than the roster. Every entity it
+lists must be claimed by some contact, or Thane refuses to start and names
+the unclaimed ones — which catches a config that has drifted from the contact
+graph instead of quietly shrinking the roster and taking the ingest floor,
+channel enrichment, UniFi room updates, and the MQTT AP sensors with it. It
+may be omitted entirely; the bindings alone are sufficient. When the key is present — even as `{}` — startup
 atomically reconciles the stored set to config. CardDAV still emits
 `X-THANE-HA-PERSON`, but treats it as a read-only projection and preserves
 it when clients omit unknown vCard fields. An explicitly present value must

--- a/docs/operating/getting-started.md
+++ b/docs/operating/getting-started.md
@@ -61,8 +61,9 @@ Initialization first generates a stable UUID into
 Pass
 `-operator-name "Your Name"` to `thane init` to name it immediately; the
 default display name is `Operator`. The generated config includes an explicit
-empty `person.contact_bindings` map, ready for UUID-to-Home-Assistant-person
-bindings once `person.track` is configured.
+empty `person.contact_bindings` map. Adding a binding there is what puts a
+person in the presence roster — the binding is the declaration of interest,
+and nothing else has to be configured to track them.
 
 In normal operation the runtime reads `core/config.yaml` from the
 workspace and nothing else (`-insecure-config` exists as a recovery path

--- a/docs/operating/homeassistant.md
+++ b/docs/operating/homeassistant.md
@@ -68,8 +68,9 @@ Persistent connection for real-time `state_changed` events. The event feed
 is gated client-side by the subscription registry: ingest-mode entity
 subscriptions (ids or globs like `binary_sensor.*door*`, added via
 `add_entity_subscription` from any owner) plus the system-seeded presence
-floor decide what is captured. That floor contains `person.track` and the
-device trackers linked from each person's HA `device_trackers` attribute,
+floor decide what is captured. That floor contains the person entities bound
+to contacts through `ha_person_entity` and the device trackers linked from
+each person's HA `device_trackers` attribute,
 allowing attribute-only Bermuda room changes through without ingesting the
 whole `device_tracker.*` domain. This is the same mechanism used by the HA
 frontend and mobile apps — the official, first-class event bus.

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -1193,7 +1193,7 @@ compaction:
 #     collected and published. Default: 60. Minimum: 10.
 #     interval: 60
 #
-# (optional) Person configures household member presence tracking. When Track
+# (optional) Person configures household member presence tracking.
 # person:
 #   Track is a startup assertion, not the roster. Presence membership
 #   comes from the contact store: a contact is tracked because it

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -1195,9 +1195,16 @@ compaction:
 #
 # (optional) Person configures household member presence tracking. When Track
 # person:
-#   Track is a list of Home Assistant person entity IDs to monitor
-#   (e.g., ["person.nugget", "person.dan"]). Each entry must begin
-#   with "person.". An empty list disables person tracking.
+#   Track is a startup assertion, not the roster. Presence membership
+#   comes from the contact store: a contact is tracked because it
+#   carries an ha_person_entity binding. Every entity listed here must
+#   be claimed by some contact, or startup fails and names the
+#   unclaimed ones — which catches a config that has drifted from the
+#   contact graph instead of quietly shrinking the roster.
+#
+#   Each entry must begin with "person.". An empty list asserts
+#   nothing and does not disable tracking; a contact store with no
+#   bindings does that.
 #   track:
 #     - person.alice
 #     - person.bob
@@ -1210,9 +1217,12 @@ compaction:
 #   bindings; this key is ignored in recovery mode.
 #   contact_bindings:
 #     0d1f8a6e-4c2b-4b7e-9f00-3a7d0e2c9b41: person.alice
-#   Devices maps tracked person entity IDs to their wireless device
-#   MAC addresses. Used by the UniFi poller to determine which person
-#   a wireless client belongs to for room-level presence.
+#   Devices maps person entity IDs to their wireless device MAC
+#   addresses. Used by the UniFi poller to determine which person a
+#   wireless client belongs to for room-level presence. Keys need not
+#   appear in Track — membership is the contact store's answer, not
+#   this file's — but each key must name at least one MAC, since the
+#   poller with no mappings can attribute nothing.
 #   devices:
 #     person.alice:
 #       - # MAC is the device's MAC address (e.g., "AA:BB:CC:DD:EE:FF").

--- a/internal/app/loop_definition_builtins.go
+++ b/internal/app/loop_definition_builtins.go
@@ -50,7 +50,7 @@ const (
 // members below use the same predicates — so the gate and its members cannot
 // drift into an empty container or a member orphaned under a missing parent.
 func unifiPollerEnabled(cfg *config.Config) bool {
-	return cfg.Unifi.Configured() && len(cfg.Person.Track) > 0
+	return cfg.Unifi.Configured() && len(cfg.Person.Devices) > 0
 }
 
 func emailServicesEnabled(cfg *config.Config) bool {

--- a/internal/app/loop_definition_builtins.go
+++ b/internal/app/loop_definition_builtins.go
@@ -50,7 +50,20 @@ const (
 // members below use the same predicates — so the gate and its members cannot
 // drift into an empty container or a member orphaned under a missing parent.
 func unifiPollerEnabled(cfg *config.Config) bool {
-	return cfg.Unifi.Configured() && len(cfg.Person.Devices) > 0
+	return cfg.Unifi.Configured() && personDeviceMappings(cfg) > 0
+}
+
+// personDeviceMappings counts configured MAC-to-person mappings, which is
+// the UniFi poller's real input: deviceOwners is built solely from
+// person.devices, so a poller with none polls the controller every
+// interval and can attribute nothing. Counting mappings rather than map
+// keys means `person.devices: {person.alice: []}` does not enable it.
+func personDeviceMappings(cfg *config.Config) int {
+	total := 0
+	for _, devices := range cfg.Person.Devices {
+		total += len(devices)
+	}
+	return total
 }
 
 func emailServicesEnabled(cfg *config.Config) bool {

--- a/internal/app/loop_definition_hydration_test.go
+++ b/internal/app/loop_definition_hydration_test.go
@@ -72,7 +72,9 @@ func TestBuildLoopDefinitionBaseSpecs_AppendsConfiguredBuiltIns(t *testing.T) {
 			PollIntervalSec: 30,
 		},
 		Person: config.PersonConfig{
-			Track: []string{"person.dan"},
+			Devices: map[string][]config.DeviceMapping{
+				"person.dan": {{MAC: "aa:bb:cc:dd:ee:ff"}},
+			},
 		},
 		Email: emailcfg.Config{
 			PollIntervalSec: 300,
@@ -287,7 +289,11 @@ func TestBuildLoopDefinitionBaseSpecs_GroupingContainers(t *testing.T) {
 	}
 	// Enable the pollers members so the pollers container and its members appear.
 	cfg.Unifi = config.UnifiConfig{URL: "https://unifi.local", APIKey: "key", PollIntervalSec: 30}
-	cfg.Person = config.PersonConfig{Track: []string{"person.dan"}}
+	cfg.Person = config.PersonConfig{
+		Devices: map[string][]config.DeviceMapping{
+			"person.dan": {{MAC: "aa:bb:cc:dd:ee:ff"}},
+		},
+	}
 	cfg.Email = emailcfg.Config{
 		PollIntervalSec: 300,
 		Accounts: []emailcfg.AccountConfig{{

--- a/internal/app/new_awareness.go
+++ b/internal/app/new_awareness.go
@@ -637,7 +637,7 @@ func (a *App) presenceRoster(cfg *config.Config) ([]string, error) {
 	}
 	if len(unclaimed) > 0 {
 		return nil, fmt.Errorf(
-			"person.track names %d Home Assistant person %s no contact claims (%s): presence membership now comes from contact ha_person_entity bindings, so bind them under person.contact_bindings or drop them from person.track",
+			"person.track names %d Home Assistant person %s that no contact claims (%s): presence membership now comes from contact ha_person_entity bindings, so bind each under person.contact_bindings or drop it from person.track",
 			len(unclaimed), pluralEntity(len(unclaimed)), strings.Join(unclaimed, ", "))
 	}
 	return roster, nil

--- a/internal/app/new_awareness.go
+++ b/internal/app/new_awareness.go
@@ -407,7 +407,7 @@ func (a *App) initAwareness(s *newState) error {
 	// roster to place and MAC mappings to place them by; the predicate
 	// must stay identical to unifiPollerEnabled, or the loop definition
 	// and the poller it describes drift apart.
-	if cfg.Unifi.Configured() && s.personTracker != nil && len(cfg.Person.Devices) > 0 {
+	if cfg.Unifi.Configured() && s.personTracker != nil && personDeviceMappings(cfg) > 0 {
 		unifiClient := unifi.NewClient(cfg.Unifi.URL, cfg.Unifi.APIKey, logger)
 
 		// Build MAC -> entity_id mapping from config.
@@ -445,7 +445,7 @@ func (a *App) initAwareness(s *newState) error {
 		)
 	} else if cfg.Unifi.Configured() && s.personTracker == nil {
 		logger.Warn("unifi configured but no contact carries an ha_person_entity binding, so there is nobody to place in a room")
-	} else if cfg.Unifi.Configured() && len(cfg.Person.Devices) == 0 {
+	} else if cfg.Unifi.Configured() && personDeviceMappings(cfg) == 0 {
 		logger.Warn("unifi configured but person.devices maps no MAC addresses, so room presence cannot attribute a client to anyone")
 	}
 

--- a/internal/app/new_awareness.go
+++ b/internal/app/new_awareness.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
 	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant/contextfmt"
 	"github.com/nugget/thane-ai-agent/internal/integrations/unifi"
+	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agent"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/state/awareness"
@@ -320,12 +322,16 @@ func (a *App) initAwareness(s *newState) error {
 	// initialization (personTracker was nil). Catch up immediately
 	// after construction when HA is available. Initialize is idempotent,
 	// so a redundant call from OnReady is harmless.
-	if len(cfg.Person.Track) > 0 {
+	presenceRoster, rosterErr := a.presenceRoster(cfg)
+	if rosterErr != nil {
+		return rosterErr
+	}
+	if len(presenceRoster) > 0 {
 		// Contact-rooted presence: the model reasons about people, and
 		// without a contact id here it cannot chain into
 		// contact_whereabouts on a turn with no counterparty binding.
-		// Resolved per render, so a contact bound to a person entity
-		// after startup is picked up without a restart.
+		// Resolved per render, so a contact renamed or re-zoned after
+		// startup is picked up without a restart.
 		var presenceOpts []contacts.PresenceOption
 		if a.contactStore != nil {
 			store := a.contactStore
@@ -354,7 +360,7 @@ func (a *App) initAwareness(s *newState) error {
 					}, true
 				}))
 		}
-		s.personTracker = contacts.NewPresenceTracker(cfg.Person.Track, cfg.Timezone, logger, presenceOpts...)
+		s.personTracker = contacts.NewPresenceTracker(presenceRoster, cfg.Timezone, logger, presenceOpts...)
 		s.personTracker.OnIngestEntitiesChange(seedPresenceIngestFloor)
 		s.personTracker.OnLinkedTrackersChange(func(entityIDs []string) {
 			if a.ha == nil || len(entityIDs) == 0 {
@@ -380,7 +386,7 @@ func (a *App) initAwareness(s *newState) error {
 			s.personTracker.SetDeviceMACs(entityID, macs)
 		}
 
-		logger.Info("person tracking enabled", "entities", cfg.Person.Track)
+		logger.Info("person tracking enabled", "entities", presenceRoster)
 
 		if a.ha != nil {
 			initCtx, initCancel := context.WithTimeout(s.ctx, 10*time.Second)
@@ -397,9 +403,11 @@ func (a *App) initAwareness(s *newState) error {
 
 	// --- UniFi room presence ---
 	// Optional: polls UniFi controller for wireless client associations
-	// and pushes room-level presence into the person tracker. Requires
-	// both person.track and unifi config to be set.
-	if cfg.Unifi.Configured() && s.personTracker != nil {
+	// and pushes room-level presence into the person tracker. Needs a
+	// roster to place and MAC mappings to place them by; the predicate
+	// must stay identical to unifiPollerEnabled, or the loop definition
+	// and the poller it describes drift apart.
+	if cfg.Unifi.Configured() && s.personTracker != nil && len(cfg.Person.Devices) > 0 {
 		unifiClient := unifi.NewClient(cfg.Unifi.URL, cfg.Unifi.APIKey, logger)
 
 		// Build MAC -> entity_id mapping from config.
@@ -436,7 +444,9 @@ func (a *App) initAwareness(s *newState) error {
 			"ap_rooms", len(cfg.Person.APRooms),
 		)
 	} else if cfg.Unifi.Configured() && s.personTracker == nil {
-		logger.Warn("unifi configured but person tracking disabled (no person.track entries)")
+		logger.Warn("unifi configured but no contact carries an ha_person_entity binding, so there is nobody to place in a room")
+	} else if cfg.Unifi.Configured() && len(cfg.Person.Devices) == 0 {
+		logger.Warn("unifi configured but person.devices maps no MAC addresses, so room presence cannot attribute a client to anyone")
 	}
 
 	// Forge account context is now injected via tag context provider
@@ -589,4 +599,53 @@ func (a *App) initAwareness(s *newState) error {
 	}
 
 	return nil
+}
+
+// presenceRoster derives the tracked person entities from the contact
+// store, where a contact's ha_person_entity binding is its declaration
+// of interest, and reconciles that roster against person.track.
+//
+// person.track is an assertion here, not a source: every entity it names
+// must be claimed by a contact. Twelve consumers hang off the tracker —
+// the prompt block, the ingest floor, Snapshot for channel enrichment
+// and contact_whereabouts, UniFi room updates, the MQTT AP sensor — and
+// an entity that quietly leaves the roster takes all of them with it at
+// once. An unclaimed entry refuses the boot and names itself rather than
+// shrinking the roster where nobody would notice.
+func (a *App) presenceRoster(cfg *config.Config) ([]string, error) {
+	if a.contactStore == nil {
+		// Only reachable in tests; initChannels fails the boot when the
+		// contact store cannot be opened. Without the identity root
+		// there is no roster to derive.
+		return nil, nil
+	}
+
+	roster, err := a.contactStore.HAPersonBoundEntities()
+	if err != nil {
+		return nil, fmt.Errorf("derive presence roster from contact bindings: %w", err)
+	}
+
+	bound := make(map[string]bool, len(roster))
+	for _, entity := range roster {
+		bound[entity] = true
+	}
+	var unclaimed []string
+	for _, entity := range cfg.Person.Track {
+		if trimmed := strings.TrimSpace(entity); trimmed != "" && !bound[trimmed] {
+			unclaimed = append(unclaimed, trimmed)
+		}
+	}
+	if len(unclaimed) > 0 {
+		return nil, fmt.Errorf(
+			"person.track names %d Home Assistant person %s no contact claims (%s): presence membership now comes from contact ha_person_entity bindings, so bind them under person.contact_bindings or drop them from person.track",
+			len(unclaimed), pluralEntity(len(unclaimed)), strings.Join(unclaimed, ", "))
+	}
+	return roster, nil
+}
+
+func pluralEntity(n int) string {
+	if n == 1 {
+		return "entity"
+	}
+	return "entities"
 }

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -704,7 +704,7 @@ func (a *App) initServers(s *newState) error {
 	if a.mqttPub != nil && s.personTracker != nil && cfg.Unifi.Configured() {
 		var apSensors []mqtt.DynamicSensor
 		mqttInstanceID := a.mqttInstanceID
-		for _, entityID := range cfg.Person.Track {
+		for _, entityID := range s.personTracker.EntityIDs() {
 			shortName := entityID
 			if idx := strings.IndexByte(entityID, '.'); idx >= 0 {
 				shortName = entityID[idx+1:]

--- a/internal/app/presence_roster_test.go
+++ b/internal/app/presence_roster_test.go
@@ -1,0 +1,103 @@
+package app
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/config"
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
+	"github.com/nugget/thane-ai-agent/internal/state/contacts"
+)
+
+func newRosterTestApp(t *testing.T, bindings map[string]string) *App {
+	t.Helper()
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("database.OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store, err := contacts.NewStore(db, slog.Default())
+	if err != nil {
+		t.Fatalf("contacts.NewStore: %v", err)
+	}
+	for name, entity := range bindings {
+		c, err := store.Upsert(&contacts.Contact{FormattedName: name})
+		if err != nil {
+			t.Fatalf("upsert %s: %v", name, err)
+		}
+		if err := store.SetHAPersonEntity(c.ID, entity); err != nil {
+			t.Fatalf("bind %s: %v", name, err)
+		}
+	}
+	return &App{contactStore: store}
+}
+
+// TestPresenceRosterComesFromContactBindings pins the inversion: the
+// contact store decides who is tracked, not person.track. The bound
+// contact that person.track does NOT name must still be in the roster —
+// that is the whole point of rooting identity in the contacts database.
+func TestPresenceRosterComesFromContactBindings(t *testing.T) {
+	a := newRosterTestApp(t, map[string]string{
+		"Alice Operator": "person.alice",
+		"Zoe Resident":   "person.zoe",
+	})
+	cfg := &config.Config{}
+	cfg.Person.Track = []string{"person.alice"}
+
+	roster, err := a.presenceRoster(cfg)
+	if err != nil {
+		t.Fatalf("presenceRoster: %v", err)
+	}
+	if len(roster) != 2 {
+		t.Fatalf("roster = %v, want both bound contacts", roster)
+	}
+	var sawZoe bool
+	for _, entity := range roster {
+		if entity == "person.zoe" {
+			sawZoe = true
+		}
+	}
+	if !sawZoe {
+		t.Error("person.zoe is bound to a contact but absent from the roster; membership is still coming from person.track")
+	}
+}
+
+// TestPresenceRosterRefusesUnclaimedTrackEntry pins the fail-loud
+// reconciliation. person.track names entities no contact claims, which
+// before this change silently halved the roster and took the ingest
+// floor, Snapshot, and the MQTT AP sensors with it.
+func TestPresenceRosterRefusesUnclaimedTrackEntry(t *testing.T) {
+	a := newRosterTestApp(t, map[string]string{"Alice Operator": "person.alice"})
+	cfg := &config.Config{}
+	cfg.Person.Track = []string{"person.alice", "person.ghost"}
+
+	roster, err := a.presenceRoster(cfg)
+	if err == nil {
+		t.Fatalf("presenceRoster accepted an unclaimed person.track entry, roster = %v", roster)
+	}
+	// The operator has to be able to act on this without reading code.
+	if !strings.Contains(err.Error(), "person.ghost") {
+		t.Errorf("error does not name the unclaimed entity: %v", err)
+	}
+	if strings.Contains(err.Error(), "person.alice") {
+		t.Errorf("error names a correctly bound entity: %v", err)
+	}
+}
+
+// TestPresenceRosterWithoutContactStore covers the test-only path where
+// no identity root exists: no roster, and no error either, since there is
+// nothing to reconcile against.
+func TestPresenceRosterWithoutContactStore(t *testing.T) {
+	a := &App{}
+	cfg := &config.Config{}
+	cfg.Person.Track = []string{"person.alice"}
+
+	roster, err := a.presenceRoster(cfg)
+	if err != nil {
+		t.Fatalf("presenceRoster: %v", err)
+	}
+	if len(roster) != 0 {
+		t.Fatalf("roster = %v, want empty", roster)
+	}
+}

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -2241,15 +2241,22 @@ func (c MQTTConfig) Configured() bool {
 	return c.Broker != "" && c.DeviceName != ""
 }
 
-// PersonConfig configures household member presence tracking. When Track
-// contains entity IDs, the person tracker maintains in-memory state from Home
-// Assistant, follows each person's linked device trackers for supported room
-// providers, and injects a presence summary into the agent's system prompt on
-// every wake.
+// PersonConfig configures household member presence tracking.
+// When the contact store holds ha_person_entity bindings, the person tracker
+// maintains in-memory state from Home Assistant for those people, follows each
+// one's linked device trackers for supported room providers, and injects a
+// presence summary into the agent's system prompt on every wake.
 type PersonConfig struct {
-	// Track is a list of Home Assistant person entity IDs to monitor
-	// (e.g., ["person.nugget", "person.dan"]). Each entry must begin
-	// with "person.". An empty list disables person tracking.
+	// Track is a startup assertion, not the roster. Presence membership
+	// comes from the contact store: a contact is tracked because it
+	// carries an ha_person_entity binding. Every entity listed here must
+	// be claimed by some contact, or startup fails and names the
+	// unclaimed ones — which catches a config that has drifted from the
+	// contact graph instead of quietly shrinking the roster.
+	//
+	// Each entry must begin with "person.". An empty list asserts
+	// nothing and does not disable tracking; a contact store with no
+	// bindings does that.
 	Track []string `yaml:"track"`
 
 	// ContactBindings maps stable contact UUIDs to tracked Home
@@ -2261,9 +2268,12 @@ type PersonConfig struct {
 	// bindings; this key is ignored in recovery mode.
 	ContactBindings map[string]string `yaml:"contact_bindings"`
 
-	// Devices maps tracked person entity IDs to their wireless device
-	// MAC addresses. Used by the UniFi poller to determine which person
-	// a wireless client belongs to for room-level presence.
+	// Devices maps person entity IDs to their wireless device MAC
+	// addresses. Used by the UniFi poller to determine which person a
+	// wireless client belongs to for room-level presence. Keys need not
+	// appear in Track — membership is the contact store's answer, not
+	// this file's — but each key must name at least one MAC, since the
+	// poller with no mappings can attribute nothing.
 	Devices map[string][]DeviceMapping `yaml:"devices"`
 
 	// APRooms maps AP names (e.g., "ap-hor-office") to human-readable
@@ -3619,11 +3629,6 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("person.track[%d] %q must start with \"person.\"", i, id)
 		}
 	}
-	// Validate person.devices references only tracked entities.
-	tracked := make(map[string]bool, len(c.Person.Track))
-	for _, id := range c.Person.Track {
-		tracked[id] = true
-	}
 	contactIDs := make([]string, 0, len(c.Person.ContactBindings))
 	for contactID := range c.Person.ContactBindings {
 		contactIDs = append(contactIDs, contactID)
@@ -3639,20 +3644,21 @@ func (c *Config) Validate() error {
 		if !validHAPersonEntityID(entityID) {
 			return fmt.Errorf("person.contact_bindings[%s] %q must match person.<object_id> (lowercase letters, digits, underscores)", contactID, entityID)
 		}
-		if !tracked[entityID] {
-			return fmt.Errorf("person.contact_bindings[%s] references untracked entity %q", contactID, entityID)
-		}
 		if holder, exists := claimedPeople[entityID]; exists {
 			return fmt.Errorf("person.contact_bindings assigns %q to both %s and %s", entityID, holder, contactID)
 		}
 		claimedPeople[entityID] = contactID
 	}
-	for entityID := range c.Person.Devices {
-		if !tracked[entityID] {
-			return fmt.Errorf("person.devices references untracked entity %q", entityID)
-		}
-	}
 	for entityID, devs := range c.Person.Devices {
+		// Membership lives in the contact store, which config validation
+		// cannot reach, so this checks shape only: presenceRoster does the
+		// reconciliation at startup where the bindings are readable.
+		if !validHAPersonEntityID(entityID) {
+			return fmt.Errorf("person.devices key %q must match person.<object_id> (lowercase letters, digits, underscores)", entityID)
+		}
+		if len(devs) == 0 {
+			return fmt.Errorf("person.devices[%s] lists no devices; remove the key or give it a MAC, since an empty list polls UniFi and can attribute nothing", entityID)
+		}
 		for i, d := range devs {
 			if d.MAC == "" {
 				return fmt.Errorf("person.devices[%s][%d].mac must not be empty", entityID, i)

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -381,8 +381,9 @@ type Config struct {
 	// set, Thane connects to the broker and registers as an HA device.
 	MQTT MQTTConfig `yaml:"mqtt"`
 
-	// Person configures household member presence tracking. When Track
-	// contains entity IDs, the agent receives a "People & Presence"
+	// Person configures household member presence tracking.
+	// Membership comes from the contact store: when a contact carries an
+	// ha_person_entity binding, the agent receives a "People & Presence"
 	// section in its system prompt on every wake, eliminating tool
 	// calls for basic presence questions.
 	Person PersonConfig `yaml:"person"`

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -448,19 +448,68 @@ func TestAgentConfig_NoDefaultsWhenDisabled(t *testing.T) {
 	}
 }
 
-func TestValidate_PersonDevicesUntrackedEntity(t *testing.T) {
+// TestValidate_PersonDevicesOutsideTrackIsAllowed pins the inversion.
+// Presence membership comes from contact ha_person_entity bindings, which
+// config validation cannot read, so a device mapping for an entity absent
+// from person.track is legitimate — and rejecting it would leave UniFi
+// room presence hostage to the list that no longer decides membership.
+func TestValidate_PersonDevicesOutsideTrackIsAllowed(t *testing.T) {
 	cfg := Default()
 	cfg.Person.Track = []string{"person.alice"}
 	cfg.Person.Devices = map[string][]DeviceMapping{
-		"person.bob": {{MAC: "aa:bb:cc:dd:ee:ff"}}, // bob is not tracked
+		"person.bob": {{MAC: "aa:bb:cc:dd:ee:ff"}},
 	}
 
-	err := cfg.Validate()
-	if err == nil {
-		t.Fatal("expected error for untracked entity in person.devices")
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v, want a device mapping outside person.track to be accepted", err)
 	}
-	if !strings.Contains(err.Error(), "person.bob") {
-		t.Errorf("error should mention person.bob, got: %v", err)
+}
+
+// TestValidate_PersonDevicesShape covers what config CAN still answer:
+// the key is a well-formed person entity, and the list is not empty. An
+// empty list passes a len(Devices) > 0 gate while contributing no MAC,
+// which starts a UniFi poll loop that can never attribute a client.
+func TestValidate_PersonDevicesShape(t *testing.T) {
+	tests := []struct {
+		name      string
+		devices   map[string][]DeviceMapping
+		wantError string
+	}{
+		{
+			name:      "empty device list",
+			devices:   map[string][]DeviceMapping{"person.alice": {}},
+			wantError: "lists no devices",
+		},
+		{
+			name:      "malformed key",
+			devices:   map[string][]DeviceMapping{"person.Alice": {{MAC: "aa:bb:cc:dd:ee:ff"}}},
+			wantError: "must match person.<object_id>",
+		},
+		{
+			name:      "empty mac",
+			devices:   map[string][]DeviceMapping{"person.alice": {{MAC: ""}}},
+			wantError: "must not be empty",
+		},
+		{
+			name:    "well formed",
+			devices: map[string][]DeviceMapping{"person.alice": {{MAC: "aa:bb:cc:dd:ee:ff"}}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Default()
+			cfg.Person.Devices = tt.devices
+			err := cfg.Validate()
+			if tt.wantError == "" {
+				if err != nil {
+					t.Fatalf("Validate() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("Validate() error = %v, want substring %q", err, tt.wantError)
+			}
+		})
 	}
 }
 
@@ -1036,9 +1085,11 @@ func TestValidate_PersonContactBindings(t *testing.T) {
 			wantError: "must match person.<object_id>",
 		},
 		{
-			name:      "untracked person entity",
-			bindings:  map[string]string{aliceID: "person.carol"},
-			wantError: "untracked entity",
+			// The contact store decides membership, so a binding for an
+			// entity person.track omits is legitimate; presenceRoster
+			// reconciles the two at startup where bindings are readable.
+			name:     "person entity outside person.track",
+			bindings: map[string]string{aliceID: "person.carol"},
 		},
 		{
 			name:      "duplicate person claim",

--- a/internal/state/contacts/counterparty.go
+++ b/internal/state/contacts/counterparty.go
@@ -222,3 +222,40 @@ func (s *Store) FindByHAPersonEntity(entity string) (*Contact, error) {
 	}
 	return s.Get(parsed)
 }
+
+// HAPersonBoundEntities returns the Home Assistant person entities bound
+// to active contacts, in a stable order.
+//
+// This is the presence roster. A contact appears in the presence block
+// because it carries a binding, so the binding is the declaration of
+// interest and there is no separate membership list to keep in sync.
+//
+// Ordered by entity rather than by contact name: the roster fixes the row
+// order of an always-on prompt block, and renaming a contact must not
+// reorder every row and invalidate the cached prompt prefix.
+func (s *Store) HAPersonBoundEntities() ([]string, error) {
+	rows, err := s.db.Query(
+		`SELECT ha_person_entity FROM contacts
+		 WHERE ha_person_entity IS NOT NULL AND ha_person_entity != '' AND deleted_at IS NULL
+		 ORDER BY ha_person_entity`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list ha person bindings: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var entities []string
+	for rows.Next() {
+		var entity string
+		if err := rows.Scan(&entity); err != nil {
+			return nil, fmt.Errorf("scan ha person binding: %w", err)
+		}
+		if entity = strings.TrimSpace(entity); entity != "" {
+			entities = append(entities, entity)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list ha person bindings: %w", err)
+	}
+	return entities, nil
+}

--- a/internal/state/contacts/counterparty_test.go
+++ b/internal/state/contacts/counterparty_test.go
@@ -1,6 +1,7 @@
 package contacts
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -210,5 +211,54 @@ func TestReplaceHAPersonBindingsRollback(t *testing.T) {
 	got, _, _ = store.HAPersonEntity(alice.ID)
 	if got != "person.alice" {
 		t.Fatalf("binding after duplicate rollback = %q, want person.alice", got)
+	}
+}
+
+// TestHAPersonBoundEntitiesIsThePresenceRoster pins the membership query.
+// A contact renders in the presence block because it carries a binding,
+// so this result IS the roster: an unbound contact must not appear, and a
+// soft-deleted one must not either — a deleted person who kept rendering
+// would leak from an always-on block.
+func TestHAPersonBoundEntitiesIsThePresenceRoster(t *testing.T) {
+	store := newCounterpartyTestStore(t)
+
+	// Names sort opposite to entities on purpose: ordering by contact
+	// name would give [person.zoe, person.alice] and fail below.
+	bound := map[string]string{"Alice Operator": "person.zoe", "Zoe Resident": "person.alice"}
+	ids := make(map[string]uuid.UUID, len(bound))
+	for name, entity := range bound {
+		c, err := store.Upsert(&Contact{FormattedName: name})
+		if err != nil {
+			t.Fatalf("upsert %s: %v", name, err)
+		}
+		if err := store.SetHAPersonEntity(c.ID, entity); err != nil {
+			t.Fatalf("bind %s: %v", name, err)
+		}
+		ids[name] = c.ID
+	}
+	if _, err := store.Upsert(&Contact{FormattedName: "Unbound Acquaintance"}); err != nil {
+		t.Fatalf("upsert unbound: %v", err)
+	}
+
+	got, err := store.HAPersonBoundEntities()
+	if err != nil {
+		t.Fatalf("HAPersonBoundEntities: %v", err)
+	}
+	// Ordered by entity, not by contact name: the roster fixes row order
+	// in an always-on block, so a rename must not reshuffle every row.
+	want := []string{"person.alice", "person.zoe"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("roster = %v, want %v", got, want)
+	}
+
+	if err := store.Delete(ids["Alice Operator"]); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	got, err = store.HAPersonBoundEntities()
+	if err != nil {
+		t.Fatalf("HAPersonBoundEntities after delete: %v", err)
+	}
+	if !slices.Equal(got, []string{"person.alice"}) {
+		t.Fatalf("roster after delete = %v, want [person.alice]", got)
 	}
 }


### PR DESCRIPTION
The contacts database is the beginning and ending of identity questions, and everything else is a downstream attribute of a contact record. The presence roster was the exception.

## The binding is the declaration of interest

`config.person.track` — a hand-kept YAML list of HA person entities — decided who rendered, and contact identity was resolved onto those rows afterward. Membership now comes from the store: a contact appears because it carries an `ha_person_entity` binding.

That needs no residency taxonomy, no household class, and no second list to keep in sync. Binding a contact to a person entity already *is* saying "track this person."

`HAPersonBoundEntities` orders by entity rather than by contact name. The roster fixes row order in an always-on block, so ordering by name would let a rename reshuffle every row and invalidate the cached prompt prefix.

## person.track is now an assertion

Every entity it names must be claimed by a contact, or the boot fails and names the unclaimed ones.

This is the real regression risk, not a stylistic choice. `person.contact_bindings` is validated as a **subset** of `person.track` (`config.go:3642`) with nothing validating the reverse, so `track` can legitimately name entities no contact claims. Twelve consumers hang off this tracker — the prompt block, the ingest floor, `Snapshot` for channel enrichment and `contact_whereabouts`, UniFi room updates, the MQTT AP sensors — and an unclaimed entity would have quietly left the roster and taken all of them at once. `track` comes out entirely in a follow-up, once bindings carry the roster.

## No runtime refresh, deliberately

Membership stays fixed for the tracker's life, exactly as it is today — `cfg.Person.Track` was read once at construction, so store-sourced derivation at startup is a strict non-regression.

A mutator would also buy nothing. In config-owned mode (what `thane init` seeds) `ReplaceHAPersonBindings` replaces every binding atomically at boot, so a runtime binding change is overwritten at the next restart regardless. And it would make an `order`/`people` divergence reachable for the first time in a provider that renders on every turn — `presenceRows` does `p := t.people[id]` then `p.EntityID` with no nil guard, and there is no `recover()` anywhere under `internal/runtime`.

## Following the edges

Three sites still read the old membership source:

- the startup log named the config list rather than the roster it actually tracks
- the **MQTT AP sensors** were built from `person.track`, so a bound contact outside that list got no sensor at all
- the **UniFi poller** was gated on `person.track`, which would have silently killed room presence for an operator who dropped the key

`deviceOwners` is built solely from `person.devices` (`new_awareness.go:412-416`), so the poller with no MAC mappings polls the controller and attributes nothing. Both its loop-definition gate and its runtime gate now require `person.devices` — they must agree, since `unifiPollerEnabled`'s own doc says the predicate and its members "cannot drift into an empty container or a member orphaned under a missing parent." Two fixtures that expressed "enable the poller" as `Track` now express it as `Devices`.

## Test plan

- [x] `just ci` passes — 74 packages ok, 0 FAIL, architecture baseline held at 128
- [x] A bound contact that `person.track` does not name is still in the roster
- [x] An unclaimed `person.track` entry refuses the boot and names itself, without naming correctly-bound entities
- [x] Soft-deleted contacts leave the roster
- [x] Ordering survives a contact rename (fixture names sort opposite to entities on purpose)
- [x] **Mutation-verified**, four mutations, each compiling and failing only its intended test: roster reverting to `cfg.Person.Track`; the unclaimed check removed; `ORDER BY formatted_name`; soft-deleted rows included

## Next

Loop-subscription presence enrichment — a service loop subscribing to `person.*` currently gets raw HA state with no room, no `contact_id`, and no provenance — then counterparty scoping, then trust-zone predicates on the whereabouts tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
