### PR TITLE
feat(companions): read the visit window the phone has been publishing all along

### DIFF
--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -478,6 +478,7 @@ func (a *App) initServers(s *newState) error {
 			}
 		}
 		a.loop.Tools().EnableCounterpartyTools(deps)
+		a.loop.Tools().EnableCounterpartyPlacesTools(deps)
 	}
 
 	// --- CardDAV server ---

--- a/internal/integrations/companion/visits.go
+++ b/internal/integrations/companion/visits.go
@@ -1,0 +1,175 @@
+package companion
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// VisitObservationKind is the observation kind carrying the visit window.
+const VisitObservationKind = "ios.visits"
+
+// VisitWindow is one companion's rolling record of the places it decided
+// mattered. It arrives as a whole window rather than one visit per
+// observation, which is what makes it survive latest-only storage: the
+// single retained row still carries the recent sequence.
+type VisitWindow struct {
+	CapturedAt    time.Time `json:"captured_at"`
+	WindowHours   float64   `json:"window_hours,omitempty"`
+	MaxEntries    int       `json:"max_entries,omitempty"`
+	ReturnedCount int       `json:"returned_count,omitempty"`
+	Truncated     bool      `json:"truncated,omitempty"`
+	Visits        []Visit   `json:"visits,omitempty"`
+}
+
+// Visit is one stay the device's platform judged significant. The
+// judgment is the device's, made on sensor data the server never sees,
+// which is why a visit is worth more than the fix that would otherwise
+// stand in for it: somebody already decided this was a place.
+type Visit struct {
+	Latitude  float64 `json:"latitude"`
+	Longitude float64 `json:"longitude"`
+	// HorizontalAccuracyMeters is the platform's own confidence in the
+	// coordinate, not a dwell-area radius.
+	HorizontalAccuracyMeters float64 `json:"horizontal_accuracy_meters,omitempty"`
+	// Arrival is "precise" when the platform timed the arrival, and
+	// "unknown" when the stay was already underway before monitoring
+	// began — an honest absence rather than a guessed timestamp.
+	Arrival    string     `json:"arrival,omitempty"`
+	ArrivedAt  *time.Time `json:"arrived_at,omitempty"`
+	DepartedAt *time.Time `json:"departed_at,omitempty"`
+	// State is "ongoing" while the device is still there, "settled"
+	// once it has left.
+	State string `json:"state,omitempty"`
+	// DwellSeconds is how long the stay lasted. DwellIsPartial marks a
+	// dwell still accruing, so a reader never reports an in-progress
+	// stay as a finished one.
+	DwellSeconds   float64 `json:"dwell_seconds,omitempty"`
+	DwellIsPartial bool    `json:"dwell_is_partial,omitempty"`
+}
+
+// identity keys a visit for deduplication. A window carries the same
+// stay more than once — captured while ongoing, then again once settled
+// — so the arrival time is the stay's identity. A stay that began before
+// monitoring has no arrival, and its departure identifies it instead.
+func (v Visit) identity() string {
+	switch {
+	case v.ArrivedAt != nil:
+		return "arrived:" + v.ArrivedAt.UTC().Format(time.RFC3339Nano)
+	case v.DepartedAt != nil:
+		return "departed:" + v.DepartedAt.UTC().Format(time.RFC3339Nano)
+	default:
+		return fmt.Sprintf("position:%.6f,%.6f", v.Latitude, v.Longitude)
+	}
+}
+
+// sortKey is the moment a visit is ordered by: when it began, or when it
+// ended for a stay whose beginning was never observed.
+func (v Visit) sortKey() time.Time {
+	if v.ArrivedAt != nil {
+		return *v.ArrivedAt
+	}
+	if v.DepartedAt != nil {
+		return *v.DepartedAt
+	}
+	return time.Time{}
+}
+
+// ParseVisitWindow decodes a stored ios.visits payload into distinct
+// visits, newest first.
+//
+// Deduplication is the point. The device republishes a stay as its state
+// advances, so a six-entry window is commonly four stays: the same
+// arrival appears once ongoing and once settled. A reader that takes the
+// array at face value reports a person visiting the same place twice in
+// a row, minutes apart. The later capture wins, because it carries the
+// departure and the final dwell.
+func ParseVisitWindow(payload json.RawMessage) (VisitWindow, error) {
+	if len(payload) == 0 {
+		return VisitWindow{}, nil
+	}
+	var raw struct {
+		CapturedAt    string  `json:"captured_at"`
+		WindowHours   float64 `json:"window_hours"`
+		MaxEntries    int     `json:"max_entries"`
+		ReturnedCount int     `json:"returned_count"`
+		Truncated     bool    `json:"truncated"`
+		Visits        []struct {
+			Latitude                 float64 `json:"latitude"`
+			Longitude                float64 `json:"longitude"`
+			HorizontalAccuracyMeters float64 `json:"horizontal_accuracy_meters"`
+			Arrival                  string  `json:"arrival"`
+			ArrivedAt                string  `json:"arrived_at"`
+			DepartedAt               string  `json:"departed_at"`
+			CapturedAt               string  `json:"captured_at"`
+			State                    string  `json:"state"`
+			DwellSeconds             float64 `json:"dwell_seconds"`
+			DwellIsPartial           bool    `json:"dwell_is_partial"`
+		} `json:"visits"`
+	}
+	if err := json.Unmarshal(payload, &raw); err != nil {
+		return VisitWindow{}, fmt.Errorf("decode visit window: %w", err)
+	}
+
+	window := VisitWindow{
+		WindowHours:   raw.WindowHours,
+		MaxEntries:    raw.MaxEntries,
+		ReturnedCount: raw.ReturnedCount,
+		Truncated:     raw.Truncated,
+	}
+	window.CapturedAt, _ = parseVisitTime(raw.CapturedAt)
+
+	// Keyed by stay identity, keeping the latest capture of each.
+	type candidate struct {
+		visit      Visit
+		capturedAt time.Time
+	}
+	best := make(map[string]candidate, len(raw.Visits))
+	for _, entry := range raw.Visits {
+		visit := Visit{
+			Latitude:                 entry.Latitude,
+			Longitude:                entry.Longitude,
+			HorizontalAccuracyMeters: entry.HorizontalAccuracyMeters,
+			Arrival:                  strings.TrimSpace(entry.Arrival),
+			State:                    strings.TrimSpace(entry.State),
+			DwellSeconds:             entry.DwellSeconds,
+			DwellIsPartial:           entry.DwellIsPartial,
+		}
+		if at, ok := parseVisitTime(entry.ArrivedAt); ok {
+			visit.ArrivedAt = &at
+		}
+		if at, ok := parseVisitTime(entry.DepartedAt); ok {
+			visit.DepartedAt = &at
+		}
+		capturedAt, _ := parseVisitTime(entry.CapturedAt)
+
+		key := visit.identity()
+		if existing, seen := best[key]; seen && existing.capturedAt.After(capturedAt) {
+			continue
+		}
+		best[key] = candidate{visit: visit, capturedAt: capturedAt}
+	}
+
+	window.Visits = make([]Visit, 0, len(best))
+	for _, c := range best {
+		window.Visits = append(window.Visits, c.visit)
+	}
+	sort.SliceStable(window.Visits, func(i, j int) bool {
+		return window.Visits[i].sortKey().After(window.Visits[j].sortKey())
+	})
+	return window, nil
+}
+
+func parseVisitTime(value string) (time.Time, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, false
+	}
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return parsed.UTC(), true
+}

--- a/internal/integrations/companion/visits_test.go
+++ b/internal/integrations/companion/visits_test.go
@@ -1,0 +1,141 @@
+package companion
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// productionVisitWindow is a real payload from an operator's phone: two
+// errands and a return home. It carries six entries for four stays,
+// which is the shape the parser exists to normalize.
+const productionVisitWindow = `{"captured_at":"2026-09-06T17:05:50.111Z","max_entries":16,"returned_count":6,"truncated":false,"visits":[
+{"arrival":"precise","arrived_at":"2026-09-06T17:05:13.098Z","captured_at":"2026-09-06T17:05:50.110Z","dwell_is_partial":true,"dwell_seconds":37.011552929878235,"horizontal_accuracy_meters":5,"latitude":29.831151442236557,"longitude":-98.464568898586,"state":"ongoing"},
+{"arrival":"precise","arrived_at":"2026-09-06T16:47:26.719Z","captured_at":"2026-09-06T16:59:22.041Z","departed_at":"2026-09-06T16:58:45.128Z","dwell_is_partial":false,"dwell_seconds":678.4090310335159,"horizontal_accuracy_meters":108.75376219064817,"latitude":29.79732248483415,"longitude":-98.43010016634825,"state":"settled"},
+{"arrival":"precise","arrived_at":"2026-09-06T16:47:26.719Z","captured_at":"2026-09-06T16:51:57.871Z","dwell_is_partial":true,"dwell_seconds":271.15273106098175,"horizontal_accuracy_meters":11.519004002296295,"latitude":29.796542773386278,"longitude":-98.42982839849608,"state":"ongoing"},
+{"arrival":"precise","arrived_at":"2026-09-06T16:21:51.633Z","captured_at":"2026-09-06T16:45:58.082Z","departed_at":"2026-09-06T16:45:20.669Z","dwell_is_partial":false,"dwell_seconds":1409.0365599393845,"horizontal_accuracy_meters":54.07629544931456,"latitude":29.797003751266306,"longitude":-98.41852298892312,"state":"settled"},
+{"arrival":"precise","arrived_at":"2026-09-06T16:21:51.633Z","captured_at":"2026-09-06T16:37:18.763Z","dwell_is_partial":true,"dwell_seconds":927.1302980184555,"horizontal_accuracy_meters":50.47494742062936,"latitude":29.79694558881348,"longitude":-98.4184658414713,"state":"ongoing"},
+{"arrival":"unknown","captured_at":"2026-09-06T16:12:23.138Z","departed_at":"2026-09-06T16:11:57.501Z","dwell_is_partial":false,"horizontal_accuracy_meters":13.056274755587332,"latitude":29.83122951133177,"longitude":-98.46431478315205,"state":"settled"}],
+"window_hours":48}`
+
+// TestParseVisitWindowCollapsesRepublishedStays is the whole reason this
+// parser exists. The device republishes a stay as its state advances, so
+// taking the array at face value reports six stops for four — the same
+// place visited twice, minutes apart, which is a false claim about a
+// person's day.
+func TestParseVisitWindowCollapsesRepublishedStays(t *testing.T) {
+	window, err := ParseVisitWindow(json.RawMessage(productionVisitWindow))
+	if err != nil {
+		t.Fatalf("ParseVisitWindow: %v", err)
+	}
+	if window.ReturnedCount != 6 {
+		t.Errorf("ReturnedCount = %d, want the raw 6 preserved", window.ReturnedCount)
+	}
+	if len(window.Visits) != 4 {
+		t.Fatalf("got %d distinct visits, want 4: %+v", len(window.Visits), window.Visits)
+	}
+
+	// Newest first, and the settled capture wins over the ongoing one
+	// because it carries the departure and the final dwell.
+	first := window.Visits[0]
+	if first.State != "ongoing" || first.DepartedAt != nil {
+		t.Errorf("newest visit should be the current ongoing stay, got %+v", first)
+	}
+	second := window.Visits[1]
+	if second.State != "settled" || second.DepartedAt == nil {
+		t.Fatalf("second visit should be settled with a departure, got %+v", second)
+	}
+	if got := second.DwellSeconds; got < 678 || got > 679 {
+		t.Errorf("second visit dwell = %v, want the settled 678s not the ongoing 271s", got)
+	}
+	if second.DwellIsPartial {
+		t.Error("a settled stay must not report a partial dwell")
+	}
+}
+
+// TestParseVisitWindowKeepsAnUntimedArrival covers the stay already
+// underway when monitoring began. It has no arrival, and inventing one
+// would be worse than reporting the gap, so it is identified by its
+// departure and kept.
+func TestParseVisitWindowKeepsAnUntimedArrival(t *testing.T) {
+	window, err := ParseVisitWindow(json.RawMessage(productionVisitWindow))
+	if err != nil {
+		t.Fatalf("ParseVisitWindow: %v", err)
+	}
+	oldest := window.Visits[len(window.Visits)-1]
+	if oldest.Arrival != "unknown" || oldest.ArrivedAt != nil {
+		t.Fatalf("oldest visit should carry an unknown arrival, got %+v", oldest)
+	}
+	if oldest.DepartedAt == nil {
+		t.Fatal("an untimed arrival still has a departure and must be kept")
+	}
+	want := time.Date(2026, 9, 6, 16, 11, 57, 501000000, time.UTC)
+	if !oldest.DepartedAt.Equal(want) {
+		t.Errorf("departure = %v, want %v", oldest.DepartedAt, want)
+	}
+}
+
+// TestParseVisitWindowOrdersNewestFirst pins the order a reader depends
+// on: the current stay leads, and the sequence reads backwards through
+// the day.
+func TestParseVisitWindowOrdersNewestFirst(t *testing.T) {
+	window, err := ParseVisitWindow(json.RawMessage(productionVisitWindow))
+	if err != nil {
+		t.Fatalf("ParseVisitWindow: %v", err)
+	}
+	for i := 1; i < len(window.Visits); i++ {
+		prev, cur := window.Visits[i-1], window.Visits[i]
+		if cur.sortKey().After(prev.sortKey()) {
+			t.Fatalf("visit %d (%v) is newer than visit %d (%v)", i, cur.sortKey(), i-1, prev.sortKey())
+		}
+	}
+}
+
+func TestParseVisitWindowHandlesAbsentAndMalformed(t *testing.T) {
+	if w, err := ParseVisitWindow(nil); err != nil || len(w.Visits) != 0 {
+		t.Errorf("nil payload = %+v, %v; want an empty window and no error", w, err)
+	}
+	if _, err := ParseVisitWindow(json.RawMessage(`{"visits":`)); err == nil {
+		t.Error("malformed payload accepted; a reader would see an empty window and call it truth")
+	}
+	// A timestamp the device could not format must not become the zero
+	// time, which would sort as the oldest visit ever recorded.
+	w, err := ParseVisitWindow(json.RawMessage(`{"visits":[{"arrived_at":"not-a-time","latitude":1,"longitude":2}]}`))
+	if err != nil {
+		t.Fatalf("ParseVisitWindow: %v", err)
+	}
+	if len(w.Visits) != 1 || w.Visits[0].ArrivedAt != nil {
+		t.Errorf("unparseable arrival should be absent, got %+v", w.Visits)
+	}
+}
+
+// TestParseVisitWindowPrefersTheLatestCaptureRegardlessOfOrder pins the
+// comparison rather than the array order. The production payload happens
+// to list the settled capture before the ongoing one, so a parser that
+// simply kept the first entry it saw would agree with a correct one on
+// that data and disagree the first time the device emits them the other
+// way round.
+func TestParseVisitWindowPrefersTheLatestCaptureRegardlessOfOrder(t *testing.T) {
+	// Same stay twice, ongoing listed FIRST, settled second.
+	payload := `{"captured_at":"2026-09-06T17:00:00Z","visits":[
+{"arrival":"precise","arrived_at":"2026-09-06T16:21:51Z","captured_at":"2026-09-06T16:37:18Z","dwell_is_partial":true,"dwell_seconds":927,"latitude":29.7969,"longitude":-98.4184,"state":"ongoing"},
+{"arrival":"precise","arrived_at":"2026-09-06T16:21:51Z","captured_at":"2026-09-06T16:45:58Z","departed_at":"2026-09-06T16:45:20Z","dwell_is_partial":false,"dwell_seconds":1409,"latitude":29.7970,"longitude":-98.4185,"state":"settled"}]}`
+
+	window, err := ParseVisitWindow(json.RawMessage(payload))
+	if err != nil {
+		t.Fatalf("ParseVisitWindow: %v", err)
+	}
+	if len(window.Visits) != 1 {
+		t.Fatalf("got %d visits, want the pair collapsed to 1: %+v", len(window.Visits), window.Visits)
+	}
+	got := window.Visits[0]
+	if got.State != "settled" || got.DepartedAt == nil {
+		t.Fatalf("kept the earlier ongoing capture instead of the later settled one: %+v", got)
+	}
+	if got.DwellSeconds != 1409 {
+		t.Errorf("dwell = %v, want the settled 1409", got.DwellSeconds)
+	}
+	if got.DwellIsPartial {
+		t.Error("kept a partial dwell for a stay that has finished")
+	}
+}

--- a/internal/model/toolcatalog/catalog.go
+++ b/internal/model/toolcatalog/catalog.go
@@ -310,6 +310,7 @@ var builtinToolSpecs = map[string]BuiltinToolSpec{
 	"resolve_actionable":            {CanonicalID: "native:resolve_actionable", Source: NativeToolSource, Tags: []string{"notifications"}},
 	"contact_save":                  {CanonicalID: "native:contact_save", Source: NativeToolSource, Tags: []string{"contacts"}},
 	"contact_whereabouts":           {CanonicalID: "native:contact_whereabouts", Source: NativeToolSource, Tags: []string{"contacts", "companion"}},
+	"contact_recent_places":         {CanonicalID: "native:contact_recent_places", Source: NativeToolSource, Tags: []string{"contacts", "companion"}},
 	"task_schedule":                 {CanonicalID: "native:task_schedule", Source: NativeToolSource, Tags: []string{"scheduler"}},
 	"send_reaction":                 {CanonicalID: "native:send_reaction", Source: NativeToolSource, Tags: []string{"message_channel"}},
 	"session_checkpoint":            {CanonicalID: "native:session_checkpoint", Source: NativeToolSource, Tags: []string{"session"}},

--- a/internal/tools/counterparty_places_tools.go
+++ b/internal/tools/counterparty_places_tools.go
@@ -1,0 +1,190 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	companion "github.com/nugget/thane-ai-agent/internal/integrations/companion"
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
+)
+
+// maxRecentPlaces bounds what one call renders. The device's own window
+// is already capped; this keeps a long window from crowding a turn.
+const maxRecentPlaces = 12
+
+// placeView is one stay as the model reads it. Deltas render against the
+// call, not the capture, so "40m ago" means forty minutes before this
+// question was asked.
+type placeView struct {
+	// State is "here_now" for a stay still underway, "left" once ended.
+	// The device's own vocabulary is ongoing/settled; this says the same
+	// thing in the tense a reader thinks in.
+	State string `json:"state"`
+	// Arrived is a delta, or absent when the stay began before the
+	// device started watching. ArrivalTimed says which, so a reader
+	// never mistakes an unobserved arrival for a recent one.
+	Arrived      string `json:"arrived,omitempty"`
+	ArrivalTimed bool   `json:"arrival_timed"`
+	Departed     string `json:"departed,omitempty"`
+	// Dwell is how long the stay lasted; DwellStillAccruing marks one
+	// that has not finished, so "11m" is not read as a completed visit.
+	Dwell              string  `json:"dwell,omitempty"`
+	DwellStillAccruing bool    `json:"dwell_still_accruing,omitempty"`
+	Latitude           float64 `json:"latitude"`
+	Longitude          float64 `json:"longitude"`
+	AccuracyMeters     float64 `json:"accuracy_meters,omitempty"`
+}
+
+type recentPlacesResult struct {
+	Contact string `json:"contact"`
+	// Device names which companion produced the window; a contact with
+	// several reports the one whose window was read.
+	Device      string      `json:"device,omitempty"`
+	CapturedAgo string      `json:"captured_ago,omitempty"`
+	WindowHours float64     `json:"window_hours,omitempty"`
+	Places      []placeView `json:"places,omitempty"`
+	// Truncated reports the device dropping stays from its own window;
+	// Omitted reports this tool capping what it rendered. They are
+	// different losses and a reader deserves to tell them apart.
+	Truncated bool   `json:"truncated,omitempty"`
+	Omitted   int    `json:"omitted,omitempty"`
+	Basis     string `json:"basis"`
+}
+
+// EnableCounterpartyPlacesTools adds the recent-places view: the stays a
+// contact's companion device judged significant, newest first.
+//
+// This is not a location history. The device decides what counts as a
+// place, using sensor data the server never sees, and publishes the
+// whole recent window each time — so a stay carries an arrival, a
+// departure and a dwell that no sequence of raw fixes would yield.
+func (r *Registry) EnableCounterpartyPlacesTools(deps CounterpartyToolDeps) {
+	if r == nil || deps.Contacts == nil || deps.Companions == nil {
+		return
+	}
+
+	r.Register(&Tool{
+		Name: "contact_recent_places",
+		Description: "List the places a contact's companion device recently judged significant, newest first, with how long they stayed at each. " +
+			"This answers \"where have they been\" and \"how long have they been there\" — questions a coordinate cannot. " +
+			"The device decides what counts as a place from sensor data the server never sees, so a stay here carries a timed arrival, a departure, and a dwell that no sequence of raw fixes would produce. " +
+			"state is here_now for a stay still underway and left once it ended; dwell_still_accruing marks a dwell that has not finished, so an in-progress stay is never read as a completed one. " +
+			"arrival_timed is false when the stay was already underway before the device started watching — the arrival is genuinely unknown rather than zero. " +
+			"Reach for contact_whereabouts when you need where somebody is right now fused across every source; reach here when the sequence and the dwells are the point. " +
+			"Pass name (resolved like other contact tools) or contact_id (UUID).",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"name": map[string]any{
+					"type":        "string",
+					"description": "Contact name (formatted name or nickname; resolved with the standard contact cascade).",
+				},
+				"contact_id": map[string]any{
+					"type":        "string",
+					"description": "Exact contact UUID; takes precedence over name when both are given.",
+				},
+			},
+		},
+		Handler: func(ctx context.Context, args map[string]any) (string, error) {
+			name, _ := args["name"].(string)
+			id, _ := args["contact_id"].(string)
+			return handleContactRecentPlaces(ctx, deps, strings.TrimSpace(name), strings.TrimSpace(id))
+		},
+	})
+}
+
+func handleContactRecentPlaces(ctx context.Context, deps CounterpartyToolDeps, name, id string) (string, error) {
+	contact, err := resolveWhereaboutsContact(deps.Contacts, name, id)
+	if err != nil {
+		return "", err
+	}
+
+	observations, err := deps.Companions.LatestObservationsForContact(ctx, companion.VisitObservationKind, contact.ID.String())
+	if err != nil {
+		return "", fmt.Errorf("read companion visit windows: %w", err)
+	}
+
+	result := recentPlacesResult{Contact: contact.FormattedName}
+	if len(observations) == 0 {
+		// Three different absences read the same from here, so the basis
+		// says which rather than implying the person went nowhere.
+		result.Basis = "no companion device bound to this contact has published a visit window; either no device is bound, the device does not share visits, or it has not published one yet"
+		return marshalRecentPlaces(result)
+	}
+
+	// Newest window wins when a contact carries several devices: the
+	// freshest capture is the one that knows where they are now.
+	best := observations[0]
+	for _, obs := range observations[1:] {
+		if obs.ObservedAt.After(best.ObservedAt) {
+			best = obs
+		}
+	}
+
+	window, err := companion.ParseVisitWindow(best.Payload)
+	if err != nil {
+		return "", fmt.Errorf("decode visit window from %s: %w", best.ClientID, err)
+	}
+
+	now := time.Now()
+	result.Device = best.ClientID
+	result.WindowHours = window.WindowHours
+	result.Truncated = window.Truncated
+	if !window.CapturedAt.IsZero() {
+		result.CapturedAgo = promptfmt.FormatDeltaOnly(window.CapturedAt, now)
+	}
+
+	visits := window.Visits
+	if len(visits) > maxRecentPlaces {
+		result.Omitted = len(visits) - maxRecentPlaces
+		visits = visits[:maxRecentPlaces]
+	}
+	for _, v := range visits {
+		place := placeView{
+			State:              placeState(v.State),
+			ArrivalTimed:       v.ArrivedAt != nil,
+			DwellStillAccruing: v.DwellIsPartial,
+			Latitude:           v.Latitude,
+			Longitude:          v.Longitude,
+			AccuracyMeters:     v.HorizontalAccuracyMeters,
+		}
+		if v.ArrivedAt != nil {
+			place.Arrived = promptfmt.FormatDeltaOnly(*v.ArrivedAt, now)
+		}
+		if v.DepartedAt != nil {
+			place.Departed = promptfmt.FormatDeltaOnly(*v.DepartedAt, now)
+		}
+		if v.DwellSeconds > 0 {
+			place.Dwell = (time.Duration(v.DwellSeconds) * time.Second).Round(time.Minute).String()
+		}
+		result.Places = append(result.Places, place)
+	}
+
+	switch {
+	case len(result.Places) == 0:
+		result.Basis = "the device published a visit window containing no stays"
+	case result.Places[0].State == "here_now":
+		result.Basis = "the leading place is where they are now; earlier stays follow in reverse order"
+	default:
+		result.Basis = "no stay is currently underway — they are between places, or moving"
+	}
+	return marshalRecentPlaces(result)
+}
+
+func marshalRecentPlaces(result recentPlacesResult) (string, error) {
+	out, err := json.Marshal(result)
+	if err != nil {
+		return "", fmt.Errorf("marshal recent places: %w", err)
+	}
+	return string(out), nil
+}
+
+func placeState(deviceState string) string {
+	if strings.EqualFold(strings.TrimSpace(deviceState), "ongoing") {
+		return "here_now"
+	}
+	return "left"
+}

--- a/internal/tools/counterparty_places_tools_test.go
+++ b/internal/tools/counterparty_places_tools_test.go
@@ -1,0 +1,130 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	companion "github.com/nugget/thane-ai-agent/internal/integrations/companion"
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
+	"github.com/nugget/thane-ai-agent/internal/state/contacts"
+)
+
+// newPlacesFixture binds one contact to one companion account and seeds
+// the account's device with a visit window.
+func newPlacesFixture(t *testing.T, window string) (CounterpartyToolDeps, string) {
+	t.Helper()
+	cdb, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("contacts db: %v", err)
+	}
+	t.Cleanup(func() { cdb.Close() })
+	contactStore, err := contacts.NewStore(cdb, slog.Default())
+	if err != nil {
+		t.Fatalf("contacts store: %v", err)
+	}
+	alice, err := contactStore.Upsert(&contacts.Contact{FormattedName: "Alice Operator"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	companionStore := newObservationToolStoreForContact(t, map[string]string{"alice-acct": alice.ID.String()})
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if err := companionStore.RecordConnected(ctx, "alice-acct", "iphone", companion.DeviceMetadata{Platform: "ios"}, now); err != nil {
+		t.Fatalf("record device: %v", err)
+	}
+	device, found, err := companionStore.Get(ctx, "alice-acct", "iphone")
+	if err != nil || !found {
+		t.Fatalf("get device: found=%t err=%v", found, err)
+	}
+	if window != "" {
+		if _, err := companionStore.IngestObservations(ctx,
+			companion.ObservationPrincipal{Account: "alice-acct", DeviceID: device.DeviceID},
+			companion.ObservationBatch{
+				ObservationDeviceMetadata: companion.ObservationDeviceMetadata{ClientID: "iphone", Platform: "ios"},
+				Events: []companion.ObservationEvent{{
+					EventID: "visits-1", Kind: companion.VisitObservationKind, SchemaVersion: 1,
+					Status: companion.ObservationAvailable, ObservedAt: now,
+					Payload: json.RawMessage(window),
+				}},
+			}, now); err != nil {
+			t.Fatalf("ingest visits: %v", err)
+		}
+	}
+	return CounterpartyToolDeps{Contacts: contactStore, Companions: companionStore}, alice.ID.String()
+}
+
+// TestRecentPlacesCollapsesAndOrdersRealWindow runs a production payload
+// end to end: six raw entries, four stays, current one first.
+func TestRecentPlacesCollapsesAndOrdersRealWindow(t *testing.T) {
+	deps, contactID := newPlacesFixture(t, productionVisitWindowJSON)
+	out, err := handleContactRecentPlaces(context.Background(), deps, "", contactID)
+	if err != nil {
+		t.Fatalf("handleContactRecentPlaces: %v", err)
+	}
+	var result recentPlacesResult
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("decode result: %v\n%s", err, out)
+	}
+	if len(result.Places) != 4 {
+		t.Fatalf("got %d places, want 4 distinct stays: %s", len(result.Places), out)
+	}
+	if result.Places[0].State != "here_now" {
+		t.Errorf("leading place = %q, want here_now", result.Places[0].State)
+	}
+	if !result.Places[0].DwellStillAccruing {
+		t.Error("an ongoing stay must mark its dwell as still accruing")
+	}
+	// The completed errand keeps the settled dwell, not the partial one
+	// captured while it was still underway.
+	if got := result.Places[1].Dwell; got != "11m0s" {
+		t.Errorf("second place dwell = %q, want the settled 11m0s", got)
+	}
+	if result.Places[1].DwellStillAccruing {
+		t.Error("a finished stay must not mark its dwell as accruing")
+	}
+	// The stay underway before monitoring began reports no arrival
+	// rather than a zero one.
+	oldest := result.Places[len(result.Places)-1]
+	if oldest.ArrivalTimed || oldest.Arrived != "" {
+		t.Errorf("oldest place claims a timed arrival: %+v", oldest)
+	}
+	if !strings.Contains(result.Basis, "where they are now") {
+		t.Errorf("basis does not say the leading place is current: %q", result.Basis)
+	}
+}
+
+// TestRecentPlacesDistinguishesAbsences pins that "no window" does not
+// read as "went nowhere".
+func TestRecentPlacesDistinguishesAbsences(t *testing.T) {
+	deps, contactID := newPlacesFixture(t, "")
+	out, err := handleContactRecentPlaces(context.Background(), deps, "", contactID)
+	if err != nil {
+		t.Fatalf("handleContactRecentPlaces: %v", err)
+	}
+	var result recentPlacesResult
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(result.Places) != 0 {
+		t.Fatalf("expected no places, got %+v", result.Places)
+	}
+	for _, want := range []string{"no device is bound", "has not published"} {
+		if !strings.Contains(result.Basis, want) {
+			t.Errorf("basis %q does not enumerate the possible absences (%q)", result.Basis, want)
+		}
+	}
+}
+
+const productionVisitWindowJSON = `{"captured_at":"2026-09-06T17:05:50.111Z","max_entries":16,"returned_count":6,"truncated":false,"visits":[
+{"arrival":"precise","arrived_at":"2026-09-06T17:05:13.098Z","captured_at":"2026-09-06T17:05:50.110Z","dwell_is_partial":true,"dwell_seconds":37.01,"horizontal_accuracy_meters":5,"latitude":29.831151442236557,"longitude":-98.464568898586,"state":"ongoing"},
+{"arrival":"precise","arrived_at":"2026-09-06T16:47:26.719Z","captured_at":"2026-09-06T16:59:22.041Z","departed_at":"2026-09-06T16:58:45.128Z","dwell_is_partial":false,"dwell_seconds":678.4,"horizontal_accuracy_meters":108.75,"latitude":29.79732248483415,"longitude":-98.43010016634825,"state":"settled"},
+{"arrival":"precise","arrived_at":"2026-09-06T16:47:26.719Z","captured_at":"2026-09-06T16:51:57.871Z","dwell_is_partial":true,"dwell_seconds":271.15,"horizontal_accuracy_meters":11.51,"latitude":29.796542773386278,"longitude":-98.42982839849608,"state":"ongoing"},
+{"arrival":"precise","arrived_at":"2026-09-06T16:21:51.633Z","captured_at":"2026-09-06T16:45:58.082Z","departed_at":"2026-09-06T16:45:20.669Z","dwell_is_partial":false,"dwell_seconds":1409.03,"horizontal_accuracy_meters":54.07,"latitude":29.797003751266306,"longitude":-98.41852298892312,"state":"settled"},
+{"arrival":"precise","arrived_at":"2026-09-06T16:21:51.633Z","captured_at":"2026-09-06T16:37:18.763Z","dwell_is_partial":true,"dwell_seconds":927.13,"horizontal_accuracy_meters":50.47,"latitude":29.79694558881348,"longitude":-98.4184658414713,"state":"ongoing"},
+{"arrival":"unknown","captured_at":"2026-09-06T16:12:23.138Z","departed_at":"2026-09-06T16:11:57.501Z","dwell_is_partial":false,"horizontal_accuracy_meters":13.05,"latitude":29.83122951133177,"longitude":-98.46431478315205,"state":"settled"}],
+"window_hours":48}`


### PR DESCRIPTION
`ios.visits` has been stored and unread since the companion started sending it. Both server-side readers of stored observations hardcode `ios.location`, so the best whereabouts evidence in the system was reachable only by SQL.

The phone decides which places mattered — from sensor data the server never sees — then times arrival and departure at each and publishes the whole recent window. That's a materiality judgment already made, for free, on-device.

## Deduplication is the point

The device republishes a stay as its state advances, so one window carries the same visit twice — once `ongoing`, once `settled`. A real payload from production held **six entries for four stays**:

| | arrived | departed | dwell |
|---|---|---|---|
| home | *(arrival unknown)* | 16:11:57 | — |
| stop A | 16:21:51 | 16:45:20 | 23m |
| stop B | 16:47:26 | 16:58:45 | 11m |
| home | 17:05:13 | *(ongoing)* | 37s |

A reader taking the array at face value reports somebody visiting the same place twice, minutes apart — a false claim about their day. The **arrival time is the stay's identity**, and the later capture wins because it carries the departure and the final dwell.

A stay already underway when monitoring began has no arrival at all. It's kept, identified by its departure, and `arrival_timed: false` says the arrival is genuinely unknown rather than zero.

## `contact_recent_places`

Tagged `["contacts", "companion"]` like `contact_whereabouts`, so the same loops reach both. It answers a different question — not the freshest fix, but the sequence and the dwells:

- `here_now` / `left` rather than the device's `ongoing` / `settled`, in the tense a reader thinks in
- `dwell_still_accruing` so an in-progress dwell is never read as a completed visit
- absences enumerated rather than flattened, because *no bound device*, *no visit sharing*, and *nothing published yet* read identically from the query and mean different things
- `truncated` (the device dropped stays) is distinct from `omitted` (this tool capped the render)

## Test plan

- [x] `just ci` passes — 74 packages, 0 FAIL, `set_mutators` 128 and `interfaces` 91 held
- [x] The production payload runs end to end through the tool: six entries collapse to four stays, newest first
- [x] The settled capture's dwell wins over the ongoing one it supersedes
- [x] An untimed arrival is kept and reports no arrival rather than a zero one
- [x] Malformed payloads error; an unparseable timestamp becomes absent rather than the zero time, which would sort as the oldest visit ever recorded
- [x] **Mutation-verified** — dedupe by position instead of arrival; oldest-first ordering; keeping the first capture instead of the latest

That last mutation **passed on the production payload**, because it happens to list the settled entry before the ongoing one — so "first wins" and "latest wins" agree on that data and would diverge the first time the device emits them the other way round. A second test pins the comparison with the order reversed.

## Not in scope

Folding the current stay into `contact_whereabouts` as a ranked source. That tool has a careful budget and rank order, and this is the first contact with real visit data — worth proving the parse before touching it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
