### PR TITLE
feat(documents): refuse baked deltas on the write path

### DIFF
--- a/docs/model-facing-context.md
+++ b/docs/model-facing-context.md
@@ -246,6 +246,21 @@ presentation of the status_line rather than the author's view of it,
 and it went a release shipping braces while the same facet served over
 HTTP rendered correctly.
 
+The write path enforces this rather than trusting it. Prose supplied to
+`doc_write`, `doc_edit`, `doc_journal_update` or any publish tool is
+scanned, and a rendered delta — this project's own `-2h2m` shape — is
+refused outright, because prose acquires one almost exclusively by
+transcribing a tool result verbatim. Natural-language relative time
+("yesterday", "21 minutes ago") decays just as fast but is ordinary
+English, so it warns and the write lands. The scan skips frontmatter,
+fenced blocks and inline code, which is both the escape hatch for
+writing a literal delta and the reason JSON facets need no special case
+— a faceted document stores one as a fenced block.
+
+Only the text a call supplies is scanned, never the merged document. A
+document that already rotted has to stay writable, or the loop whose
+prose went stale would be the one loop unable to repair it.
+
 Day words are a calendar comparison, so every reader expands against
 *now in the household timezone* — expanding in UTC renders tomorrow as
 "today" through the last hours of a local evening. Each rendered

--- a/internal/app/loop_output_publish.go
+++ b/internal/app/loop_output_publish.go
@@ -35,7 +35,7 @@ func buildFacetPublishTool(docTools *documents.Tools, output looppkg.OutputSpec,
 	properties := make(map[string]any, len(fields)+1)
 	required := make([]string, 0, len(fields))
 	for _, field := range fields {
-		description := field.Guidance + looppkg.FormatGuidance(field.Format)
+		description := field.Guidance + looppkg.FormatGuidance(field.Format) + documentfacets.RelativeTimeGuidance
 		if field.MaxRunes > 0 {
 			description = fmt.Sprintf("%s Maximum %d characters — a ceiling, not a target; compose comfortably under it.", description, field.MaxRunes)
 		}

--- a/internal/model/promptfmt/baked.go
+++ b/internal/model/promptfmt/baked.go
@@ -1,0 +1,214 @@
+package promptfmt
+
+import (
+	"regexp"
+	"strings"
+)
+
+// BakedDeltaTier ranks how confident a finding is that stored prose
+// carries a relative time that was true only at the moment it was
+// written. The tiers exist because the two classes deserve different
+// answers: one is unmistakably this project's own machine output and
+// can be refused, the other is ordinary English that happens to be
+// time-relative and can only be pointed at.
+type BakedDeltaTier int
+
+const (
+	// BakedDeltaFormatted is this project's own delta vocabulary —
+	// "-21m", "+3d16h", "-513s" — the exact shapes [FormatDeltaOnly]
+	// emits. Prose containing one almost always got it by transcribing
+	// a tool result, and it is wrong within the minute. Callers refuse
+	// these.
+	BakedDeltaFormatted BakedDeltaTier = iota + 1
+
+	// BakedDeltaNarrative is natural-language relative time — "21
+	// minutes ago", "yesterday", "in three days". Just as stale, but
+	// the phrasing is ordinary English and a matcher cannot be sure it
+	// is dating anything, so callers warn rather than refuse.
+	BakedDeltaNarrative
+)
+
+// BakedDelta is one relative-time expression found in authored prose,
+// carrying enough to name it back to the author: the text itself and
+// the 1-indexed line it sits on.
+type BakedDelta struct {
+	Text string
+	Tier BakedDeltaTier
+	Line int
+}
+
+// narrativeDeltas matches the natural-language relative-time forms
+// worth flagging. Deliberately narrow: every pattern here names a
+// distance from now, so vague currency words ("recently", "currently")
+// are left alone — they do not decay into a false statement the way a
+// counted distance does. Day words are included because they are
+// exactly as perishable as "-1d" despite reading as plain English.
+var narrativeDeltas = regexp.MustCompile(`(?i)\b(` +
+	narrativeQuantity + `\s+` + narrativeUnit + `\s+(?:ago|from\s+now)` +
+	`|in\s+` + narrativeQuantity + `\s+` + narrativeUnit +
+	`|(?:yesterday|tomorrow)` +
+	`|(?:last|next)\s+(?:night|week|month|year|monday|tuesday|wednesday|thursday|friday|saturday|sunday)` +
+	`|(?:this|earlier\s+this)\s+(?:morning|afternoon|evening)` +
+	`|just\s+now` +
+	`)\b`)
+
+// narrativeQuantity and narrativeUnit spell the counted part of a
+// relative phrase. The multi-word quantities lead the alternation
+// because Go's regexp is leftmost-first at a given start position: with
+// bare "a" first, "a few hours ago" reports itself as "few hours ago"
+// and the warning quotes a phrase the author never wrote.
+const (
+	narrativeQuantity = `(?:a\s+few|a\s+couple\s+of|couple\s+of|several|a|an|one|two|three|four|five|six|seven|eight|nine|ten|few|\d+)`
+	narrativeUnit     = `(?:second|minute|hour|day|week|month|year)s?`
+)
+
+// FindBakedDeltas reports relative-time expressions in authored prose,
+// so a write path can refuse the ones that are unmistakably machine
+// output and warn about the rest. The whole point of the
+// {{delta:...}} template is that the value re-renders on every read;
+// prose that hardcodes the rendered form is true once and false
+// forever after.
+//
+// Three regions are exempt, and one structural rule covers all three:
+// YAML frontmatter (where created_delta/updated_delta are stamped by
+// the writer, not the author), fenced code blocks, and inline code
+// spans. That single rule is why JSON facets need no special case —
+// a faceted document stores a JSON facet as a ```json fence, so it is
+// already skipped, and an author documenting the delta format writes
+// it in backticks the way documentation does anyway.
+//
+// The scan is line-oriented so findings can name a line, and it never
+// allocates when the prose contains no candidate.
+func FindBakedDeltas(body string) []BakedDelta {
+	var found []BakedDelta
+
+	lines := strings.Split(body, "\n")
+	inFence := false
+	inFrontmatter := len(lines) > 0 && strings.TrimRight(lines[0], "\r") == "---"
+
+	for i, raw := range lines {
+		line := strings.TrimRight(raw, "\r")
+		lineNo := i + 1
+
+		// Frontmatter runs from the opening --- to the next one. Its
+		// contents are the writer's stamps, not the author's prose.
+		if inFrontmatter {
+			if i > 0 && (line == "---" || line == "...") {
+				inFrontmatter = false
+			}
+			continue
+		}
+
+		if isFenceDelimiter(line) {
+			inFence = !inFence
+			continue
+		}
+		if inFence {
+			continue
+		}
+
+		for _, prose := range outsideCodeSpans(line) {
+			for _, text := range formattedDeltasIn(prose) {
+				found = append(found, BakedDelta{Text: text, Tier: BakedDeltaFormatted, Line: lineNo})
+			}
+			for _, m := range narrativeDeltas.FindAllString(prose, -1) {
+				found = append(found, BakedDelta{Text: m, Tier: BakedDeltaNarrative, Line: lineNo})
+			}
+		}
+	}
+	return found
+}
+
+// isFenceDelimiter reports whether a line opens or closes a fenced code
+// block. Both CommonMark fence characters count, and an info string
+// ("```json") rides along on the opening line.
+func isFenceDelimiter(line string) bool {
+	trimmed := strings.TrimLeft(line, " \t")
+	return strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~")
+}
+
+// outsideCodeSpans splits a line into the runs that sit outside
+// backtick-delimited spans. An unterminated backtick opens nothing —
+// the rest of the line stays prose — because a stray tick in ordinary
+// writing must not blind the scanner to everything after it.
+func outsideCodeSpans(line string) []string {
+	if !strings.Contains(line, "`") {
+		return []string{line}
+	}
+	var out []string
+	for {
+		open := strings.IndexByte(line, '`')
+		if open < 0 {
+			out = append(out, line)
+			return out
+		}
+		close := strings.IndexByte(line[open+1:], '`')
+		if close < 0 {
+			out = append(out, line)
+			return out
+		}
+		out = append(out, line[:open])
+		line = line[open+1+close+1:]
+	}
+}
+
+// formattedDeltasIn finds this package's own delta vocabulary in a run
+// of prose. Hand-rolled rather than a regexp because the boundary rule
+// needs a look behind the candidate — RE2 has no lookaround, and
+// without one "-98.41852298892312" (a longitude, which this corpus is
+// full of) would need the surrounding bytes checked anyway.
+//
+// A candidate is confirmed by [parseDeltaTerms], the same parser
+// [ParseTimeOrDelta] uses, so the matcher accepts exactly the grammar
+// the formatters emit rather than a second, drifting definition of it.
+func formattedDeltasIn(prose string) []string {
+	var out []string
+	for i := 0; i < len(prose); i++ {
+		if prose[i] != '+' && prose[i] != '-' {
+			continue
+		}
+		// A sign glued to a word or a number is part of that token
+		// ("UTC-5", "29.83-98.46"), not the start of a delta.
+		if i > 0 && isDeltaBoundaryByte(prose[i-1]) {
+			continue
+		}
+		end := i + 1
+		for end < len(prose) && (isDigit(prose[end]) || isDeltaUnit(prose[end])) {
+			end++
+		}
+		if end == i+1 {
+			continue
+		}
+		// A trailing word character means the run was a fragment of
+		// something longer ("+3days", "-5min"), which the formatters
+		// never emit.
+		if end < len(prose) && isDeltaBoundaryByte(prose[end]) {
+			continue
+		}
+		candidate := prose[i:end]
+		if _, err := parseDeltaTerms(candidate); err != nil {
+			continue
+		}
+		out = append(out, candidate)
+		i = end - 1
+	}
+	return out
+}
+
+func isDigit(b byte) bool { return b >= '0' && b <= '9' }
+
+func isDeltaUnit(b byte) bool {
+	_, ok := deltaUnits[b]
+	return ok
+}
+
+// isDeltaBoundaryByte reports whether a byte glues a candidate to a
+// neighbouring token. Letters and digits obviously do; so does '.',
+// which is what keeps decimal coordinates out of the results.
+func isDeltaBoundaryByte(b byte) bool {
+	switch {
+	case b >= 'a' && b <= 'z', b >= 'A' && b <= 'Z', isDigit(b), b == '.', b == '_':
+		return true
+	}
+	return false
+}

--- a/internal/model/promptfmt/baked.go
+++ b/internal/model/promptfmt/baked.go
@@ -3,6 +3,8 @@ package promptfmt
 import (
 	"regexp"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 )
 
 // BakedDeltaTier ranks how confident a finding is that stored prose
@@ -83,27 +85,17 @@ func FindBakedDeltas(body string) []BakedDelta {
 	var found []BakedDelta
 
 	lines := strings.Split(body, "\n")
-	inFence := false
-	inFrontmatter := len(lines) > 0 && strings.TrimRight(lines[0], "\r") == "---"
+	skipTo := frontmatterEnd(lines)
+	var fence fenceState
 
 	for i, raw := range lines {
+		if i < skipTo {
+			continue
+		}
 		line := strings.TrimRight(raw, "\r")
 		lineNo := i + 1
 
-		// Frontmatter runs from the opening --- to the next one. Its
-		// contents are the writer's stamps, not the author's prose.
-		if inFrontmatter {
-			if i > 0 && (line == "---" || line == "...") {
-				inFrontmatter = false
-			}
-			continue
-		}
-
-		if isFenceDelimiter(line) {
-			inFence = !inFence
-			continue
-		}
-		if inFence {
+		if closed := fence.consume(line); closed || fence.open {
 			continue
 		}
 
@@ -119,48 +111,156 @@ func FindBakedDeltas(body string) []BakedDelta {
 	return found
 }
 
-// isFenceDelimiter reports whether a line opens or closes a fenced code
-// block. Both CommonMark fence characters count, and an info string
-// ("```json") rides along on the opening line.
-func isFenceDelimiter(line string) bool {
-	trimmed := strings.TrimLeft(line, " \t")
-	return strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~")
+// frontmatterEnd returns the first line index that is prose, skipping a
+// leading YAML frontmatter block when there is one.
+//
+// A block counts only when its closing delimiter is actually present.
+// The guarded inputs are document bodies, where a leading "---" is far
+// more likely a thematic break than an envelope, and an unterminated
+// block would otherwise swallow the entire document — turning a
+// horizontal rule at the top of a page into a way to write anything at
+// all past the guard.
+func frontmatterEnd(lines []string) int {
+	if len(lines) == 0 || strings.TrimRight(lines[0], "\r") != "---" {
+		return 0
+	}
+	for i := 1; i < len(lines); i++ {
+		switch strings.TrimRight(lines[i], "\r") {
+		case "---", "...":
+			return i + 1
+		}
+	}
+	return 0
 }
 
-// outsideCodeSpans splits a line into the runs that sit outside
-// backtick-delimited spans. An unterminated backtick opens nothing —
-// the rest of the line stays prose — because a stray tick in ordinary
-// writing must not blind the scanner to everything after it.
+// fenceState tracks an open fenced code block. CommonMark closes a
+// fence only with the character it opened with, at least as long as the
+// opening run, so a "```" line inside a "~~~" block is content — and
+// treating it as a close would drop the rest of that block back into
+// the scan and refuse a write over a documented example.
+type fenceState struct {
+	open   bool
+	marker byte
+	length int
+}
+
+// consume applies one line to the fence state and reports whether that
+// line was the closing delimiter (which is itself not prose).
+func (f *fenceState) consume(line string) bool {
+	marker, length, ok := fenceDelimiter(line)
+	if !ok {
+		return false
+	}
+	if !f.open {
+		f.open, f.marker, f.length = true, marker, length
+		return true
+	}
+	if marker == f.marker && length >= f.length {
+		f.open, f.marker, f.length = false, 0, 0
+		return true
+	}
+	return false
+}
+
+// fenceDelimiter reports the marker byte and run length of a fence
+// line: up to three leading spaces, then three or more backticks or
+// tildes.
+func fenceDelimiter(line string) (byte, int, bool) {
+	i := 0
+	for i < len(line) && i < 3 && line[i] == ' ' {
+		i++
+	}
+	if i >= len(line) || (line[i] != '`' && line[i] != '~') {
+		return 0, 0, false
+	}
+	marker := line[i]
+	run := 0
+	for i+run < len(line) && line[i+run] == marker {
+		run++
+	}
+	if run < 3 {
+		return 0, 0, false
+	}
+	return marker, run, true
+}
+
+// outsideCodeSpans splits a line into the runs that sit outside inline
+// code spans. CommonMark delimits a span with equal-length backtick
+// runs, so "“-2h“" is code just as "`-2h`" is; pairing single
+// backticks instead would leave the inner text exposed and refuse a
+// write over the very escape hatch the refusal message offers.
+//
+// An unterminated run opens nothing — the rest of the line stays prose
+// — because a stray tick in ordinary writing must not blind the scanner
+// to everything after it.
 func outsideCodeSpans(line string) []string {
 	if !strings.Contains(line, "`") {
 		return []string{line}
 	}
 	var out []string
-	for {
-		open := strings.IndexByte(line, '`')
-		if open < 0 {
-			out = append(out, line)
+	pos := 0
+	for pos < len(line) {
+		openStart, openLen := backtickRun(line, pos)
+		if openLen == 0 {
+			out = append(out, line[pos:])
 			return out
 		}
-		close := strings.IndexByte(line[open+1:], '`')
-		if close < 0 {
-			out = append(out, line)
+		closeStart, ok := matchingBacktickRun(line, openStart+openLen, openLen)
+		if !ok {
+			out = append(out, line[pos:])
 			return out
 		}
-		out = append(out, line[:open])
-		line = line[open+1+close+1:]
+		out = append(out, line[pos:openStart])
+		pos = closeStart + openLen
 	}
+	return out
 }
 
-// formattedDeltasIn finds this package's own delta vocabulary in a run
-// of prose. Hand-rolled rather than a regexp because the boundary rule
+// backtickRun finds the next run of backticks at or after from,
+// returning its start and length (length 0 when there is none).
+func backtickRun(line string, from int) (int, int) {
+	start := strings.IndexByte(line[from:], '`')
+	if start < 0 {
+		return 0, 0
+	}
+	start += from
+	run := 0
+	for start+run < len(line) && line[start+run] == '`' {
+		run++
+	}
+	return start, run
+}
+
+// matchingBacktickRun finds the next backtick run of exactly want
+// length, which is what closes a span of that width.
+func matchingBacktickRun(line string, from, want int) (int, bool) {
+	for pos := from; pos < len(line); {
+		start, run := backtickRun(line, pos)
+		if run == 0 {
+			return 0, false
+		}
+		if run == want {
+			return start, true
+		}
+		pos = start + run
+	}
+	return 0, false
+}
+
+// formattedDeltasIn finds this package's delta vocabulary in a run of
+// prose. Hand-rolled rather than a regexp because the boundary rule
 // needs a look behind the candidate — RE2 has no lookaround, and
 // without one "-98.41852298892312" (a longitude, which this corpus is
 // full of) would need the surrounding bytes checked anyway.
 //
-// A candidate is confirmed by [parseDeltaTerms], the same parser
-// [ParseTimeOrDelta] uses, so the matcher accepts exactly the grammar
-// the formatters emit rather than a second, drifting definition of it.
+// A candidate is confirmed by [parseDeltaTerms], which is the vocabulary
+// [ParseTimeOrDelta] accepts rather than the narrower set
+// [FormatDeltaOnly] emits. That is deliberate and slightly wider than
+// "machine output": "-30m" and "-2w" never come off a formatter (which
+// would render them "-1800s" and "-14d"), but a model that writes
+// either has still hardcoded a relative time that decays, and a tool
+// argument may echo one back verbatim. Matching the parser also keeps
+// one definition of the grammar instead of a second that drifts.
 func formattedDeltasIn(prose string) []string {
 	var out []string
 	for i := 0; i < len(prose); i++ {
@@ -169,7 +269,7 @@ func formattedDeltasIn(prose string) []string {
 		}
 		// A sign glued to a word or a number is part of that token
 		// ("UTC-5", "29.83-98.46"), not the start of a delta.
-		if i > 0 && isDeltaBoundaryByte(prose[i-1]) {
+		if gluedBefore(prose, i) {
 			continue
 		}
 		end := i + 1
@@ -182,7 +282,7 @@ func formattedDeltasIn(prose string) []string {
 		// A trailing word character means the run was a fragment of
 		// something longer ("+3days", "-5min"), which the formatters
 		// never emit.
-		if end < len(prose) && isDeltaBoundaryByte(prose[end]) {
+		if gluedAfter(prose, end) {
 			continue
 		}
 		candidate := prose[i:end]
@@ -202,13 +302,28 @@ func isDeltaUnit(b byte) bool {
 	return ok
 }
 
-// isDeltaBoundaryByte reports whether a byte glues a candidate to a
-// neighbouring token. Letters and digits obviously do; so does '.',
-// which is what keeps decimal coordinates out of the results.
-func isDeltaBoundaryByte(b byte) bool {
-	switch {
-	case b >= 'a' && b <= 'z', b >= 'A' && b <= 'Z', isDigit(b), b == '.', b == '_':
-		return true
+// glued reports whether the rune ending at (or starting at) an offset
+// joins a candidate to a neighbouring token. Letters and digits of any
+// script count, not just ASCII: "café-1h" is one identifier the same
+// way "retention-1h" is, and an ASCII-only check would refuse a write
+// over the accented one while exempting the plain one. '.' and '_'
+// join too, which is what keeps decimal coordinates out of the results.
+func gluedRune(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '.' || r == '_'
+}
+
+func gluedBefore(prose string, i int) bool {
+	if i == 0 {
+		return false
 	}
-	return false
+	r, _ := utf8.DecodeLastRuneInString(prose[:i])
+	return gluedRune(r)
+}
+
+func gluedAfter(prose string, i int) bool {
+	if i >= len(prose) {
+		return false
+	}
+	r, _ := utf8.DecodeRuneInString(prose[i:])
+	return gluedRune(r)
 }

--- a/internal/model/promptfmt/baked_test.go
+++ b/internal/model/promptfmt/baked_test.go
@@ -36,6 +36,10 @@ func TestFindBakedDeltasTiers(t *testing.T) {
 		// the look-behind exists for: every other guard passes it.
 		{"suffix on an identifier", "the retention-30d policy applies", nil},
 		{"countdown notation", "at T-5m we abort", nil},
+		// Boundaries are runes, not ASCII bytes: an accented identifier
+		// must be exempt exactly as its plain-ASCII twin is.
+		{"non-ASCII identifier", "the café-1h special", nil},
+		{"CJK identifier", "the 保持-30d policy", nil},
 		{"spelled-out unit", "waited +3days", nil},
 		{"abbreviated unit", "waited -5min", nil},
 		{"sign with no terms", "a - b and c + d", nil},
@@ -112,6 +116,83 @@ func TestFindBakedDeltasSkipsNonProseRegions(t *testing.T) {
 	}
 	if got[0].Line != 18 {
 		t.Errorf("line = %d, want 18 — line numbers must survive every skipped region", got[0].Line)
+	}
+}
+
+// TestFindBakedDeltasUnterminatedFrontmatterIsProse pins the bypass this
+// guard would otherwise hand any author: a body whose first line is a
+// thematic break rather than an envelope. Skipping to EOF looking for a
+// delimiter that never comes would make "---" at the top of a page a
+// way to write anything at all past the guard.
+func TestFindBakedDeltasUnterminatedFrontmatterIsProse(t *testing.T) {
+	t.Parallel()
+
+	got := FindBakedDeltas("---\narrived -2h\n")
+	if len(got) != 1 || got[0].Text != "-2h" {
+		t.Errorf("FindBakedDeltas = %+v, want the delta scanned as prose", got)
+	}
+}
+
+// TestFindBakedDeltasFenceMarkersDoNotCross pins CommonMark's rule that
+// a fence closes only with the character it opened with. A "```" line
+// inside a "~~~" block is content, and treating it as a close drops the
+// rest of that block back into the scan — refusing a write over a
+// documented example.
+func TestFindBakedDeltasFenceMarkersDoNotCross(t *testing.T) {
+	t.Parallel()
+
+	body := "~~~\n```\n-2h\n~~~\nafter -3h\n"
+	got := FindBakedDeltas(body)
+	if len(got) != 1 {
+		t.Fatalf("want only the prose after the block, got %+v", got)
+	}
+	if got[0].Text != "-3h" || got[0].Line != 5 {
+		t.Errorf("finding = %+v, want -3h on line 5", got[0])
+	}
+}
+
+// TestFindBakedDeltasMultiBacktickSpans pins the escape hatch the
+// refusal message promises. CommonMark delimits a span with equal-length
+// backtick runs, so a doubled span is code exactly as a single one is;
+// pairing individual backticks would expose the inner text and refuse a
+// write over the very escape the message offered.
+func TestFindBakedDeltasMultiBacktickSpans(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body string
+		want int
+	}{
+		{"single", "write `-2h` here", 0},
+		{"doubled", "write ``-2h`` here", 0},
+		{"tripled around a tick", "write ```-2h``` here", 0},
+		{"doubled span containing a single tick", "write ``a ` -2h`` here", 0},
+		{"unmatched width leaves prose", "write ``-2h` here", 1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := FindBakedDeltas(tc.body); len(got) != tc.want {
+				t.Errorf("FindBakedDeltas(%q) = %+v, want %d finding(s)", tc.body, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFindBakedDeltasVocabularyIsWiderThanFormatterOutput pins a
+// deliberate choice. The matcher confirms candidates with the parser
+// ParseTimeOrDelta uses, not the narrower set FormatDeltaOnly emits:
+// "-30m" and "-2w" never come off a formatter, but a model that writes
+// either has still hardcoded a time that decays.
+func TestFindBakedDeltasVocabularyIsWiderThanFormatterOutput(t *testing.T) {
+	t.Parallel()
+
+	for _, body := range []string{"waited -30m", "waited -2w", "stamped +0s"} {
+		got := FindBakedDeltas(body)
+		if len(got) != 1 || got[0].Tier != BakedDeltaFormatted {
+			t.Errorf("FindBakedDeltas(%q) = %+v, want one tier-1 finding", body, got)
+		}
 	}
 }
 

--- a/internal/model/promptfmt/baked_test.go
+++ b/internal/model/promptfmt/baked_test.go
@@ -1,0 +1,157 @@
+package promptfmt
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFindBakedDeltasTiers pins what each tier claims. Tier 1 is this
+// package's own output shape and gets refused by callers, so its
+// boundary rules carry the weight: a false positive there blocks a
+// legitimate write.
+func TestFindBakedDeltasTiers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body string
+		want []BakedDelta
+	}{
+		// The shapes the formatters actually emit, branch by branch.
+		{"seconds", "left -3247s", []BakedDelta{{Text: "-3247s", Tier: BakedDeltaFormatted, Line: 1}}},
+		{"hours and minutes", "away -26h45m", []BakedDelta{{Text: "-26h45m", Tier: BakedDeltaFormatted, Line: 1}}},
+		{"days and hours", "due +5d9h", []BakedDelta{{Text: "+5d9h", Tier: BakedDeltaFormatted, Line: 1}}},
+		{"whole days", "opens +20d", []BakedDelta{{Text: "+20d", Tier: BakedDeltaFormatted, Line: 1}}},
+		{"zero", "stamped -0s", []BakedDelta{{Text: "-0s", Tier: BakedDeltaFormatted, Line: 1}}},
+
+		// A bullet's own dash is not a sign, and the delta after it is.
+		{"inside a bullet", "- state home since -2h2m", []BakedDelta{{Text: "-2h2m", Tier: BakedDeltaFormatted, Line: 1}}},
+
+		// Boundary rules. The corpus this guards is full of coordinates,
+		// so a longitude must never read as a delta.
+		{"longitude", "at 29.797003, -98.41852298892312 now", nil},
+		{"signed integer", "delta of -98 units", nil},
+		{"offset in a zone name", "recorded UTC-5 sharp", nil},
+		// A valid delta glued to the end of an identifier is the case
+		// the look-behind exists for: every other guard passes it.
+		{"suffix on an identifier", "the retention-30d policy applies", nil},
+		{"countdown notation", "at T-5m we abort", nil},
+		{"spelled-out unit", "waited +3days", nil},
+		{"abbreviated unit", "waited -5min", nil},
+		{"sign with no terms", "a - b and c + d", nil},
+		{"unknown unit", "ran -5k", nil},
+
+		// Natural language: stale in exactly the same way, but only a
+		// warning, because English is not proof of dating.
+		{"counted ago", "the panel cleared 21 minutes ago", []BakedDelta{{Text: "21 minutes ago", Tier: BakedDeltaNarrative, Line: 1}}},
+		{"worded ago", "rebooted a few hours ago", []BakedDelta{{Text: "a few hours ago", Tier: BakedDeltaNarrative, Line: 1}}},
+		{"forward looking", "lands in three days", []BakedDelta{{Text: "in three days", Tier: BakedDeltaNarrative, Line: 1}}},
+		{"day word", "verified yesterday", []BakedDelta{{Text: "yesterday", Tier: BakedDeltaNarrative, Line: 1}}},
+		{"named period", "shipped last week", []BakedDelta{{Text: "last week", Tier: BakedDeltaNarrative, Line: 1}}},
+		{"time of day", "installed this morning", []BakedDelta{{Text: "this morning", Tier: BakedDeltaNarrative, Line: 1}}},
+
+		// Currency words name no distance, so they cannot decay into a
+		// false statement and are deliberately left alone.
+		{"vague currency", "the panel is currently clean and was recently rebuilt", nil},
+		{"absolute date", "verified on 2026-09-06 at 11:13 CDT", nil},
+		{"template is the fix, not the defect", "opens {{delta:2026-09-08}}", nil},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := FindBakedDeltas(tc.body)
+			if len(got) != len(tc.want) {
+				t.Fatalf("FindBakedDeltas(%q) = %+v, want %+v", tc.body, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("finding %d = %+v, want %+v", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestFindBakedDeltasSkipsNonProseRegions pins the one structural rule
+// that makes the guard usable. All three exemptions were found by
+// scanning the production corpus: frontmatter carries writer-stamped
+// created_delta/updated_delta, documentation of the delta format is
+// written in backticks, and a faceted document stores a JSON facet as
+// a fenced block — so JSON needs no special case of its own.
+func TestFindBakedDeltasSkipsNonProseRegions(t *testing.T) {
+	t.Parallel()
+
+	body := strings.Join([]string{
+		"---",
+		`created_delta: "-747402s"`,
+		`updated_delta: "-0s"`,
+		"---",
+		"",
+		"## Digest",
+		"",
+		"```json",
+		`{"room_since": "-513s", "state": "home"}`,
+		"```",
+		"",
+		"Write `(-127s)` rather than a bare phrase.",
+		"",
+		"```",
+		"Expected: [-47s] user: what time is it",
+		"```",
+		"",
+		"- room Office since -513s",
+	}, "\n")
+
+	got := FindBakedDeltas(body)
+	if len(got) != 1 {
+		t.Fatalf("want exactly the prose finding, got %+v", got)
+	}
+	if got[0].Text != "-513s" || got[0].Tier != BakedDeltaFormatted {
+		t.Errorf("finding = %+v, want the prose -513s as tier 1", got[0])
+	}
+	if got[0].Line != 18 {
+		t.Errorf("line = %d, want 18 — line numbers must survive every skipped region", got[0].Line)
+	}
+}
+
+// TestFindBakedDeltasStrayBacktickDoesNotBlindTheLine pins the failure
+// mode of treating an unpaired tick as an opening: everything after it
+// would stop being scanned, and the guard would go quiet on exactly the
+// sloppily-written prose most likely to carry a baked delta.
+func TestFindBakedDeltasStrayBacktickDoesNotBlindTheLine(t *testing.T) {
+	t.Parallel()
+
+	got := FindBakedDeltas("the `person.nugget state is home since -2h2m")
+	if len(got) != 1 || got[0].Text != "-2h2m" {
+		t.Errorf("FindBakedDeltas = %+v, want the delta after the stray tick", got)
+	}
+}
+
+// TestFindBakedDeltasFencesReopen pins that a fence closes: prose after
+// a code block is prose again.
+func TestFindBakedDeltasFencesReopen(t *testing.T) {
+	t.Parallel()
+
+	body := "before -1h\n```\n-2h\n```\nafter -3h\n"
+	got := FindBakedDeltas(body)
+	if len(got) != 2 {
+		t.Fatalf("want the two prose findings, got %+v", got)
+	}
+	if got[0].Text != "-1h" || got[0].Line != 1 {
+		t.Errorf("first = %+v, want -1h on line 1", got[0])
+	}
+	if got[1].Text != "-3h" || got[1].Line != 5 {
+		t.Errorf("second = %+v, want -3h on line 5", got[1])
+	}
+}
+
+// TestFindBakedDeltasCleanProse pins the common case: prose with
+// nothing to report allocates nothing.
+func TestFindBakedDeltasCleanProse(t *testing.T) {
+	t.Parallel()
+
+	if got := FindBakedDeltas("Home since 12:06 CDT; appointment was 11:30-12:00.\n"); got != nil {
+		t.Errorf("clean prose produced %+v, want nil", got)
+	}
+}

--- a/internal/state/documents/baked_delta_guard.go
+++ b/internal/state/documents/baked_delta_guard.go
@@ -63,6 +63,13 @@ func describeBakedDeltas(findings []promptfmt.BakedDelta) string {
 // on account of prose the author did not touch, and the loop whose
 // document rotted would be the one loop unable to repair it.
 //
+// It also sits above Write/Edit/JournalUpdate rather than at the file
+// writer, which is what keeps Move, Copy and the section transfers out
+// of scope: those relocate prose that already exists instead of
+// authoring it, and refusing them would leave a rotted document
+// permanently unmovable — unable to be filed, archived, or split apart
+// on the way to being fixed.
+//
 // Tier 1 refuses: those shapes are this package's own formatter output,
 // and prose almost always acquires one by transcribing a tool result
 // verbatim. Tier 2 warns and lets the write through: "yesterday" decays

--- a/internal/state/documents/baked_delta_guard.go
+++ b/internal/state/documents/baked_delta_guard.go
@@ -1,0 +1,96 @@
+package documents
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
+)
+
+// bakedDeltaReportLimit caps how many findings a refusal or warning
+// names. A document that has been rotting for weeks can carry dozens;
+// listing them all buries the instruction that tells the author what
+// to do instead. The count of the rest still ships, because silently
+// truncating reads as "that was all of them".
+const bakedDeltaReportLimit = 5
+
+// BakedDeltaRefusedError refuses a write whose prose carries this
+// project's own delta vocabulary. The rendered form is true at the
+// instant it is written and false immediately after, which is the
+// whole reason {{delta:...}} exists: the template re-renders on every
+// read, so an authored document stays true between rewrites.
+type BakedDeltaRefusedError struct {
+	Ref      string
+	Findings []promptfmt.BakedDelta
+}
+
+func (e *BakedDeltaRefusedError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf(
+		"%s: this write bakes a rendered delta into stored prose (%s). A delta is true only at the moment it is written. "+
+			"Write the absolute value wrapped in a template instead — {{delta:2026-09-18T14:30:00-05:00}} for an instant, "+
+			"{{delta:2026-09-18}} for a date — and it re-renders correctly on every read. "+
+			"To store the literal text (documenting the format, quoting tool output), put it in backticks or a fenced block, which are not scanned.",
+		e.Ref, describeBakedDeltas(e.Findings))
+}
+
+// describeBakedDeltas renders findings as a quoted, line-numbered list,
+// capped and counted.
+func describeBakedDeltas(findings []promptfmt.BakedDelta) string {
+	shown := findings
+	if len(shown) > bakedDeltaReportLimit {
+		shown = shown[:bakedDeltaReportLimit]
+	}
+	parts := make([]string, 0, len(shown))
+	for _, f := range shown {
+		parts = append(parts, fmt.Sprintf("%q on line %d", f.Text, f.Line))
+	}
+	out := strings.Join(parts, ", ")
+	if rest := len(findings) - len(shown); rest > 0 {
+		out += fmt.Sprintf(", and %d more", rest)
+	}
+	return out
+}
+
+// guardAuthoredProse inspects the text a single write introduces and
+// decides what to do about relative times in it.
+//
+// It scans what this call supplies — never the merged document —
+// because a document that already carries a baked delta must stay
+// writable. Scanning the merged result would refuse every future write
+// on account of prose the author did not touch, and the loop whose
+// document rotted would be the one loop unable to repair it.
+//
+// Tier 1 refuses: those shapes are this package's own formatter output,
+// and prose almost always acquires one by transcribing a tool result
+// verbatim. Tier 2 warns and lets the write through: "yesterday" decays
+// exactly as fast, but it is ordinary English and a matcher cannot know
+// whether it dates anything.
+func guardAuthoredProse(ref string, texts ...string) ([]string, error) {
+	var refuse, warn []promptfmt.BakedDelta
+	for _, text := range texts {
+		if strings.TrimSpace(text) == "" {
+			continue
+		}
+		for _, finding := range promptfmt.FindBakedDeltas(text) {
+			switch finding.Tier {
+			case promptfmt.BakedDeltaFormatted:
+				refuse = append(refuse, finding)
+			case promptfmt.BakedDeltaNarrative:
+				warn = append(warn, finding)
+			}
+		}
+	}
+	if len(refuse) > 0 {
+		return nil, &BakedDeltaRefusedError{Ref: ref, Findings: refuse}
+	}
+	if len(warn) == 0 {
+		return nil, nil
+	}
+	return []string{fmt.Sprintf(
+		"%s: stored prose carries a relative time that will not stay true (%s). "+
+			"Prefer {{delta:<absolute date or RFC3339 instant>}}, which re-renders on every read. Written as-is.",
+		ref, describeBakedDeltas(warn))}, nil
+}

--- a/internal/state/documents/baked_delta_guard_test.go
+++ b/internal/state/documents/baked_delta_guard_test.go
@@ -1,0 +1,174 @@
+package documents
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestGuardRefusesBakedDeltaOnEveryAuthorPath pins that the guard sits
+// on the author's text rather than on one tool. doc_write, doc_edit and
+// doc_journal_update each supply prose through a different field, and a
+// guard installed on only one of them is a hole an author reaches by
+// picking a different tool.
+func TestGuardRefusesBakedDeltaOnEveryAuthorPath(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	const rotten = "## Evidence\n\n- room Office since -513s\n"
+
+	t.Run("doc_write", func(t *testing.T) {
+		t.Parallel()
+		store, _ := newMutationStore(t)
+		_, err := store.Write(ctx, WriteArgs{Ref: "kb:w.md", Title: "W", Body: stringPtr(rotten)})
+		assertBakedDeltaRefusal(t, err, "-513s")
+	})
+
+	t.Run("doc_write journal entry", func(t *testing.T) {
+		t.Parallel()
+		store, _ := newMutationStore(t)
+		_, err := store.Write(ctx, WriteArgs{Ref: "kb:wj.md", Title: "WJ", JournalEntry: "checked in -2h2m"})
+		assertBakedDeltaRefusal(t, err, "-2h2m")
+	})
+
+	t.Run("doc_edit append_body", func(t *testing.T) {
+		t.Parallel()
+		store, _ := newMutationStore(t)
+		if _, err := store.Write(ctx, WriteArgs{Ref: "kb:e.md", Title: "E", Body: stringPtr("clean\n")}); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		_, err := store.Edit(ctx, EditArgs{Ref: "kb:e.md", Mode: "append_body", Body: "arrived -2h45m\n"})
+		assertBakedDeltaRefusal(t, err, "-2h45m")
+	})
+
+	t.Run("doc_journal_update", func(t *testing.T) {
+		t.Parallel()
+		store, _ := newMutationStore(t)
+		_, err := store.JournalUpdate(ctx, JournalUpdateArgs{Ref: "kb:j.md", Title: "J", Entry: "departed -2h20m"})
+		assertBakedDeltaRefusal(t, err, "-2h20m")
+	})
+}
+
+// TestGuardScansOnlyWhatTheWriteSupplies is the property that keeps the
+// guard from being a trap. A document that already carries a baked
+// delta must stay writable: scanning the merged result would refuse
+// every future write on account of prose the author did not touch, and
+// the loop whose document rotted would be the one loop unable to
+// repair it.
+func TestGuardScansOnlyWhatTheWriteSupplies(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store, _ := newMutationStore(t)
+
+	// Seed a rotted body the way production got one — before the guard
+	// existed — by writing it through the file path the guard does not
+	// sit on.
+	seeded := "---\ntitle: \"Rotted\"\n---\n\n## Evidence\n\n- room Office since -513s\n"
+	if err := store.writeDocumentFile(ctx, "kb", "rotted.md", seeded); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// An unrelated edit to the same document must succeed: the author is
+	// supplying clean prose, whatever the rest of the file still says.
+	result, err := store.Edit(ctx, EditArgs{
+		Ref:  "kb:rotted.md",
+		Mode: "upsert_section",
+		// Deliberately no baked delta in the supplied text.
+		Heading: "Status",
+		Section: "Status",
+		Body:    "Home since 12:06 CDT.\n",
+	})
+	if err != nil {
+		t.Fatalf("edit of an already-rotted document was refused: %v", err)
+	}
+	if len(result.Warnings) != 0 {
+		t.Errorf("clean supplied prose produced warnings: %v", result.Warnings)
+	}
+}
+
+// TestGuardWarnsWithoutRefusingNarrativeTime pins the tier split: the
+// write lands, and the author is told what will go stale.
+func TestGuardWarnsWithoutRefusingNarrativeTime(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store, _ := newMutationStore(t)
+
+	result, err := store.Write(ctx, WriteArgs{
+		Ref:   "kb:narrative.md",
+		Title: "N",
+		Body:  stringPtr("Awaiting the sensor installation tomorrow morning.\n"),
+	})
+	if err != nil {
+		t.Fatalf("narrative relative time must warn, not refuse: %v", err)
+	}
+	if len(result.Warnings) != 1 {
+		t.Fatalf("Warnings = %v, want exactly one", result.Warnings)
+	}
+	for _, want := range []string{"tomorrow", "line 1", "{{delta:"} {
+		if !strings.Contains(result.Warnings[0], want) {
+			t.Errorf("warning missing %q: %s", want, result.Warnings[0])
+		}
+	}
+}
+
+// TestGuardIgnoresBodyOnModesThatDiscardIt pins that an inert argument
+// cannot refuse a write. A body passed alongside mode "metadata" never
+// reaches the document, so scanning it would refuse a write over text
+// the store was about to throw away.
+func TestGuardIgnoresBodyOnModesThatDiscardIt(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store, _ := newMutationStore(t)
+	if _, err := store.Write(ctx, WriteArgs{Ref: "kb:m.md", Title: "M", Body: stringPtr("clean\n")}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if _, err := store.Edit(ctx, EditArgs{
+		Ref:   "kb:m.md",
+		Mode:  "metadata",
+		Title: "Retitled",
+		Body:  "arrived -2h45m",
+	}); err != nil {
+		t.Fatalf("metadata edit refused over a discarded body: %v", err)
+	}
+}
+
+// TestGuardExemptsFencedAndInlineCode pins the escape hatch the refusal
+// message promises. An author quoting tool output or documenting the
+// delta format has somewhere to put it.
+func TestGuardExemptsFencedAndInlineCode(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store, _ := newMutationStore(t)
+
+	body := "Write `(-127s)` rather than a bare phrase.\n\n```json\n{\"room_since\": \"-513s\"}\n```\n"
+	result, err := store.Write(ctx, WriteArgs{Ref: "kb:doc.md", Title: "D", Body: stringPtr(body)})
+	if err != nil {
+		t.Fatalf("code regions must not be scanned: %v", err)
+	}
+	if len(result.Warnings) != 0 {
+		t.Errorf("Warnings = %v, want none", result.Warnings)
+	}
+}
+
+func assertBakedDeltaRefusal(t *testing.T, err error, wantText string) {
+	t.Helper()
+	var refusal *BakedDeltaRefusedError
+	if !errors.As(err, &refusal) {
+		t.Fatalf("err = %v, want *BakedDeltaRefusedError", err)
+	}
+	if !strings.Contains(refusal.Error(), wantText) {
+		t.Errorf("refusal does not name %q: %s", wantText, refusal.Error())
+	}
+	if !strings.Contains(refusal.Error(), "{{delta:") {
+		t.Errorf("refusal must name the fix: %s", refusal.Error())
+	}
+	if !strings.Contains(refusal.Error(), "backticks") {
+		t.Errorf("refusal must name the escape hatch: %s", refusal.Error())
+	}
+}

--- a/internal/state/documents/baked_delta_guard_test.go
+++ b/internal/state/documents/baked_delta_guard_test.go
@@ -2,6 +2,7 @@ package documents
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -171,4 +172,71 @@ func assertBakedDeltaRefusal(t *testing.T, err error, wantText string) {
 	if !strings.Contains(refusal.Error(), "backticks") {
 		t.Errorf("refusal must name the escape hatch: %s", refusal.Error())
 	}
+}
+
+// TestGuardWarningReachesTheModel pins the tier-2 advisory at the layer
+// that matters. The store's MutationResult is not what an author sees:
+// the tool surface re-projects it through modelMutationResult, and a
+// warning that stops at that boundary makes the whole advisory tier a
+// no-op while a store-level test still passes.
+func TestGuardWarningReachesTheModel(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store, _ := newMutationStore(t)
+	tools := NewTools(store)
+
+	out, err := tools.Write(ctx, WriteArgs{
+		Ref:   "kb:narrative.md",
+		Title: "N",
+		Body:  stringPtr("Awaiting the sensor installation tomorrow morning.\n"),
+	})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	var payload struct {
+		Applied  bool     `json:"applied"`
+		Warnings []string `json:"warnings"`
+	}
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("decode tool result %q: %v", out, err)
+	}
+	if !payload.Applied {
+		t.Errorf("tier 2 must not block the write: %s", out)
+	}
+	if len(payload.Warnings) != 1 {
+		t.Fatalf("model-facing warnings = %v, want exactly one\n%s", payload.Warnings, out)
+	}
+	if !strings.Contains(payload.Warnings[0], "tomorrow") {
+		t.Errorf("warning does not name the phrase: %s", payload.Warnings[0])
+	}
+}
+
+// TestGuardCleanWriteCarriesNoWarningsField pins the quiet case: a
+// clean write must not grow a warnings key, so its presence in a tool
+// result always means something.
+func TestGuardCleanWriteCarriesNoWarningsField(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	tools := NewTools(mustMutationStore(t))
+
+	out, err := tools.Write(ctx, WriteArgs{
+		Ref:   "kb:clean.md",
+		Title: "C",
+		Body:  stringPtr("Home since 12:06 CDT.\n"),
+	})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if strings.Contains(out, "warnings") {
+		t.Errorf("clean write carried a warnings key: %s", out)
+	}
+}
+
+func mustMutationStore(t *testing.T) *Store {
+	t.Helper()
+	store, _ := newMutationStore(t)
+	return store
 }

--- a/internal/state/documents/facets/contract.go
+++ b/internal/state/documents/facets/contract.go
@@ -219,6 +219,12 @@ func IsKey(key string) bool {
 	return ok
 }
 
+// RelativeTimeGuidance is the one clause every prose-carrying parameter
+// appends. Stored prose outlives the moment it was written, so a
+// rendered delta is a defect the write path refuses outright; saying so
+// at the parameter costs one clause and saves a refused write.
+const RelativeTimeGuidance = " Never write a rendered delta (-2h2m) or a relative phrase (\"yesterday\"): wrap the absolute value as {{delta:2026-09-18}} or {{delta:2026-09-18T14:30:00-05:00}} and it re-renders on every read."
+
 // FormatGuidance returns model-facing guidance for non-default encodings.
 func FormatGuidance(format Format) string {
 	switch format {

--- a/internal/state/documents/model_tool_mutation_results.go
+++ b/internal/state/documents/model_tool_mutation_results.go
@@ -19,6 +19,10 @@ type modelMutationResult struct {
 	SizeBytes     int64    `json:"size_bytes"`
 	Section       string   `json:"section,omitempty"`
 	Window        string   `json:"window,omitempty"`
+	// Warnings reach the author, so a write that landed with a
+	// reservation says so. Without this field the store's warnings stop
+	// at the envelope and the advisory tier is a no-op.
+	Warnings []string `json:"warnings,omitempty"`
 }
 
 type modelDeleteResult struct {
@@ -125,6 +129,7 @@ func toModelMutationResult(result *MutationResult, now time.Time) *modelMutation
 		SizeBytes:     result.SizeBytes,
 		Section:       result.Section,
 		Window:        result.Window,
+		Warnings:      append([]string(nil), result.Warnings...),
 	}
 }
 

--- a/internal/state/documents/mutate.go
+++ b/internal/state/documents/mutate.go
@@ -124,6 +124,11 @@ type MutationResult struct {
 	SizeBytes   int64    `json:"size_bytes"`
 	Section     string   `json:"section,omitempty"`
 	Window      string   `json:"window,omitempty"`
+	// Warnings carry advisories about a write that succeeded — today,
+	// relative-time prose that will not stay true. Advisory rather than
+	// fatal because the author still wrote something legible; the
+	// refusals live in typed errors.
+	Warnings []string `json:"warnings,omitempty"`
 	// Revision advances the hidden read receipt after a successful mutation.
 	Revision string `json:"-"`
 }
@@ -229,6 +234,14 @@ func (s *Store) Write(ctx context.Context, args WriteArgs) (*MutationResult, err
 		args.Body = &normalized
 	}
 	args.JournalEntry = normalizeGlyphArtifacts(args.JournalEntry)
+	suppliedBody := ""
+	if args.Body != nil {
+		suppliedBody = *args.Body
+	}
+	warnings, err := guardAuthoredProse(args.Ref, suppliedBody, args.JournalEntry)
+	if err != nil {
+		return nil, err
+	}
 	root, relPath, err := parseRef(args.Ref)
 	if err != nil {
 		return nil, err
@@ -311,7 +324,9 @@ func (s *Store) Write(ctx context.Context, args WriteArgs) (*MutationResult, err
 		return nil, err
 	}
 	s.attachMutationRevision(ctx, record, revision)
-	return mutationResultFromRecord(action, record, existed, sectionName, ""), nil
+	result := mutationResultFromRecord(action, record, existed, sectionName, "")
+	result.Warnings = warnings
+	return result, nil
 }
 
 func (s *Store) Edit(ctx context.Context, args EditArgs) (*MutationResult, error) {
@@ -365,6 +380,15 @@ func (s *Store) Edit(ctx context.Context, args EditArgs) (*MutationResult, error
 		return nil, fmt.Errorf("unsupported edit mode %q; use one of [metadata, replace_body, append_body, prepend_body, upsert_section, delete_section]", args.Mode)
 	}
 
+	var warnings []string
+	switch mode {
+	case "replace_body", "append_body", "prepend_body", "upsert_section":
+		warnings, err = guardAuthoredProse(args.Ref, args.Body)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	raw := rawFrontmatter
 	if len(args.Frontmatter) > 0 || args.Title != "" || args.Description != "" || len(args.Tags) > 0 {
 		meta := mergeDocumentFrontmatter(record, args.Title, args.Description, args.Tags, args.Frontmatter, time.Now())
@@ -383,12 +407,18 @@ func (s *Store) Edit(ctx context.Context, args EditArgs) (*MutationResult, error
 		return nil, err
 	}
 	s.attachMutationRevision(ctx, record, revision)
-	return mutationResultFromRecord("doc_edit", record, true, sectionName, ""), nil
+	editResult := mutationResultFromRecord("doc_edit", record, true, sectionName, "")
+	editResult.Warnings = warnings
+	return editResult, nil
 }
 
 func (s *Store) JournalUpdate(ctx context.Context, args JournalUpdateArgs) (*MutationResult, error) {
 	args.Entry = normalizeGlyphArtifacts(args.Entry)
 	root, relPath, err := parseRef(args.Ref)
+	if err != nil {
+		return nil, err
+	}
+	journalWarnings, err := guardAuthoredProse(args.Ref, args.Entry)
 	if err != nil {
 		return nil, err
 	}
@@ -459,7 +489,9 @@ func (s *Store) JournalUpdate(ctx context.Context, args JournalUpdateArgs) (*Mut
 		return nil, err
 	}
 	s.attachMutationRevision(ctx, record, revision)
-	return mutationResultFromRecord("doc_journal_update", record, existed, windowHeading, windowKind), nil
+	journalResult := mutationResultFromRecord("doc_journal_update", record, existed, windowHeading, windowKind)
+	journalResult.Warnings = journalWarnings
+	return journalResult, nil
 }
 
 // maxReadableDocumentBytes caps how much of a managed document Thane will read

--- a/internal/tools/contact_tools.go
+++ b/internal/tools/contact_tools.go
@@ -385,7 +385,7 @@ func registerContactDossierWriteTool(r *Registry, contactTools *contacts.Tools) 
 	}
 	required := []string{"contact_id"}
 	for _, field := range fields {
-		description := field.Guidance + documentfacets.FormatGuidance(field.Format)
+		description := field.Guidance + documentfacets.FormatGuidance(field.Format) + documentfacets.RelativeTimeGuidance
 		if field.Key == "status_line" || field.Key == "teaser" {
 			description += " Omit the contact's canonical name: the structured record and dossier title already identify the subject."
 		}

--- a/internal/tools/document_intake_tools.go
+++ b/internal/tools/document_intake_tools.go
@@ -234,7 +234,7 @@ func projectionProperty(name documentfacets.Name, optional bool) map[string]any 
 		key = "full"
 	}
 	field, _ := documentfacets.FieldByKey(key)
-	description := field.Guidance + documentfacets.FormatGuidance(field.Format)
+	description := field.Guidance + documentfacets.FormatGuidance(field.Format) + documentfacets.RelativeTimeGuidance
 	if field.MaxRunes > 0 {
 		description = fmt.Sprintf("%s Maximum %d characters.", description, field.MaxRunes)
 	}

--- a/internal/tools/document_mutation_tools.go
+++ b/internal/tools/document_mutation_tools.go
@@ -46,11 +46,11 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 				},
 				"body": map[string]any{
 					"type":        "string",
-					"description": "Markdown body content to write. Omit to preserve an existing document's body; pass an empty string to intentionally clear it. Creating a new document requires body. Ordinary content-mutation tools name their markdown parameter body; structured publish tools expose projections such as full instead.",
+					"description": "Markdown body content to write. Omit to preserve an existing document's body; pass an empty string to intentionally clear it. Creating a new document requires body. Ordinary content-mutation tools name their markdown parameter body; structured publish tools expose projections such as full instead." + documentfacets.RelativeTimeGuidance,
 				},
 				"journal_entry": map[string]any{
 					"type":        "string",
-					"description": "Optional timestamped note to append under the managed `Journal` section while writing the current document state.",
+					"description": "Optional timestamped note to append under the managed `Journal` section while writing the current document state." + documentfacets.RelativeTimeGuidance,
 				},
 			},
 			"required": []string{"ref"},
@@ -288,7 +288,7 @@ func registerDocumentWriteTool(r *Registry, dt *documents.Tools) {
 		if !ok {
 			continue
 		}
-		description := field.Guidance + documentfacets.FormatGuidance(field.Format)
+		description := field.Guidance + documentfacets.FormatGuidance(field.Format) + documentfacets.RelativeTimeGuidance
 		if field.MaxRunes > 0 {
 			description = fmt.Sprintf("%s Maximum %d characters — a ceiling, not a target; compose comfortably under it.", description, field.MaxRunes)
 		}

--- a/internal/tools/document_mutation_tools.go
+++ b/internal/tools/document_mutation_tools.go
@@ -109,7 +109,7 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 				},
 				"body": map[string]any{
 					"type":        "string",
-					"description": "Markdown text for the body-only edit — the same parameter name doc_body_write uses. For the body modes this is the document's new body (whole or appended/prepended text); for upsert_section it is only that one section's text — never the whole document, and never the section's heading line (the heading is rendered automatically from `section`/`heading`; a leading duplicate heading line is stripped).",
+					"description": "Markdown text for the body-only edit — the same parameter name doc_body_write uses. For the body modes this is the document's new body (whole or appended/prepended text); for upsert_section it is only that one section's text — never the whole document, and never the section's heading line (the heading is rendered automatically from `section`/`heading`; a leading duplicate heading line is stripped)." + documentfacets.RelativeTimeGuidance,
 				},
 				"section": map[string]any{
 					"type":        "string",
@@ -197,7 +197,7 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 				},
 				"entry": map[string]any{
 					"type":        "string",
-					"description": "Journal note content to append under the current rolling window.",
+					"description": "Journal note content to append under the current rolling window." + documentfacets.RelativeTimeGuidance,
 				},
 				"window": map[string]any{
 					"type":        "string",


### PR DESCRIPTION
The reader side expands `{{delta:...}}` so authored prose stays true between rewrites (#1541). Nothing stopped an author writing the *rendered* form in the first place — and production shows they do.

## The evidence

Scanned the live corpus, 130 documents / 427 KB. 17 delta-shaped tokens. Every genuine one came from a loop transcribing a tool result verbatim:

```
whereabouts/nugget.md:35  - 23-minute dwell at ... (arrived -2h45m, departed -2h22m)
whereabouts/nugget.md:33  - `person.nugget` state `home` since -2h2m
```

Already false by the time anyone read them.

## Two tiers

| tier | example | action | why |
|---|---|---|---|
| 1 — formatter output | `-2h2m`, `+3d16h`, `-513s` | **refuse** | prose acquires these almost exclusively by copying a tool result |
| 2 — natural language | "yesterday", "21 minutes ago" | **warn, write lands** | decays identically, but a matcher cannot be sure English is dating anything |

The refusal names the offending text and line, the template that fixes it, and the escape hatch.

## The corpus settled the exemptions

Of the 17 tokens, **9 must not fire**: 6 are writer-stamped `created_delta`/`updated_delta` frontmatter, one documents the format in backticks, one is a fenced example, one is a JSON facet value.

One structural rule — skip frontmatter, fenced blocks, inline code — covers all nine. **JSON needs no special case**: a faceted document stores a JSON facet as a fenced block, so it is already skipped. That leaves 8 findings, all genuine, all in the two whereabouts documents. No false positives, no misses.

## Placement

The guard sits on the author's text at all four entry points — `doc_write`'s body and journal entry, `doc_edit`'s body for the modes that consume it, `doc_journal_update`'s entry — not on one tool, since picking a different tool would otherwise be a hole. The faceted publish path funnels through `Store.Write` too, so `publish_output_*` is covered.

It scans **only what a call supplies**, never the merged document. Scanning the result would refuse every future write over prose the author never touched, and the loop whose document rotted would be the one loop unable to repair it.

## Operational note

The whereabouts document currently carries 8 tier-1 findings. Because a faceted republish supplies the whole body, its **next publish will be refused** until the loop rewrites those lines. That is the intended self-healing path — the refusal names each line and the fix, and the loop regenerates that prose every iteration — but it is a live behaviour change worth watching on the first run after deploy.

## Verification

`just ci` green, baselines unchanged. Every claim mutation-tested: 5 mutations against the detector's structural rules, 6 against the guard's install points, all caught. One mutation initially **survived** — the look-behind that keeps `retention-30d` and `T-5m` from reading as deltas was load-bearing but untested; that case is now pinned.