### PR TITLE
feat(loops): let the guided path declare a facet's encoding

### DIFF
--- a/internal/state/documents/facets/json_format_test.go
+++ b/internal/state/documents/facets/json_format_test.go
@@ -1,0 +1,62 @@
+package facets
+
+import (
+	"strings"
+	"testing"
+)
+
+func jsonDigestContract() Contract {
+	return Contract{Facets: []Spec{
+		{Name: StatusLine},
+		{Name: Digest, Format: FormatJSON},
+	}}
+}
+
+// TestJSONFacetRejectsProse pins the guarantee a json projection makes.
+// A consumer that asked for json and received prose has no recourse at
+// read time, so the refusal has to happen at publish.
+func TestJSONFacetRejectsProse(t *testing.T) {
+	err := jsonDigestContract().Validate(Payload{
+		StatusLine: "nugget home since 09:14",
+		Digest:     "He has been home all morning.",
+		Full:       "# Nugget\n\nHome.\n",
+	})
+	if err == nil {
+		t.Fatal("Validate() accepted prose in a json projection")
+	}
+	if !strings.Contains(err.Error(), "not valid JSON") {
+		t.Errorf("error does not name the cause: %v", err)
+	}
+	if !strings.Contains(err.Error(), string(Digest)) {
+		t.Errorf("error does not name the offending projection: %v", err)
+	}
+}
+
+// TestJSONFacetAcceptsJSON covers the other side, and that the sibling
+// markdown projection is unaffected by its neighbour's format.
+func TestJSONFacetAcceptsJSON(t *testing.T) {
+	if err := jsonDigestContract().Validate(Payload{
+		StatusLine: "nugget home since 09:14",
+		Digest:     `{"reading":"home","expires_at":"2026-09-05T18:00:00Z"}`,
+		Full:       "# Nugget\n\nHome.\n",
+	}); err != nil {
+		t.Fatalf("Validate() rejected valid JSON: %v", err)
+	}
+}
+
+// TestJSONFacetStillHonorsTheOtherBudgets guards against the format
+// check short-circuiting the rest: a json value is still rune-capped and
+// still single-line where the projection is.
+func TestJSONFacetStillHonorsTheOtherBudgets(t *testing.T) {
+	long := `{"reading":"` + strings.Repeat("x", statusLineMaxRunes) + `"}`
+	err := Contract{Facets: []Spec{{Name: StatusLine, Format: FormatJSON}}}.Validate(Payload{
+		StatusLine: long,
+		Full:       "# x\n",
+	})
+	if err == nil {
+		t.Fatal("Validate() accepted an over-budget json status_line")
+	}
+	if !strings.Contains(err.Error(), "the limit is") {
+		t.Errorf("error does not report the budget: %v", err)
+	}
+}

--- a/internal/tools/loop_create_tool.go
+++ b/internal/tools/loop_create_tool.go
@@ -1059,9 +1059,22 @@ func thaneLoopCreateSchema() map[string]any {
 						"description": "Optional human title for the document. Defaults to the loop name.",
 					},
 					"facets": map[string]any{
-						"type":        "array",
-						"items":       map[string]any{"type": "string", "enum": []string{"status_line", "teaser", "digest"}},
-						"description": "Publish selected projections alongside the full body, so each consumer takes the shape it needs. status_line and teaser are both outward-facing signals: status_line is the tight ambient form and teaser is the roomier search or cross-reference form. digest carries enough context to act. status_line is required whenever facets are declared — the one-line projection every surface can take — and teaser and digest are optional. Declaring any swaps the loop's generated tool from replace_output_* to publish_output_*, which takes one argument per declared projection plus full.",
+						"type": "array",
+						"items": map[string]any{
+							"anyOf": []map[string]any{
+								{"type": "string", "enum": []string{"status_line", "teaser", "digest"}},
+								{
+									"type": "object",
+									"properties": map[string]any{
+										"name":   map[string]any{"type": "string", "enum": []string{"status_line", "teaser", "digest"}},
+										"format": map[string]any{"type": "string", "enum": []string{"markdown", "plain", "json"}},
+									},
+									"required":             []string{"name"},
+									"additionalProperties": false,
+								},
+							},
+						},
+						"description": "Publish selected projections alongside the full body, so each consumer takes the shape it needs. status_line and teaser are both outward-facing signals: status_line is the tight ambient form and teaser is the roomier search or cross-reference form. digest carries enough context to act. status_line is required whenever facets are declared — the one-line projection every surface can take — and teaser and digest are optional. Declaring any swaps the loop's generated tool from replace_output_* to publish_output_*, which takes one argument per declared projection plus full. Write a bare name for the default markdown encoding, or {\"name\": \"digest\", \"format\": \"json\"} for a projection a program reads rather than a person — a json projection is rejected at publish if it is not valid JSON, so a consumer that asked for json never receives prose.",
 					},
 					"initial": map[string]any{
 						"type":        "object",

--- a/internal/tools/loop_intent_tools.go
+++ b/internal/tools/loop_intent_tools.go
@@ -608,6 +608,16 @@ func parseOutputFacetItem(index int, item any) (looppkg.FacetSpec, error) {
 	case looppkg.FacetSpec:
 		return v, nil
 	case map[string]any:
+		// The schema declares additionalProperties: false, but nothing
+		// enforces a tool's JSON Schema at entry. Left unchecked, a
+		// typo'd key is silently ignored and the projection quietly
+		// defaults to markdown — the caller asked for one encoding and
+		// got another, with no error to notice.
+		for key := range v {
+			if key != "name" && key != "format" {
+				return looppkg.FacetSpec{}, fmt.Errorf("output.facets[%d] has unknown key %q; an object facet takes name and format only", index, key)
+			}
+		}
 		name, ok := v["name"]
 		if !ok {
 			return looppkg.FacetSpec{}, fmt.Errorf("output.facets[%d] has no name; an object facet is {\"name\": \"digest\", \"format\": \"json\"}", index)

--- a/internal/tools/loop_intent_tools.go
+++ b/internal/tools/loop_intent_tools.go
@@ -566,38 +566,82 @@ func parseOutputFacets(raw any) ([]looppkg.FacetSpec, error) {
 	}
 
 	// A decoded tool call yields []any; a Go caller is likelier to build
-	// []string. Both are accepted, and a non-string element is named by
-	// index and type rather than coerced — an element coerced to "" would
-	// be reported as an empty facet name, which describes the symptom
-	// instead of the mistake.
-	var names []string
+	// []string. Both are accepted. An element is a bare name for the
+	// default encoding, or an object naming a format — the same shape
+	// the spec-based loop tools already accept by unmarshalling straight
+	// into looppkg.Spec, so the guided path is not the narrower one.
+	var items []any
 	switch v := raw.(type) {
 	case []string:
-		names = v
-	case []any:
-		names = make([]string, 0, len(v))
-		for i, item := range v {
-			name, ok := item.(string)
-			if !ok {
-				return nil, fmt.Errorf("output.facets[%d] is %T; facet names are strings — status_line, teaser, or digest", i, item)
-			}
-			names = append(names, name)
+		items = make([]any, 0, len(v))
+		for _, name := range v {
+			items = append(items, name)
 		}
+	case []looppkg.FacetSpec:
+		return append([]looppkg.FacetSpec(nil), v...), nil
+	case []any:
+		items = v
 	default:
-		return nil, fmt.Errorf("output.facets must be an array of facet names, got %T", raw)
+		return nil, fmt.Errorf("output.facets must be an array of facet names or {name, format} objects, got %T", raw)
 	}
 
-	out := make([]looppkg.FacetSpec, 0, len(names))
-	for _, name := range names {
-		facet := looppkg.OutputFacet(strings.TrimSpace(name))
-		switch facet {
-		case looppkg.OutputFacetStatusLine, looppkg.OutputFacetTeaser, looppkg.OutputFacetDigest:
-			out = append(out, looppkg.FacetSpec{Name: facet})
-		default:
-			return nil, fmt.Errorf("output.facets %q is not a projection; use status_line, teaser, or digest", name)
+	out := make([]looppkg.FacetSpec, 0, len(items))
+	for i, item := range items {
+		spec, err := parseOutputFacetItem(i, item)
+		if err != nil {
+			return nil, err
 		}
+		out = append(out, spec)
 	}
 	return out, nil
+}
+
+// parseOutputFacetItem reads one declared projection. A non-string,
+// non-object element is named by index and type rather than coerced — an
+// element coerced to "" would be reported as an empty facet name, which
+// describes the symptom instead of the mistake.
+func parseOutputFacetItem(index int, item any) (looppkg.FacetSpec, error) {
+	var rawName, rawFormat string
+	switch v := item.(type) {
+	case string:
+		rawName = v
+	case looppkg.FacetSpec:
+		return v, nil
+	case map[string]any:
+		name, ok := v["name"]
+		if !ok {
+			return looppkg.FacetSpec{}, fmt.Errorf("output.facets[%d] has no name; an object facet is {\"name\": \"digest\", \"format\": \"json\"}", index)
+		}
+		if rawName, ok = name.(string); !ok {
+			return looppkg.FacetSpec{}, fmt.Errorf("output.facets[%d].name is %T; facet names are strings — status_line, teaser, or digest", index, name)
+		}
+		if format, present := v["format"]; present {
+			if rawFormat, ok = format.(string); !ok {
+				return looppkg.FacetSpec{}, fmt.Errorf("output.facets[%d].format is %T; formats are strings — %s, %s, or %s", index, format, looppkg.FacetFormatMarkdown, looppkg.FacetFormatPlain, looppkg.FacetFormatJSON)
+			}
+		}
+	default:
+		return looppkg.FacetSpec{}, fmt.Errorf("output.facets[%d] is %T; write a bare name like \"digest\", or {\"name\": \"digest\", \"format\": \"json\"}", index, item)
+	}
+
+	facet := looppkg.OutputFacet(strings.TrimSpace(rawName))
+	switch facet {
+	case looppkg.OutputFacetStatusLine, looppkg.OutputFacetTeaser, looppkg.OutputFacetDigest:
+	default:
+		return looppkg.FacetSpec{}, fmt.Errorf("output.facets %q is not a projection; use status_line, teaser, or digest", rawName)
+	}
+
+	spec := looppkg.FacetSpec{Name: facet}
+	if trimmed := strings.TrimSpace(rawFormat); trimmed != "" {
+		format := looppkg.FacetFormat(trimmed)
+		switch format {
+		case looppkg.FacetFormatMarkdown, looppkg.FacetFormatPlain, looppkg.FacetFormatJSON:
+			spec.Format = format
+		default:
+			return looppkg.FacetSpec{}, fmt.Errorf("output.facets[%d].format %q is not an encoding; use %s, %s, or %s", index, rawFormat, looppkg.FacetFormatMarkdown, looppkg.FacetFormatPlain, looppkg.FacetFormatJSON)
+		}
+	}
+	return spec, nil
 }
 
 // buildWorkingNotesSpec derives the private log that sits beside a

--- a/internal/tools/loop_output_facet_format_test.go
+++ b/internal/tools/loop_output_facet_format_test.go
@@ -1,0 +1,86 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+)
+
+// TestParseOutputFacetsAcceptsFormats pins the guided path against the
+// spec-based one. loop_definition_* and spawn_loop unmarshal straight
+// into looppkg.Spec, so they have always accepted {name, format}; a
+// projection a program reads must be declarable through thane_loop_create
+// too, or the recommended path is the one that cannot express it.
+func TestParseOutputFacetsAcceptsFormats(t *testing.T) {
+	got, err := parseOutputFacets([]any{
+		"status_line",
+		map[string]any{"name": "teaser"},
+		map[string]any{"name": "digest", "format": "json"},
+	})
+	if err != nil {
+		t.Fatalf("parseOutputFacets: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("parsed %d facets, want 3: %+v", len(got), got)
+	}
+	if got[0].Name != looppkg.OutputFacetStatusLine || got[0].Format != "" {
+		t.Errorf("bare name should carry no explicit format, got %+v", got[0])
+	}
+	if got[1].Name != looppkg.OutputFacetTeaser || got[1].Format != "" {
+		t.Errorf("object without format should carry none, got %+v", got[1])
+	}
+	if got[2].Name != looppkg.OutputFacetDigest || got[2].Format != looppkg.FacetFormatJSON {
+		t.Errorf("digest format = %+v, want json", got[2])
+	}
+	// A bare name must still mean markdown, not an unset that renders
+	// differently from what the schema promises.
+	if got[0].EffectiveFormat() != looppkg.FacetFormatMarkdown {
+		t.Errorf("bare name EffectiveFormat = %q, want markdown", got[0].EffectiveFormat())
+	}
+}
+
+// TestParseOutputFacetsRejectsBadInput covers every way a declaration can
+// be wrong, and checks the error names the offending element rather than
+// describing a symptom.
+func TestParseOutputFacetsRejectsBadInput(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     any
+		wantErr string
+	}{
+		{"unknown facet name", []any{"summary"}, "not a projection"},
+		{"unknown format", []any{map[string]any{"name": "digest", "format": "yaml"}}, "not an encoding"},
+		{"object without a name", []any{map[string]any{"format": "json"}}, "has no name"},
+		{"non-string name", []any{map[string]any{"name": 7}}, "facet names are strings"},
+		{"non-string format", []any{map[string]any{"name": "digest", "format": 7}}, "formats are strings"},
+		{"element is neither", []any{42}, "output.facets[0] is int"},
+		{"not an array", "digest", "must be an array"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseOutputFacets(tt.raw)
+			if err == nil {
+				t.Fatalf("parseOutputFacets(%v) error = nil, want %q", tt.raw, tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %v, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestParseOutputFacetsStillTakesBareNames guards the older shape, which
+// every existing caller and the create tool's own examples still use.
+func TestParseOutputFacetsStillTakesBareNames(t *testing.T) {
+	got, err := parseOutputFacets([]string{"status_line", "digest"})
+	if err != nil {
+		t.Fatalf("parseOutputFacets: %v", err)
+	}
+	if len(got) != 2 || got[0].Name != looppkg.OutputFacetStatusLine || got[1].Name != looppkg.OutputFacetDigest {
+		t.Fatalf("bare-name parse = %+v", got)
+	}
+	if nilFacets, err := parseOutputFacets(nil); err != nil || nilFacets != nil {
+		t.Errorf("parseOutputFacets(nil) = %v, %v; want nil, nil", nilFacets, err)
+	}
+}

--- a/internal/tools/loop_output_facet_format_test.go
+++ b/internal/tools/loop_output_facet_format_test.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -82,5 +83,68 @@ func TestParseOutputFacetsStillTakesBareNames(t *testing.T) {
 	}
 	if nilFacets, err := parseOutputFacets(nil); err != nil || nilFacets != nil {
 		t.Errorf("parseOutputFacets(nil) = %v, %v; want nil, nil", nilFacets, err)
+	}
+}
+
+// TestParseOutputFacetsRejectsUnknownKeys covers the gap between the
+// declared schema and the handler. Nothing enforces a tool's JSON Schema
+// at entry, so additionalProperties: false is a promise the parser has to
+// keep itself — otherwise a typo'd key is dropped and the projection
+// silently falls back to markdown while the caller believes it asked for
+// json.
+func TestParseOutputFacetsRejectsUnknownKeys(t *testing.T) {
+	_, err := parseOutputFacets([]any{map[string]any{"name": "digest", "formatt": "json"}})
+	if err == nil {
+		t.Fatal("parseOutputFacets accepted an unknown key; the caller would silently get markdown")
+	}
+	if !strings.Contains(err.Error(), "formatt") {
+		t.Errorf("error does not name the offending key: %v", err)
+	}
+}
+
+// TestCreateToolSchemaOffersBothFacetForms pins the model-visible half of
+// this change. Every parser test here passes with the schema's object
+// alternative deleted, so without this the contract models actually read
+// is uncovered.
+func TestCreateToolSchemaOffersBothFacetForms(t *testing.T) {
+	rig := newCurateTestRig(t)
+
+	props := rig.tool.Parameters["properties"].(map[string]any)
+	output := props["output"].(map[string]any)["properties"].(map[string]any)
+	items := output["facets"].(map[string]any)["items"].(map[string]any)
+
+	alternatives, ok := items["anyOf"].([]map[string]any)
+	if !ok || len(alternatives) != 2 {
+		t.Fatalf("output.facets.items does not offer two alternatives: %#v", items)
+	}
+
+	bare, object := alternatives[0], alternatives[1]
+	if bare["type"] != "string" {
+		t.Errorf("first alternative is not the bare name form: %#v", bare)
+	}
+	if object["type"] != "object" {
+		t.Fatalf("second alternative is not the object form: %#v", object)
+	}
+	if additional, present := object["additionalProperties"]; !present || additional != false {
+		t.Errorf("object form must refuse unknown keys, got additionalProperties=%v", additional)
+	}
+
+	objectProps := object["properties"].(map[string]any)
+	formats := objectProps["format"].(map[string]any)["enum"].([]string)
+	for _, want := range []string{"markdown", "plain", "json"} {
+		if !slices.Contains(formats, want) {
+			t.Errorf("format enum missing %q: %v", want, formats)
+		}
+	}
+
+	// Every name the parser accepts must be offered, in both forms, or a
+	// model reading the schema cannot reach a projection that works.
+	for _, alternative := range []map[string]any{bare, objectProps["name"].(map[string]any)} {
+		names := alternative["enum"].([]string)
+		for _, want := range []string{"status_line", "teaser", "digest"} {
+			if !slices.Contains(names, want) {
+				t.Errorf("facet name enum missing %q: %v", want, names)
+			}
+		}
 	}
 }


### PR DESCRIPTION
The spec-based loop tools have always accepted a facet's format. `decodeLoopSpecArg` unmarshals straight into `looppkg.Spec`, whose `FacetSpec` carries `{name, format}`, and `loop_spec_schema.go` says so outright — *"Write a bare name for the default encoding, or an object to set a format."*

`thane_loop_create` — the guided path, and the one models are steered toward — took bare names only and refused an object with *"output.facets must be an array of facet names."* So the narrower contract belonged to the recommended tool, and a JSON projection was declarable only by hand-writing a full spec.

## What changed

`parseOutputFacets` accepts either shape, and the create tool's schema advertises it:

```json
"facets": ["status_line", "teaser", {"name": "digest", "format": "json"}]
```

An unknown encoding is refused by name rather than stored. A format nothing recognizes would otherwise reach the contract, resolve to markdown through `EffectiveFormat`, and be rendered as markdown while the declaration claimed something else.

## The enforcement was already written and never exercised

`Contract.Validate` has always rejected a `json`-declared projection whose value isn't valid JSON:

```go
if field.Format == FormatJSON && !json.Valid([]byte(value)) {
```

That branch had **no test in the facets package** — grep for `FormatJSON` in its own tests returned nothing — because no facet could reach it. It has three now: prose refused, JSON accepted, and the rune and single-line budgets still applied to a JSON value so the format check can't short-circuit the rest.

I was wrong when I described this as missing enforcement earlier; it was unreachable enforcement, which is a better starting position.

## Test plan

- [x] `just ci` passes — 74 packages, 0 FAIL, `set_mutators` 128 and `interfaces` 91 both held
- [x] Mixed bare-name and object declarations parse, with a bare name still resolving to markdown
- [x] Seven rejection cases, each checking the error names the offending element rather than a symptom
- [x] Bare-name arrays and `nil` unchanged
- [x] **Mutation-verified**, three mutations, each compiling and failing only its intended test: the parser silently dropping a declared format; the JSON validity check applied to the wrong format; unknown encodings stored rather than refused

The first attempt at the enforcement mutation didn't compile — deleting the branch orphaned the `encoding/json` import — so it proved nothing and was redone by pointing the check at the wrong format instead.

## Next

The contact-tracker loop, which needs no further code: a `whereabouts:` root declaration, then one `thane_loop_create` call with `audience: "subscribers"` and a `json` digest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
