### PR TITLE
feat(awareness): give a subscribed person a room and a name

### DIFF
--- a/internal/app/new_awareness.go
+++ b/internal/app/new_awareness.go
@@ -677,9 +677,12 @@ func (a *App) presenceContactResolver(logger *slog.Logger) func(string) (contact
 //
 // The tracker is constructed after the providers that render its people,
 // so this closes over the init state and reads the tracker per render.
-// Everything degrades to raw Home Assistant state: no tracker, an
-// untracked entity, or no contact claiming it each return the row
-// unchanged rather than inventing an identity.
+//
+// Degradation is per-source, not all-or-nothing. No tracker or an
+// untracked entity yields nothing, and the row renders as raw Home
+// Assistant state. A tracked person whom no contact claims — or whom
+// contact resolution could not resolve — still contributes room data;
+// only the identity fields are omitted, rather than inventing one.
 func (a *App) watchedPersonPresence(s *newState, logger *slog.Logger) awareness.PersonPresenceSource {
 	resolveContact := a.presenceContactResolver(logger)
 	return func(entityID string) (awareness.PersonPresenceFields, bool) {

--- a/internal/app/new_awareness.go
+++ b/internal/app/new_awareness.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -161,7 +162,14 @@ func (a *App) initAwareness(s *newState) error {
 		// The registry client stays the concrete a.ha: registry reads
 		// are a different interface with their own cache.
 		haStateReads = homeassistant.NewStateReadCache(a.ha)
-		watchlistProvider = awareness.NewWatchlistProvider(watchlistStore, haStateReads, logger)
+
+		// Presence enrichment is bound lazily: the person tracker is
+		// built further down this function, after both providers are
+		// registered, so the closure reads it at render time rather
+		// than capturing a nil.
+		presenceOption := awareness.WithPersonPresence(a.watchedPersonPresence(s, logger))
+
+		watchlistProvider = awareness.NewWatchlistProvider(watchlistStore, haStateReads, logger, presenceOption)
 		watchlistProvider.SetRegistryClient(a.ha)
 		a.loop.RegisterAlwaysContextProvider(watchlistProvider)
 
@@ -172,7 +180,7 @@ func (a *App) initAwareness(s *newState) error {
 		// scope_tag indirection. Loop-scoped, not always-on: a loop's
 		// declared watch set is its eyes, and a task-mode worker keeps
 		// its eyes while shedding the ambient identity (#1363).
-		loopSubProvider = awareness.NewLoopSubscriptionProvider(a.loopRegistry, watchlistStore, haStateReads, logger)
+		loopSubProvider = awareness.NewLoopSubscriptionProvider(a.loopRegistry, watchlistStore, haStateReads, logger, presenceOption)
 		loopSubProvider.SetRegistryClient(a.ha)
 		a.loop.RegisterLoopScopedContextProvider(loopSubProvider)
 
@@ -333,32 +341,8 @@ func (a *App) initAwareness(s *newState) error {
 		// Resolved per render, so a contact renamed or re-zoned after
 		// startup is picked up without a restart.
 		var presenceOpts []contacts.PresenceOption
-		if a.contactStore != nil {
-			store := a.contactStore
-			bindings := a.contactBindingResolver
-			presenceOpts = append(presenceOpts, contacts.WithContactResolver(
-				func(entityID string) (contacts.ContactIdentity, bool) {
-					contact, err := store.FindByHAPersonEntity(entityID)
-					if err != nil {
-						// An unclaimed entity is (nil, nil) and degrades
-						// silently by design. A store failure degrades
-						// identically but is not routine: it strips
-						// contact_id and operator status out of an
-						// always-on block, so say so.
-						logger.Warn("presence contact resolution failed, rendering entity-only",
-							"entity_id", entityID, "error", err)
-						return contacts.ContactIdentity{}, false
-					}
-					if contact == nil {
-						return contacts.ContactIdentity{}, false
-					}
-					return contacts.ContactIdentity{
-						ID:         contact.ID.String(),
-						Name:       contact.FormattedName,
-						TrustZone:  contact.TrustZone,
-						IsOperator: bindings.isOperator(contact),
-					}, true
-				}))
+		if resolver := a.presenceContactResolver(logger); resolver != nil {
+			presenceOpts = append(presenceOpts, contacts.WithContactResolver(resolver))
 		}
 		s.personTracker = contacts.NewPresenceTracker(presenceRoster, cfg.Timezone, logger, presenceOpts...)
 		s.personTracker.OnIngestEntitiesChange(seedPresenceIngestFloor)
@@ -648,4 +632,78 @@ func pluralEntity(n int) string {
 		return "entity"
 	}
 	return "entities"
+}
+
+// presenceContactResolver resolves a Home Assistant person entity to the
+// contact that claims it. Returns nil when there is no contact store, in
+// which case presence renders entity-only.
+//
+// One resolver serves every surface that names a person — the ambient
+// presence block and subscription rendering both — so the two cannot
+// disagree about who somebody is, or about whether they are the operator.
+func (a *App) presenceContactResolver(logger *slog.Logger) func(string) (contacts.ContactIdentity, bool) {
+	if a.contactStore == nil {
+		return nil
+	}
+	store := a.contactStore
+	bindings := a.contactBindingResolver
+	return func(entityID string) (contacts.ContactIdentity, bool) {
+		contact, err := store.FindByHAPersonEntity(entityID)
+		if err != nil {
+			// An unclaimed entity is (nil, nil) and degrades silently by
+			// design. A store failure degrades identically but is not
+			// routine: it strips contact_id and operator status out of an
+			// always-on block, so say so.
+			logger.Warn("presence contact resolution failed, rendering entity-only",
+				"entity_id", entityID, "error", err)
+			return contacts.ContactIdentity{}, false
+		}
+		if contact == nil {
+			return contacts.ContactIdentity{}, false
+		}
+		return contacts.ContactIdentity{
+			ID:         contact.ID.String(),
+			Name:       contact.FormattedName,
+			TrustZone:  contact.TrustZone,
+			IsOperator: bindings.isOperator(contact),
+		}, true
+	}
+}
+
+// watchedPersonPresence joins a subscribed person entity to the presence
+// tracker's view of them, so a service loop that declares person.* in its
+// subscriptions sees who the person is and which room they are in rather
+// than a bare "not_home".
+//
+// The tracker is constructed after the providers that render its people,
+// so this closes over the init state and reads the tracker per render.
+// Everything degrades to raw Home Assistant state: no tracker, an
+// untracked entity, or no contact claiming it each return the row
+// unchanged rather than inventing an identity.
+func (a *App) watchedPersonPresence(s *newState, logger *slog.Logger) awareness.PersonPresenceSource {
+	resolveContact := a.presenceContactResolver(logger)
+	return func(entityID string) (awareness.PersonPresenceFields, bool) {
+		if s.personTracker == nil {
+			return awareness.PersonPresenceFields{}, false
+		}
+		snap, tracked := s.personTracker.Snapshot(entityID)
+		if !tracked {
+			return awareness.PersonPresenceFields{}, false
+		}
+		fields := awareness.PersonPresenceFields{
+			Room:         snap.Room,
+			RoomProvider: snap.RoomProvider,
+			RoomSource:   snap.RoomSource,
+			RoomConflict: snap.RoomConflict,
+		}
+		if resolveContact != nil {
+			if identity, ok := resolveContact(entityID); ok {
+				fields.Contact = identity.Name
+				fields.ContactID = identity.ID
+				fields.TrustZone = identity.TrustZone
+				fields.IsOperator = identity.IsOperator
+			}
+		}
+		return fields, true
+	}
 }

--- a/internal/app/watched_person_presence_test.go
+++ b/internal/app/watched_person_presence_test.go
@@ -1,0 +1,78 @@
+package app
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
+	"github.com/nugget/thane-ai-agent/internal/state/contacts"
+)
+
+// TestWatchedPersonPresenceDegradesPerSource pins the contract the doc
+// comment states: tracker and contact store fail independently. A person
+// the tracker knows but no contact claims still contributes their room —
+// dropping the whole row there would lose live house state over a
+// missing vCard.
+func TestWatchedPersonPresenceDegradesPerSource(t *testing.T) {
+	logger := slog.Default()
+
+	t.Run("no tracker yields nothing", func(t *testing.T) {
+		a := &App{}
+		source := a.watchedPersonPresence(&newState{}, logger)
+		if _, ok := source("person.nugget"); ok {
+			t.Error("presence reported for a nil tracker")
+		}
+	})
+
+	t.Run("untracked entity yields nothing", func(t *testing.T) {
+		a := &App{}
+		s := &newState{personTracker: contacts.NewPresenceTracker(
+			[]string{"person.nugget"}, "UTC", logger)}
+		source := a.watchedPersonPresence(s, logger)
+		if _, ok := source("person.stranger"); ok {
+			t.Error("presence reported for an untracked entity")
+		}
+	})
+
+	t.Run("tracked with a store but no claiming contact keeps room", func(t *testing.T) {
+		// A live store that simply holds no contact for this entity:
+		// the resolver runs and reports no match, which must omit
+		// identity without discarding the room.
+		db, err := database.OpenMemory()
+		if err != nil {
+			t.Fatalf("database.OpenMemory: %v", err)
+		}
+		t.Cleanup(func() { _ = db.Close() })
+		store, err := contacts.NewStore(db, logger)
+		if err != nil {
+			t.Fatalf("contacts.NewStore: %v", err)
+		}
+		a := &App{contactStore: store}
+		s := &newState{personTracker: contacts.NewPresenceTracker(
+			[]string{"person.nugget"}, "UTC", logger)}
+		source := a.watchedPersonPresence(s, logger)
+
+		fields, ok := source("person.nugget")
+		if !ok {
+			t.Fatal("a tracked person with no claiming contact reported no presence at all")
+		}
+		if fields.Contact != "" || fields.ContactID != "" {
+			t.Errorf("identity invented without a contact: %+v", fields)
+		}
+	})
+
+	t.Run("tracked without a contact store keeps room, omits identity", func(t *testing.T) {
+		a := &App{}
+		s := &newState{personTracker: contacts.NewPresenceTracker(
+			[]string{"person.nugget"}, "UTC", logger)}
+		source := a.watchedPersonPresence(s, logger)
+
+		fields, ok := source("person.nugget")
+		if !ok {
+			t.Fatal("a tracked person reported no presence at all")
+		}
+		if fields.Contact != "" || fields.ContactID != "" || fields.TrustZone != "" || fields.IsOperator {
+			t.Errorf("identity invented without a contact: %+v", fields)
+		}
+	})
+}

--- a/internal/state/awareness/glob_subscription.go
+++ b/internal/state/awareness/glob_subscription.go
@@ -76,10 +76,12 @@ func renderWatchedState(
 	now time.Time,
 	registries *renderRegistries,
 	transitions TransitionSource,
+	presence PersonPresenceSource,
 ) string {
 	state = watchlistStateWithForecast(ctx, ha, logger, sub, state, "failed to fetch watched weather forecast")
 
 	content := formatEntityContextWithMetadata(state, now, registries.entityMetadata(sub.EntityID, state, sub.Include))
+	content = enrichPersonPresence(content, state, presence)
 	content = enrichWithLastKnownGood(ctx, ha, content, state, now)
 	content = enrichUnavailable(content, state, registries)
 	if sub.WantsTransitions() {
@@ -133,6 +135,7 @@ func expandGlobSubscription(
 	now time.Time,
 	registries *renderRegistries,
 	transitions TransitionSource,
+	presence PersonPresenceSource,
 	maxExpansion int,
 	exclude map[string]struct{},
 ) string {
@@ -159,7 +162,7 @@ func expandGlobSubscription(
 	globMarker := func(matched, shown int) string {
 		return formatGlobTruncation(pattern, matched, shown)
 	}
-	return renderExpandedMatches(ctx, ha, logger, sub, matchedIDs, stateByID, now, registries, transitions, maxExpansion, globMarker)
+	return renderExpandedMatches(ctx, ha, logger, sub, matchedIDs, stateByID, now, registries, transitions, presence, maxExpansion, globMarker)
 }
 
 // formatGlobTruncation renders the marker appended when a glob matched

--- a/internal/state/awareness/glob_subscription_test.go
+++ b/internal/state/awareness/glob_subscription_test.go
@@ -128,6 +128,7 @@ func TestExpandGlobSubscription_ExcludesAlreadyVisible(t *testing.T) {
 		time.Now(),
 		nil, // no registries
 		nil, // no transition source
+		nil, // no presence source
 		25,
 		exclude,
 	)

--- a/internal/state/awareness/loop_subscription_provider.go
+++ b/internal/state/awareness/loop_subscription_provider.go
@@ -28,6 +28,7 @@ type LoopSubscriptionProvider struct {
 	transitions      TransitionSource // optional; nil marks requested logs unavailable
 	logger           *slog.Logger
 	maxGlobExpansion int
+	presence         PersonPresenceSource // optional; nil renders person entities as raw HA state
 }
 
 // SetTransitionSource wires the per-entity retention that backs
@@ -46,11 +47,12 @@ func (p *LoopSubscriptionProvider) SetTransitionSource(source TransitionSource) 
 // loop-scoped would render twice in the prompt and double the HA
 // fetch traffic. Pass nil only in tests that don't care about the
 // double-render guard.
-func NewLoopSubscriptionProvider(loops *looppkg.Registry, store *WatchlistStore, ha StateGetter, logger *slog.Logger) *LoopSubscriptionProvider {
+func NewLoopSubscriptionProvider(loops *looppkg.Registry, store *WatchlistStore, ha StateGetter, logger *slog.Logger, opts ...SubscriptionOption) *LoopSubscriptionProvider {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &LoopSubscriptionProvider{loops: loops, store: store, ha: ha, logger: logger, maxGlobExpansion: defaultMaxGlobExpansion}
+	resolved := newSubscriptionOptions(opts)
+	return &LoopSubscriptionProvider{loops: loops, store: store, ha: ha, logger: logger, maxGlobExpansion: defaultMaxGlobExpansion, presence: resolved.presence}
 }
 
 // SetMaxGlobExpansion overrides the per-turn cap on how many entities a
@@ -174,10 +176,10 @@ func (p *LoopSubscriptionProvider) TagContext(ctx context.Context, req agentctx.
 			// Pass alreadyVisible so a loop glob (e.g. sensor.*) doesn't
 			// re-render entities the always-visible watchlist already
 			// injects — same dedup the concrete path applies below.
-			body.WriteString(expandGlobSubscription(ctx, p.ha, p.logger, sub, states, statesErr, now, registries, p.transitions, p.maxGlobExpansion, alreadyVisible))
+			body.WriteString(expandGlobSubscription(ctx, p.ha, p.logger, sub, states, statesErr, now, registries, p.transitions, p.presence, p.maxGlobExpansion, alreadyVisible))
 		case target.IsRegistryTarget():
 			states, statesErr := snap.get(ctx)
-			body.WriteString(expandRegistryTargetSubscription(ctx, p.ha, p.logger, sub, target, states, statesErr, now, registries, p.transitions, p.maxGlobExpansion, alreadyVisible))
+			body.WriteString(expandRegistryTargetSubscription(ctx, p.ha, p.logger, sub, target, states, statesErr, now, registries, p.transitions, p.presence, p.maxGlobExpansion, alreadyVisible))
 		default:
 			if _, dup := alreadyVisible[sub.EntityID]; dup {
 				continue
@@ -208,5 +210,5 @@ func (p *LoopSubscriptionProvider) renderLoopSubscription(ctx context.Context, s
 		)
 		return formatFetchError(sub.EntityID)
 	}
-	return renderWatchedState(ctx, p.ha, p.logger, sub, state, now, registries, p.transitions)
+	return renderWatchedState(ctx, p.ha, p.logger, sub, state, now, registries, p.transitions, p.presence)
 }

--- a/internal/state/awareness/person_presence.go
+++ b/internal/state/awareness/person_presence.go
@@ -1,0 +1,131 @@
+package awareness
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant/contextfmt"
+)
+
+// PersonPresenceFields is the presence tracker's view of a person,
+// spliced onto the raw Home Assistant row when a subscription renders a
+// person entity.
+//
+// It deliberately carries no state or timestamp. The watched row already
+// holds authoritative live state read this turn, and overlaying the
+// tracker's copy would let a stale room ride along with a fresh state.
+// Only what HA cannot say appears here: who this is, and where in the
+// house they are.
+type PersonPresenceFields struct {
+	Contact      string `json:"contact,omitempty"`
+	ContactID    string `json:"contact_id,omitempty"`
+	TrustZone    string `json:"trust_zone,omitempty"`
+	IsOperator   bool   `json:"is_operator,omitempty"`
+	Room         string `json:"room,omitempty"`
+	RoomProvider string `json:"room_provider,omitempty"`
+	RoomSource   string `json:"room_source,omitempty"`
+	RoomConflict bool   `json:"room_conflict,omitempty"`
+}
+
+func (f PersonPresenceFields) empty() bool {
+	return f == PersonPresenceFields{}
+}
+
+// PersonPresenceSource resolves a person entity to the tracker's view of
+// it. The bool reports whether that person is tracked at all.
+//
+// A function value rather than a package dependency: the presence tracker
+// is constructed after the providers that render its people, so this is
+// bound to a closure that reads it at render time.
+type PersonPresenceSource func(entityID string) (PersonPresenceFields, bool)
+
+// attachPersonPresence splices presence onto a rendered person row.
+//
+// The splice is textual, mirroring [contextfmt.AttachMetadata], because
+// round-tripping through map[string]any re-marshals with sorted keys and
+// would scatter contact identity through the row — the presence block
+// puts identity first on purpose, since the model reasons about people.
+//
+// Room is gated on the live state saying home, and dropped when the
+// tracker reports conflicting observations. The tracker clears rooms only
+// on a literal "not_home", so a person sitting in a named zone can still
+// hold a room they left hours ago; the live row is the authority on
+// whether they are home to have one.
+func attachPersonPresence(formatted, haState string, fields PersonPresenceFields) string {
+	if !strings.EqualFold(haState, "home") || fields.RoomConflict {
+		fields.Room, fields.RoomProvider, fields.RoomSource = "", "", ""
+	}
+	if !strings.EqualFold(haState, "home") {
+		fields.RoomConflict = false
+	}
+	if fields.empty() {
+		return formatted
+	}
+
+	trimmed := strings.TrimSpace(formatted)
+	if len(trimmed) < 2 || trimmed[0] != '{' || trimmed[len(trimmed)-1] != '}' {
+		return formatted
+	}
+	if !json.Valid([]byte(trimmed)) {
+		return formatted
+	}
+	encoded, err := json.Marshal(fields)
+	if err != nil || len(encoded) < 2 {
+		return formatted
+	}
+	// Strip the object braces and splice the members in, so the base
+	// row's own key order survives.
+	members := string(encoded[1 : len(encoded)-1])
+	if members == "" {
+		return formatted
+	}
+	if trimmed == "{}" {
+		return "{" + members + "}"
+	}
+	return trimmed[:len(trimmed)-1] + "," + members + "}"
+}
+
+// enrichPersonPresence adds tracker presence to a person row. Non-person
+// entities, untracked people, and an unwired tracker all pass through.
+func enrichPersonPresence(formatted string, state *homeassistant.State, presence PersonPresenceSource) string {
+	if presence == nil || state == nil || contextfmt.EntityDomain(state.EntityID) != "person" {
+		return formatted
+	}
+	fields, ok := presence(state.EntityID)
+	if !ok {
+		return formatted
+	}
+	return attachPersonPresence(formatted, state.State, fields)
+}
+
+// SubscriptionOption configures optional behaviour shared by the entity
+// subscription providers.
+//
+// A construction option rather than a setter: presence enrichment is
+// wiring, fixed for the provider's life, and the architecture baseline
+// counts exported mutator growth deliberately. Variadic, so existing
+// call sites are untouched.
+type SubscriptionOption func(*subscriptionOptions)
+
+type subscriptionOptions struct {
+	presence PersonPresenceSource
+}
+
+func newSubscriptionOptions(opts []SubscriptionOption) subscriptionOptions {
+	var resolved subscriptionOptions
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&resolved)
+		}
+	}
+	return resolved
+}
+
+// WithPersonPresence enriches rendered person entities with the presence
+// tracker's contact-rooted view: who the person is, and which room they
+// are in while home. Without it a person renders as raw Home Assistant
+// state, which cannot tell "at the mailbox" from "in another state".
+func WithPersonPresence(source PersonPresenceSource) SubscriptionOption {
+	return func(o *subscriptionOptions) { o.presence = source }
+}

--- a/internal/state/awareness/person_presence_test.go
+++ b/internal/state/awareness/person_presence_test.go
@@ -1,0 +1,114 @@
+package awareness
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+)
+
+func personState(entityID, state string) *homeassistant.State {
+	return &homeassistant.State{EntityID: entityID, State: state}
+}
+
+func trackedPresence(fields PersonPresenceFields) PersonPresenceSource {
+	return func(string) (PersonPresenceFields, bool) { return fields, true }
+}
+
+// TestEnrichPersonPresenceKeepsBaseKeyOrder pins the splice against the
+// obvious implementation. Round-tripping through map[string]any
+// re-marshals with sorted keys, which would bury "entity" and "state"
+// behind alphabetically earlier presence keys and scatter identity
+// through the row.
+func TestEnrichPersonPresenceKeepsBaseKeyOrder(t *testing.T) {
+	base := `{"entity":"person.nugget","state":"home","since":"-1h"}`
+	got := enrichPersonPresence(base, personState("person.nugget", "home"),
+		trackedPresence(PersonPresenceFields{Contact: "Nugget", ContactID: "019c76e4", Room: "office"}))
+
+	if !strings.HasPrefix(got, `{"entity":"person.nugget","state":"home","since":"-1h",`) {
+		t.Fatalf("base row key order not preserved: %s", got)
+	}
+	if !json.Valid([]byte(got)) {
+		t.Fatalf("enriched row is not valid JSON: %s", got)
+	}
+	for _, want := range []string{`"contact":"Nugget"`, `"contact_id":"019c76e4"`, `"room":"office"`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %s in %s", want, got)
+		}
+	}
+}
+
+// TestEnrichPersonPresenceDropsRoomWhenNotHome covers the stale-room
+// hazard. The tracker clears rooms only on a literal "not_home", so a
+// person whose HA state moved to a named zone still holds the room they
+// were last seen in. The live row is the authority on whether they are
+// home to have one.
+func TestEnrichPersonPresenceDropsRoomWhenNotHome(t *testing.T) {
+	fields := PersonPresenceFields{Contact: "Nugget", Room: "kitchen", RoomProvider: "bermuda", RoomSource: "ble"}
+	for _, state := range []string{"not_home", "zone.work", "unknown"} {
+		got := enrichPersonPresence(`{"entity":"person.nugget","state":"x"}`,
+			personState("person.nugget", state), trackedPresence(fields))
+		if strings.Contains(got, "kitchen") || strings.Contains(got, "room_provider") {
+			t.Errorf("state %q kept a room: %s", state, got)
+		}
+		if !strings.Contains(got, `"contact":"Nugget"`) {
+			t.Errorf("state %q dropped contact identity too: %s", state, got)
+		}
+	}
+}
+
+// TestEnrichPersonPresenceDropsRoomOnConflict pins that disagreement
+// asserts no room, matching the ambient block rather than picking a
+// winner.
+func TestEnrichPersonPresenceDropsRoomOnConflict(t *testing.T) {
+	got := enrichPersonPresence(`{"entity":"person.nugget","state":"home"}`,
+		personState("person.nugget", "home"),
+		trackedPresence(PersonPresenceFields{Room: "office", RoomConflict: true}))
+	if strings.Contains(got, "office") {
+		t.Errorf("conflicting observations still asserted a room: %s", got)
+	}
+	if !strings.Contains(got, `"room_conflict":true`) {
+		t.Errorf("conflict not reported while home: %s", got)
+	}
+}
+
+// TestEnrichPersonPresencePassesThrough covers every degradation: a
+// non-person entity, an untracked person, no tracker wired at all, and a
+// tracked person the presence tracker knows nothing else about.
+func TestEnrichPersonPresencePassesThrough(t *testing.T) {
+	base := `{"entity":"sensor.porch","state":"12"}`
+	if got := enrichPersonPresence(base, personState("sensor.porch", "12"),
+		trackedPresence(PersonPresenceFields{Contact: "Nugget"})); got != base {
+		t.Errorf("non-person entity enriched: %s", got)
+	}
+
+	personBase := `{"entity":"person.stranger","state":"home"}`
+	untracked := PersonPresenceSource(func(string) (PersonPresenceFields, bool) {
+		return PersonPresenceFields{}, false
+	})
+	if got := enrichPersonPresence(personBase, personState("person.stranger", "home"), untracked); got != personBase {
+		t.Errorf("untracked person enriched: %s", got)
+	}
+	if got := enrichPersonPresence(personBase, personState("person.stranger", "home"), nil); got != personBase {
+		t.Errorf("nil source enriched: %s", got)
+	}
+	if got := enrichPersonPresence(personBase, personState("person.stranger", "home"),
+		trackedPresence(PersonPresenceFields{})); got != personBase {
+		t.Errorf("empty fields added keys: %s", got)
+	}
+}
+
+// TestEnrichPersonPresenceRefusesNonObject guards the prompt path. Rows
+// that are not JSON objects reach this function — the glob truncation
+// marker and fetch-error rows among them — and must pass through rather
+// than being spliced into malformed JSON.
+func TestEnrichPersonPresenceRefusesNonObject(t *testing.T) {
+	for _, base := range []string{"", "not json", "[1,2]", "{unterminated", `{"a":}`, `{"a":1,}`} {
+		got := enrichPersonPresence(base, personState("person.nugget", "home"),
+			trackedPresence(PersonPresenceFields{Contact: "Nugget"}))
+		if got != base {
+			t.Errorf("base %q was modified to %q", base, got)
+		}
+	}
+}

--- a/internal/state/awareness/person_presence_wiring_test.go
+++ b/internal/state/awareness/person_presence_wiring_test.go
@@ -1,0 +1,154 @@
+package awareness
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+)
+
+// These tests cover the WIRING rather than the projection: that each
+// provider actually consults its presence source on every render path.
+// Testing enrichPersonPresence alone would leave the option, the struct
+// field, and every p.presence argument free to be deleted with CI green.
+
+func presenceTestStore(t *testing.T) *WatchlistStore {
+	t.Helper()
+	db, err := sql.Open("sqlite-thane", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	store, err := NewWatchlistStore(db, nil)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	return store
+}
+
+func presenceTestHA() *fakeHA {
+	return &fakeHA{states: map[string]*homeassistant.State{
+		"person.nugget": {EntityID: "person.nugget", State: "home"},
+		"person.dan":    {EntityID: "person.dan", State: "home"},
+	}}
+}
+
+// officePresence records which entities the provider asked about, so a
+// test can prove the source was consulted on the path under test rather
+// than inferring it from the rendered output alone.
+func officePresence(seen *[]string) PersonPresenceSource {
+	return func(entityID string) (PersonPresenceFields, bool) {
+		*seen = append(*seen, entityID)
+		return PersonPresenceFields{Contact: "Nugget", ContactID: "019c76e4", Room: "office"}, true
+	}
+}
+
+func TestWatchlistProviderEnrichesConcretePersonSubscription(t *testing.T) {
+	var seen []string
+	store := presenceTestStore(t)
+	p := NewWatchlistProvider(store, presenceTestHA(), slog.Default(),
+		WithPersonPresence(officePresence(&seen)))
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "person.nugget"}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	out, err := p.TagContext(context.Background(), agentctx.ContextRequest{IncludeAlways: true})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	for _, want := range []string{`"contact":"Nugget"`, `"contact_id":"019c76e4"`, `"room":"office"`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("watchlist concrete render missing %s:\n%s", want, out)
+		}
+	}
+	if len(seen) == 0 {
+		t.Error("presence source was never consulted on the concrete path")
+	}
+}
+
+func TestWatchlistProviderEnrichesGlobPersonSubscription(t *testing.T) {
+	var seen []string
+	store := presenceTestStore(t)
+	p := NewWatchlistProvider(store, presenceTestHA(), slog.Default(),
+		WithPersonPresence(officePresence(&seen)))
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "person.*"}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	out, err := p.TagContext(context.Background(), agentctx.ContextRequest{IncludeAlways: true})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	if !strings.Contains(out, `"contact":"Nugget"`) {
+		t.Errorf("glob expansion did not enrich:\n%s", out)
+	}
+	if len(seen) < 2 {
+		t.Errorf("glob expansion consulted presence for %v, want both people", seen)
+	}
+}
+
+func TestLoopSubscriptionProviderEnrichesPersonSubscription(t *testing.T) {
+	var seen []string
+	store := presenceTestStore(t)
+	reg := looppkg.NewRegistry()
+	p := NewLoopSubscriptionProvider(reg, store, presenceTestHA(), slog.Default(),
+		WithPersonPresence(officePresence(&seen)))
+
+	// The motivating case: a service loop declares the people it may
+	// see, and needs a room and a contact id to act on them.
+	doorbell, err := looppkg.New(looppkg.Config{
+		Name:          "doorbell",
+		Task:          "answer the door",
+		Subscriptions: []looppkg.EntitySubscription{{EntityID: "person.nugget"}},
+	}, looppkg.Deps{Runner: noopRunnerForLoopSub{}})
+	if err != nil {
+		t.Fatalf("new loop: %v", err)
+	}
+	if err := reg.Register(doorbell); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	ctx := looppkg.WithLoopIDForTest(context.Background(), doorbell.ID())
+	out, err := p.TagContext(ctx, agentctx.ContextRequest{IncludeLoopScoped: true})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	for _, want := range []string{`"contact":"Nugget"`, `"contact_id":"019c76e4"`, `"room":"office"`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("loop-scoped render missing %s:\n%s", want, out)
+		}
+	}
+	if len(seen) == 0 {
+		t.Error("presence source was never consulted on the loop-scoped path")
+	}
+}
+
+// TestSubscriptionProvidersWithoutPresenceRenderRawState pins the
+// degradation: no option means the raw Home Assistant row, unchanged.
+func TestSubscriptionProvidersWithoutPresenceRenderRawState(t *testing.T) {
+	store := presenceTestStore(t)
+	p := NewWatchlistProvider(store, presenceTestHA(), slog.Default())
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "person.nugget"}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	out, err := p.TagContext(context.Background(), agentctx.ContextRequest{IncludeAlways: true})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	if !strings.Contains(out, "person.nugget") {
+		t.Fatalf("person row missing entirely:\n%s", out)
+	}
+	// Match JSON keys, not bare words: the block's own header prose
+	// mentions "other rooms".
+	for _, unwanted := range []string{`"contact":`, `"contact_id":`, `"room":`, `"trust_zone":`} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("unwired provider emitted %s:\n%s", unwanted, out)
+		}
+	}
+}

--- a/internal/state/awareness/registry_target_subscription.go
+++ b/internal/state/awareness/registry_target_subscription.go
@@ -36,6 +36,7 @@ func expandRegistryTargetSubscription(
 	now time.Time,
 	registries *renderRegistries,
 	transitions TransitionSource,
+	presence PersonPresenceSource,
 	maxExpansion int,
 	exclude map[string]struct{},
 ) string {
@@ -87,7 +88,7 @@ func expandRegistryTargetSubscription(
 	// than emit misleading empty arrays; the tool boundaries reject
 	// the combination where they can see the target kind.
 	sub.Transitions, sub.TransitionsWindowSeconds = 0, 0
-	return renderExpandedMatches(ctx, ha, logger, sub, matchedIDs, stateByID, now, registries, transitions, maxExpansion, truncationMarker)
+	return renderExpandedMatches(ctx, ha, logger, sub, matchedIDs, stateByID, now, registries, transitions, presence, maxExpansion, truncationMarker)
 }
 
 // renderExpandedMatches is the shared tail of glob and registry-target
@@ -107,6 +108,7 @@ func renderExpandedMatches(
 	now time.Time,
 	registries *renderRegistries,
 	transitions TransitionSource,
+	presence PersonPresenceSource,
 	maxExpansion int,
 	truncationMarker func(matched, shown int) string,
 ) string {
@@ -121,7 +123,7 @@ func renderExpandedMatches(
 	for _, id := range matchedIDs {
 		matchSub := sub
 		matchSub.EntityID = id
-		sb.WriteString(renderWatchedState(ctx, ha, logger, matchSub, stateByID[id], now, registries, transitions))
+		sb.WriteString(renderWatchedState(ctx, ha, logger, matchSub, stateByID[id], now, registries, transitions, presence))
 		sb.WriteByte('\n')
 	}
 	if truncated {

--- a/internal/state/awareness/watchlist_provider.go
+++ b/internal/state/awareness/watchlist_provider.go
@@ -34,6 +34,7 @@ type WatchlistProvider struct {
 	transitions      TransitionSource // optional; nil marks requested logs unavailable
 	logger           *slog.Logger
 	maxGlobExpansion int
+	presence         PersonPresenceSource // optional; nil renders person entities as raw HA state
 }
 
 // SetTransitionSource wires the per-entity retention that backs
@@ -44,15 +45,17 @@ func (p *WatchlistProvider) SetTransitionSource(source TransitionSource) {
 }
 
 // NewWatchlistProvider creates a watchlist context provider.
-func NewWatchlistProvider(store *WatchlistStore, ha StateGetter, logger *slog.Logger) *WatchlistProvider {
+func NewWatchlistProvider(store *WatchlistStore, ha StateGetter, logger *slog.Logger, opts ...SubscriptionOption) *WatchlistProvider {
 	if logger == nil {
 		logger = slog.Default()
 	}
+	resolved := newSubscriptionOptions(opts)
 	return &WatchlistProvider{
 		store:            store,
 		ha:               ha,
 		logger:           logger,
 		maxGlobExpansion: defaultMaxGlobExpansion,
+		presence:         resolved.presence,
 	}
 }
 
@@ -131,10 +134,10 @@ func (p *WatchlistProvider) TagContext(ctx context.Context, req agentctx.Context
 			states, statesErr := snap.get(ctx)
 			// No exclusion set — this provider IS the always-visible
 			// surface, so there is nothing upstream to dedup against.
-			body.WriteString(expandGlobSubscription(ctx, p.ha, p.logger, sub, states, statesErr, now, registries, p.transitions, p.maxGlobExpansion, nil))
+			body.WriteString(expandGlobSubscription(ctx, p.ha, p.logger, sub, states, statesErr, now, registries, p.transitions, p.presence, p.maxGlobExpansion, nil))
 		case target.IsRegistryTarget():
 			states, statesErr := snap.get(ctx)
-			body.WriteString(expandRegistryTargetSubscription(ctx, p.ha, p.logger, sub, target, states, statesErr, now, registries, p.transitions, p.maxGlobExpansion, nil))
+			body.WriteString(expandRegistryTargetSubscription(ctx, p.ha, p.logger, sub, target, states, statesErr, now, registries, p.transitions, p.presence, p.maxGlobExpansion, nil))
 		default:
 			body.WriteString(p.renderSubscriptionContext(ctx, sub, now, registries))
 			body.WriteByte('\n')
@@ -159,7 +162,7 @@ func (p *WatchlistProvider) renderSubscriptionContext(ctx context.Context, sub l
 		)
 		return formatFetchError(sub.EntityID)
 	}
-	return renderWatchedState(ctx, p.ha, p.logger, sub, state, now, registries, p.transitions)
+	return renderWatchedState(ctx, p.ha, p.logger, sub, state, now, registries, p.transitions, p.presence)
 }
 
 func watchlistStateWithForecast(


### PR DESCRIPTION
A loop declares what it may see through `Spec.Subscriptions`, and that is the delegation mechanism for service loops: a doorbell loop or a package-delivery loop subscribes to person entities and sees them under `IncludeLoopScoped`, independent of the ambient bucket. It needs no exemption from anything.

What it saw was useless for the job:

```json
{"entity":"person.nugget","state":"not_home","since":"-1h","source":"device_tracker.phone"}
```

A binary that cannot tell the mailbox from another state, with no `contact_id` to chain into `contact_whereabouts`. `formatPerson`'s own doc comment named the gap — *"the PresenceTracker has richer data (room, device MACs) that the raw HA state doesn't carry."*

Now:

```json
{"entity":"person.nugget","state":"home","since":"-1h","contact":"Nugget",
 "contact_id":"019c76e4-…","trust_zone":"admin","is_operator":true,
 "room":"office","room_provider":"bermuda","room_source":"ble"}
```

## Where the enrichment sits

`renderWatchedState`, which both the loop-scoped provider and the always-visible watchlist route through — eight effective paths across concrete, glob, and registry-target expansion. Its own doc says it exists *"so the two can't drift"*, and rendering the same person two ways inside one `## LIVE STATE` section is exactly the drift it was written to prevent. A person entity reaches the watchlist too: nothing rejects a core-owned `person.*` subscription.

## Three deliberate non-goals

**No state, no timestamp.** The watched row already holds authoritative live state read this turn. Overlaying the tracker's copy is how a stale room rides along with a fresh state.

**Room is gated on the live row saying home.** The tracker clears rooms only on a literal `not_home` (`ha_presence.go:245-248`), so a person sitting in a named zone still holds the room they left hours ago. The live row is the authority on whether they are home to have one. Conflicting observations assert no room, matching the ambient block rather than picking a winner.

**Textual splice, not a map round-trip.** `json.Marshal` on `map[string]any` sorts keys, which would bury `entity` and `state` behind alphabetically earlier presence keys and scatter identity through a row that puts it first on purpose. This mirrors the existing `contextfmt.AttachMetadata`.

## Wiring

A **variadic option**, not a setter: the architecture baseline counts exported mutator growth deliberately, `PersonPresenceSource` is a func type so it costs nothing on the `interfaces` metric either, and every existing constructor call site is untouched.

It binds **lazily** — the person tracker is constructed at `new_awareness.go:355`, after both providers are registered at `:166` and `:177`, so the closure reads it at render time rather than capturing a nil.

The contact resolver #1534 introduced is **extracted rather than copied** into `App.presenceContactResolver`, so the ambient block and subscription rendering cannot disagree about who somebody is or whether they are the operator.

## Test plan

- [x] `just ci` passes — 74 packages ok, 0 FAIL, `set_mutators` 128 and `interfaces` 91 both held
- [x] Base row key order survives enrichment
- [x] A room is dropped for `not_home`, a named zone, and `unknown` — while contact identity survives
- [x] Conflicting observations assert no room but still report the conflict
- [x] Degrades on all four axes: non-person entity, untracked person, nil source, empty fields
- [x] Malformed and non-object rows pass through untouched
- [x] **Mutation-verified**, four mutations, each compiling and failing only its intended test: map round-trip instead of splice; room gate removed; domain check inverted; JSON validity guard dropped

Two of those mutations needed a second attempt — the first domain mutation didn't compile, and the first validity mutation passed because `"{unterminated"` is rejected by the brace check before `json.Valid` is reached. Both tests were strengthened.

## Not in scope

Counterparty scoping and trust-zone gating on these rows. Worth noting for phasing: this puts `contact_id`, `trust_zone` and `is_operator` into the loop-scoped and always-visible buckets, which a non-owner counterparty turn can reach. That was already true of the ambient presence block, so it changes the volume rather than the fact — but it is one more reason the scoping phase matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
