### PR TITLE
feat(companions): put a device's contact on its row

### DIFF
--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sort"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -467,25 +466,6 @@ func (a *App) initServers(s *newState) error {
 		}
 		if s.personTracker != nil {
 			deps.Presence = s.personTracker.Snapshot
-		}
-		if a.companionDevices != nil {
-			devices := a.companionDevices
-			deps.AccountsForContact = func(contactID string) []string {
-				bound, err := devices.DevicesForContact(context.Background(), contactID)
-				if err != nil {
-					logger.Warn("companion accounts for contact failed", "contact_id", contactID, "error", err)
-					return nil
-				}
-				seen := make(map[string]bool, len(bound))
-				accounts := make([]string, 0, len(bound))
-				for _, d := range bound {
-					if !seen[d.Account] {
-						seen[d.Account] = true
-						accounts = append(accounts, d.Account)
-					}
-				}
-				return accounts
-			}
 		}
 		if a.companionRegistry != nil {
 			registry := a.companionRegistry
@@ -1013,18 +993,4 @@ func companionContactForAccount(cfg config.CompanionConfig) func(string) string 
 		return nil
 	}
 	return func(account string) string { return contactByAccount[account] }
-}
-
-// companionAccountNames lists every configured companion account, so
-// startup can reconcile each one's device bindings against config.
-func companionAccountNames(cfg config.CompanionConfig) []string {
-	if !cfg.Configured() {
-		return nil
-	}
-	accounts := make([]string, 0, len(cfg.Providers))
-	for account := range cfg.Providers {
-		accounts = append(accounts, account)
-	}
-	sort.Strings(accounts)
-	return accounts
 }

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -409,11 +410,6 @@ func (a *App) initServers(s *newState) error {
 	// apps to be configured — and both degrade to absence when their
 	// source is missing.
 	// Canonical contact-UUID → bound companion accounts, shared by the
-	// channel enrichment join and the fused whereabouts tool. Config
-	// may spell a binding in any form uuid.Parse accepts; lookups
-	// compare against contact.ID.String().
-	accountsByContact := companionAccountsByContact(cfg.Companion)
-
 	if s.contactLookup != nil {
 		if s.personTracker != nil {
 			tracker := s.personTracker
@@ -425,17 +421,9 @@ func (a *App) initServers(s *newState) error {
 				return counterpartyPresenceView(snap, time.Now())
 			}
 		}
-		if len(accountsByContact) > 0 && a.companionDevices != nil {
+		if a.companionDevices != nil {
 			s.contactLookup.devicesFor = func(ctx context.Context, contactID string) []agent.CounterpartyDevice {
-				accounts := accountsByContact[contactID]
-				if len(accounts) == 0 {
-					return nil
-				}
-				owned := make(map[string]bool, len(accounts))
-				for _, acct := range accounts {
-					owned[acct] = true
-				}
-				devices, err := a.companionDevices.List(ctx)
+				devices, err := a.companionDevices.DevicesForContact(ctx, contactID)
 				if err != nil {
 					logger.Warn("counterparty device join failed", "error", err)
 					return nil
@@ -449,9 +437,6 @@ func (a *App) initServers(s *newState) error {
 				now := time.Now()
 				var views []agent.CounterpartyDevice
 				for _, d := range devices {
-					if !owned[d.Account] || d.State != companions.DeviceStateActive {
-						continue
-					}
 					availability := "offline"
 					if live[[2]string{d.Account, d.ClientID}] {
 						availability = "online"
@@ -483,9 +468,23 @@ func (a *App) initServers(s *newState) error {
 		if s.personTracker != nil {
 			deps.Presence = s.personTracker.Snapshot
 		}
-		if len(accountsByContact) > 0 {
+		if a.companionDevices != nil {
+			devices := a.companionDevices
 			deps.AccountsForContact = func(contactID string) []string {
-				return accountsByContact[contactID]
+				bound, err := devices.DevicesForContact(context.Background(), contactID)
+				if err != nil {
+					logger.Warn("companion accounts for contact failed", "contact_id", contactID, "error", err)
+					return nil
+				}
+				seen := make(map[string]bool, len(bound))
+				accounts := make([]string, 0, len(bound))
+				for _, d := range bound {
+					if !seen[d.Account] {
+						seen[d.Account] = true
+						accounts = append(accounts, d.Account)
+					}
+				}
+				return accounts
 			}
 		}
 		if a.companionRegistry != nil {
@@ -990,19 +989,42 @@ func counterpartyPresenceView(snap contacts.PersonSnapshot, now time.Time) *agen
 // companion source is configured. Provider entries may remain in disabled
 // config, but they must not keep persisted companion data reachable through
 // contact joins after the operator disables the integration.
-func companionAccountsByContact(cfg config.CompanionConfig) map[string][]string {
+// companionContactForAccount resolves an account to the canonical
+// contact UUID the operator declared for it, or "" when the account is
+// unclaimed or the binding is unparseable.
+//
+// Config may spell a binding in any form uuid.Parse accepts; the value
+// this returns is canonical, because it is written to the device row and
+// compared against contact.ID.String().
+func companionContactForAccount(cfg config.CompanionConfig) func(string) string {
 	if !cfg.Configured() {
 		return nil
 	}
-	accountsByContact := make(map[string][]string)
+	contactByAccount := make(map[string]string, len(cfg.Providers))
 	for account, provider := range cfg.Providers {
 		if provider.Contact == "" {
 			continue
 		}
 		if id, err := uuid.Parse(provider.Contact); err == nil {
-			canonicalID := id.String()
-			accountsByContact[canonicalID] = append(accountsByContact[canonicalID], account)
+			contactByAccount[account] = id.String()
 		}
 	}
-	return accountsByContact
+	if len(contactByAccount) == 0 {
+		return nil
+	}
+	return func(account string) string { return contactByAccount[account] }
+}
+
+// companionAccountNames lists every configured companion account, so
+// startup can reconcile each one's device bindings against config.
+func companionAccountNames(cfg config.CompanionConfig) []string {
+	if !cfg.Configured() {
+		return nil
+	}
+	accounts := make([]string, 0, len(cfg.Providers))
+	for account := range cfg.Providers {
+		accounts = append(accounts, account)
+	}
+	sort.Strings(accounts)
+	return accounts
 }

--- a/internal/app/new_servers_test.go
+++ b/internal/app/new_servers_test.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"slices"
 	"testing"
 	"time"
 
@@ -96,12 +95,20 @@ func TestCounterpartyPresenceView(t *testing.T) {
 	}
 }
 
-func TestCompanionAccountsByContactRequiresConfiguredSource(t *testing.T) {
+// TestCompanionContactForAccountRequiresConfiguredSource pins the
+// resolver that stamps a device's contact at registration. An
+// unconfigured or unclaimed source must yield nil rather than an empty
+// resolver, because a resolver that answers "" for everything would
+// unbind every device on the next reconcile.
+func TestCompanionContactForAccountRequiresConfiguredSource(t *testing.T) {
 	const contactID = "8A1F50A7-91C1-4DE5-90D3-B239719D29A8"
+	const canonical = "8a1f50a7-91c1-4de5-90d3-b239719d29a8"
 	tests := []struct {
-		name string
-		cfg  config.CompanionConfig
-		want map[string][]string
+		name    string
+		cfg     config.CompanionConfig
+		account string
+		want    string
+		wantNil bool
 	}{
 		{
 			name: "disabled with retained provider",
@@ -110,6 +117,7 @@ func TestCompanionAccountsByContactRequiresConfiguredSource(t *testing.T) {
 					"alice": {Tokens: []string{"token"}, Contact: contactID},
 				},
 			},
+			wantNil: true,
 		},
 		{
 			name: "enabled without token",
@@ -119,30 +127,46 @@ func TestCompanionAccountsByContactRequiresConfiguredSource(t *testing.T) {
 					"alice": {Contact: contactID},
 				},
 			},
+			wantNil: true,
 		},
 		{
-			name: "configured",
+			name: "configured binding is canonicalized",
 			cfg: config.CompanionConfig{
 				Enabled: true,
 				Providers: map[string]config.CompanionProviderConfig{
 					"alice": {Tokens: []string{"token"}, Contact: contactID},
 				},
 			},
-			want: map[string][]string{
-				"8a1f50a7-91c1-4de5-90d3-b239719d29a8": {"alice"},
+			account: "alice",
+			want:    canonical,
+		},
+		{
+			name: "configured account the operator did not claim",
+			cfg: config.CompanionConfig{
+				Enabled: true,
+				Providers: map[string]config.CompanionProviderConfig{
+					"alice": {Tokens: []string{"token"}, Contact: contactID},
+					"bob":   {Tokens: []string{"token"}},
+				},
 			},
+			account: "bob",
+			want:    "",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := companionAccountsByContact(tt.cfg)
-			if len(got) != len(tt.want) {
-				t.Fatalf("bindings = %#v, want %#v", got, tt.want)
-			}
-			for contactID, wantAccounts := range tt.want {
-				if !slices.Equal(got[contactID], wantAccounts) {
-					t.Errorf("accounts for %s = %#v, want %#v", contactID, got[contactID], wantAccounts)
+			resolve := companionContactForAccount(tt.cfg)
+			if tt.wantNil {
+				if resolve != nil {
+					t.Fatalf("resolver = non-nil, want nil for an unconfigured source")
 				}
+				return
+			}
+			if resolve == nil {
+				t.Fatal("resolver = nil, want a resolver")
+			}
+			if got := resolve(tt.account); got != tt.want {
+				t.Errorf("resolve(%q) = %q, want %q", tt.account, got, tt.want)
 			}
 		})
 	}

--- a/internal/app/new_stores.go
+++ b/internal/app/new_stores.go
@@ -149,11 +149,32 @@ func (a *App) initStores(s *newState) error {
 	// companion config that feeds it — unconfiguring companions must not
 	// orphan the records. Shares the main thane.db connection; no
 	// separate close hook (mem owns the DB).
-	companionDevices, err := companions.NewStore(a.mem.DB(), logger)
+	// The operator's account-to-contact declaration reaches the store as
+	// a resolver, so a device is stamped with its contact as it registers
+	// rather than joined to one through config at read time.
+	contactForAccount := companionContactForAccount(a.cfg.Companion)
+	companionDevices, err := companions.NewStore(a.mem.DB(), logger,
+		companions.WithContactForAccount(contactForAccount))
 	if err != nil {
 		return fmt.Errorf("companion device store: %w", err)
 	}
 	a.companionDevices = companionDevices
+
+	// Registration stamps a device as it connects, which covers every
+	// future pairing. This covers the rest in one pass: rows written
+	// before the column existed, and accounts whose declared contact
+	// changed while their devices were not connecting. A failure here
+	// leaves stale bindings rather than none, so it warns instead of
+	// refusing the boot.
+	if accounts := companionAccountNames(a.cfg.Companion); len(accounts) > 0 {
+		changed, err := companionDevices.ReconcileContactBindings(s.ctx, accounts)
+		switch {
+		case err != nil:
+			logger.Warn("companion contact binding reconcile incomplete; some devices may still name a stale contact", "error", err)
+		case changed > 0:
+			logger.Info("companion contact bindings reconciled", "devices", changed)
+		}
+	}
 
 	// Daily prune for the completions journal Ack writes — the audit
 	// trail is bounded by age, mirroring the log-index pruner's shape.

--- a/internal/app/new_stores.go
+++ b/internal/app/new_stores.go
@@ -166,14 +166,14 @@ func (a *App) initStores(s *newState) error {
 	// changed while their devices were not connecting. A failure here
 	// leaves stale bindings rather than none, so it warns instead of
 	// refusing the boot.
-	if accounts := companionAccountNames(a.cfg.Companion); len(accounts) > 0 {
-		changed, err := companionDevices.ReconcileContactBindings(s.ctx, accounts)
-		switch {
-		case err != nil:
-			logger.Warn("companion contact binding reconcile incomplete; some devices may still name a stale contact", "error", err)
-		case changed > 0:
-			logger.Info("companion contact bindings reconciled", "devices", changed)
-		}
+	// Unconditional: the case that matters is the account config no
+	// longer declares, and a sweep gated on configured accounts is
+	// exactly the sweep that never visits it.
+	switch changed, err := companionDevices.ReconcileContactBindings(s.ctx); {
+	case err != nil:
+		logger.Warn("companion contact binding reconcile incomplete; some devices may still name a stale contact", "error", err)
+	case changed > 0:
+		logger.Info("companion contact bindings reconciled", "devices", changed)
 	}
 
 	// Daily prune for the completions journal Ack writes — the audit

--- a/internal/state/companions/contact_binding_test.go
+++ b/internal/state/companions/contact_binding_test.go
@@ -1,0 +1,193 @@
+package companions
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/companion"
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
+)
+
+func bindingTestStore(t *testing.T, contactByAccount map[string]string) *Store {
+	t.Helper()
+	db, err := database.Open(filepath.Join(t.TempDir(), "devices.db"))
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store, err := NewStore(db, nil, WithContactForAccount(func(account string) string {
+		return contactByAccount[account]
+	}))
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	return store
+}
+
+const (
+	bindingContactA = "019c76e4-2ff1-7918-8d6f-6c2488f5098d"
+	bindingContactB = "019cd331-9ed4-7294-9177-c982db7c8196"
+)
+
+// TestRegistrationStampsTheConfiguredContact is the point of moving the
+// binding onto the row: a device that pairs while the process is running
+// joins its person immediately, with no restart and no config re-read.
+func TestRegistrationStampsTheConfiguredContact(t *testing.T) {
+	store := bindingTestStore(t, map[string]string{"nugget": bindingContactA})
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	if err := store.RecordConnected(ctx, "nugget", "iphone-1", companion.DeviceMetadata{ClientName: "Nugget's iPhone"}, now); err != nil {
+		t.Fatalf("RecordConnected: %v", err)
+	}
+	devices, err := store.DevicesForContact(ctx, bindingContactA)
+	if err != nil {
+		t.Fatalf("DevicesForContact: %v", err)
+	}
+	if len(devices) != 1 || devices[0].ClientID != "iphone-1" {
+		t.Fatalf("devices = %+v, want the freshly paired iphone-1", devices)
+	}
+	if devices[0].ContactID != bindingContactA {
+		t.Errorf("ContactID = %q, want %q", devices[0].ContactID, bindingContactA)
+	}
+}
+
+// TestUnclaimedAccountBindsNothing covers the account the operator never
+// declared: its devices exist and belong to nobody, rather than to a
+// zero-value contact that a query for "" would sweep up.
+func TestUnclaimedAccountBindsNothing(t *testing.T) {
+	store := bindingTestStore(t, map[string]string{"nugget": bindingContactA})
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	if err := store.RecordConnected(ctx, "guest", "ipad-1", companion.DeviceMetadata{}, now); err != nil {
+		t.Fatalf("RecordConnected: %v", err)
+	}
+	if devices, err := store.DevicesForContact(ctx, ""); err != nil || len(devices) != 0 {
+		t.Fatalf("DevicesForContact(\"\") = %+v, %v; an empty contact must match nothing", devices, err)
+	}
+	all, err := store.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(all) != 1 || all[0].ContactID != "" {
+		t.Fatalf("device = %+v, want one unbound row", all)
+	}
+}
+
+// TestReconcileFollowsConfigInBothDirections covers the rows registration
+// cannot reach: written before the column existed, or belonging to an
+// account whose declared contact changed while the device was offline.
+// Unbinding matters as much as binding — an account the operator stopped
+// claiming must not leave its devices pointing at the old person.
+func TestReconcileFollowsConfigInBothDirections(t *testing.T) {
+	contactByAccount := map[string]string{"nugget": bindingContactA}
+	db, err := database.Open(filepath.Join(t.TempDir(), "devices.db"))
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store, err := NewStore(db, nil, WithContactForAccount(func(a string) string { return contactByAccount[a] }))
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if err := store.RecordConnected(ctx, "nugget", "iphone-1", companion.DeviceMetadata{}, now); err != nil {
+		t.Fatalf("RecordConnected: %v", err)
+	}
+
+	// The operator reassigns the account to a different person.
+	contactByAccount["nugget"] = bindingContactB
+	changed, err := store.ReconcileContactBindings(ctx, []string{"nugget"})
+	if err != nil {
+		t.Fatalf("ReconcileContactBindings: %v", err)
+	}
+	if changed != 1 {
+		t.Errorf("changed = %d, want 1", changed)
+	}
+	if devices, _ := store.DevicesForContact(ctx, bindingContactA); len(devices) != 0 {
+		t.Errorf("old contact still owns %d devices", len(devices))
+	}
+	if devices, _ := store.DevicesForContact(ctx, bindingContactB); len(devices) != 1 {
+		t.Errorf("new contact owns %d devices, want 1", len(devices))
+	}
+
+	// And the operator stops claiming the account entirely.
+	delete(contactByAccount, "nugget")
+	if _, err := store.ReconcileContactBindings(ctx, []string{"nugget"}); err != nil {
+		t.Fatalf("ReconcileContactBindings unbind: %v", err)
+	}
+	if devices, _ := store.DevicesForContact(ctx, bindingContactB); len(devices) != 0 {
+		t.Errorf("unclaimed account left %d devices bound", len(devices))
+	}
+
+	// A reconcile that changes nothing reports nothing, so the startup
+	// log stays quiet on an unchanged deployment.
+	if changed, err := store.ReconcileContactBindings(ctx, []string{"nugget"}); err != nil || changed != 0 {
+		t.Errorf("idempotent reconcile = %d, %v; want 0, nil", changed, err)
+	}
+}
+
+// TestDevicesForContactExcludesRetiredHardware keeps a deregistered
+// device out of the live source inventory.
+func TestDevicesForContactExcludesRetiredHardware(t *testing.T) {
+	store := bindingTestStore(t, map[string]string{"nugget": bindingContactA})
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if err := store.RecordConnected(ctx, "nugget", "iphone-old", companion.DeviceMetadata{}, now); err != nil {
+		t.Fatalf("RecordConnected: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx,
+		`UPDATE companion_devices SET state = 'retired' WHERE client_id = ?`, "iphone-old"); err != nil {
+		t.Fatalf("retire device: %v", err)
+	}
+	devices, err := store.DevicesForContact(ctx, bindingContactA)
+	if err != nil {
+		t.Fatalf("DevicesForContact: %v", err)
+	}
+	if len(devices) != 0 {
+		t.Errorf("retired device still listed: %+v", devices)
+	}
+}
+
+// TestReconnectRefreshesAStaleBinding covers the device that was already
+// known when its account changed hands. Registration is an upsert, so a
+// returning phone must adopt the account's current contact rather than
+// keeping the one it was first stamped with — otherwise a reassignment
+// only takes effect for hardware that has never connected before.
+func TestReconnectRefreshesAStaleBinding(t *testing.T) {
+	contactByAccount := map[string]string{"nugget": bindingContactA}
+	db, err := database.Open(filepath.Join(t.TempDir(), "devices.db"))
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store, err := NewStore(db, nil, WithContactForAccount(func(a string) string { return contactByAccount[a] }))
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if err := store.RecordConnected(ctx, "nugget", "iphone-1", companion.DeviceMetadata{}, now); err != nil {
+		t.Fatalf("first connect: %v", err)
+	}
+
+	contactByAccount["nugget"] = bindingContactB
+	if err := store.RecordConnected(ctx, "nugget", "iphone-1", companion.DeviceMetadata{}, now.Add(time.Minute)); err != nil {
+		t.Fatalf("reconnect: %v", err)
+	}
+
+	if devices, _ := store.DevicesForContact(ctx, bindingContactA); len(devices) != 0 {
+		t.Errorf("reconnect kept the stale binding: %d devices still on the old contact", len(devices))
+	}
+	devices, err := store.DevicesForContact(ctx, bindingContactB)
+	if err != nil {
+		t.Fatalf("DevicesForContact: %v", err)
+	}
+	if len(devices) != 1 {
+		t.Fatalf("new contact owns %d devices, want 1", len(devices))
+	}
+}

--- a/internal/state/companions/contact_binding_test.go
+++ b/internal/state/companions/contact_binding_test.go
@@ -101,7 +101,7 @@ func TestReconcileFollowsConfigInBothDirections(t *testing.T) {
 
 	// The operator reassigns the account to a different person.
 	contactByAccount["nugget"] = bindingContactB
-	changed, err := store.ReconcileContactBindings(ctx, []string{"nugget"})
+	changed, err := store.ReconcileContactBindings(ctx)
 	if err != nil {
 		t.Fatalf("ReconcileContactBindings: %v", err)
 	}
@@ -117,7 +117,7 @@ func TestReconcileFollowsConfigInBothDirections(t *testing.T) {
 
 	// And the operator stops claiming the account entirely.
 	delete(contactByAccount, "nugget")
-	if _, err := store.ReconcileContactBindings(ctx, []string{"nugget"}); err != nil {
+	if _, err := store.ReconcileContactBindings(ctx); err != nil {
 		t.Fatalf("ReconcileContactBindings unbind: %v", err)
 	}
 	if devices, _ := store.DevicesForContact(ctx, bindingContactB); len(devices) != 0 {
@@ -126,7 +126,7 @@ func TestReconcileFollowsConfigInBothDirections(t *testing.T) {
 
 	// A reconcile that changes nothing reports nothing, so the startup
 	// log stays quiet on an unchanged deployment.
-	if changed, err := store.ReconcileContactBindings(ctx, []string{"nugget"}); err != nil || changed != 0 {
+	if changed, err := store.ReconcileContactBindings(ctx); err != nil || changed != 0 {
 		t.Errorf("idempotent reconcile = %d, %v; want 0, nil", changed, err)
 	}
 }
@@ -190,4 +190,113 @@ func TestReconnectRefreshesAStaleBinding(t *testing.T) {
 	if len(devices) != 1 {
 		t.Fatalf("new contact owns %d devices, want 1", len(devices))
 	}
+}
+
+// TestReconcileVisitsAccountsConfigNoLongerNames is the dangerous case: a
+// provider deleted, renamed, or disabled is never named by config again,
+// so a sweep driven by configured accounts never visits it and its
+// devices keep answering for a contact the operator revoked. The sweep
+// walks the table instead.
+func TestReconcileVisitsAccountsConfigNoLongerNames(t *testing.T) {
+	contactByAccount := map[string]string{"nugget": bindingContactA, "monica": bindingContactB}
+	db, err := database.Open(filepath.Join(t.TempDir(), "devices.db"))
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store, err := NewStore(db, nil, WithContactForAccount(func(a string) string { return contactByAccount[a] }))
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	ctx := context.Background()
+	now := time.Now().UTC()
+	for _, acct := range []string{"nugget", "monica"} {
+		if err := store.RecordConnected(ctx, acct, "phone", companion.DeviceMetadata{}, now); err != nil {
+			t.Fatalf("RecordConnected %s: %v", acct, err)
+		}
+	}
+
+	// The operator deletes the monica provider outright.
+	delete(contactByAccount, "monica")
+	if _, err := store.ReconcileContactBindings(ctx); err != nil {
+		t.Fatalf("ReconcileContactBindings: %v", err)
+	}
+	if devices, _ := store.DevicesForContact(ctx, bindingContactB); len(devices) != 0 {
+		t.Errorf("a deleted provider left %d devices bound to its old contact", len(devices))
+	}
+	if devices, _ := store.DevicesForContact(ctx, bindingContactA); len(devices) != 1 {
+		t.Errorf("the surviving provider lost its binding: %d devices", len(devices))
+	}
+}
+
+// TestReconcileUnbindsEverythingWhenCompanionsAreOff covers the whole
+// integration being switched off. The binding is a projection of config,
+// so config saying nothing must mean no binding — not the last binding
+// anyone happened to write.
+func TestReconcileUnbindsEverythingWhenCompanionsAreOff(t *testing.T) {
+	store := bindingTestStore(t, map[string]string{"nugget": bindingContactA})
+	ctx := context.Background()
+	if err := store.RecordConnected(ctx, "nugget", "phone", companion.DeviceMetadata{}, time.Now().UTC()); err != nil {
+		t.Fatalf("RecordConnected: %v", err)
+	}
+
+	// A store with no resolver at all is what an unconfigured or
+	// disabled companion integration produces.
+	off, err := NewStore(store.db, nil)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	if _, err := off.ReconcileContactBindings(ctx); err != nil {
+		t.Fatalf("ReconcileContactBindings: %v", err)
+	}
+	if devices, _ := off.DevicesForContact(ctx, bindingContactA); len(devices) != 0 {
+		t.Errorf("companions disabled but %d devices still bound", len(devices))
+	}
+}
+
+// TestObservationsForContactExcludeRetiredDevices pins the filter that
+// collapsing a contact to account names used to lose: one account holding
+// a retired phone and a live one must not answer with the retired one's
+// last known location.
+func TestObservationsForContactExcludeRetiredDevices(t *testing.T) {
+	store := bindingTestStore(t, map[string]string{"nugget": bindingContactA})
+	ctx := context.Background()
+	now := time.Now().UTC()
+	for _, client := range []string{"iphone-old", "iphone-new"} {
+		if err := store.RecordConnected(ctx, "nugget", client, companion.DeviceMetadata{}, now); err != nil {
+			t.Fatalf("RecordConnected %s: %v", client, err)
+		}
+	}
+	devices, err := store.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	for _, d := range devices {
+		if err := seedContactLocation(t, store, d.Account, d.ClientID, d.DeviceID, now); err != nil {
+			t.Fatalf("seed observation: %v", err)
+		}
+	}
+	if _, err := store.db.ExecContext(ctx,
+		`UPDATE companion_devices SET state = 'retired' WHERE client_id = ?`, "iphone-old"); err != nil {
+		t.Fatalf("retire device: %v", err)
+	}
+
+	observations, err := store.LatestObservationsForContact(ctx, "ios.location", bindingContactA)
+	if err != nil {
+		t.Fatalf("LatestObservationsForContact: %v", err)
+	}
+	if len(observations) != 1 {
+		t.Fatalf("got %d observations, want only the active device's", len(observations))
+	}
+	if observations[0].ClientID != "iphone-new" {
+		t.Errorf("observation came from %q, want iphone-new", observations[0].ClientID)
+	}
+}
+
+func seedContactLocation(t *testing.T, store *Store, account, clientID, deviceID string, at time.Time) error {
+	t.Helper()
+	_, err := store.IngestObservations(context.Background(),
+		companion.ObservationPrincipal{Account: account, DeviceID: deviceID},
+		observationBatch(clientID, deviceID+"-loc", at), at)
+	return err
 }

--- a/internal/state/companions/observations.go
+++ b/internal/state/companions/observations.go
@@ -296,6 +296,44 @@ func scanLatestObservation(row *sql.Rows) (companion.LatestObservation, error) {
 	return observation, nil
 }
 
+// LatestObservationsForContact returns the latest observation of one
+// kind for every ACTIVE device belonging to one contact.
+//
+// Contact-scoped rather than account-scoped on purpose: an account can
+// hold both a retired phone and a live one, and collapsing a contact to
+// account names loses the device state filter, so the retired handset's
+// last known location comes back alongside the current one. Scoping at
+// the device row keeps ownership and liveness in the same predicate.
+func (s *Store) LatestObservationsForContact(ctx context.Context, kind, contactID string) ([]companion.LatestObservation, error) {
+	kind = strings.TrimSpace(kind)
+	contactID = strings.TrimSpace(contactID)
+	if kind == "" || contactID == "" {
+		return nil, nil
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT d.account, o.device_id, d.client_id, o.kind, o.event_id,
+		       o.schema_version, o.status, o.observed_at, o.received_at, o.payload
+		FROM companion_latest_observations o
+		JOIN companion_devices d ON d.device_id = o.device_id
+		WHERE o.kind = ? AND d.contact_id = ? AND d.state = ?
+		ORDER BY d.account, d.client_id
+	`, kind, contactID, DeviceStateActive)
+	if err != nil {
+		return nil, fmt.Errorf("list %s observations for contact: %w", kind, err)
+	}
+	defer rows.Close()
+
+	var observations []companion.LatestObservation
+	for rows.Next() {
+		observation, err := scanLatestObservation(rows)
+		if err != nil {
+			return nil, err
+		}
+		observations = append(observations, observation)
+	}
+	return observations, rows.Err()
+}
+
 // LatestObservationsByKind returns the latest observation of one kind
 // for every device belonging to the given accounts, ordered by
 // account/client for a stable shape. Scoped at the query so a caller

--- a/internal/state/companions/schema.go
+++ b/internal/state/companions/schema.go
@@ -38,6 +38,7 @@ var devicesSchema = database.Schema{
 				capabilities         TEXT NOT NULL DEFAULT '[]',
 				capabilities_recorded_at TIMESTAMP,
 				state                TEXT NOT NULL DEFAULT 'active',
+				contact_id           TEXT NOT NULL DEFAULT '',
 				UNIQUE (account, client_id)
 			)`,
 		},
@@ -46,6 +47,17 @@ var devicesSchema = database.Schema{
 		// from TableCreate above.
 		database.ColumnAdd{
 			Table: "companion_devices", Column: "metadata_recorded_at", Typedef: "TIMESTAMP",
+		},
+		// The contact a device belongs to lives on the row rather than in
+		// config, so a phone that pairs after boot joins its person without
+		// waiting for a restart, and so "which devices can observe this
+		// contact" is one query instead of a config lookup feeding a filter.
+		database.ColumnAdd{
+			Table: "companion_devices", Column: "contact_id", Typedef: "TEXT NOT NULL DEFAULT ''",
+		},
+		database.IndexCreate{
+			Name: "idx_companion_devices_contact",
+			SQL:  `CREATE INDEX IF NOT EXISTS idx_companion_devices_contact ON companion_devices(contact_id) WHERE contact_id != ''`,
 		},
 		// Anchor legacy metadata to the connection time that guarded it before
 		// observation ingestion added a shared cross-transport recency timestamp.

--- a/internal/state/companions/store.go
+++ b/internal/state/companions/store.go
@@ -319,7 +319,7 @@ func (s *Store) List(ctx context.Context) ([]Device, error) {
 }
 
 // DevicesForContact returns the active devices belonging to one
-// contact, newest connection first.
+// contact, most recently seen first.
 //
 // This is the live answer to "what companion hardware can observe this
 // person right now": it reads the binding off the row, so a device that
@@ -342,21 +342,49 @@ func (s *Store) DevicesForContact(ctx context.Context, contactID string) ([]Devi
 	`, contactID, DeviceStateActive)
 }
 
-// ReconcileContactBindings stamps every device with its account's
-// configured contact and returns how many rows changed.
+// ReconcileContactBindings brings every persisted device's contact into
+// line with the operator's declaration, and returns how many rows
+// changed.
 //
 // Registration stamps a device as it connects, which covers everything
 // that pairs from now on. This covers the rest: rows written before the
-// column existed, and rows whose account changed hands in config while
-// the device was not connecting. Config is the source of truth in both
-// directions — an account the operator no longer claims has its devices
-// unbound rather than left pointing at the old contact.
-func (s *Store) ReconcileContactBindings(ctx context.Context, accounts []string) (int, error) {
+// column existed, and rows whose account changed hands while the device
+// was not connecting.
+//
+// It walks the accounts PRESENT IN THE TABLE rather than the accounts
+// present in config, because the dangerous case is the account config no
+// longer mentions. A provider that is deleted, renamed, or disabled is
+// never visited by a config-driven sweep, so its devices keep a binding
+// the operator has revoked and keep answering for that contact. Walking
+// the table means an account with no declaration resolves to "" and is
+// unbound, which is also what happens when companions are switched off
+// entirely — the binding is a projection of config, so config saying
+// nothing means no binding.
+func (s *Store) ReconcileContactBindings(ctx context.Context) (int, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT DISTINCT account FROM companion_devices`)
+	if err != nil {
+		return 0, fmt.Errorf("enumerate companion accounts for reconcile: %w", err)
+	}
+	var accounts []string
+	for rows.Next() {
+		var account string
+		if err := rows.Scan(&account); err != nil {
+			rows.Close()
+			return 0, fmt.Errorf("scan companion account for reconcile: %w", err)
+		}
+		accounts = append(accounts, account)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("enumerate companion accounts for reconcile: %w", err)
+	}
+
 	changed := 0
 	for _, account := range accounts {
+		want := s.contactIDForAccount(account)
 		result, err := s.db.ExecContext(ctx,
 			`UPDATE companion_devices SET contact_id = ? WHERE account = ? AND contact_id != ?`,
-			s.contactIDForAccount(account), account, s.contactIDForAccount(account))
+			want, account, want)
 		if err != nil {
 			return changed, fmt.Errorf("reconcile companion contact binding for %s: %w", account, err)
 		}

--- a/internal/state/companions/store.go
+++ b/internal/state/companions/store.go
@@ -53,6 +53,11 @@ type Device struct {
 	// non-empty device metadata accepted from any companion transport.
 	MetadataRecordedAt time.Time
 
+	// ContactID is the contact this device belongs to, empty when the
+	// account is unclaimed. Stamped at registration from the operator's
+	// account declaration, so a reader asks the row rather than config.
+	ContactID string
+
 	FirstSeenAt time.Time
 	LastSeenAt  time.Time
 	// LastConnectedAt and LastDisconnectedAt are zero when the event has
@@ -76,18 +81,55 @@ type Device struct {
 type Store struct {
 	db     *sql.DB
 	logger *slog.Logger
+
+	// contactForAccount resolves an account to the contact the operator
+	// declared it belongs to. Nil leaves every device unbound.
+	contactForAccount func(account string) string
 }
 
 // NewStore creates a companion-device store, running migrations on
 // first use. The db handle is borrowed (the memory store owns it).
-func NewStore(db *sql.DB, logger *slog.Logger) (*Store, error) {
+func NewStore(db *sql.DB, logger *slog.Logger, opts ...StoreOption) (*Store, error) {
 	if logger == nil {
 		logger = slog.Default()
 	}
 	if err := database.Migrate(db, devicesSchema, logger); err != nil {
 		return nil, err
 	}
-	return &Store{db: db, logger: logger}, nil
+	store := &Store{db: db, logger: logger}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(store)
+		}
+	}
+	return store, nil
+}
+
+// StoreOption configures optional store wiring. A construction option
+// rather than a setter: the resolver is fixed for the store's life, and
+// the architecture baseline counts exported mutator growth deliberately.
+type StoreOption func(*Store)
+
+// WithContactForAccount supplies the operator's account-to-contact
+// declaration. A device is stamped with its account's contact when it
+// registers, so a phone that pairs after boot joins its person without
+// waiting for a restart.
+//
+// The mapping stays operator config — who a device belongs to is a
+// custody decision, not something a device asserts about itself — but
+// the binding it produces lives on the row, where a reader can ask for
+// it without consulting config.
+func WithContactForAccount(resolve func(account string) string) StoreOption {
+	return func(s *Store) { s.contactForAccount = resolve }
+}
+
+// contactIDForAccount resolves an account's configured contact, or ""
+// when the account is unclaimed or no resolver is wired.
+func (s *Store) contactIDForAccount(account string) string {
+	if s == nil || s.contactForAccount == nil {
+		return ""
+	}
+	return strings.TrimSpace(s.contactForAccount(account))
 }
 
 // RecordConnected upserts the device row for a successful companion
@@ -116,9 +158,10 @@ func (s *Store) RecordConnected(ctx context.Context, account, clientID string, m
 	_, err = s.db.ExecContext(ctx, `
 		INSERT INTO companion_devices (
 			device_id, account, client_id, client_name, platform, app_version, os_version, metadata_recorded_at,
-			first_seen_at, last_seen_at, last_connected_at, state
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			first_seen_at, last_seen_at, last_connected_at, state, contact_id
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(account, client_id) DO UPDATE SET
+			contact_id = excluded.contact_id,
 			first_seen_at = MIN(companion_devices.first_seen_at, excluded.first_seen_at),
 			client_name = CASE WHEN excluded.client_name != ''
 					AND (companion_devices.client_name = '' OR companion_devices.metadata_recorded_at IS NULL
@@ -144,7 +187,8 @@ func (s *Store) RecordConnected(ctx context.Context, account, clientID string, m
 			last_connected_at = MAX(companion_devices.last_connected_at, excluded.last_connected_at)
 	`, deviceID, account, clientID,
 		meta.ClientName, meta.Platform, meta.AppVersion, meta.OSVersion,
-		deviceMetadataTime(meta, at), at, at, at, DeviceStateActive)
+		deviceMetadataTime(meta, at), at, at, at, DeviceStateActive,
+		s.contactIDForAccount(account))
 	if err != nil {
 		return fmt.Errorf("record companion connect %s/%s: %w", account, clientID, err)
 	}
@@ -249,7 +293,7 @@ func (s *Store) Get(ctx context.Context, account, clientID string) (Device, bool
 	devices, err := s.scanDevices(ctx, `
 		SELECT device_id, account, client_id, client_name, platform, app_version, os_version,
 		       metadata_recorded_at, first_seen_at, last_seen_at, last_connected_at, last_disconnected_at,
-		       capabilities, capabilities_recorded_at, state
+		       capabilities, capabilities_recorded_at, state, contact_id
 		FROM companion_devices
 		WHERE account = ? AND client_id = ?
 	`, account, clientID)
@@ -268,10 +312,59 @@ func (s *Store) List(ctx context.Context) ([]Device, error) {
 	return s.scanDevices(ctx, `
 		SELECT device_id, account, client_id, client_name, platform, app_version, os_version,
 		       metadata_recorded_at, first_seen_at, last_seen_at, last_connected_at, last_disconnected_at,
-		       capabilities, capabilities_recorded_at, state
+		       capabilities, capabilities_recorded_at, state, contact_id
 		FROM companion_devices
 		ORDER BY account ASC, client_id ASC
 	`)
+}
+
+// DevicesForContact returns the active devices belonging to one
+// contact, newest connection first.
+//
+// This is the live answer to "what companion hardware can observe this
+// person right now": it reads the binding off the row, so a device that
+// paired since boot is included and one whose account lost its claim is
+// not. Callers previously mapped a contact to accounts through config
+// and filtered the full device list, which could only be as current as
+// the last restart.
+func (s *Store) DevicesForContact(ctx context.Context, contactID string) ([]Device, error) {
+	contactID = strings.TrimSpace(contactID)
+	if contactID == "" {
+		return nil, nil
+	}
+	return s.scanDevices(ctx, `
+		SELECT device_id, account, client_id, client_name, platform, app_version, os_version,
+		       metadata_recorded_at, first_seen_at, last_seen_at, last_connected_at, last_disconnected_at,
+		       capabilities, capabilities_recorded_at, state, contact_id
+		FROM companion_devices
+		WHERE contact_id = ? AND state = ?
+		ORDER BY last_seen_at DESC, account ASC, client_id ASC
+	`, contactID, DeviceStateActive)
+}
+
+// ReconcileContactBindings stamps every device with its account's
+// configured contact and returns how many rows changed.
+//
+// Registration stamps a device as it connects, which covers everything
+// that pairs from now on. This covers the rest: rows written before the
+// column existed, and rows whose account changed hands in config while
+// the device was not connecting. Config is the source of truth in both
+// directions — an account the operator no longer claims has its devices
+// unbound rather than left pointing at the old contact.
+func (s *Store) ReconcileContactBindings(ctx context.Context, accounts []string) (int, error) {
+	changed := 0
+	for _, account := range accounts {
+		result, err := s.db.ExecContext(ctx,
+			`UPDATE companion_devices SET contact_id = ? WHERE account = ? AND contact_id != ?`,
+			s.contactIDForAccount(account), account, s.contactIDForAccount(account))
+		if err != nil {
+			return changed, fmt.Errorf("reconcile companion contact binding for %s: %w", account, err)
+		}
+		if n, err := result.RowsAffected(); err == nil {
+			changed += int(n)
+		}
+	}
+	return changed, nil
 }
 
 func (s *Store) scanDevices(ctx context.Context, query string, args ...any) ([]Device, error) {
@@ -294,7 +387,7 @@ func (s *Store) scanDevices(ctx context.Context, query string, args ...any) ([]D
 		if err := rows.Scan(
 			&d.DeviceID, &d.Account, &d.ClientID, &d.ClientName, &d.Platform, &d.AppVersion, &d.OSVersion,
 			&metadataAt, &d.FirstSeenAt, &d.LastSeenAt, &connected, &disconnected,
-			&capsJSON, &capsAt, &d.State,
+			&capsJSON, &capsAt, &d.State, &d.ContactID,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/tools/companion_observation_tools_test.go
+++ b/internal/tools/companion_observation_tools_test.go
@@ -12,6 +12,25 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/state/companions"
 )
 
+// newObservationToolStoreForContact builds a store whose registrations
+// stamp each account's declared contact, mirroring how the app wires the
+// operator's companion.providers.<account>.contact declaration.
+func newObservationToolStoreForContact(t *testing.T, contactByAccount map[string]string) *companions.Store {
+	t.Helper()
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("open memory db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	store, err := companions.NewStore(db, nil, companions.WithContactForAccount(func(account string) string {
+		return contactByAccount[account]
+	}))
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	return store
+}
+
 func newObservationToolStore(t *testing.T) *companions.Store {
 	t.Helper()
 	db, err := database.OpenMemory()

--- a/internal/tools/counterparty_tools.go
+++ b/internal/tools/counterparty_tools.go
@@ -29,9 +29,6 @@ type CounterpartyToolDeps struct {
 	// Presence returns the live tracker snapshot for an HA person
 	// entity; nil when no tracker is configured.
 	Presence func(entity string) (contacts.PersonSnapshot, bool)
-	// AccountsForContact maps a canonical contact UUID string to the
-	// companion accounts bound to it; nil when no bindings exist.
-	AccountsForContact func(contactID string) []string
 	// LiveIdentities reports which (account, client_id) pairs have an
 	// open connection right now; nil when companions are unconfigured.
 	LiveIdentities func() map[[2]string]bool
@@ -203,12 +200,20 @@ func handleContactWhereabouts(ctx context.Context, deps CounterpartyToolDeps, na
 		observedAt time.Time
 	}
 	var availableDevices, withdrawnDevices []timedSource
-	var boundAccounts []string
-	if deps.AccountsForContact != nil {
-		boundAccounts = deps.AccountsForContact(contact.ID.String())
+	// Bound-device existence is its own question from bound-device
+	// output: a contact with a paired phone that has never published is
+	// bound-but-silent, not unbound, and the two produce different
+	// answers below.
+	var boundDevices []companions.Device
+	if deps.Companions != nil {
+		devices, err := deps.Companions.DevicesForContact(ctx, contact.ID.String())
+		if err != nil {
+			return "", fmt.Errorf("read bound companion devices: %w", err)
+		}
+		boundDevices = devices
 	}
-	if deps.Companions != nil && len(boundAccounts) > 0 {
-		observations, err := deps.Companions.LatestObservationsByKind(ctx, "ios.location", boundAccounts)
+	if deps.Companions != nil {
+		observations, err := deps.Companions.LatestObservationsForContact(ctx, "ios.location", contact.ID.String())
 		if err != nil {
 			return "", fmt.Errorf("read companion observations: %w", err)
 		}
@@ -261,7 +266,7 @@ func handleContactWhereabouts(ctx context.Context, deps CounterpartyToolDeps, na
 	// unbound contact. A bound contact whose sources yielded nothing
 	// gets a valid empty result whose basis says exactly which binding
 	// produced nothing — bound-but-silent is not misconfigured.
-	if !hasHABinding && len(boundAccounts) == 0 {
+	if !hasHABinding && len(boundDevices) == 0 {
 		return "", fmt.Errorf("contact %q has no HA person binding and no bound companion devices — there is no whereabouts source to consult; the operator binds the contact UUID to a tracked person entity via signed person.contact_bindings and companion accounts via companion.providers.<account>.contact", contact.FormattedName)
 	}
 
@@ -355,12 +360,12 @@ func handleContactWhereabouts(ctx context.Context, deps CounterpartyToolDeps, na
 
 	if len(result.Sources) == 0 {
 		switch {
-		case hasHABinding && len(boundAccounts) > 0:
+		case hasHABinding && len(boundDevices) > 0:
 			result.Basis = "bound, but silent: the person entity is not tracked (check person.track) and no bound device has published a location"
 		case hasHABinding:
 			result.Basis = "bound to a person entity that the presence tracker does not track (check person.track); no companion devices bound"
 		default:
-			result.Basis = "companion accounts are bound but no device has published a location yet"
+			result.Basis = "companion devices are bound but none has published a location yet"
 		}
 		out, err := json.Marshal(result)
 		if err != nil {

--- a/internal/tools/counterparty_tools_test.go
+++ b/internal/tools/counterparty_tools_test.go
@@ -77,7 +77,10 @@ func newWhereaboutsFixture(t *testing.T, state, room string, observations map[st
 		t.Fatal(err)
 	}
 
-	companionStore := newObservationToolStore(t)
+	// The account-to-contact declaration reaches the store as a resolver,
+	// so seeded devices are stamped with alice's contact exactly as a real
+	// registration would stamp them.
+	companionStore := newObservationToolStoreForContact(t, map[string]string{"alice-acct": alice.ID.String()})
 	now := time.Now().UTC()
 	i := 0
 	for device, status := range observations {
@@ -100,12 +103,6 @@ func newWhereaboutsFixture(t *testing.T, state, room string, observations map[st
 				snap.RoomSince = now.Add(-20 * time.Minute)
 			}
 			return snap, true
-		},
-		AccountsForContact: func(id string) []string {
-			if id == alice.ID.String() {
-				return []string{"alice-acct"}
-			}
-			return nil
 		},
 		LiveIdentities: func() map[[2]string]bool { return nil },
 	}


### PR DESCRIPTION
Which contact a companion device belongs to was a config lookup done at read time. `companionAccountsByContact` built a contact→accounts map once at startup, and both readers mapped a contact to accounts and then filtered the full device list.

**A phone that paired after boot belonged to nobody until a restart**, because the map it needed to appear in was built before it existed.

## What changed

`companion_devices.contact_id`, stamped from the account's configured contact when the device registers. A phone that pairs while the process is running joins its person on the same connection, and "which devices can observe this contact" is one indexed query instead of a config hop feeding a filter.

**Custody does not move.** `companion.providers.<account>.contact` is still the only thing that decides who a device belongs to — a device never asserts its own owner. What changed is where the answer is kept, so a reader asks the row rather than asking config.

## Two write paths, deliberately

**Registration** covers everything that pairs from now on, including the reconnect case: the upsert refreshes `contact_id` from `excluded`, so a device that was already known when its account changed hands adopts the current contact instead of keeping the one it was first stamped with.

**`ReconcileContactBindings`** covers the rest at startup — rows written before the column existed, and accounts whose declared contact changed while their devices were offline. It follows config in **both directions**: an account the operator stopped claiming has its devices unbound rather than left pointing at the person who used to own them. It reports only when something changed, so an unchanged deployment stays quiet at boot.

## Readers

`contactLookup.devicesFor` and the fused whereabouts tool's `AccountsForContact` are both queries against `contact_id` now. The two-hop map is gone, along with the `owned[d.Account]` filter each reader used to apply.

## Test plan

- [x] `just ci` passes — 74 packages, 0 FAIL, `set_mutators` 128, `interfaces` 91, `database_opens` 9, all held
- [x] Registration stamps the configured contact, so a fresh pairing is queryable immediately
- [x] A reconnect adopts the account's current contact rather than keeping a stale one
- [x] An unclaimed account's devices bind to nobody, and a query for `""` matches nothing rather than sweeping up every unbound row
- [x] Reconcile rebinds, unbinds, and is idempotent
- [x] A retired device is excluded from the live inventory
- [x] The config resolver returns nil for an unconfigured source — a resolver answering `""` for everything would unbind every device on the next reconcile
- [x] **Mutation-verified**, five mutations, each compiling and failing only its intended test: registration not stamping; the upsert not refreshing on reconnect; retired devices included; an empty contact matching unbound rows

The reconnect mutation passed on my first attempt, which is how I found that nothing covered a returning device whose account had been reassigned. That test exists because the mutation was silent.

## Why

This is the first piece of making a contact record answer "what data sources exist for this person right now." The HA binding and the linked device trackers were already live; the companion leg was frozen at boot. It isn't anymore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
