### PR TITLE
fix(usage): price claude-opus-5 and claude-sonnet-5, warn on unpriced paid models

### DIFF
--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -1717,12 +1717,12 @@ archivist:
 #   claude-haiku-4-5:
 #     input_per_million: 1.0
 #     output_per_million: 5.0
-#   claude-opus-4-8:
+#   claude-opus-5:
 #     input_per_million: 5.0
 #     output_per_million: 25.0
-#   claude-sonnet-4-6:
-#     input_per_million: 3.0
-#     output_per_million: 15.0
+#   claude-sonnet-5:
+#     input_per_million: 2.0
+#     output_per_million: 10.0
 #
 # Logging configures Thane's filesystem datasets, stdout policy, and
 # queryable request/log retention.

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -3344,10 +3344,15 @@ func (c *Config) applyDefaults() {
 
 	if c.Pricing == nil {
 		c.Pricing = map[string]PricingEntry{
-			// Current models (per-million USD, input/output).
+			// Current models (per-million USD, input/output). Sonnet 5
+			// is $2/$10, below Sonnet 4.6's $3/$15.
+			"claude-opus-5":    {InputPerMillion: 5.0, OutputPerMillion: 25.0},
+			"claude-sonnet-5":  {InputPerMillion: 2.0, OutputPerMillion: 10.0},
+			"claude-haiku-4-5": {InputPerMillion: 1.0, OutputPerMillion: 5.0},
+			// Previous generation, still served and still present in
+			// usage history.
 			"claude-opus-4-8":   {InputPerMillion: 5.0, OutputPerMillion: 25.0},
 			"claude-sonnet-4-6": {InputPerMillion: 3.0, OutputPerMillion: 15.0},
-			"claude-haiku-4-5":  {InputPerMillion: 1.0, OutputPerMillion: 5.0},
 			// Deprecated models kept for pricing historical usage records
 			// (retire 2026-06-15 / 2026-04-19); note Opus 4 was $15/$75,
 			// far above Opus 4.8's $5/$25.

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -561,12 +561,14 @@ func TestContentMaxLength_Default(t *testing.T) {
 }
 
 // TestApplyDefaults_PricingHasCurrentModels locks in cost-tracking
-// pricing for the current model fleet. Opus 4.8 is $5/$25 — far below
-// the retired Opus 4's $15/$75 — so a missing entry would silently
-// mis-price usage rather than error.
+// pricing for the current model fleet. A model missing from the table
+// records every call at $0 rather than erroring, so a fleet move that
+// outruns this table is invisible in cost reports.
 func TestApplyDefaults_PricingHasCurrentModels(t *testing.T) {
 	cfg := Default()
 	want := map[string]PricingEntry{
+		"claude-opus-5":     {InputPerMillion: 5.0, OutputPerMillion: 25.0},
+		"claude-sonnet-5":   {InputPerMillion: 2.0, OutputPerMillion: 10.0},
 		"claude-opus-4-8":   {InputPerMillion: 5.0, OutputPerMillion: 25.0},
 		"claude-sonnet-4-6": {InputPerMillion: 3.0, OutputPerMillion: 15.0},
 		"claude-haiku-4-5":  {InputPerMillion: 1.0, OutputPerMillion: 5.0},

--- a/internal/platform/config/example.go
+++ b/internal/platform/config/example.go
@@ -532,13 +532,13 @@ func ExampleConfig() *Config {
 		},
 
 		Pricing: map[string]PricingEntry{
-			"claude-opus-4-8": {
+			"claude-opus-5": {
 				InputPerMillion:  5.0,
 				OutputPerMillion: 25.0,
 			},
-			"claude-sonnet-4-6": {
-				InputPerMillion:  3.0,
-				OutputPerMillion: 15.0,
+			"claude-sonnet-5": {
+				InputPerMillion:  2.0,
+				OutputPerMillion: 10.0,
 			},
 			"claude-haiku-4-5": {
 				InputPerMillion:  1.0,

--- a/internal/platform/usage/store.go
+++ b/internal/platform/usage/store.go
@@ -358,38 +358,44 @@ func ComputeDetailedCostForIdentity(identity ModelIdentity, inputTokens, cacheCr
 // charged at the 5m rate to avoid retroactive price spikes on legacy
 // records.
 func ComputeDetailedCostForIdentityWithTTL(identity ModelIdentity, inputTokens, cacheCreationTotal, cacheCreation5m, cacheCreation1h, cacheReadInputTokens, outputTokens int, pricing map[string]config.PricingEntry) float64 {
-	if len(pricing) == 0 {
+	entry, ok := PricingFor(identity, pricing)
+	if !ok {
 		return 0
 	}
+	cost := float64(inputTokens) / 1_000_000.0 * entry.InputPerMillion
 
-	keys := []string{identity.Model}
+	// Breakdown-aware cache-write pricing. Anything in
+	// cacheCreationTotal not attributed to 5m or 1h is charged at
+	// the 5m rate (conservative default, matches legacy records
+	// written before the breakdown columns existed).
+	attributed := cacheCreation5m + cacheCreation1h
+	unattributed := cacheCreationTotal - attributed
+	if unattributed < 0 {
+		unattributed = 0
+	}
+	cost += float64(cacheCreation5m+unattributed) / 1_000_000.0 * (entry.InputPerMillion * anthropicCacheWrite5mMultiplier)
+	cost += float64(cacheCreation1h) / 1_000_000.0 * (entry.InputPerMillion * anthropicCacheWrite1hMultiplier)
+
+	cost += float64(cacheReadInputTokens) / 1_000_000.0 * (entry.InputPerMillion * anthropicCacheReadMultiplier)
+	cost += float64(outputTokens) / 1_000_000.0 * entry.OutputPerMillion
+	return cost
+}
+
+// PricingFor returns the pricing entry for identity: the
+// deployment-qualified model first, then the upstream model. ok is
+// false when neither is in the table. The cost functions read that as
+// $0, which is right for a local model and wrong for a paid one, so
+// callers recording paid usage should check it.
+func PricingFor(identity ModelIdentity, pricing map[string]config.PricingEntry) (config.PricingEntry, bool) {
+	if entry, ok := pricing[identity.Model]; ok {
+		return entry, true
+	}
 	if identity.UpstreamModel != "" && identity.UpstreamModel != identity.Model {
-		keys = append(keys, identity.UpstreamModel)
-	}
-	for _, key := range keys {
-		entry, ok := pricing[key]
-		if !ok {
-			continue
+		if entry, ok := pricing[identity.UpstreamModel]; ok {
+			return entry, true
 		}
-		cost := float64(inputTokens) / 1_000_000.0 * entry.InputPerMillion
-
-		// Breakdown-aware cache-write pricing. Anything in
-		// cacheCreationTotal not attributed to 5m or 1h is charged at
-		// the 5m rate (conservative default, matches legacy records
-		// written before the breakdown columns existed).
-		attributed := cacheCreation5m + cacheCreation1h
-		unattributed := cacheCreationTotal - attributed
-		if unattributed < 0 {
-			unattributed = 0
-		}
-		cost += float64(cacheCreation5m+unattributed) / 1_000_000.0 * (entry.InputPerMillion * anthropicCacheWrite5mMultiplier)
-		cost += float64(cacheCreation1h) / 1_000_000.0 * (entry.InputPerMillion * anthropicCacheWrite1hMultiplier)
-
-		cost += float64(cacheReadInputTokens) / 1_000_000.0 * (entry.InputPerMillion * anthropicCacheReadMultiplier)
-		cost += float64(outputTokens) / 1_000_000.0 * entry.OutputPerMillion
-		return cost
 	}
-	return 0
+	return config.PricingEntry{}, false
 }
 
 // ComputeCostForIdentity calculates USD cost for a resolved model

--- a/internal/platform/usage/store_test.go
+++ b/internal/platform/usage/store_test.go
@@ -544,6 +544,34 @@ func TestComputeCost_NilPricing(t *testing.T) {
 	}
 }
 
+func TestPricingFor(t *testing.T) {
+	pricing := map[string]config.PricingEntry{
+		"claude-sonnet-5": {InputPerMillion: 2.0, OutputPerMillion: 10.0},
+	}
+	tests := []struct {
+		name     string
+		identity ModelIdentity
+		pricing  map[string]config.PricingEntry
+		wantOK   bool
+	}{
+		{"model priced directly", ModelIdentity{Model: "claude-sonnet-5", UpstreamModel: "claude-sonnet-5"}, pricing, true},
+		{"deployment falls back to upstream", ModelIdentity{Model: "anthropic/claude-sonnet-5", UpstreamModel: "claude-sonnet-5"}, pricing, true},
+		{"model missing from table", ModelIdentity{Model: "claude-opus-5", UpstreamModel: "claude-opus-5"}, pricing, false},
+		{"nil table", ModelIdentity{Model: "claude-sonnet-5", UpstreamModel: "claude-sonnet-5"}, nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entry, ok := PricingFor(tt.identity, tt.pricing)
+			if ok != tt.wantOK {
+				t.Fatalf("PricingFor ok = %v, want %v", ok, tt.wantOK)
+			}
+			if ok && entry != pricing["claude-sonnet-5"] {
+				t.Errorf("PricingFor entry = %+v, want %+v", entry, pricing["claude-sonnet-5"])
+			}
+		})
+	}
+}
+
 func TestRecord_AutoID(t *testing.T) {
 	s := testStore(t)
 	ctx := context.Background()

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -309,6 +309,7 @@ type Loop struct {
 	requestRecorder     logging.RequestRecordFunc      // nil = request detail inspection disabled
 	usageStore          *usage.Store                   // nil = no usage recording
 	pricing             map[string]config.PricingEntry // model→cost for usage recording
+	unpricedModels      sync.Map                       // paid models already warned as missing from pricing
 	usageCatalog        *fleet.Catalog
 	modelRegistry       *fleet.Registry
 	modelRuntime        *fleet.Runtime
@@ -3659,6 +3660,11 @@ func (l *Loop) recordUsage(ctx context.Context, req *Request, model string, tota
 
 	identity := usage.ResolveModelIdentity(model, l.currentModelCatalog())
 	cost := usage.ComputeDetailedCostForIdentityWithTTL(identity, totalIn, cacheCreateIn, cacheCreate5m, cacheCreate1h, cacheReadIn, totalOut, l.pricing)
+	if identity.Provider == "anthropic" {
+		if _, priced := usage.PricingFor(identity, l.pricing); !priced {
+			l.warnUnpricedModel(identity)
+		}
+	}
 	rec := usage.Record{
 		Timestamp:                  time.Now(),
 		RequestID:                  requestID,
@@ -3686,4 +3692,19 @@ func (l *Loop) recordUsage(ctx context.Context, req *Request, model string, tota
 			"request_id", requestID,
 		)
 	}
+}
+
+// warnUnpricedModel reports, once per model, a paid-provider model
+// with no pricing entry. Its usage records carry cost_usd 0, so every
+// cost report under-counts until the model is added to the pricing
+// table.
+func (l *Loop) warnUnpricedModel(identity usage.ModelIdentity) {
+	if _, seen := l.unpricedModels.LoadOrStore(identity.Model, struct{}{}); seen {
+		return
+	}
+	l.logger.Warn("usage cost not recorded: model has no pricing entry",
+		"model", identity.Model,
+		"upstream_model", identity.UpstreamModel,
+		"provider", identity.Provider,
+	)
 }

--- a/internal/runtime/agent/usage_record_test.go
+++ b/internal/runtime/agent/usage_record_test.go
@@ -1,0 +1,61 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/config"
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
+	"github.com/nugget/thane-ai-agent/internal/platform/usage"
+)
+
+// TestRecordUsage_WarnsOncePerUnpricedPaidModel guards the detector for
+// a fleet move that outruns the pricing table: an unpriced Anthropic
+// model records at $0, so it must say so — once, not on every call —
+// while priced models and free local models stay quiet.
+func TestRecordUsage_WarnsOncePerUnpricedPaidModel(t *testing.T) {
+	const warnMsg = "usage cost not recorded: model has no pricing entry"
+	pricing := map[string]config.PricingEntry{
+		"claude-sonnet-5": {InputPerMillion: 2.0, OutputPerMillion: 10.0},
+	}
+	tests := []struct {
+		name      string
+		models    []string
+		wantWarns int
+	}{
+		{"unpriced anthropic model warns once across repeated calls", []string{"claude-opus-5", "claude-opus-5", "claude-opus-5"}, 1},
+		{"each unpriced anthropic model warns once", []string{"claude-opus-5", "claude-fable-5-1", "claude-opus-5"}, 2},
+		{"priced anthropic model is silent", []string{"claude-sonnet-5", "claude-sonnet-5"}, 0},
+		{"unpriced local model is silent", []string{"qwen3:32b", "qwen3:32b"}, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, err := database.OpenMemory()
+			if err != nil {
+				t.Fatalf("database.OpenMemory: %v", err)
+			}
+			t.Cleanup(func() { db.Close() })
+			store, err := usage.NewStore(db, nil)
+			if err != nil {
+				t.Fatalf("usage.NewStore: %v", err)
+			}
+
+			var logBuf bytes.Buffer
+			l := &Loop{
+				logger:     slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn})),
+				usageStore: store,
+				pricing:    pricing,
+			}
+			for _, model := range tt.models {
+				l.recordUsage(context.Background(), &Request{}, model, 1000, 100, 0, 0, 0, 0, "conv", "session", "r_test", "")
+			}
+
+			if got := strings.Count(logBuf.String(), warnMsg); got != tt.wantWarns {
+				t.Errorf("unpriced-model warnings = %d, want %d; log:\n%s", got, tt.wantWarns, logBuf.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`claude-opus-5` and `claude-sonnet-5` were missing from the default pricing table, and a model missing from the table prices at $0 without a word. An install that moved its fleet to the Claude 5 models has been writing every Anthropic usage record with `cost_usd = 0` since — so `cost_summary`, `/v1/telemetry/usage`, and the dashboard all report free Claude usage while real spend continues. That includes the agent's own view: a loop that checks its spend with `cost_summary` has been told it is spending nothing.

## Why it stayed invisible — $0 is a legitimate answer

The cost functions treat a missing entry as free because most models Thane talks to *are* free: local Ollama, vLLM, LM Studio. The table can't simply fail closed. What changes is that an unpriced **Anthropic** model now logs a WARN once per model, on its first call, so the next fleet move shows up in the logs the day it happens rather than in an audit.

## What changes for the operator

- Opus 5 ($5/$25) and Sonnet 5 ($2/$10 — cheaper than Sonnet 4.6) are priced out of the box. The 4.x entries stay, since they are still served and still present in usage history.
- A config with its own `pricing:` block replaces the defaults wholesale, so an operator who set one needs to add these models by hand. The regenerated `examples/config.example.yaml` shows the current set.
- Rows already written at $0 stay that way. Every input the price needs is already stored on the row, so an affected install can recompute them with a one-shot `UPDATE` against `usage_records`; that is an operational step rather than a migration.

## Test plan

- [x] `just ci`
- [ ] After deploy: new Anthropic rows in `usage_records` carry non-zero `cost_usd`
- [ ] After deploy: no `usage cost not recorded` WARN for current models

🤖 Generated with [Claude Code](https://claude.com/claude-code)
