### PR TITLE
feat(tools): give the whereabouts tools an absolute instant beside every delta

### DIFF
--- a/internal/tools/counterparty_places_tools.go
+++ b/internal/tools/counterparty_places_tools.go
@@ -26,9 +26,18 @@ type placeView struct {
 	// Arrived is a delta, or absent when the stay began before the
 	// device started watching. ArrivalTimed says which, so a reader
 	// never mistakes an unobserved arrival for a recent one.
+	//
+	// ArrivedAt and DepartedAt carry the same moments absolutely. Both
+	// forms ship because they serve opposite jobs: the delta is how a
+	// reader judges recency in this turn, the instant is the only form
+	// that survives being written down. A caller with just the delta
+	// either copies a value that starts rotting immediately or does
+	// clock arithmetic this project deliberately keeps away from models.
 	Arrived      string `json:"arrived,omitempty"`
+	ArrivedAt    string `json:"arrived_at,omitempty"`
 	ArrivalTimed bool   `json:"arrival_timed"`
 	Departed     string `json:"departed,omitempty"`
+	DepartedAt   string `json:"departed_at,omitempty"`
 	// Dwell is how long the stay lasted; DwellStillAccruing marks one
 	// that has not finished, so "11m" is not read as a completed visit.
 	Dwell              string  `json:"dwell,omitempty"`
@@ -44,6 +53,7 @@ type recentPlacesResult struct {
 	// several reports the one whose window was read.
 	Device      string      `json:"device,omitempty"`
 	CapturedAgo string      `json:"captured_ago,omitempty"`
+	CapturedAt  string      `json:"captured_at,omitempty"`
 	WindowHours float64     `json:"window_hours,omitempty"`
 	Places      []placeView `json:"places,omitempty"`
 	// Truncated reports the device dropping stays from its own window;
@@ -74,6 +84,8 @@ func (r *Registry) EnableCounterpartyPlacesTools(deps CounterpartyToolDeps) {
 			"state is here_now for a stay still underway and left once it ended; dwell_still_accruing marks a dwell that has not finished, so an in-progress stay is never read as a completed one. " +
 			"arrival_timed is false when the stay was already underway before the device started watching — the arrival is genuinely unknown rather than zero. " +
 			"Reach for contact_whereabouts when you need where somebody is right now fused across every source; reach here when the sequence and the dwells are the point. " +
+			"Every moment ships twice: arrived/departed/captured_ago are deltas for judging recency in this turn, arrived_at/departed_at/captured_at are the same moments absolutely. " +
+			"Anything you write into a document takes the absolute form — a delta copied into stored prose is wrong minutes later, and document writes refuse it. " +
 			"Pass name (resolved like other contact tools) or contact_id (UUID).",
 		Parameters: map[string]any{
 			"type": "object",
@@ -135,6 +147,7 @@ func handleContactRecentPlaces(ctx context.Context, deps CounterpartyToolDeps, n
 	result.Truncated = window.Truncated
 	if !window.CapturedAt.IsZero() {
 		result.CapturedAgo = promptfmt.FormatDeltaOnly(window.CapturedAt, now)
+		result.CapturedAt = window.CapturedAt.In(now.Location()).Format(time.RFC3339)
 	}
 
 	visits := window.Visits
@@ -153,9 +166,11 @@ func handleContactRecentPlaces(ctx context.Context, deps CounterpartyToolDeps, n
 		}
 		if v.ArrivedAt != nil {
 			place.Arrived = promptfmt.FormatDeltaOnly(*v.ArrivedAt, now)
+			place.ArrivedAt = v.ArrivedAt.In(now.Location()).Format(time.RFC3339)
 		}
 		if v.DepartedAt != nil {
 			place.Departed = promptfmt.FormatDeltaOnly(*v.DepartedAt, now)
+			place.DepartedAt = v.DepartedAt.In(now.Location()).Format(time.RFC3339)
 		}
 		if v.DwellSeconds > 0 {
 			place.Dwell = (time.Duration(v.DwellSeconds) * time.Second).Round(time.Minute).String()

--- a/internal/tools/counterparty_places_tools_test.go
+++ b/internal/tools/counterparty_places_tools_test.go
@@ -128,3 +128,50 @@ const productionVisitWindowJSON = `{"captured_at":"2026-09-06T17:05:50.111Z","ma
 {"arrival":"precise","arrived_at":"2026-09-06T16:21:51.633Z","captured_at":"2026-09-06T16:37:18.763Z","dwell_is_partial":true,"dwell_seconds":927.13,"horizontal_accuracy_meters":50.47,"latitude":29.79694558881348,"longitude":-98.4184658414713,"state":"ongoing"},
 {"arrival":"unknown","captured_at":"2026-09-06T16:12:23.138Z","departed_at":"2026-09-06T16:11:57.501Z","dwell_is_partial":false,"horizontal_accuracy_meters":13.05,"latitude":29.83122951133177,"longitude":-98.46431478315205,"state":"settled"}],
 "window_hours":48}`
+
+// TestRecentPlacesCarriesAbsoluteInstants pins the pairing this tool
+// owes a caller writing a document. The delta answers "how recent" in
+// this turn; only the instant survives being written down. Shipping the
+// delta alone is what put "arrived -2h45m, departed -2h22m" into
+// production prose — the loop quoted its evidence verbatim, exactly as
+// asked, and the document was wrong minutes later.
+func TestRecentPlacesCarriesAbsoluteInstants(t *testing.T) {
+	deps, contactID := newPlacesFixture(t, productionVisitWindowJSON)
+	out, err := handleContactRecentPlaces(context.Background(), deps, "", contactID)
+	if err != nil {
+		t.Fatalf("handleContactRecentPlaces: %v", err)
+	}
+	var result recentPlacesResult
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("decode result: %v\n%s", err, out)
+	}
+
+	if result.CapturedAgo == "" || result.CapturedAt == "" {
+		t.Errorf("window carries captured_ago=%q captured_at=%q, want both", result.CapturedAgo, result.CapturedAt)
+	}
+	if _, err := time.Parse(time.RFC3339, result.CapturedAt); err != nil {
+		t.Errorf("captured_at %q is not RFC3339: %v", result.CapturedAt, err)
+	}
+
+	timed := 0
+	for i, place := range result.Places {
+		if place.ArrivalTimed {
+			timed++
+			if place.ArrivedAt == "" {
+				t.Errorf("place %d has a timed arrival but no arrived_at: %+v", i, place)
+				continue
+			}
+			if _, err := time.Parse(time.RFC3339, place.ArrivedAt); err != nil {
+				t.Errorf("place %d arrived_at %q is not RFC3339: %v", i, place.ArrivedAt, err)
+			}
+		} else if place.ArrivedAt != "" {
+			t.Errorf("place %d reports arrived_at without a timed arrival: %+v", i, place)
+		}
+		if place.Departed != "" && place.DepartedAt == "" {
+			t.Errorf("place %d has a departure delta but no departed_at: %+v", i, place)
+		}
+	}
+	if timed == 0 {
+		t.Fatal("fixture exercised no timed arrival")
+	}
+}

--- a/internal/tools/counterparty_tools.go
+++ b/internal/tools/counterparty_tools.go
@@ -92,9 +92,16 @@ type whereaboutsSource struct {
 	State string `json:"state,omitempty"`
 	Room  string `json:"room,omitempty"`
 	// RoomVia is provider-specific evidence, such as a UniFi AP name.
-	RoomVia   string `json:"room_via,omitempty"`
-	Since     string `json:"since,omitempty"`
-	RoomSince string `json:"room_since,omitempty"`
+	RoomVia string `json:"room_via,omitempty"`
+	// Since and RoomSince are deltas; SinceAt and RoomSinceAt are the
+	// same moments absolutely. Both forms ship because they serve
+	// opposite jobs: the delta is how a reader judges recency in this
+	// turn, the instant is the only form that survives being written
+	// down. Quote the instant into a document and the delta nowhere.
+	Since       string `json:"since,omitempty"`
+	SinceAt     string `json:"since_at,omitempty"`
+	RoomSince   string `json:"room_since,omitempty"`
+	RoomSinceAt string `json:"room_since_at,omitempty"`
 
 	// Device fields (companion_location sources). Account, ClientID,
 	// and DeviceID make each entry uniquely identifiable and let the
@@ -175,6 +182,7 @@ func handleContactWhereabouts(ctx context.Context, deps CounterpartyToolDeps, na
 				zone := whereaboutsSource{Source: "ha_person_zone", State: snap.State}
 				if !snap.Since.IsZero() {
 					zone.Since = promptfmt.FormatDeltaOnly(snap.Since, now)
+					zone.SinceAt = snap.Since.In(now.Location()).Format(time.RFC3339)
 				}
 				if home && !roomConflict && snap.Room != "" {
 					room := whereaboutsSource{
@@ -184,6 +192,7 @@ func handleContactWhereabouts(ctx context.Context, deps CounterpartyToolDeps, na
 					}
 					if !snap.RoomSince.IsZero() {
 						room.RoomSince = promptfmt.FormatDeltaOnly(snap.RoomSince, now)
+						room.RoomSinceAt = snap.RoomSince.In(now.Location()).Format(time.RFC3339)
 					}
 					presenceSources = append(presenceSources, room)
 				}

--- a/internal/tools/counterparty_tools.go
+++ b/internal/tools/counterparty_tools.go
@@ -58,7 +58,11 @@ func (r *Registry) EnableCounterpartyTools(deps CounterpartyToolDeps) {
 			"companion_last_known_location only when you need one specific device's stored fix. " +
 			"Pass name (resolved like other contact tools) or contact_id (UUID). A contact with no HA " +
 			"person binding and no bound companion devices returns an error saying so — that is a " +
-			"configuration gap, not an unknown location.",
+			"configuration gap, not an unknown location. " +
+			"Every moment ships twice: since/room_since are deltas for judging recency in this turn, " +
+			"since_at/room_since_at are the same moments absolutely. Anything you write into a document " +
+			"takes the absolute form — a delta copied into stored prose is wrong minutes later, and " +
+			"document writes refuse it.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{

--- a/internal/tools/counterparty_tools_test.go
+++ b/internal/tools/counterparty_tools_test.go
@@ -140,6 +140,31 @@ func TestContactWhereaboutsHomeRanking(t *testing.T) {
 	if res.BestSource != "unifi_room" || !strings.Contains(res.Basis, "home") {
 		t.Errorf("verdict = %q / %q", res.BestSource, res.Basis)
 	}
+
+	// Every moment ships twice. The delta answers "how recent" inside
+	// this turn; only the instant keeps its meaning once a loop writes
+	// it into a document, and document writes now refuse the delta —
+	// so a source carrying one without the other leaves the caller
+	// with nothing it is allowed to store.
+	room, zone := res.Sources[0], res.Sources[1]
+	if room.RoomSince == "" || room.RoomSinceAt == "" {
+		t.Errorf("room source = %+v, want both room_since and room_since_at", room)
+	}
+	if _, err := time.Parse(time.RFC3339, room.RoomSinceAt); err != nil {
+		t.Errorf("room_since_at %q is not RFC3339: %v", room.RoomSinceAt, err)
+	}
+	if zone.Since == "" || zone.SinceAt == "" {
+		t.Errorf("zone source = %+v, want both since and since_at", zone)
+	}
+	if _, err := time.Parse(time.RFC3339, zone.SinceAt); err != nil {
+		t.Errorf("since_at %q is not RFC3339: %v", zone.SinceAt, err)
+	}
+	// The pair must name the same moment, not two independent reads of
+	// the clock: the fixture puts the zone change two hours back.
+	at, err := time.Parse(time.RFC3339, zone.SinceAt)
+	if err == nil && time.Since(at).Round(time.Minute) != 2*time.Hour {
+		t.Errorf("since_at %q does not match the delta %q", zone.SinceAt, zone.Since)
+	}
 }
 
 func TestContactWhereaboutsReportsRoomConflictWithoutGuessing(t *testing.T) {


### PR DESCRIPTION
#1542's write guard refuses a stored delta. This gives the whereabouts loop a way to comply — without it the guard would block the loop with no compliant path, one deploy from now.

## The gap

`contact_recent_places` answered **only** in deltas — `arrived`, `departed`, `captured_ago` — with no absolute timestamp anywhere. `contact_whereabouts` did the same for `since` and `room_since`. So the loop was told to write absolute instants, handed nothing but deltas, and would now be refused for quoting its own evidence.

That is what already happened on 2026-09-06, before the guard existed:

```
- 23-minute dwell at 29.797003, -98.418522 (arrived -2h45m, departed -2h22m)
```

Copied verbatim out of the tool result. The loop did what a careful reader does — it quoted its source. The tool was the one withholding the form that survives being written down.

## The change

Both tools now answer twice:

| delta (judge recency in this turn) | instant (survives being written down) |
|---|---|
| `arrived` | `arrived_at` |
| `departed` | `departed_at` |
| `captured_ago` | `captured_at` |
| `since` | `since_at` |
| `room_since` | `room_since_at` |

Neither has to be computed from the other, which is the point — this project deliberately keeps clock arithmetic away from models (`docs/model-facing-context.md`, and `FormatDeltaOnly`'s own doc comment). The tool description now says which form goes where.

## Scope

Deliberately narrow. `FormatDeltaOnly` is the house convention at ~130 call sites and stays exactly as it is — deltas are *correct* for tool results, which re-render on every call. This changes only the two tools whose output a loop is explicitly instructed to quote into a stored document.

## Verification

`just ci` green, baselines unchanged. Four mutations — dropping each `_at` field, and emitting `arrived_at` for an untimed arrival — all caught.