### PR TITLE
fix(anthropic): cache the conversation tail alongside explicit system markers

### DIFF
--- a/docs/prompt-caching.md
+++ b/docs/prompt-caching.md
@@ -141,16 +141,32 @@ Thane enforces this in `applyCacheBreakpointGuards`: under-minimum runs
 have their `cache_control` stripped at request time with a WARN log.
 Unknown model families default to the strictest minimum.
 
+### Conversation History
+
+Every request also carries Anthropic's automatic, request-level
+`cache_control`. It lands on the last message block and moves forward
+as the conversation grows, so each call in a tool loop reads the
+transcript the previous call wrote and pays full input price only for
+what is new since then. It composes with the explicit system and tool
+markers: the explicit markers pin the stable prefix, the automatic one
+follows the tail. Without it, a long tool loop re-sends its whole
+growing transcript as uncached input on every iteration.
+
+It keeps the default 5m TTL. Anthropic requires longer-TTL entries to
+precede shorter ones, and the tail sits after the `5m` system run.
+
 ### The 4-Breakpoint Cap
 
 Anthropic rejects requests carrying more than four `cache_control`
-markers total across system blocks, tools, and messages. Today's policy
-normally emits two system breakpoints plus one tool breakpoint.
+markers total across system blocks, tools, and messages, and the
+automatic breakpoint counts as one. Today's policy normally emits two
+system breakpoints, one tool breakpoint, and the automatic one.
 
-The guard in `applyCacheBreakpointGuards` drops excess breakpoints
-before the request is sent. It drops the blanket tool breakpoint first,
-then trims trailing system breakpoints. Every drop logs a WARN so
-operators can see why the cache did not apply.
+The guard in `applyCacheBreakpointGuards` reserves the automatic slot,
+then drops excess explicit breakpoints before the request is sent. It
+drops the blanket tool breakpoint first, then trims trailing system
+breakpoints. Every drop logs a WARN so operators can see why the cache
+did not apply.
 
 ### Anthropic Anti-Patterns
 
@@ -158,7 +174,8 @@ operators can see why the cache did not apply.
   `LIVE STATE`, or `CONTINUITY CONTEXT`.
 - Fragmenting stable sections into many TTL runs. Each TTL transition
   can create a breakpoint.
-- Assuming four breakpoints is plenty. Tools already take one slot.
+- Assuming four breakpoints is plenty. Tools and the conversation tail
+  already take two.
 - Ignoring minimum prefix lengths. A too-short breakpoint is a no-op.
 
 ## Future Providers
@@ -192,6 +209,9 @@ For Anthropic today, inspect:
 - `cache_hit_rate` on Anthropic debug log lines
 - `cache_hit_rate` in the session stats JSON served by `/stats`
 - raw `cache_creation_input_tokens` and `cache_read_input_tokens`
+- `request_cache_control_ttl` on the debug `outbound cache markers`
+  line: `default` means the conversation tail carries the automatic
+  breakpoint; empty means history is being re-sent uncached
 
 ## References
 

--- a/docs/prompt-caching.md
+++ b/docs/prompt-caching.md
@@ -143,7 +143,7 @@ Unknown model families default to the strictest minimum.
 
 ### Conversation History
 
-Every request also carries Anthropic's automatic, request-level
+Requests worth caching also carry Anthropic's automatic, request-level
 `cache_control`. It lands on the last message block and moves forward
 as the conversation grows, so each call in a tool loop reads the
 transcript the previous call wrote and pays full input price only for
@@ -151,6 +151,14 @@ what is new since then. It composes with the explicit system and tool
 markers: the explicit markers pin the stable prefix, the automatic one
 follows the tail. Without it, a long tool loop re-sends its whole
 growing transcript as uncached input on every iteration.
+
+`anthropicPromptCacheControl` decides which requests are worth it. The
+automatic breakpoint is sent when the system prompt carries explicit
+markers, or when `shouldUseAnthropicPromptCaching` sees any of: tool
+definitions, three or more messages, an assistant turn, or a system
+prompt of at least 4096 characters. A short one-shot request with none
+of those goes out without it, because there is nothing a later call
+would read back.
 
 It keeps the default 5m TTL. Anthropic requires longer-TTL entries to
 precede shorter ones, and the tail sits after the `5m` system run.
@@ -160,13 +168,17 @@ precede shorter ones, and the tail sits after the `5m` system run.
 Anthropic rejects requests carrying more than four `cache_control`
 markers total across system blocks, tools, and messages, and the
 automatic breakpoint counts as one. Today's policy normally emits two
-system breakpoints, one tool breakpoint, and the automatic one.
+system breakpoints, one tool breakpoint, and the automatic one when the
+request qualifies for it.
 
-The guard in `applyCacheBreakpointGuards` reserves the automatic slot,
-then drops excess explicit breakpoints before the request is sent. It
-drops the blanket tool breakpoint first, then trims trailing system
-breakpoints. Every drop logs a WARN so operators can see why the cache
-did not apply.
+The guard in `applyCacheBreakpointGuards` reserves the automatic slot
+when one is being sent, then drops excess explicit breakpoints before
+the request is sent. It drops the blanket tool breakpoint first, then
+trims trailing system breakpoints. Each over-cap drop logs a WARN,
+since exceeding the cap means the assembly plan changed. Under-minimum
+drops log at DEBUG instead: a short section is a structural fact of
+the prompt that recurs on every request. Every drop, at either level,
+is also listed on the debug `outbound cache markers` line.
 
 ### Anthropic Anti-Patterns
 
@@ -211,7 +223,9 @@ For Anthropic today, inspect:
 - raw `cache_creation_input_tokens` and `cache_read_input_tokens`
 - `request_cache_control_ttl` on the debug `outbound cache markers`
   line: `default` means the conversation tail carries the automatic
-  breakpoint; empty means history is being re-sent uncached
+  breakpoint. Empty is expected on a short one-shot request; on a
+  tool-bearing or multi-turn request it means history is being re-sent
+  uncached
 
 ## References
 

--- a/internal/model/fleet/providers/anthropic.go
+++ b/internal/model/fleet/providers/anthropic.go
@@ -350,13 +350,21 @@ func (c *AnthropicClient) ChatStream(ctx context.Context, model string, messages
 	anthropicTools := convertToolsToAnthropic(tools)
 	systemPayload := anthropicSystemPayload(messages, systemPrompt)
 
+	// The request-level breakpoint occupies one of the four slots, so
+	// decide it before the guards and let them leave room for it.
+	requestCache := anthropicPromptCacheControl(systemPrompt, anthropicMsgs, anthropicTools, anthropicUsesExplicitPromptCaching(systemPayload))
+	reservedSlots := 0
+	if requestCache != nil {
+		reservedSlots = 1
+	}
+
 	// Enforce Anthropic cache-breakpoint guards (≤4 total, per-model
 	// minimum cached-prefix length) on the assembled blocks+tools.
 	// Runs below the model minimum and excess breakpoints are silently
 	// ignored by the API, so we drop them here and warn instead.
 	var cacheDrops []CacheBreakpointDrop
 	if blocks, ok := systemPayload.([]anthropicContent); ok {
-		cacheDrops = applyCacheBreakpointGuards(blocks, anthropicTools, model, c.callLogger(ctx))
+		cacheDrops = applyCacheBreakpointGuards(blocks, anthropicTools, model, reservedSlots, c.callLogger(ctx))
 	}
 	explicitCaching := anthropicUsesExplicitPromptCaching(systemPayload)
 
@@ -751,8 +759,19 @@ func (c *AnthropicClient) handleStreaming(ctx context.Context, body io.Reader, c
 	return resp, nil
 }
 
+// anthropicPromptCacheControl decides Anthropic's automatic,
+// request-level cache breakpoint. It rides the last message block and
+// moves forward as the conversation grows, so each iteration of a tool
+// loop reads the history the previous iteration wrote. Explicit system
+// markers do not replace it: they pin the stable prefix, and without
+// the automatic breakpoint every iteration re-sends the growing
+// transcript as uncached input.
+//
+// It keeps the default 5m TTL. Anthropic requires longer-TTL entries
+// to precede shorter ones, and the automatic breakpoint lands after
+// the 5m system run.
 func anthropicPromptCacheControl(systemPrompt string, messages []anthropicMessage, tools []anthropicTool, explicit bool) *anthropicCacheControl {
-	if explicit || !shouldUseAnthropicPromptCaching(systemPrompt, messages, tools) {
+	if !explicit && !shouldUseAnthropicPromptCaching(systemPrompt, messages, tools) {
 		return nil
 	}
 	return &anthropicCacheControl{Type: "ephemeral"}
@@ -902,15 +921,18 @@ type CacheBreakpointDrop struct {
 //     model-specific minimum, strip cache_control. The block itself
 //     remains; only the breakpoint is removed.
 //  2. Count surviving system breakpoints plus the one blanket tool
-//     cache (if any). If the total still exceeds 4, drop the tool
-//     cache first — it is an undifferentiated "cache the last tool"
+//     cache (if any) against the cap: 4 minus reservedSlots, the
+//     slots the caller has already committed to the request-level
+//     breakpoint. If the total exceeds it, drop the tool cache
+//     first — it is an undifferentiated "cache the last tool"
 //     policy, whereas system breakpoints reflect deliberate
 //     per-section TTL choices.
 //  3. If still over the cap, drop trailing system breakpoints (the
 //     earliest runs typically cover the largest stable prefix, so
 //     dropping from the tail minimizes the loss).
-func applyCacheBreakpointGuards(blocks []anthropicContent, tools []anthropicTool, model string, logger *slog.Logger) []CacheBreakpointDrop {
+func applyCacheBreakpointGuards(blocks []anthropicContent, tools []anthropicTool, model string, reservedSlots int, logger *slog.Logger) []CacheBreakpointDrop {
 	minTokens := minCacheablePrefixTokens(model)
+	limit := maxAnthropicCacheBreakpoints - reservedSlots
 	var drops []CacheBreakpointDrop
 
 	// Step 1: strip under-minimum breakpoints from system blocks.
@@ -952,7 +974,7 @@ func applyCacheBreakpointGuards(blocks []anthropicContent, tools []anthropicTool
 	}
 
 	total := systemBreakpoints + toolBreakpoint
-	if total <= maxAnthropicCacheBreakpoints {
+	if total <= limit {
 		return drops
 	}
 
@@ -965,7 +987,8 @@ func applyCacheBreakpointGuards(blocks []anthropicContent, tools []anthropicTool
 		logger.Warn("dropping tool cache breakpoint to fit Anthropic 4-breakpoint cap",
 			"system_breakpoints", systemBreakpoints,
 			"total_requested", total,
-			"max", maxAnthropicCacheBreakpoints,
+			"reserved_slots", reservedSlots,
+			"max", limit,
 		)
 		drops = append(drops, CacheBreakpointDrop{
 			Reason:     "over_cap_tool_breakpoint",
@@ -975,13 +998,13 @@ func applyCacheBreakpointGuards(blocks []anthropicContent, tools []anthropicTool
 		})
 		tools[len(tools)-1].CacheControl = nil
 		total--
-		if total <= maxAnthropicCacheBreakpoints {
+		if total <= limit {
 			return drops
 		}
 	}
 
 	// Step 4: drop trailing system breakpoints until we fit.
-	excess := total - maxAnthropicCacheBreakpoints
+	excess := total - limit
 	for i := len(blocks) - 1; i >= 0 && excess > 0; i-- {
 		if blocks[i].CacheControl == nil {
 			continue

--- a/internal/model/fleet/providers/anthropic_test.go
+++ b/internal/model/fleet/providers/anthropic_test.go
@@ -346,7 +346,47 @@ func TestAnthropicPromptCacheControl_NotSuppressedByToolCacheBreakpoints(t *test
 	}
 }
 
-func TestAnthropicPromptCacheControl_SuppressedBySectionCacheBreakpoints(t *testing.T) {
+func TestApplyCacheBreakpointGuards_ReservedSlot(t *testing.T) {
+	body := strings.Repeat("x", 4100)
+	tests := []struct {
+		name       string
+		systemRuns int
+		wantSystem int
+		wantTool   bool
+	}{
+		{"production shape fits beside the reserved slot", 2, 2, true},
+		{"reserved slot displaces the tool breakpoint", 3, 3, false},
+		{"reserved slot displaces trailing system breakpoints", 4, 3, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			blocks := make([]anthropicContent, tt.systemRuns)
+			for i := range blocks {
+				blocks[i] = textBlock(body, "1h")
+			}
+			tools := []anthropicTool{
+				{Name: "t", CacheControl: &anthropicCacheControl{Type: "ephemeral", TTL: "1h"}},
+			}
+
+			applyCacheBreakpointGuards(blocks, tools, "claude-sonnet-4-5", 1, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+			surviving := 0
+			for _, b := range blocks {
+				if b.CacheControl != nil {
+					surviving++
+				}
+			}
+			if surviving != tt.wantSystem {
+				t.Errorf("surviving system breakpoints = %d, want %d", surviving, tt.wantSystem)
+			}
+			if gotTool := tools[0].CacheControl != nil; gotTool != tt.wantTool {
+				t.Errorf("tool breakpoint kept = %v, want %v", gotTool, tt.wantTool)
+			}
+		})
+	}
+}
+
+func TestAnthropicPromptCacheControl_ComposesWithSectionCacheBreakpoints(t *testing.T) {
 	systemPayload := anthropicSystemPayload([]llm.Message{
 		{
 			Role:    "system",
@@ -363,8 +403,11 @@ func TestAnthropicPromptCacheControl_SuppressedBySectionCacheBreakpoints(t *test
 	}
 
 	ctrl := anthropicPromptCacheControl("fallback", []anthropicMessage{{Role: "user", Content: "check"}}, nil, explicit)
-	if ctrl != nil {
-		t.Fatalf("request-level cache_control = %+v, want nil when explicit system block caching is present", ctrl)
+	if ctrl == nil || ctrl.Type != "ephemeral" {
+		t.Fatalf("request-level cache_control = %+v, want ephemeral alongside explicit system block caching", ctrl)
+	}
+	if ctrl.TTL != "" {
+		t.Errorf("request-level TTL = %q, want default 5m: it lands after the 5m system run", ctrl.TTL)
 	}
 }
 
@@ -406,7 +449,7 @@ func TestApplyCacheBreakpointGuards_UnderMinimumRunsAreDropped(t *testing.T) {
 		textBlock(strings.Repeat("a", 400), "1h"),  // prefix ≈ 100 tokens — below min
 		textBlock(strings.Repeat("b", 4000), "1h"), // prefix ≈ 1100 tokens — above min
 	}
-	applyCacheBreakpointGuards(blocks, nil, "claude-sonnet-4-5", slog.Default())
+	applyCacheBreakpointGuards(blocks, nil, "claude-sonnet-4-5", 0, slog.Default())
 
 	if blocks[0].CacheControl != nil {
 		t.Error("under-minimum run should have cache_control stripped")
@@ -430,7 +473,7 @@ func TestApplyCacheBreakpointGuards_CapsAtFourBreakpointsDroppingTool(t *testing
 		{Name: "t", CacheControl: &anthropicCacheControl{Type: "ephemeral", TTL: "1h"}},
 	}
 
-	applyCacheBreakpointGuards(blocks, tools, "claude-sonnet-4-5", slog.Default())
+	applyCacheBreakpointGuards(blocks, tools, "claude-sonnet-4-5", 0, slog.Default())
 
 	if tools[0].CacheControl != nil {
 		t.Error("tool cache should be dropped when system fills the 4-breakpoint budget")
@@ -458,7 +501,7 @@ func TestApplyCacheBreakpointGuards_DropsTrailingSystemWhenAboveCap(t *testing.T
 		textBlock(body, "1h"),
 	}
 
-	applyCacheBreakpointGuards(blocks, nil, "claude-sonnet-4-5", slog.Default())
+	applyCacheBreakpointGuards(blocks, nil, "claude-sonnet-4-5", 0, slog.Default())
 
 	if blocks[4].CacheControl != nil {
 		t.Error("trailing system breakpoint should drop when budget exhausted")
@@ -482,7 +525,7 @@ func TestApplyCacheBreakpointGuards_AllowsTypicalThreeBreakpointConfig(t *testin
 		{Name: "t", CacheControl: &anthropicCacheControl{Type: "ephemeral", TTL: "1h"}},
 	}
 
-	applyCacheBreakpointGuards(blocks, tools, "claude-sonnet-4-5", slog.Default())
+	applyCacheBreakpointGuards(blocks, tools, "claude-sonnet-4-5", 0, slog.Default())
 
 	for i, b := range blocks {
 		if b.CacheControl == nil {
@@ -795,7 +838,7 @@ func TestApplyCacheBreakpointGuards_ReturnsUnderMinimumDrops(t *testing.T) {
 	}
 	tools := []anthropicTool{}
 
-	drops := applyCacheBreakpointGuards(blocks, tools, "claude-opus-4-20250514", logger)
+	drops := applyCacheBreakpointGuards(blocks, tools, "claude-opus-4-20250514", 0, logger)
 
 	if len(drops) != 2 {
 		t.Fatalf("drops = %d, want 2", len(drops))
@@ -832,7 +875,7 @@ func TestApplyCacheBreakpointGuards_ReturnsToolCapDrop(t *testing.T) {
 		{Name: "last", CacheControl: &anthropicCacheControl{Type: "ephemeral", TTL: "1h"}},
 	}
 
-	drops := applyCacheBreakpointGuards(blocks, tools, "claude-opus-4-20250514", logger)
+	drops := applyCacheBreakpointGuards(blocks, tools, "claude-opus-4-20250514", 0, logger)
 
 	if len(drops) < 1 {
 		t.Fatalf("drops = %d, want at least 1", len(drops))


### PR DESCRIPTION
## Summary

Thane has long cached the stable parts of an Anthropic request — the sectioned system prompt and the tool definitions — but it has never cached the *conversation*. Every iteration of a tool loop re-sent the entire accumulated transcript at full input price. On an agentic turn that runs dozens of iterations over a large history, that history is paid for once per iteration, and it quietly becomes the largest line on the bill.

## The trigger — a long turn paying for its history over and over

A usage audit of a production install found uncached input outweighing everything else in Anthropic spend, concentrated in long reflective loop turns: dozens of iterations, each re-sending tens of thousands of tokens of transcript it had already sent the iteration before. The debug `outbound cache markers` line on every request told the story plainly: two system breakpoints, one tool breakpoint, and an empty `request_cache_control_ttl`.

## Why the history fell through — two caching modes treated as either/or

Anthropic offers two ways to cache. *Explicit* breakpoints sit on specific blocks and suit prefixes that change at different rates. The *automatic*, request-level breakpoint follows the end of the conversation and moves forward as it grows. When the system prompt began carrying explicit markers, the automatic breakpoint was switched off, as though the two were alternatives. They compose, and Anthropic recommends exactly that pairing for agent loops: explicit markers pin the stable prefix, the automatic one tracks the growing tail. Only three of the four breakpoint slots were ever in use; the fourth sat empty.

## What changes

The automatic breakpoint now rides along with explicit system markers. Because it takes a slot, it is decided first, and the breakpoint guard reserves room for it before trimming explicit markers — the usual shape (two system, one tool, one automatic) fits exactly with nothing dropped. It stays on the default 5m TTL: Anthropic requires longer-TTL entries to precede shorter ones, and the tail sits after the 5m system run.

The payoff is that each iteration pays full price only for what it added and reads the rest back at a tenth of the input rate. A single-shot turn pays a small write premium on its tail that no later iteration reads; a long loop saves most of its input cost.

`docs/prompt-caching.md` now describes the conversation-tail breakpoint, counts it against the cap, and names the log field that confirms it is being sent.

## Test plan

- [x] `just ci`
- [ ] After deploy: `outbound cache markers` debug lines show `request_cache_control_ttl: default`
- [ ] After deploy: the uncached share of Anthropic input in `usage_records` drops sharply on multi-iteration turns
- [ ] After deploy: no Anthropic 400s mentioning `cache_control`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
