### PR TITLE
feat(context): expand temporal templates on two more reader surfaces, and defend the author ones

### DIFF
--- a/docs/model-facing-context.md
+++ b/docs/model-facing-context.md
@@ -224,13 +224,23 @@ Curated prose gets the same treatment through temporal templates:
 time via `promptfmt.ExpandTemporalTemplates` — day words for a date
 ("today", "+20d"), a signed compact delta for an instant ("+3d16h") —
 so an authored document stays true between rewrites. Only reader
-surfaces expand — tagged-article injection and advertisement
-materialization; author surfaces
-(`doc_read`, the publish tools, git) keep the raw template so the
-round-trip is byte-exact, and a malformed template renders verbatim
-rather than disappearing. Templates render values, never claims —
-prose whose truth changes with data is a wake concern, not a
-substitution concern (#1431).
+surfaces expand — tagged-article injection, origin-derived context
+refs (`BuildRefs`), advertisement materialization, and the loop-output
+endpoint (`GET /v1/loops/{name}/outputs/{output}`, every negotiated
+representation); author surfaces (`doc_read`, the publish tools, git)
+keep the raw template so the round-trip is byte-exact, and a malformed
+template renders verbatim rather than disappearing. Classify each new
+surface as it is built: a reader that forgets to expand ships braces
+to the model, and an author surface that expands silently bakes a
+delta into the stored document at the next rewrite. Templates render
+values, never claims — prose whose truth changes with data is a wake
+concern, not a substitution concern (#1431).
+
+Day words are a calendar comparison, so every reader expands against
+*now in the household timezone*, sampled once per assembly. Expanding
+in UTC renders tomorrow as "today" through the last hours of a local
+evening, and sampling per document lets one prompt render the same
+date two ways a few lines apart.
 
 ### Keep schemas stable and deterministic
 

--- a/docs/model-facing-context.md
+++ b/docs/model-facing-context.md
@@ -225,8 +225,9 @@ time via `promptfmt.ExpandTemporalTemplates` — day words for a date
 ("today", "+20d"), a signed compact delta for an instant ("+3d16h") —
 so an authored document stays true between rewrites. Only reader
 surfaces expand — tagged-article injection, origin-derived context
-refs (`BuildRefs`), advertisement materialization, and the loop-output
-endpoint (`GET /v1/loops/{name}/outputs/{output}`, every negotiated
+refs (`BuildRefs`), the document advertiser's materializations, the
+metacognitive verdict block, and the loop-output endpoint
+(`GET /v1/loops/{name}/outputs/{output}`, every negotiated
 representation); author surfaces (`doc_read`, the publish tools, git)
 keep the raw template so the round-trip is byte-exact, and a malformed
 template renders verbatim rather than disappearing. Classify each new
@@ -236,11 +237,24 @@ delta into the stored document at the next rewrite. Templates render
 values, never claims — prose whose truth changes with data is a wake
 concern, not a substitution concern (#1431).
 
+Materialization is not one surface but one per advertiser, and each
+carries the obligation separately — a new `ContextAdvertiser` that
+returns authored prose expands nothing until it says so. The
+metacognitive verdict is the worked example of the trap: it reaches
+the model as a rendered block (heading plus age stamp), so it is a
+presentation of the status_line rather than the author's view of it,
+and it went a release shipping braces while the same facet served over
+HTTP rendered correctly.
+
 Day words are a calendar comparison, so every reader expands against
-*now in the household timezone*, sampled once per assembly. Expanding
-in UTC renders tomorrow as "today" through the last hours of a local
-evening, and sampling per document lets one prompt render the same
-date two ways a few lines apart.
+*now in the household timezone* — expanding in UTC renders tomorrow as
+"today" through the last hours of a local evening. Each rendered
+aggregate samples that clock exactly once: the tagged-article set, the
+ref set, and each materialized block. Sampling per document instead
+would let one block render the same date as "today" above and
+"tomorrow" below. The guarantee stops at the aggregate, though — a
+single prompt assembles several, so a prompt built across local
+midnight can still carry two of them a day apart.
 
 ### Keep schemas stable and deterministic
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -115,7 +115,7 @@ filesystem paths, signer principals, or the contents of `.allowed_signers`.
 | `GET` | `/v1/loops` | Running loop status snapshots. Optional `?state=` filter (`pending`, `sleeping`, `waiting`, `processing`, `error`, `stopped`). |
 | `GET` | `/v1/loops/{id}` | One running loop's status. |
 | `GET` | `/v1/loops/{id}/logs` | Structured logs for a running loop's recent conversation IDs (bare array, newest first; `?limit=` default 50, max 200). |
-| `GET` | `/v1/loops/{name}/outputs/{output}` | One declared loop output at a negotiated fidelity: `text/plain` = `status_line` when that signal shape is declared, `application/json` = typed facets + full body, `text/markdown` (default) = document body. A plain-only request is not acceptable for an output without `status_line`. |
+| `GET` | `/v1/loops/{name}/outputs/{output}` | One declared loop output at a negotiated fidelity: `text/plain` = `status_line` when that signal shape is declared, `application/json` = typed facets + full body, `text/markdown` (default) = document body. A plain-only request is not acceptable for an output without `status_line`. Temporal templates in the prose arrive expanded (household timezone); the stored document keeps the raw template. |
 | `GET` | `/v1/loops/events` | SSE stream: initial loop snapshot, then loop and delegate events. |
 | `GET` | `/v1/schedules` | Scheduler tasks (`at`/`every`/`cron`) each with its next fire time. Optional `?enabled=true`. |
 | `GET` | `/v1/schedules/{id}` | One scheduled task. |

--- a/internal/app/new_awareness.go
+++ b/internal/app/new_awareness.go
@@ -239,6 +239,17 @@ func (a *App) initAwareness(s *newState) error {
 	// class-aware projection so the window reads closed→open for a
 	// garage_door, not off→on — injected here because contextfmt imports
 	// the homeassistant package and the provider cannot import it back.
+	// One derivation of the household zone for every provider that
+	// renders day words or expands temporal templates. Two derivations
+	// would be two chances to disagree about which day it is, and the
+	// disagreement would only ever show up late in a local evening.
+	homeZone := time.Local
+	if cfg.Timezone != "" {
+		if loc, err := time.LoadLocation(cfg.Timezone); err == nil {
+			homeZone = loc
+		}
+	}
+
 	// The system's one-line self-assessment: metacog's published
 	// status_line facet, the annunciator of judgments beside the state
 	// window's annunciator of facts (#1351). Always-on (ambient
@@ -247,7 +258,7 @@ func (a *App) initAwareness(s *newState) error {
 	// The provider advertises this signal before reading it. The final
 	// discriminator selects it and prepends the materialized projection to
 	// Live State, so a busy eager state window cannot starve the verdict.
-	a.loop.RegisterAlwaysContextProvider(awareness.NewSystemSelfAssessmentProvider(a.readSystemSelfAssessmentDocument, logger))
+	a.loop.RegisterAlwaysContextProvider(awareness.NewSystemSelfAssessmentProvider(a.readSystemSelfAssessmentDocument, homeZone, logger))
 
 	// The corpus advertiser: any document root whose context policy opts
 	// in (advertise: always|tagged) offers its faceted documents to the
@@ -271,12 +282,6 @@ func (a *App) initAwareness(s *newState) error {
 			advertisePolicies[name] = documents.DocumentRootAdvertisePolicy{
 				Mode:        rootCfg.Context.EffectiveAdvertise(),
 				RequiresTag: rootCfg.Context.RequiresTag,
-			}
-		}
-		homeZone := time.Local
-		if cfg.Timezone != "" {
-			if loc, err := time.LoadLocation(cfg.Timezone); err == nil {
-				homeZone = loc
 			}
 		}
 		registry := a.loopDefinitionRegistry

--- a/internal/app/temporal_author_surface_test.go
+++ b/internal/app/temporal_author_surface_test.go
@@ -1,0 +1,74 @@
+package app
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/state/documents"
+)
+
+// authorTemplate is a temporal template with a date far enough out that
+// any expansion produces obviously different text.
+const authorTemplate = "{{delta:2026-12-25}}"
+
+// TestLoopOwnOutputInjectionKeepsRawTemplates defends the author-surface
+// half of the temporal-template contract, which nothing pinned before.
+//
+// A loop reads its own maintained document every wake and republishes a
+// complete replacement. If this injection ever expanded, the loop would
+// see "+110d" where it wrote {{delta:2026-12-25}}, and its next publish
+// would store the rendered delta — destroying the template permanently,
+// silently, with no error and no way back. That is why reader surfaces
+// expand and this one must not.
+func TestLoopOwnOutputInjectionKeepsRawTemplates(t *testing.T) {
+	store, _ := newLoopOutputDocumentStore(t)
+	docTools := documents.NewTools(store)
+
+	body := "# Winter\n\nThe hard freeze lands " + authorTemplate + " and the pipes need wrapping.\n"
+	if _, err := store.Write(context.Background(), documents.WriteArgs{
+		Ref:  "core:winter.md",
+		Body: &body,
+	}); err != nil {
+		t.Fatalf("seed document: %v", err)
+	}
+
+	outputs := []looppkg.OutputSpec{{
+		Name: "winter_watch",
+		Type: looppkg.OutputTypeMaintainedDocument,
+		Ref:  "core:winter.md",
+		Mode: looppkg.OutputModeReplace,
+	}}
+	rendered, err := renderLoopOutputContextWithNow(context.Background(), store, docTools, outputs, time.Now())
+	if err != nil {
+		t.Fatalf("renderLoopOutputContextWithNow: %v", err)
+	}
+	if !strings.Contains(rendered, authorTemplate) {
+		t.Fatalf("the loop's own document was expanded before it could republish it:\n%s", rendered)
+	}
+}
+
+// TestStoredDocumentKeepsRawTemplates pins the storage end of the same
+// contract: whatever expands, it must never be what lands on disk. A
+// rendered delta in storage is indistinguishable from prose an author
+// meant, so the damage cannot be detected later, only inherited.
+func TestStoredDocumentKeepsRawTemplates(t *testing.T) {
+	store, _ := newLoopOutputDocumentStore(t)
+
+	body := "# Winter\n\nThe hard freeze lands " + authorTemplate + ".\n"
+	if _, err := store.Write(context.Background(), documents.WriteArgs{
+		Ref:  "core:winter.md",
+		Body: &body,
+	}); err != nil {
+		t.Fatalf("seed document: %v", err)
+	}
+	record, err := store.Read(context.Background(), "core:winter.md")
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if !strings.Contains(record.Body, authorTemplate) {
+		t.Fatalf("storage does not round-trip the template byte-exact:\n%s", record.Body)
+	}
+}

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -703,6 +703,20 @@ func (l *Loop) SetTagContextAssembler(a *TagContextAssembler) {
 	}
 }
 
+// Timezone returns the IANA household timezone the loop renders
+// now-relative values in, or "" when none is configured.
+//
+// Exported for reader surfaces outside the prompt path: temporal
+// templates render day distances as a calendar comparison, so a caller
+// that expands them must use the zone the reader thinks in or a late
+// evening renders tomorrow's date as "today".
+func (l *Loop) Timezone() string {
+	if l == nil {
+		return ""
+	}
+	return l.timezone
+}
+
 func (l *Loop) contextAssemblerForPrompt() *TagContextAssembler {
 	l.pendingProvidersMu.Lock()
 	assembler := l.tagContextAssembler

--- a/internal/runtime/agent/tag_context.go
+++ b/internal/runtime/agent/tag_context.go
@@ -851,6 +851,15 @@ func (a *TagContextAssembler) BuildRefs(ctx context.Context, refs []string) stri
 		if content == "" {
 			continue
 		}
+		// Same reader-surface treatment as tagged-article injection, and
+		// for the same reason: this content is injected whole for the
+		// model to act on, so a curated "{{delta:2026-09-18}}" must read
+		// as "+20d" rather than as braces. Expansion precedes ha-inject
+		// resolution so only authored prose is expanded, never entity
+		// state fetched a moment ago. Contact origin policy points these
+		// refs at dossiers, which are exactly the documents the house
+		// rule tells authors to write templates into.
+		content = promptfmt.ExpandTemporalTemplates(content, a.templateNow())
 		resolved := homeassistant.ResolveInject(ctx, []byte(content), a.haInject, a.logger)
 		var entry strings.Builder
 		entry.WriteString("#### ")

--- a/internal/runtime/agent/tag_context.go
+++ b/internal/runtime/agent/tag_context.go
@@ -822,6 +822,13 @@ func (a *TagContextAssembler) BuildRefs(ctx context.Context, refs []string) stri
 		return ""
 	}
 
+	// One clock for the whole aggregate. Sampling per ref would let two
+	// documents carrying the same date render "today" above and
+	// "tomorrow" below if the call crossed local midnight — two refs
+	// appearing to disagree when only the clock moved. The tagged
+	// article path holds the same invariant.
+	templateNow := a.templateNow()
+
 	seen := make(map[string]bool, len(refs))
 	var buf strings.Builder
 	for _, ref := range refs {
@@ -859,7 +866,7 @@ func (a *TagContextAssembler) BuildRefs(ctx context.Context, refs []string) stri
 		// state fetched a moment ago. Contact origin policy points these
 		// refs at dossiers, which are exactly the documents the house
 		// rule tells authors to write templates into.
-		content = promptfmt.ExpandTemporalTemplates(content, a.templateNow())
+		content = promptfmt.ExpandTemporalTemplates(content, templateNow)
 		resolved := homeassistant.ResolveInject(ctx, []byte(content), a.haInject, a.logger)
 		var entry strings.Builder
 		entry.WriteString("#### ")

--- a/internal/runtime/agent/tag_context_test.go
+++ b/internal/runtime/agent/tag_context_test.go
@@ -1853,8 +1853,9 @@ func TestBuildRefsExpandsTemporalTemplates(t *testing.T) {
 		t.Fatalf("write document: %v", err)
 	}
 	resolver := paths.New(map[string]string{"kb": documentRoot})
-	assembler := NewTagContextAssembler(TagContextAssemblerConfig{Resolver: resolver})
-	// A fixed now makes the rendered distance deterministic.
+	// UTC explicitly: an unset Timezone falls back to the host zone, and
+	// 09:00 UTC is still December 4 west of the line, which renders +21d.
+	assembler := NewTagContextAssembler(TagContextAssemblerConfig{Resolver: resolver, Timezone: "UTC"})
 	assembler.nowFunc = func() time.Time { return time.Date(2026, 12, 5, 9, 0, 0, 0, time.UTC) }
 
 	got := assembler.BuildRefs(context.Background(), []string{"kb:winter.md"})
@@ -1863,5 +1864,40 @@ func TestBuildRefsExpandsTemporalTemplates(t *testing.T) {
 	}
 	if !strings.Contains(got, "+20d") {
 		t.Fatalf("template did not render as a day distance: %q", got)
+	}
+}
+
+// TestBuildRefsSamplesOneClockForEveryRef holds the same invariant the
+// tagged-article path holds: two refs carrying the identical date must
+// render identical words. A per-ref clock sample lets one prompt say
+// "today" above and "tomorrow" below for the same day, which reads as
+// two documents disagreeing when only the clock moved.
+func TestBuildRefsSamplesOneClockForEveryRef(t *testing.T) {
+	t.Parallel()
+
+	documentRoot := t.TempDir()
+	body := "Freeze lands {{delta:2026-12-06}}."
+	for _, name := range []string{"one.md", "two.md"} {
+		if err := os.WriteFile(filepath.Join(documentRoot, name), []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	resolver := paths.New(map[string]string{"kb": documentRoot})
+	assembler := NewTagContextAssembler(TagContextAssemblerConfig{Resolver: resolver, Timezone: "UTC"})
+
+	// The clock crosses midnight between the two reads, so a per-ref
+	// sample renders "tomorrow" for the first and "today" for the second.
+	calls := 0
+	assembler.nowFunc = func() time.Time {
+		calls++
+		if calls == 1 {
+			return time.Date(2026, 12, 5, 23, 59, 0, 0, time.UTC)
+		}
+		return time.Date(2026, 12, 6, 0, 1, 0, 0, time.UTC)
+	}
+
+	got := assembler.BuildRefs(context.Background(), []string{"kb:one.md", "kb:two.md"})
+	if strings.Count(got, "tomorrow") != 2 {
+		t.Fatalf("refs rendered the same date differently: %q", got)
 	}
 }

--- a/internal/runtime/agent/tag_context_test.go
+++ b/internal/runtime/agent/tag_context_test.go
@@ -1835,3 +1835,33 @@ func TestFastProviderWarningStaysQuiet(t *testing.T) {
 		t.Errorf("a fast provider emitted a breakdown:\n%s", logs)
 	}
 }
+
+// TestBuildRefsExpandsTemporalTemplates pins session-origin context refs
+// as a reader surface, matching its sibling in the same file.
+//
+// These refs are injected whole for the model to act on, and contact
+// origin policy points them at dossiers — the documents the house rule
+// most wants templates in. Before this they were the only injection path
+// that resolved ha-inject without expanding, so a curated date arrived as
+// braces and the author had no way to tell from the teaching.
+func TestBuildRefsExpandsTemporalTemplates(t *testing.T) {
+	t.Parallel()
+
+	documentRoot := t.TempDir()
+	body := "The hard freeze lands {{delta:2026-12-25}} and the pipes need wrapping."
+	if err := os.WriteFile(filepath.Join(documentRoot, "winter.md"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write document: %v", err)
+	}
+	resolver := paths.New(map[string]string{"kb": documentRoot})
+	assembler := NewTagContextAssembler(TagContextAssemblerConfig{Resolver: resolver})
+	// A fixed now makes the rendered distance deterministic.
+	assembler.nowFunc = func() time.Time { return time.Date(2026, 12, 5, 9, 0, 0, 0, time.UTC) }
+
+	got := assembler.BuildRefs(context.Background(), []string{"kb:winter.md"})
+	if strings.Contains(got, "{{delta:") {
+		t.Fatalf("session-origin ref delivered a raw template to a reader: %q", got)
+	}
+	if !strings.Contains(got, "+20d") {
+		t.Fatalf("template did not render as a day distance: %q", got)
+	}
+}

--- a/internal/server/api/loop_outputs.go
+++ b/internal/server/api/loop_outputs.go
@@ -6,7 +6,9 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/state/documents"
 )
@@ -221,6 +223,18 @@ func (s *Server) handleLoopOutputGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// This is a reader surface: whoever fetches this is consuming the
+	// prose, not about to rewrite it, so curated "{{delta:2026-09-18}}"
+	// must arrive as "+20d" rather than as braces. Expanded before the
+	// facet parse so every negotiated representation agrees; the stored
+	// document keeps the raw template, which is what the author
+	// round-trip depends on.
+	//
+	// Day distance is a calendar comparison, so now is taken in the
+	// household zone — expanding in UTC renders tomorrow as "today" for
+	// the last hours of a local evening.
+	record.Body = promptfmt.ExpandTemporalTemplates(record.Body, s.readerTemplateNow())
+
 	// The declared contract gates every representation: this endpoint
 	// is addressed by an output name on a definition, so what it serves
 	// is what that definition declares. A hand-edited body that happens
@@ -233,6 +247,15 @@ func (s *Server) handleLoopOutputGet(w http.ResponseWriter, r *http.Request) {
 		declared[string(facet.Name)] = true
 	}
 
+	// This is a reader surface: whoever fetches this is consuming the
+	// prose, not about to rewrite it, so curated "{{delta:2026-09-18}}"
+	// must arrive as "+20d" rather than as braces. Expanded once here so
+	// every negotiated representation agrees; the stored document keeps
+	// the raw template, which is what the author round-trip depends on.
+	//
+	// Day distance is a calendar comparison, so now is taken in the
+	// household zone — expanding in UTC renders tomorrow as "today" for
+	// the last hours of a local evening.
 	verdict := ""
 	if faceted && declared[string(looppkg.OutputFacetStatusLine)] {
 		if line, ok := payload.FacetByKey(string(looppkg.OutputFacetStatusLine)); ok {
@@ -286,4 +309,24 @@ func (s *Server) handleLoopOutputGet(w http.ResponseWriter, r *http.Request) {
 		}
 		s.errorResponse(w, http.StatusNotAcceptable, "output "+outputName+" declares or has published no status_line; available representations: "+available)
 	}
+}
+
+// readerTemplateNow is the instant temporal templates expand against on
+// this reader surface, in the household timezone the loop renders in.
+// An unset or unloadable zone falls back to local time, which is the
+// honest answer when the zone database cannot say otherwise.
+func (s *Server) readerTemplateNow() time.Time {
+	now := time.Now()
+	if s == nil || s.loop == nil {
+		return now
+	}
+	name := strings.TrimSpace(s.loop.Timezone())
+	if name == "" {
+		return now
+	}
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		return now
+	}
+	return now.In(loc)
 }

--- a/internal/server/api/loop_outputs.go
+++ b/internal/server/api/loop_outputs.go
@@ -233,29 +233,20 @@ func (s *Server) handleLoopOutputGet(w http.ResponseWriter, r *http.Request) {
 	// Day distance is a calendar comparison, so now is taken in the
 	// household zone — expanding in UTC renders tomorrow as "today" for
 	// the last hours of a local evening.
-	record.Body = promptfmt.ExpandTemporalTemplates(record.Body, s.readerTemplateNow())
+	body := promptfmt.ExpandTemporalTemplates(record.Body, s.readerTemplateNow())
 
 	// The declared contract gates every representation: this endpoint
 	// is addressed by an output name on a definition, so what it serves
 	// is what that definition declares. A hand-edited body that happens
 	// to contain a reserved heading is content, not contract — parsed
 	// sections count only when the spec declared facets.
-	payload, sectioned := looppkg.ParseFacetSections(record.Body)
+	payload, sectioned := looppkg.ParseFacetSections(body)
 	faceted := sectioned && output.HasFacets()
 	declared := make(map[string]bool, len(output.Facets))
 	for _, facet := range output.Facets {
 		declared[string(facet.Name)] = true
 	}
 
-	// This is a reader surface: whoever fetches this is consuming the
-	// prose, not about to rewrite it, so curated "{{delta:2026-09-18}}"
-	// must arrive as "+20d" rather than as braces. Expanded once here so
-	// every negotiated representation agrees; the stored document keeps
-	// the raw template, which is what the author round-trip depends on.
-	//
-	// Day distance is a calendar comparison, so now is taken in the
-	// household zone — expanding in UTC renders tomorrow as "today" for
-	// the last hours of a local evening.
 	verdict := ""
 	if faceted && declared[string(looppkg.OutputFacetStatusLine)] {
 		if line, ok := payload.FacetByKey(string(looppkg.OutputFacetStatusLine)); ok {
@@ -277,7 +268,7 @@ func (s *Server) handleLoopOutputGet(w http.ResponseWriter, r *http.Request) {
 			Output:     outputName,
 			Ref:        output.Ref,
 			ModifiedAt: record.ModifiedAt,
-			Full:       record.Body,
+			Full:       body,
 		}
 		if faceted {
 			out.Full = payload.Full
@@ -295,7 +286,7 @@ func (s *Server) handleLoopOutputGet(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, out, s.logger)
 	case loopOutputMarkdown:
 		w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
-		_, _ = w.Write([]byte(record.Body))
+		_, _ = w.Write([]byte(body))
 	default:
 		// Nothing acceptable is servable. The common shape is a
 		// plain-only request against a document with no published
@@ -317,10 +308,25 @@ func (s *Server) handleLoopOutputGet(w http.ResponseWriter, r *http.Request) {
 // honest answer when the zone database cannot say otherwise.
 func (s *Server) readerTemplateNow() time.Time {
 	now := time.Now()
-	if s == nil || s.loop == nil {
+	if s == nil {
 		return now
 	}
-	name := strings.TrimSpace(s.loop.Timezone())
+	if s.nowFunc != nil {
+		now = s.nowFunc()
+	}
+	if s.loop == nil {
+		return now
+	}
+	return templateNowInZone(now, s.loop.Timezone())
+}
+
+// templateNowInZone restates an instant in a named IANA zone, leaving
+// it alone when the name is empty or the zone database cannot load it.
+// Falling back rather than failing is deliberate: local time is the
+// honest answer when nothing better is known, and a reader surface
+// should still serve prose when tzdata is missing.
+func templateNowInZone(now time.Time, zone string) time.Time {
+	name := strings.TrimSpace(zone)
 	if name == "" {
 		return now
 	}

--- a/internal/server/api/loop_outputs_test.go
+++ b/internal/server/api/loop_outputs_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -208,5 +209,168 @@ func TestNegotiateLoopOutputAccept(t *testing.T) {
 				t.Fatalf("negotiateLoopOutputAccept(%q, %v) = %q, want %q", tc.header, tc.statusLine, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestHandleLoopOutputGetExpandsTemporalTemplatesInEveryRepresentation
+// pins the reader-side expansion at the HTTP boundary. Consumption
+// reads render "{{delta:...}}" as a live delta; authoring reads keep it
+// byte-exact, so the source record this handler was handed must come
+// back out of the call unmodified.
+//
+// All three representations are asserted because they take different
+// paths through the handler: text/plain serves a parsed facet, JSON
+// serves parsed facets plus the parsed full, and text/markdown serves
+// the whole body. Expansion moved back after ParseFacetSections would
+// still satisfy the markdown case while shipping raw braces to the
+// other two.
+func TestHandleLoopOutputGetExpandsTemporalTemplatesInEveryRepresentation(t *testing.T) {
+	t.Parallel()
+
+	reg, err := looppkg.NewDefinitionRegistry([]looppkg.Spec{{
+		Name:      "whereabouts_nugget",
+		Enabled:   true,
+		Task:      "track one contact",
+		Operation: looppkg.OperationService,
+		Outputs: []looppkg.OutputSpec{{
+			Name: "whereabouts",
+			Type: looppkg.OutputTypeMaintainedDocument,
+			Ref:  "whereabouts:nugget.md",
+			Facets: []looppkg.FacetSpec{
+				{Name: looppkg.OutputFacetStatusLine},
+				{Name: looppkg.OutputFacetDigest},
+			},
+		}},
+	}})
+	if err != nil {
+		t.Fatalf("NewDefinitionRegistry: %v", err)
+	}
+
+	// One instant for the whole test, so both template forms render a
+	// fixed answer: the RFC3339 instant is 2d3h behind it, and the bare
+	// date is two calendar days ahead of it.
+	const (
+		instantTemplate = "{{delta:2026-09-04T09:00:00Z}}"
+		dateTemplate    = "{{delta:2026-09-08}}"
+		wantInstant     = "-2d3h"
+		wantDate        = "+2d"
+	)
+	now := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+
+	stored := &documents.DocumentRecord{
+		Ref: "whereabouts:nugget.md",
+		Body: "## Status Line\n\naway since " + instantTemplate + ", back " + dateTemplate + "\n\n" +
+			"## Digest\n\nFollow-up " + dateTemplate + ".\n\n" +
+			"## Details\n\nDeparted " + instantTemplate + "; the follow-up lands " + dateTemplate + ".\n",
+		ModifiedAt: now.Format(time.RFC3339Nano),
+	}
+	sourceBody := stored.Body
+
+	s := &Server{logger: slog.Default(), nowFunc: func() time.Time { return now }}
+	s.UseLoopDefinitionRegistry(reg)
+	s.UseDocumentReader(func(_ context.Context, ref string) (*documents.DocumentRecord, error) {
+		if ref != stored.Ref {
+			t.Errorf("read unexpected ref %q", ref)
+		}
+		// Deliberately the same record every call: a handler that
+		// expands in place would corrupt whatever the reader owns.
+		return stored, nil
+	})
+
+	get := func(accept string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, "/v1/loops/whereabouts_nugget/outputs/whereabouts", nil)
+		if accept != "" {
+			req.Header.Set("Accept", accept)
+		}
+		req.SetPathValue("name", "whereabouts_nugget")
+		req.SetPathValue("output", "whereabouts")
+		rec := httptest.NewRecorder()
+		s.handleLoopOutputGet(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("Accept %q = %d %q", accept, rec.Code, rec.Body.String())
+		}
+		if strings.Contains(rec.Body.String(), "{{delta:") {
+			t.Errorf("Accept %q served an unexpanded template:\n%s", accept, rec.Body.String())
+		}
+		return rec
+	}
+
+	wantStatusLine := "away since " + wantInstant + ", back " + wantDate
+
+	if got := strings.TrimSpace(get("text/plain").Body.String()); got != wantStatusLine {
+		t.Errorf("text/plain = %q, want %q", got, wantStatusLine)
+	}
+
+	var typed loopOutputJSON
+	if err := json.Unmarshal(get("application/json").Body.Bytes(), &typed); err != nil {
+		t.Fatalf("decode json representation: %v", err)
+	}
+	if got := typed.Facets["status_line"]; got != wantStatusLine {
+		t.Errorf("json status_line = %q, want %q", got, wantStatusLine)
+	}
+	if got, want := typed.Facets["digest"], "Follow-up "+wantDate+"."; got != want {
+		t.Errorf("json digest = %q, want %q", got, want)
+	}
+	if got, want := strings.TrimSpace(typed.Full), "Departed "+wantInstant+"; the follow-up lands "+wantDate+"."; got != want {
+		t.Errorf("json full = %q, want %q", got, want)
+	}
+
+	wantMarkdown := strings.NewReplacer(instantTemplate, wantInstant, dateTemplate, wantDate).Replace(sourceBody)
+	if got := get("text/markdown").Body.String(); got != wantMarkdown {
+		t.Errorf("text/markdown = %q, want %q", got, wantMarkdown)
+	}
+
+	// The authoring round-trip depends on this: three consumption reads
+	// must leave the document exactly as the store handed it over.
+	if stored.Body != sourceBody {
+		t.Errorf("handler rewrote the source document:\n got %q\nwant %q", stored.Body, sourceBody)
+	}
+}
+
+// TestTemplateNowInZone pins which day "today" means on this surface.
+// Day-word rendering is a calendar comparison, so expanding in the
+// wrong zone renders tomorrow's date as "today" through the last hours
+// of a local evening — the exact failure the household zone exists to
+// prevent.
+func TestTemplateNowInZone(t *testing.T) {
+	t.Parallel()
+
+	// 03:00 UTC on the 7th is still the evening of the 6th in Chicago.
+	now := time.Date(2026, 9, 7, 3, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name    string
+		zone    string
+		wantDay int
+	}{
+		{"household zone decides the day", "America/Chicago", 6},
+		{"unset zone leaves the instant alone", "", 7},
+		{"whitespace is not a zone", "   ", 7},
+		{"unloadable zone falls back", "Mars/Olympus_Mons", 7},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := templateNowInZone(now, tc.zone)
+			if !got.Equal(now) {
+				t.Errorf("templateNowInZone moved the instant: %v, want %v", got, now)
+			}
+			if got.Day() != tc.wantDay {
+				t.Errorf("templateNowInZone(%q).Day() = %d, want %d", tc.zone, got.Day(), tc.wantDay)
+			}
+		})
+	}
+}
+
+// TestReaderTemplateNowWithoutALoop pins the degenerate wiring: no loop
+// means no household zone to ask for, and the surface still has to
+// answer with an instant rather than panic.
+func TestReaderTemplateNowWithoutALoop(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 7, 3, 0, 0, 0, time.UTC)
+	s := &Server{logger: slog.Default(), nowFunc: func() time.Time { return now }}
+	if got := s.readerTemplateNow(); !got.Equal(now) {
+		t.Errorf("readerTemplateNow without a loop = %v, want %v", got, now)
 	}
 }

--- a/internal/server/api/loop_outputs_test.go
+++ b/internal/server/api/loop_outputs_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -10,8 +11,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nugget/thane-ai-agent/internal/model/llm"
+	"github.com/nugget/thane-ai-agent/internal/runtime/agent"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/state/documents"
+	"github.com/nugget/thane-ai-agent/internal/state/memory"
 )
 
 // TestHandleLoopOutputGetNegotiatesFidelity pins the #1250 HTTP read
@@ -372,5 +376,90 @@ func TestReaderTemplateNowWithoutALoop(t *testing.T) {
 	s := &Server{logger: slog.Default(), nowFunc: func() time.Time { return now }}
 	if got := s.readerTemplateNow(); !got.Equal(now) {
 		t.Errorf("readerTemplateNow without a loop = %v, want %v", got, now)
+	}
+}
+
+// refusingLLM satisfies [llm.Client] so a test can stand up a real
+// *agent.Loop. Every method refuses rather than answering: these tests
+// never take a turn, so a call here means the test drifted into
+// exercising the model instead of the handler.
+type refusingLLM struct{}
+
+func (refusingLLM) Chat(context.Context, string, []llm.Message, []map[string]any) (*llm.ChatResponse, error) {
+	return nil, errors.New("refusingLLM: handler tests do not take turns")
+}
+
+func (refusingLLM) ChatStream(context.Context, string, []llm.Message, []map[string]any, llm.StreamCallback) (*llm.ChatResponse, error) {
+	return nil, errors.New("refusingLLM: handler tests do not take turns")
+}
+
+func (refusingLLM) Ping(context.Context) error { return nil }
+
+// TestHandleLoopOutputGetExpandsInTheHouseholdZone runs the expansion
+// through the production wiring — a real *agent.Loop carrying a
+// non-UTC household zone — rather than through templateNowInZone
+// directly. The pure-function test pins what the zone math does; this
+// pins that the handler actually asks the loop for a zone. Without
+// that call the two tests would both stay green while every date
+// regressed to UTC, which is wrong for the household for the last
+// hours of every evening.
+func TestHandleLoopOutputGetExpandsInTheHouseholdZone(t *testing.T) {
+	t.Parallel()
+
+	loop, err := agent.NewLoop(agent.LoopOptions{
+		Logger:   slog.Default(),
+		Memory:   memory.NewStore(8),
+		LLM:      refusingLLM{},
+		Model:    "test-model",
+		Timezone: "America/Chicago",
+	})
+	if err != nil {
+		t.Fatalf("agent.NewLoop: %v", err)
+	}
+
+	reg, err := looppkg.NewDefinitionRegistry([]looppkg.Spec{{
+		Name:      "whereabouts_nugget",
+		Enabled:   true,
+		Task:      "track one contact",
+		Operation: looppkg.OperationService,
+		Outputs: []looppkg.OutputSpec{{
+			Name:   "whereabouts",
+			Type:   looppkg.OutputTypeMaintainedDocument,
+			Ref:    "whereabouts:nugget.md",
+			Facets: []looppkg.FacetSpec{{Name: looppkg.OutputFacetStatusLine}},
+		}},
+	}})
+	if err != nil {
+		t.Fatalf("NewDefinitionRegistry: %v", err)
+	}
+
+	// 03:00 UTC on the 7th is 22:00 on the 6th in Chicago: the two
+	// zones disagree about today's date, which is exactly the window
+	// the household zone exists to get right. Expanding in UTC renders
+	// this "yesterday" while the household is still living the day.
+	now := time.Date(2026, 9, 7, 3, 0, 0, 0, time.UTC)
+
+	s := &Server{logger: slog.Default(), loop: loop, nowFunc: func() time.Time { return now }}
+	s.UseLoopDefinitionRegistry(reg)
+	s.UseDocumentReader(func(_ context.Context, ref string) (*documents.DocumentRecord, error) {
+		return &documents.DocumentRecord{
+			Ref:  ref,
+			Body: "## Status Line\n\nhome since {{delta:2026-09-06}}\n\n## Details\n\nbody\n",
+		}, nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/loops/whereabouts_nugget/outputs/whereabouts", nil)
+	req.Header.Set("Accept", "text/plain")
+	req.SetPathValue("name", "whereabouts_nugget")
+	req.SetPathValue("output", "whereabouts")
+	rec := httptest.NewRecorder()
+	s.handleLoopOutputGet(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d %q", rec.Code, rec.Body.String())
+	}
+	if got, want := strings.TrimSpace(rec.Body.String()), "home since today"; got != want {
+		t.Errorf("text/plain = %q, want %q — expanded in %s, not the household zone",
+			got, want, now.Location())
 	}
 }

--- a/internal/server/api/server.go
+++ b/internal/server/api/server.go
@@ -74,13 +74,17 @@ type TokenObserver interface {
 
 // Server is the HTTP API server.
 type Server struct {
-	address                            string
-	port                               int
-	handler                            http.Handler
-	handlerOnce                        sync.Once
-	auth                               *authGate
-	routes                             []string
-	loop                               *agent.Loop
+	address     string
+	port        int
+	handler     http.Handler
+	handlerOnce sync.Once
+	auth        *authGate
+	routes      []string
+	loop        *agent.Loop
+	// nowFunc returns the current time. Tests override it to pin
+	// temporal template expansion on the reader surfaces to a fixed
+	// instant; production leaves it nil and reads the wall clock.
+	nowFunc                            func() time.Time
 	router                             *router.Router
 	checkpointer                       *checkpoint.Checkpointer
 	memoryStore                        *memory.SQLiteStore

--- a/internal/server/openapi/native.yaml
+++ b/internal/server/openapi/native.yaml
@@ -594,6 +594,10 @@ paths:
         ranked by q-value (q=0 refuses a type), then specificity (exact
         beats `text/*` beats `*/*`), then listed order, so a client whose
         header names application/json ahead of text/plain gets JSON.
+        This is a reader surface: temporal templates in the authored
+        prose ({{delta:2026-09-18}}) arrive expanded against the current
+        time in the household timezone, identically in every
+        representation. The stored document keeps the raw template.
       x-thane-scope: definitions:read
       parameters:
         - name: name

--- a/internal/state/awareness/system_self_assessment_provider.go
+++ b/internal/state/awareness/system_self_assessment_provider.go
@@ -41,6 +41,12 @@ type SystemSelfAssessmentProvider struct {
 	logger *slog.Logger
 	now    func() time.Time
 
+	// homeZone anchors temporal-template expansion in the verdict.
+	// Day words are a calendar comparison, so a verdict reading
+	// "freeze window opens {{delta:2026-12-25}}" renders against the
+	// household's day, not the process's. nil falls back to time.Local.
+	homeZone *time.Location
+
 	// Last-good verdict, served with its honest age when a live read
 	// fails. The 2026-08-12 prod incident was exactly this seam: the
 	// shared context budget died upstream, the read failed every turn,
@@ -53,12 +59,16 @@ type SystemSelfAssessmentProvider struct {
 }
 
 // NewSystemSelfAssessmentProvider wires the provider over a document
-// read function. logger may be nil (defaults to slog.Default()).
-func NewSystemSelfAssessmentProvider(read func(ctx context.Context) (string, time.Time, error), logger *slog.Logger) *SystemSelfAssessmentProvider {
+// read function. logger may be nil (defaults to slog.Default()), and
+// homeZone may be nil (defaults to time.Local).
+func NewSystemSelfAssessmentProvider(read func(ctx context.Context) (string, time.Time, error), homeZone *time.Location, logger *slog.Logger) *SystemSelfAssessmentProvider {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &SystemSelfAssessmentProvider{read: read, logger: logger, now: time.Now}
+	if homeZone == nil {
+		homeZone = time.Local
+	}
+	return &SystemSelfAssessmentProvider{read: read, logger: logger, now: time.Now, homeZone: homeZone}
 }
 
 // TagContextBucket places the verdict in live state: it is a current
@@ -171,6 +181,16 @@ func (p *SystemSelfAssessmentProvider) TagContext(ctx context.Context, _ agentct
 // stretching the turn unboundedly.
 const readTimeout = 1500 * time.Millisecond
 
+// zone is the household location templates and deltas render against.
+// A provider built by hand in a test can leave it nil, so the fallback
+// lives here rather than only in the constructor.
+func (p *SystemSelfAssessmentProvider) zone() *time.Location {
+	if p.homeZone == nil {
+		return time.Local
+	}
+	return p.homeZone
+}
+
 func (p *SystemSelfAssessmentProvider) clearCache() {
 	p.mu.Lock()
 	p.lastVerdict, p.lastUpdatedAt = "", time.Time{}
@@ -180,14 +200,28 @@ func (p *SystemSelfAssessmentProvider) clearCache() {
 // render formats the verdict block. cached marks a verdict served
 // because the live read failed — the age delta carries how stale it
 // is, the marker carries why.
+//
+// This is a reader surface, so temporal templates in the verdict
+// expand: metacog is told to write "{{delta:2026-09-18}}" rather than
+// a literal delta (talents/loops.md), and without expansion the one
+// line that is a judgment about the whole system reaches the model as
+// braces. The cache stores the raw verdict and expansion happens here,
+// per render, so a verdict served after a failed read carries a delta
+// computed now rather than one frozen at cache time — the block's
+// whole point is that a stale verdict wears its honest age.
+//
+// One clock for the block: the same instant renders the template and
+// the age stamp, so the two cannot disagree about what "now" is.
 func (p *SystemSelfAssessmentProvider) render(verdict string, updatedAt time.Time, cached bool) string {
+	now := p.now().In(p.zone())
+
 	var sb strings.Builder
 	sb.WriteString("### System Self-Assessment\n\n")
-	sb.WriteString(verdict)
+	sb.WriteString(promptfmt.ExpandTemporalTemplates(verdict, now))
 	sb.WriteString(" (metacognitive verdict")
 	if !updatedAt.IsZero() {
 		sb.WriteString("; age_delta=")
-		sb.WriteString(promptfmt.FormatDeltaOnly(updatedAt, p.now()))
+		sb.WriteString(promptfmt.FormatDeltaOnly(updatedAt, now))
 	}
 	if cached {
 		sb.WriteString("; cached, live read failed")

--- a/internal/state/awareness/system_self_assessment_provider_test.go
+++ b/internal/state/awareness/system_self_assessment_provider_test.go
@@ -58,7 +58,7 @@ func TestSystemSelfAssessmentProvider(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			p := NewSystemSelfAssessmentProvider(func(context.Context) (string, time.Time, error) {
 				return tc.body, tc.at, tc.err
-			}, nil)
+			}, nil, nil)
 			out, err := p.TagContext(context.Background(), agentctx.ContextRequest{})
 			if err != nil {
 				t.Fatalf("TagContext: %v", err)
@@ -85,7 +85,7 @@ func TestSystemSelfAssessmentProviderAdvertisesSignalBeforeReading(t *testing.T)
 	p := NewSystemSelfAssessmentProvider(func(context.Context) (string, time.Time, error) {
 		reads++
 		return "## Status Line\n\npanel clean\n\n## Details\n\nbody\n", time.Now(), nil
-	}, nil)
+	}, nil, nil)
 	ads, err := p.ContextAdvertisements(context.Background(), agentctx.ContextRequest{})
 	if err != nil {
 		t.Fatalf("ContextAdvertisements: %v", err)
@@ -112,5 +112,119 @@ func TestSystemSelfAssessmentProviderAdvertisesSignalBeforeReading(t *testing.T)
 	}
 	if reads != 1 || !strings.Contains(out, "panel clean") {
 		t.Fatalf("materialized output = %q after %d reads", out, reads)
+	}
+}
+
+// TestSystemSelfAssessmentProviderExpandsTemporalTemplates pins this
+// provider as a reader surface. metacog is told to write
+// "{{delta:2026-09-18}}" rather than a literal delta, so without
+// expansion the one line in the system that is a judgment about the
+// whole system reaches the model as braces — while the same facet
+// served over GET /v1/loops/{name}/outputs/{output} renders correctly.
+func TestSystemSelfAssessmentProviderExpandsTemporalTemplates(t *testing.T) {
+	t.Parallel()
+
+	chicago, err := time.LoadLocation("America/Chicago")
+	if err != nil {
+		t.Fatalf("LoadLocation: %v", err)
+	}
+
+	body := "## Status Line\n\nfreeze window opens {{delta:2026-09-08}}\n\n## Details\n\nbody\n"
+	p := NewSystemSelfAssessmentProvider(func(context.Context) (string, time.Time, error) {
+		return body, time.Date(2026, 9, 6, 11, 0, 0, 0, time.UTC), nil
+	}, chicago, nil)
+	p.now = func() time.Time { return time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC) }
+
+	out, err := p.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	if strings.Contains(out, "{{delta:") {
+		t.Errorf("verdict reached the model unexpanded: %q", out)
+	}
+	if !strings.Contains(out, "freeze window opens +2d") {
+		t.Errorf("want the expanded verdict, got: %q", out)
+	}
+}
+
+// TestSystemSelfAssessmentProviderExpandsTheCachedVerdictFreshly pins
+// where expansion happens. The cache exists so a failed read still
+// serves the last good verdict wearing its honest age; expanding at
+// cache time instead of render time would freeze the delta at the
+// moment of the last successful read, so the block would claim
+// freshness in the template while the age stamp beside it said
+// otherwise.
+func TestSystemSelfAssessmentProviderExpandsTheCachedVerdictFreshly(t *testing.T) {
+	t.Parallel()
+
+	fail := false
+	updatedAt := time.Date(2026, 9, 6, 11, 0, 0, 0, time.UTC)
+	p := NewSystemSelfAssessmentProvider(func(context.Context) (string, time.Time, error) {
+		if fail {
+			return "", time.Time{}, errors.New("substrate down")
+		}
+		return "## Status Line\n\nfreeze window opens {{delta:2026-09-08}}\n\n## Details\n\nbody\n", updatedAt, nil
+	}, time.UTC, nil)
+
+	p.now = func() time.Time { return time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC) }
+	first, err := p.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext (live): %v", err)
+	}
+	if !strings.Contains(first, "opens +2d") {
+		t.Fatalf("live read: want +2d, got %q", first)
+	}
+
+	// Two days later the read fails, so the cached verdict is served.
+	// Its template must render against now, not against the instant it
+	// was cached at.
+	fail = true
+	p.now = func() time.Time { return time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC) }
+	cached, err := p.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext (cached): %v", err)
+	}
+	if !strings.Contains(cached, "opens today") {
+		t.Errorf("cached verdict served a stale delta: %q", cached)
+	}
+	if !strings.Contains(cached, "cached, live read failed") {
+		t.Errorf("cached verdict lost its marker: %q", cached)
+	}
+}
+
+// TestSystemSelfAssessmentProviderExpandsInTheHouseholdZone pins which
+// day the verdict means. The provider's clock is the process clock, so
+// without the household zone a verdict renders the household's today
+// as yesterday for the last hours of every local evening.
+func TestSystemSelfAssessmentProviderExpandsInTheHouseholdZone(t *testing.T) {
+	t.Parallel()
+
+	chicago, err := time.LoadLocation("America/Chicago")
+	if err != nil {
+		t.Fatalf("LoadLocation: %v", err)
+	}
+
+	// 03:00 UTC on the 7th is 22:00 on the 6th in Chicago.
+	now := time.Date(2026, 9, 7, 3, 0, 0, 0, time.UTC)
+	body := "## Status Line\n\nbackup verified {{delta:2026-09-06}}\n\n## Details\n\nbody\n"
+
+	render := func(zone *time.Location) string {
+		t.Helper()
+		p := NewSystemSelfAssessmentProvider(func(context.Context) (string, time.Time, error) {
+			return body, now, nil
+		}, zone, nil)
+		p.now = func() time.Time { return now }
+		out, err := p.TagContext(context.Background(), agentctx.ContextRequest{})
+		if err != nil {
+			t.Fatalf("TagContext: %v", err)
+		}
+		return out
+	}
+
+	if got := render(chicago); !strings.Contains(got, "verified today") {
+		t.Errorf("household zone should render today: %q", got)
+	}
+	if got := render(time.UTC); !strings.Contains(got, "verified yesterday") {
+		t.Errorf("UTC should render yesterday — the fixture is not proving anything otherwise: %q", got)
 	}
 }

--- a/internal/state/documents/temporal_author_surface_test.go
+++ b/internal/state/documents/temporal_author_surface_test.go
@@ -1,0 +1,79 @@
+package documents
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestDocReadKeepsRawTemplates pins doc_read as an author surface.
+//
+// It is the read a whole-document replacement is authored against, and
+// the precondition consults it. If it expanded, a model that read a
+// document and passed the body back would store "+110d" where the author
+// wrote {{delta:2026-12-25}} — the template gone for good, with nothing
+// in the result to say it happened. The reader/author split exists for
+// exactly this, and until now nothing failed when it was violated.
+func TestDocReadKeepsRawTemplates(t *testing.T) {
+	t.Parallel()
+
+	store, _ := newMutationStore(t)
+	tools := NewTools(store)
+	const template = "{{delta:2026-12-25}}"
+	body := "# Winter\n\nThe hard freeze lands " + template + ".\n"
+	if _, err := store.Write(context.Background(), WriteArgs{Ref: "kb:winter.md", Body: &body}); err != nil {
+		t.Fatalf("seed document: %v", err)
+	}
+
+	out, err := tools.Read(context.Background(), RefArgs{Ref: "kb:winter.md"})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	// Assert on the decoded body rather than searching the serialized
+	// result: the payload carries the prose in more than one field, so a
+	// substring search passes on a surviving copy while the field the
+	// author actually round-trips has already been expanded.
+	var payload struct {
+		Body string `json:"body"`
+	}
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("decode read result: %v\n%s", err, out)
+	}
+	if payload.Body != body {
+		t.Fatalf("doc_read did not return the stored body byte-exact:\n got: %q\nwant: %q", payload.Body, body)
+	}
+	if !strings.Contains(payload.Body, template) {
+		t.Fatalf("doc_read expanded a template; the author round-trip is no longer byte-exact: %q", payload.Body)
+	}
+}
+
+// TestPublishRoundTripsTemplatesByteExact pins the write end: a template
+// passed through a faceted publish must come back out of the parse
+// unchanged, so a loop republishing every projection cannot launder its
+// own templates into rendered text.
+func TestPublishRoundTripsTemplatesByteExact(t *testing.T) {
+	t.Parallel()
+
+	store, _ := newMutationStore(t)
+	tools := NewTools(store)
+	const template = "{{delta:2026-12-25}}"
+
+	if _, err := tools.Publish(context.Background(), PublishArgs{
+		Ref:        "kb:winter.md",
+		Title:      "Winter",
+		StatusLine: "Hard freeze " + template,
+		Full:       "# Winter\n\nWrap the pipes before " + template + ".\n",
+	}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	record, err := store.Read(context.Background(), "kb:winter.md")
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if strings.Count(record.Body, template) != 2 {
+		t.Fatalf("publish did not round-trip both templates byte-exact:\n%s", record.Body)
+	}
+}


### PR DESCRIPTION
The reader/author split turns out to be settled doctrine, not an oversight — `tag_context.go:648` names doc_read, the publish tools, and git as author surfaces that keep the raw `{{delta:...}}` *"so the author round-trip stays byte-exact"*, and `docs/model-facing-context.md:226` states it as policy. What was missing was **enforcement**, and two surfaces nobody had classified.

## Nothing pinned the author half

Every existing test covered the two surfaces that *do* expand. So adding expansion to `doc_read`, or to a loop's own output injection, would have passed CI while destroying templates in production.

The mechanism is worth stating plainly: a loop reads its own maintained document every wake and republishes a **complete replacement**. One expansion upstream and `{{delta:2026-12-25}}` becomes `+110d` in storage — permanently, with no error, and nothing left in the document to say it happened. It's indistinguishable afterwards from prose the author meant.

Four tests now fail if that changes: the loop's own output injection, `doc_read`, the faceted publish round-trip, and storage itself.

## Two surfaces were unclassified, not decided

**`BuildRefs`** (session-origin context refs) is the direct sibling of the tagged-article path *in the same file* and already resolved ha-inject without expanding. Contact origin policy points those refs at dossiers — exactly the documents the house rule tells authors to write templates into.

**The HTTP output endpoint** served raw prose in all three representations, including the speakable `text/plain` status line.

Both expand now, in the **household timezone** rather than UTC, because day distance is a calendar comparison and an evening in UTC renders tomorrow as "today". `Loop.Timezone` exposes the zone the loop already renders in; the API server had none.

## Deliberately untouched

The self-injecting surfaces. `ego` and `metacognitive` both run `prompt_mode: full` and receive their own maintained documents — ego through core context, metacog through the always-on self-assessment provider — and both are instructed to republish the complete body. Expanding either would be the destructive case above, on the two documents that matter most. They need explicit guards first, and that's its own change.

## Test plan

- [x] `just ci` passes — 74 packages, `set_mutators` 128 and `interfaces` 91 held
- [x] `BuildRefs` renders `{{delta:2026-12-25}}` as `+20d` against a fixed clock
- [x] Author surfaces return the stored body byte-exact
- [x] **Mutation-verified**: removing the `BuildRefs` expansion fails its test; adding expansion to `doc_read`'s body fails the author test

The `doc_read` test **passed against its mutation on the first attempt** and had to be rewritten. The serialized result carries the prose in more than one field, so a substring search found a surviving copy while the field the author actually round-trips had already been expanded. It now decodes the payload and compares the body exactly — which is also the assertion that would have caught this by hand.

The linter also caught a dead parse I'd left by expanding after the facet parse and re-parsing; expansion now precedes the single parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
